### PR TITLE
Release 2026.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ This changelog covers all changes in **drydock** since forking from [getwud/wud]
 
 ---
 
+## 2026.2.3
+
+### Bug Fixes
+
+- **NTFY trigger auth 401** — Bearer token auth used unsupported `axios.auth.bearer` property; now sends `Authorization: Bearer <token>` header. Basic auth property names corrected to `username`/`password`. (#27)
+- **Agent mode missing /health** — Added unauthenticated `/health` endpoint to the agent server, mounted before the auth middleware so Docker healthchecks work without the agent secret. (#27)
+
+### Infrastructure
+
+- **Lefthook pre-push hooks** — Added `lefthook.yml` with pre-push checks (lint + build + test).
+
+### Maintenance
+
+- **Removed startup warning** — Removed "Known Issue" notice from README now that container startup issues are resolved.
+
+---
+
 ## 2026.2.2
 
 ### Security / CI

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-2026.2.2-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-2026.2.3-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/GHCR-image-2ea44f?logo=docker&logoColor=white" alt="GHCR package"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-C9A227" alt="License MIT"></a>
@@ -32,10 +32,6 @@
 
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
 </p>
-
-> **Known Issue — Container startup failures (Feb 2025)**
->
-> We're aware that some users are experiencing container startup issues following the rename from WUD to Drydock. The rebrand introduced changes to image paths, environment variable prefixes, and volume mounts that we're still working through. We apologise for the disruption — this is our top priority and fixes are actively landing. If you're blocked, please check the [open issues](https://github.com/CodesWhat/drydock/issues). Thanks for your patience.
 
 ---
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "drydock-app",
-    "version": "2026.2.2",
+    "version": "2026.2.3",
     "description": "drydock - the app",
     "type": "module",
     "main": "dist/index.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-ui",
-  "version": "2026.2.2",
+  "version": "2026.2.3",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Bump version to 2026.2.3
- Remove "Known Issue" startup warning from README (resolved)
- Add changelog entry for NTFY auth fix + agent /health endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)