### PR TITLE
release: v1.3.1 — release workflow fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-02-15
+
 ### Fixed
 
 - **Release SBOM generation for multi-arch images** — Replaced `anchore/sbom-action` (which fails on manifest list digests from multi-platform builds) with Docker buildx native SBOM generation (`sbom: true`), producing per-platform SBOMs embedded in image attestations.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.3.0-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.3.1-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/GHCR-image-2ea44f?logo=docker&logoColor=white" alt="GHCR package"></a>
   <a href="https://hub.docker.com/r/codeswhat/drydock"><img src="https://img.shields.io/docker/pulls/codeswhat/drydock?logo=docker&logoColor=white&label=Docker+Hub" alt="Docker Hub pulls"></a>
   <a href="https://quay.io/repository/codeswhat/drydock"><img src="https://img.shields.io/badge/Quay.io-image-ee0000?logo=redhat&logoColor=white" alt="Quay.io"></a>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-app",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-app",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ecr": "^3.894.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-app",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "drydock - the app",
   "type": "module",
   "main": "dist/index.js",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-ui",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "@fortawesome/fontawesome-free": "7.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Version bump to 1.3.1 (app, ui, README badge, changelog)
- Patch release for SBOM + Trivy pin fixes from #55

## Test plan
- [x] All lefthook checks passed locally (build, qlty, snyk, tests)
- [ ] CI passes on PR
- [ ] Tag v1.3.1 after merge triggers release workflow with working SBOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)