### PR TITLE
Add artifact-metadata permission for attestation storage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       packages: write
       id-token: write  # cosign keyless signing
       attestations: write
+      artifact-metadata: write  # attestation storage records
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Adds `artifact-metadata: write` permission to the release workflow to silence attestation storage warnings

## Test plan
- [x] Attestation step already succeeds — this adds the secondary storage record support

🤖 Generated with [Claude Code](https://claude.com/claude-code)