### PR TITLE
🐛 fix(ci): grant zizmor permissions in release workflow caller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     name: CI
     permissions:
       contents: read
+      security-events: write  # zizmor SARIF upload
+      actions: read           # zizmor workflow analysis
     uses: ./.github/workflows/ci.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- expand permissions on the `ci` caller job in `release.yml`
- add `security-events: write` for SARIF upload from zizmor
- add `actions: read` required by zizmor workflow analysis

## Why
Reusable workflow caller permissions are a ceiling for jobs in the called workflow. With only `contents: read`, the zizmor job in `ci.yml` cannot upload SARIF.

## Testing
- pre-push e2e hook passed locally during push
