### PR TITLE
Fix load-test blocking release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,7 @@ jobs:
     name: Load Test
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    continue-on-error: true  # advisory until test/ci-compose.yml and Artillery config are created
     needs: [build]
     permissions:
       contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,6 +37,6 @@ jobs:
           publish_results: true
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a  # v3.32.2
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2  # v4.32.2
         with:
           sarif_file: results.sarif

--- a/app/registries/providers/alicr/Alicr.ts
+++ b/app/registries/providers/alicr/Alicr.ts
@@ -33,7 +33,10 @@ class Alicr extends BaseRegistry {
     try {
       return new URL(withProtocol).hostname.toLowerCase();
     } catch {
-      return value.replace(/^https?:\/\//i, '').split('/')[0].toLowerCase();
+      return value
+        .replace(/^https?:\/\//i, '')
+        .split('/')[0]
+        .toLowerCase();
     }
   }
 

--- a/app/registries/providers/gar/Gar.ts
+++ b/app/registries/providers/gar/Gar.ts
@@ -23,9 +23,7 @@ class Gar extends BaseRegistry {
 
   private getRegistryHostname(image: ContainerImage): string {
     const registryUrl = image.registry?.url || '';
-    const withProtocol = /^https?:\/\//i.test(registryUrl)
-      ? registryUrl
-      : `https://${registryUrl}`;
+    const withProtocol = /^https?:\/\//i.test(registryUrl) ? registryUrl : `https://${registryUrl}`;
     try {
       return new URL(withProtocol).hostname;
     } catch {

--- a/app/registries/providers/ibmcr/Ibmcr.ts
+++ b/app/registries/providers/ibmcr/Ibmcr.ts
@@ -45,7 +45,10 @@ class Ibmcr extends BaseRegistry {
     try {
       return new URL(withProtocol).hostname.toLowerCase();
     } catch {
-      return value.replace(/^https?:\/\//i, '').split('/')[0].toLowerCase();
+      return value
+        .replace(/^https?:\/\//i, '')
+        .split('/')[0]
+        .toLowerCase();
     }
   }
 

--- a/app/registries/providers/lscr/Lscr.ts
+++ b/app/registries/providers/lscr/Lscr.ts
@@ -8,17 +8,13 @@ class Lscr extends Ghcr {
   getConfigurationSchema() {
     return this.joi.alternatives([
       // Anonymous configuration
-      this.joi
-        .string()
-        .allow(''),
+      this.joi.string().allow(''),
 
       // Auth configuration
-      this.joi
-        .object()
-        .keys({
-          username: this.joi.string().required(),
-          token: this.joi.string().required(),
-        }),
+      this.joi.object().keys({
+        username: this.joi.string().required(),
+        token: this.joi.string().required(),
+      }),
     ]);
   }
 

--- a/app/registries/providers/ocir/Ocir.ts
+++ b/app/registries/providers/ocir/Ocir.ts
@@ -33,7 +33,10 @@ class Ocir extends BaseRegistry {
     try {
       return new URL(withProtocol).hostname.toLowerCase();
     } catch {
-      return value.replace(/^https?:\/\//i, '').split('/')[0].toLowerCase();
+      return value
+        .replace(/^https?:\/\//i, '')
+        .split('/')[0]
+        .toLowerCase();
     }
   }
 

--- a/app/registries/providers/quay/Quay.ts
+++ b/app/registries/providers/quay/Quay.ts
@@ -8,18 +8,14 @@ class Quay extends BaseRegistry {
   getConfigurationSchema() {
     return this.joi.alternatives([
       // Anonymous configuration
-      this.joi
-        .string()
-        .allow(''),
+      this.joi.string().allow(''),
 
       // Auth configuration
-      this.joi
-        .object()
-        .keys({
-          namespace: this.joi.string().required(),
-          account: this.joi.string().required(),
-          token: this.joi.string().required(),
-        }),
+      this.joi.object().keys({
+        namespace: this.joi.string().required(),
+        account: this.joi.string().required(),
+        token: this.joi.string().required(),
+      }),
     ]);
   }
 

--- a/app/triggers/providers/docker/Docker.test.ts
+++ b/app/triggers/providers/docker/Docker.test.ts
@@ -1925,7 +1925,9 @@ describe('additional docker trigger coverage', () => {
     expect(backupStore.getBackupsByName).toHaveBeenCalledWith('container-name');
     expect(registryProvider.getImageFullName).not.toHaveBeenCalled();
     expect(removeImageSpy).not.toHaveBeenCalled();
-    expect(logContainer.info).toHaveBeenCalledWith(expect.stringContaining('Skipping prune of 1.0.0'));
+    expect(logContainer.info).toHaveBeenCalledWith(
+      expect.stringContaining('Skipping prune of 1.0.0'),
+    );
   });
 
   test('cleanupOldImages should skip digest pruning when digest repo is missing', async () => {

--- a/app/triggers/providers/docker/Docker.ts
+++ b/app/triggers/providers/docker/Docker.ts
@@ -1102,9 +1102,7 @@ class Docker extends Trigger {
     // no longer exists after executeContainerUpdate recreated it).
     const newContainer = await this.getCurrentContainer(dockerApi, { id: container.name });
     if (newContainer == null) {
-      logContainer.warn(
-        'Cannot find recreated container by name — skipping health monitoring',
-      );
+      logContainer.warn('Cannot find recreated container by name — skipping health monitoring');
       return;
     }
 


### PR DESCRIPTION
## Summary
- Make load-test job advisory (`continue-on-error: true`) — missing `test/ci-compose.yml` and Artillery config are v1.4 work
- Align scorecard codeql-action from v3 to v4 to match codeql.yml
- Format 8 files with biome 2.3.15 (qlty-pinned version)

## Context
v1.3.7 merge to main triggered the release workflow, which failed because the load-test job (cherry-picked from v1.4) references files that don't exist yet (`test/ci-compose.yml`, Artillery `test.yml`). The load-test had no `continue-on-error`, so it blocked Docker Build & Push.

## Test plan
- [ ] Release workflow completes — load-test allowed to fail, Docker images pushed
- [ ] All other CI jobs still pass (lint, test, build, e2e, zizmor, scorecard)
- [ ] Biome formatting clean (`qlty check --all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)