### PR TITLE
ci(release): fix cosign v3 blob signature outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
           artifact="dist/drydock-${RELEASE_TAG}.tar.gz"
           cosign sign-blob --yes \
             --bundle "${artifact}.bundle" \
+            --new-bundle-format=false \
             --output-signature "${artifact}.sig" \
             --output-certificate "${artifact}.pem" \
             "${artifact}"


### PR DESCRIPTION
## Root cause
Release run 22280490625 (attempt 2) failed in `Upload signed release assets` because `.sig`/`.pem` were not generated by cosign v3.

## Fix
Add `--new-bundle-format=false` to `cosign sign-blob` so `--output-signature` and `--output-certificate` produce files expected by release upload.

## Validation
- lefthook run pre-push --no-tty (passed)
