### PR TITLE
ci(release): guarantee .sig/.pem outputs for signed assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,34 @@ jobs:
             --output-certificate "${artifact}.pem" \
             "${artifact}"
 
+          # Cosign v3 may only emit bundle output in some keyless flows.
+          # Materialize legacy signature/cert files from the bundle when needed.
+          if [ ! -s "${artifact}.sig" ]; then
+            sig_b64="$(jq -r '.base64Signature // .messageSignature.signature // empty' "${artifact}.bundle")"
+            if [ -n "${sig_b64}" ]; then
+              printf '%s' "${sig_b64}" | base64 --decode > "${artifact}.sig"
+            fi
+          fi
+
+          if [ ! -s "${artifact}.pem" ]; then
+            cert_pem="$(jq -r '.cert // empty' "${artifact}.bundle")"
+            if [ -n "${cert_pem}" ]; then
+              printf '%s\n' "${cert_pem}" > "${artifact}.pem"
+            else
+              cert_der_b64="$(jq -r '.verificationMaterial.certificate.rawBytes // empty' "${artifact}.bundle")"
+              if [ -n "${cert_der_b64}" ]; then
+                printf '%s' "${cert_der_b64}" | base64 --decode | openssl x509 -inform DER -out "${artifact}.pem"
+              fi
+            fi
+          fi
+
+          if [ ! -s "${artifact}.sig" ] || [ ! -s "${artifact}.pem" ]; then
+            echo "::error::Expected signature outputs were not generated"
+            ls -la dist
+            jq 'keys' "${artifact}.bundle" || true
+            exit 1
+          fi
+
       - name: Attest release artifact provenance
         if: startsWith(github.ref, 'refs/tags/')
         id: attest_release_artifact


### PR DESCRIPTION
## Root cause
Cosign keyless blob signing in release CI writes `*.bundle` but may not materialize legacy `*.sig` / `*.pem` files, causing `gh release upload` to fail with:

`no matches found for dist/drydock-v1.3.8.tar.gz.sig`

## Fix
After `cosign sign-blob`, explicitly materialize missing signature/certificate files from the generated bundle:
- signature from `base64Signature` / `messageSignature.signature`
- certificate from `cert` or `verificationMaterial.certificate.rawBytes`

Then fail early with diagnostics if either file is still missing.

## Why this is robust
Works across old/new bundle structures and removes dependency on cosign emitting sidecar files directly.

## Validation
- lefthook pre-push passed locally (e2e, qlty, snyk-code, zizmor)
