### PR TITLE
fix(load-test): correct processor path in behavior and rate-limit configs

### DIFF
--- a/test/test-behavior.yml
+++ b/test/test-behavior.yml
@@ -17,7 +17,7 @@ config:
     - duration: 20
       arrivalRate: 2
       name: "Behavior steady"
-  processor: "./test/load-test.processor.cjs"
+  processor: "./load-test.processor.cjs"
   defaults:
     headers:
       Accept: "application/json"

--- a/test/test-rate-limit.yml
+++ b/test/test-rate-limit.yml
@@ -15,7 +15,7 @@ config:
     headers:
       Accept: "application/json"
       Authorization: "Basic YWRtaW46cGFzc3dvcmQ="
-  processor: "./test/load-test.processor.cjs"
+  processor: "./load-test.processor.cjs"
   ensure:
     thresholds:
       - vusers.failed: 0


### PR DESCRIPTION
## Summary
- Artillery resolves `processor` paths relative to the YAML config file, not the working directory
- Both `test/test-behavior.yml` and `test/test-rate-limit.yml` referenced `./test/load-test.processor.cjs` which resolved to `test/test/load-test.processor.cjs` (MODULE_NOT_FOUND, exit code 11)
- Fixed to `./load-test.processor.cjs` since the processor lives alongside the configs in `test/`

## Test plan
- [ ] CI load-test-ci job passes all three Artillery runs (ci, behavior, rate-limit)
- [ ] All correctness checks produce reports instead of "Report path is empty"