### PR TITLE
Fix rate-limit load test CSRF 403s

### DIFF
--- a/test/test-rate-limit.yml
+++ b/test/test-rate-limit.yml
@@ -15,6 +15,8 @@ config:
     headers:
       Accept: "application/json"
       Authorization: "Basic YWRtaW46cGFzc3dvcmQ="
+  http:
+    cookieJar: false
   processor: "./load-test.processor.cjs"
   ensure:
     thresholds:


### PR DESCRIPTION
## Summary
- Rate-limit burst test fires 31 sequential POSTs in one virtual user flow
- After first POST, session cookie is set → subsequent POSTs trigger CSRF validation → 403 Forbidden
- All 31 requests got 403 instead of reaching the rate limiter (expected ≥1 HTTP 429)
- Fix: disable Artillery's cookie jar (`http.cookieJar: false`) so every request authenticates independently via Basic auth — no cookie = no CSRF check

## Test plan
- [ ] CI Load Test (CI) job passes with rate-limit correctness check producing ≥1 HTTP 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)