### PR TITLE
RC banner and collapsible screenshots for website

### DIFF
--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -1,5 +1,6 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import Image from "next/image";
+import Link from "next/link";
 import type { ReactNode } from "react";
 import { source } from "@/lib/source";
 
@@ -30,6 +31,22 @@ export default function Layout({ children }: { children: ReactNode }) {
         },
       ]}
     >
+      <div className="border-b border-amber-200 bg-amber-50/80 dark:border-amber-900 dark:bg-amber-950/80">
+        <div className="mx-auto flex items-center justify-center gap-2 px-4 py-2 text-sm">
+          <span className="inline-flex items-center rounded-full bg-amber-200 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+            RC
+          </span>
+          <span className="text-amber-800 dark:text-amber-200">
+            These docs cover the <strong>v1.4.0 release candidate</strong>.
+          </span>
+          <Link
+            href="https://github.com/CodesWhat/drydock/releases/tag/v1.3.9"
+            className="font-medium text-amber-700 underline underline-offset-2 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+          >
+            v1.3.9 stable
+          </Link>
+        </div>
+      </div>
       {children}
     </DocsLayout>
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -426,6 +426,24 @@ export default function Home() {
         <div className="bg-grid-neutral-200/50 dark:bg-grid-neutral-800/50 fixed inset-0" />
 
         <div className="relative z-10">
+          {/* RC Banner */}
+          <div className="relative z-20 border-b border-amber-200 bg-amber-50/80 backdrop-blur-sm dark:border-amber-900 dark:bg-amber-950/80">
+            <div className="mx-auto flex max-w-6xl items-center justify-center gap-2 px-4 py-2 text-sm">
+              <span className="inline-flex items-center rounded-full bg-amber-200 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+                RC
+              </span>
+              <span className="text-amber-800 dark:text-amber-200">
+                You&apos;re viewing the <strong>v1.4.0 release candidate</strong> docs.
+              </span>
+              <Link
+                href="https://github.com/CodesWhat/drydock/releases/tag/v1.3.9"
+                className="font-medium text-amber-700 underline underline-offset-2 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-100"
+              >
+                v1.3.9 is the current stable release
+              </Link>
+            </div>
+          </div>
+
           {/* Hero Section */}
           <section className="relative flex min-h-screen flex-col items-center justify-center px-4 py-10">
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,_white_20%,_transparent_70%)] dark:bg-[radial-gradient(ellipse_at_center,_rgb(10,10,10)_20%,_transparent_70%)]" />
@@ -445,7 +463,7 @@ export default function Home() {
 
               {/* Version Badge */}
               <Badge variant="secondary" className="mb-6 px-4 py-1.5 text-sm font-medium">
-                v1.4.0 &middot; Open Source
+                v1.4.0-rc &middot; Open Source
               </Badge>
 
               {/* Heading */}

--- a/apps/web/components/screenshots-section.tsx
+++ b/apps/web/components/screenshots-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Moon, Sun } from "lucide-react";
+import { ChevronDown, Moon, Sun } from "lucide-react";
 import Image from "next/image";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
@@ -12,16 +12,53 @@ type Screenshot = {
   label: string;
 };
 
+function ScreenshotCard({
+  screenshot,
+  effectiveMode,
+  mounted,
+}: {
+  screenshot: Screenshot;
+  effectiveMode: "light" | "dark";
+  mounted: boolean;
+}) {
+  return (
+    <div className="group">
+      <div className="isolate overflow-hidden rounded-xl border border-neutral-200 bg-white/50 shadow-sm backdrop-blur-sm transition-all duration-300 group-hover:shadow-lg group-hover:border-neutral-300 dark:border-neutral-800 dark:bg-neutral-900/50 dark:group-hover:border-neutral-700">
+        <div className="relative aspect-video overflow-hidden">
+          {mounted && (
+            <Image
+              key={`${screenshot.label}-${effectiveMode}`}
+              src={effectiveMode === "dark" ? screenshot.srcDark : screenshot.srcLight}
+              alt={screenshot.alt}
+              fill
+              className="object-cover object-left-top transition-transform duration-500 group-hover:scale-105"
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            />
+          )}
+        </div>
+        <div className="px-4 py-3">
+          <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+            {screenshot.label}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ScreenshotsSection({ screenshots }: { screenshots: Screenshot[] }) {
   const { resolvedTheme } = useTheme();
   const [mode, setMode] = useState<"light" | "dark" | null>(null);
   const [mounted, setMounted] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
   const effectiveMode = mounted ? (mode ?? (resolvedTheme === "dark" ? "dark" : "light")) : "light";
+
+  const [hero, ...rest] = screenshots;
 
   return (
     <section className="px-4 py-24">
@@ -68,31 +105,41 @@ export function ScreenshotsSection({ screenshots }: { screenshots: Screenshot[] 
           </div>
         )}
 
-        <div className="grid gap-6 sm:grid-cols-2">
-          {screenshots.map((screenshot) => (
-            <div key={screenshot.label} className="group">
-              <div className="isolate overflow-hidden rounded-xl border border-neutral-200 bg-white/50 shadow-sm backdrop-blur-sm transition-all duration-300 group-hover:shadow-lg group-hover:border-neutral-300 dark:border-neutral-800 dark:bg-neutral-900/50 dark:group-hover:border-neutral-700">
-                <div className="relative aspect-video overflow-hidden">
-                  {mounted && (
-                    <Image
-                      key={`${screenshot.label}-${effectiveMode}`}
-                      src={effectiveMode === "dark" ? screenshot.srcDark : screenshot.srcLight}
-                      alt={screenshot.alt}
-                      fill
-                      className="object-cover object-left-top transition-transform duration-500 group-hover:scale-105"
-                      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                    />
-                  )}
-                </div>
-                <div className="px-4 py-3">
-                  <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
-                    {screenshot.label}
-                  </p>
-                </div>
-              </div>
+        {/* Hero screenshot — always visible */}
+        {hero && (
+          <ScreenshotCard screenshot={hero} effectiveMode={effectiveMode} mounted={mounted} />
+        )}
+
+        {/* Collapsible remaining screenshots */}
+        {rest.length > 0 && (
+          <div className="mt-6">
+            <button
+              type="button"
+              onClick={() => setExpanded((prev) => !prev)}
+              className="group/toggle mx-auto flex items-center gap-2 rounded-lg border border-neutral-200 bg-white/50 px-4 py-2 text-sm font-medium text-neutral-600 backdrop-blur-sm transition-colors hover:border-neutral-300 hover:text-neutral-900 dark:border-neutral-800 dark:bg-neutral-900/50 dark:text-neutral-400 dark:hover:border-neutral-700 dark:hover:text-neutral-100"
+            >
+              {expanded ? "Hide screenshots" : `View all screenshots (${rest.length} more)`}
+              <ChevronDown
+                className={`h-4 w-4 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+              />
+            </button>
+
+            <div
+              className={`grid gap-6 overflow-hidden transition-all duration-500 ease-in-out sm:grid-cols-2 ${
+                expanded ? "mt-6 max-h-[4000px] opacity-100" : "max-h-0 opacity-0"
+              }`}
+            >
+              {rest.map((screenshot) => (
+                <ScreenshotCard
+                  key={screenshot.label}
+                  screenshot={screenshot}
+                  effectiveMode={effectiveMode}
+                  mounted={mounted}
+                />
+              ))}
             </div>
-          ))}
-        </div>
+          </div>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Add amber RC banner to homepage and docs layout linking to v1.3.9 stable release
- Update hero badge from v1.4.0 to v1.4.0-rc
- Refactor screenshots section: hero screenshot always visible, remaining 4 behind a collapsible "View all screenshots" toggle

## Test plan
- [x] `npm run build` passes in `apps/web/`
- [x] `qlty check --all` clean
- [x] Lefthook pre-push passed