### PR TITLE
🐛 fix(ci): retry qlty on timeout and increase limit to 8 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,9 @@ jobs:
       - name: Qlty check (all plugins)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
         with:
-          timeout_minutes: 5
+          timeout_minutes: 8
           max_attempts: 3
-          retry_on: error
+          retry_on: any
           command: qlty check --all --no-progress
 
   test:


### PR DESCRIPTION
## Summary
- Change `retry_on` from `error` to `any` so qlty timeouts actually trigger retries
- Increase timeout from 5 to 8 minutes to accommodate qlty's variable CI runtime

## Context
The Lint job failed on the main push after merging PR #129 — `qlty check` hit the 5-minute timeout but `retry_on: error` only retries on non-zero exit codes, not timeouts. The job failed on attempt 1 without retrying.