### PR TITLE
✅ test: Fixing retention test for update operations

### DIFF
--- a/app/store/update-operation.test.ts
+++ b/app/store/update-operation.test.ts
@@ -282,7 +282,7 @@ describe('Update Operation Store', () => {
       });
 
       for (let i = 0; i < 97; i += 1) {
-        vi.setSystemTime(new Date(2026, 1, 1, 0, 1, i));
+        vi.setSystemTime(new Date(2026, 2, 1, 0, 1, i));
         fresh.updateOperation(third.id, {
           lastError: `error-${i}`,
         });


### PR DESCRIPTION
The test failed because the wrong 2 operations where left in the store after prune.
Reason: The 97 test updates on the third operation were executed with a timestamp earlier than the original operation timestamp. Therefore the third operation was defined as the oldest (by updatetime) of the three operations and pruned.