### PR TITLE
🐛 fix(web): remove broken SRI config that blocks docs site JS hydration (#236)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -6,9 +6,6 @@ const docsVersionPrefixes = "v1\\.5(?:/|$)|v1\\.4(?:/|$)|v1\\.3(?:/|$)";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    sri: { algorithm: "sha384" },
-  },
   images: {
     remotePatterns: [
       {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "dev": "npm run sync:docs && next dev --turbopack",
-    "build": "npm run sync:docs && next build --webpack && node scripts/apply-sri.mjs",
+    "build": "npm run sync:docs && next build --webpack",
     "start": "next start",
     "sync:docs": "node scripts/sync-docs.mjs",
     "lint": "biome check .",


### PR DESCRIPTION
## Summary
- Removes `experimental.sri` from Next.js config — the integrity manifest isn't being generated on Vercel, causing browsers to block dynamically injected scripts
- Removes the `apply-sri.mjs` post-build step from the build command
- Fixes sidebar navigation, search, and all interactive docs features being dead

## Root cause
The `experimental.sri` config tells Next.js to add `crossorigin="anonymous"` to dynamically injected scripts at runtime, but the `integrity-manifest.json` required for matching hashes was never generated on production builds. Browsers block scripts with `crossorigin` but no valid `integrity`, killing React hydration.

## Test plan
- [ ] Merge and verify docs site loads with working sidebar navigation
- [ ] Verify search (Cmd+K) works
- [ ] Verify both v1.5 and v1.4 docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)