### PR TITLE
📝 docs(changelog): normalize em-dash in rc.11 heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.5.0-rc.11] — 2026-04-21
+## [1.5.0-rc.11] - 2026-04-21
 
 ### Added
 


### PR DESCRIPTION
## Summary

- `extract-changelog-entry.mjs` requires `## [x.y.z] - YYYY-MM-DD` (ASCII hyphen) to parse the release entry. The rc.11 heading was authored with an em-dash (`—`), which broke the release-cut workflow's release-notes step.
- Same one-char fix that landed in rc.8. Purely a CHANGELOG normalization — no code changes.

## Test plan

- [x] `node scripts/extract-changelog-entry.mjs --version v1.5.0-rc.11 --file CHANGELOG.md` now returns the full rc.11 entry
- [ ] After merge, re-trigger "🏷️ Release: Cut" and confirm it tags v1.5.0-rc.11 with release notes rendered from the CHANGELOG