### PR TITLE
🐛 fix(release): keep package versions at 1.5.0 for tag-release workflow

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-app",
-  "version": "1.5.0-rc.13",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-app",
-      "version": "1.5.0-rc.13",
+      "version": "1.5.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-ecr": "3.1018.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-app",
-  "version": "1.5.0-rc.13",
+  "version": "1.5.0",
   "description": "Drydock backend — Docker container update manager",
   "engines": {
     "node": ">=24.0.0"

--- a/apps/demo/package-lock.json
+++ b/apps/demo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-demo",
-  "version": "1.5.0-rc.13",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-demo",
-      "version": "1.5.0-rc.13",
+      "version": "1.5.0",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "iconify-icon": "^3.0.2",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-demo",
-  "version": "1.5.0-rc.13",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0-rc.13",
+  "version": "1.5.0",
   "scripts": {
     "prepare": "lefthook install"
   },

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-ui",
-  "version": "1.5.0-rc.13",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-ui",
-      "version": "1.5.0-rc.13",
+      "version": "1.5.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "5.2.7",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-ui",
-  "version": "1.5.0-rc.13",
+  "version": "1.5.0",
   "description": "Drydock dashboard — Vue 3 + Tailwind CSS 4 SPA",
   "repository": "CodesWhat/drydock",
   "engines": {


### PR DESCRIPTION
## Summary

The release-from-tag workflow strips the `-rc.N` suffix from the tag and asserts that `package.json`, `app/package.json`, and `ui/package.json` all equal the BASE version (`1.5.0`). The "cut v1.5.0-rc.13" commit (`111514bd`) bumped those versions to `1.5.0-rc.13`, which broke the workflow's version-match step on the `v1.5.0-rc.13` tag and caused the Docker build + GH Release publish to be skipped.

Failing run: https://github.com/CodesWhat/drydock/actions/runs/24945075169/job/73045042166

```
##[error]Version mismatch: tag base=1.5.0 (from v1.5.0-rc.13), package.json=1.5.0-rc.13
```

Prior RC tags worked because their cut commits left `package.json` at `1.5.0`; only this rc.13 cut bumped the suffix in. Reverting the four `package.json` + three `package-lock.json` `version` fields back to `1.5.0` so the next tag push clears the verify step and publishes Docker images + GH Release.

## Test plan

- [ ] CI green (Build, Lint, Test & Coverage)
- [ ] After merge: delete + re-push `v1.5.0-rc.13` tag → release-from-tag workflow goes green → `ghcr.io/codeswhat/drydock:v1.5.0-rc.13` appears + GH Release published