### PR TITLE
🚀 v1.5.0-rc.14 — eligibility pill + popover positioning fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0-rc.14] — 2026-04-26
+
+### Fixed
+
+- **Update-eligibility pill never rendered (rc.13 regression).** The blocker pills shipped in rc.13 (`Trigger filtered`, `Below threshold`, `Maturing`, etc.) silently rendered nothing for every container in every view (table rows, side panel, full-page detail, dashboard widget). The backend computed eligibility correctly and serialised it in the API response, but the UI's `mapApiContainer()` didn't declare or pass through the `updateEligibility` field — TypeScript's structural typing dropped the unknown JSON property at the boundary. Fix is two-part:
+  - **UI mapper** — `ApiContainerInput` now declares `updateEligibility`, and `mapApiContainer` passes it through with a `deriveUpdateEligibility` validator that rejects malformed eligibility objects (missing `eligible` boolean, missing `evaluatedAt`) and filters out malformed individual blockers (bad `reason` strings, missing `message`). One change lights up every consumer (list, side panel, full-page, dashboard).
+  - **Backend SSE enrichment** — the store broadcasts raw container objects on `dd:container-added` / `dd:container-updated`, but `updateEligibility` is computed on-demand in the list handler and never persisted. Without enrichment, live SSE patches would deliver containers with eligibility undefined, flickering the pill on every update. New `sse-container-enrichment.ts` helper computes eligibility from registry triggers + active operations and attaches it to each lifecycle payload before broadcast.
+  - Reported in [#307](https://github.com/CodesWhat/drydock/discussions/307).
+- **[#323](https://github.com/CodesWhat/drydock/discussions/323) — Popovers on the Containers list rendered off-screen for the last row + drifted on scroll.** The "More" actions menu and the column picker both used `position: fixed` with coordinates captured from the trigger's `getBoundingClientRect()` and unconditionally opened *below* the trigger. When the trigger sat near the bottom of the viewport (e.g. the last container row), the menu was clipped off-screen and inaccessible. The popovers also stayed at their captured pixel coordinates while the table scrolled, drifting away from the trigger. Added a small `buildPopoverStyle` helper that measures available space below vs above and flips the popover upward when there's not enough room below; added a global `scroll` listener (capture phase, to catch internal scroll containers) that closes both popovers since their fixed coordinates can't track a moving anchor. Sibling popovers in this codebase (NotificationBell, etc.) intentionally untouched here — different UX surfaces, separate consideration.
+
+### Tests / CI
+
+- **Eligibility coverage closed end-to-end.** 13 new mapper unit tests (full eligibility roundtrip including `actionHint` / `liftableAt` / `details`, all 13 valid `UpdateBlockerReason` values, malformed-blocker filtering, missing-field rejection, non-array `blockers` handled as empty list). 7 new SSE enrichment tests (happy path, malformed payloads, error resilience). The 55 existing `UpdateEligibilityBadges` component tests already covered the render gate. Manual verification: built `drydock:dev` with the fix, ran with `DD_ACTION_DOCKER_LOCAL_AUTO=oninclude`, confirmed 23 backend `trigger-not-included` blockers render as 23 amber "Trigger filtered" pills in the Kind column.
+- **Popover positioning coverage.** 6 new tests in `ContainersView.spec.ts`: actions menu and column picker each flip up when the trigger is near viewport bottom; global scroll closes the actions menu, closes the column picker, and is a no-op when nothing is open; scroll listener is removed on unmount. Manual verification: built `drydock:dev` with the fix, scrolled the last container row to the viewport bottom, opened its More menu — the menu rendered fully within the viewport (anchored bottom: 48px from viewport top) instead of clipping off-screen.
+
 ## [1.5.0-rc.13] — 2026-04-24
 
 ### Added
@@ -1390,7 +1405,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.5.0-rc.13...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.5.0-rc.14...HEAD
+[1.5.0-rc.14]: https://github.com/CodesWhat/drydock/compare/v1.5.0-rc.13...v1.5.0-rc.14
 [1.5.0-rc.13]: https://github.com/CodesWhat/drydock/compare/v1.5.0-rc.12...v1.5.0-rc.13
 [1.5.0-rc.12]: https://github.com/CodesWhat/drydock/compare/v1.5.0-rc.11...v1.5.0-rc.12
 [1.5.0-rc.11]: https://github.com/CodesWhat/drydock/compare/v1.5.0-rc.10...v1.5.0-rc.11

--- a/app/api/sse-container-enrichment.test.ts
+++ b/app/api/sse-container-enrichment.test.ts
@@ -101,4 +101,143 @@ describe('enrichContainerLifecyclePayloadWithEligibility', () => {
       expect(result).toBe(payload);
     });
   });
+
+  describe('active operation lookup', () => {
+    // Fixture with differing local/remote tags so hasRawTagOrDigestUpdate returns true,
+    // allowing computeUpdateEligibility to proceed past the short-circuit and invoke
+    // getActiveOperation.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const updatePayload = (): any => ({
+      id: 'c1',
+      name: 'mysql',
+      image: { tag: { value: '9.6.0' } },
+      result: { tag: '9.7.0' },
+    });
+
+    test('byId returns valid in-progress operation → active-operation blocker added', () => {
+      mockGetActiveOperationByContainerId.mockReturnValueOnce({
+        id: 'op-1',
+        status: 'in-progress',
+        updatedAt: '2026-04-26T00:00:00Z',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = enrichContainerLifecyclePayloadWithEligibility(updatePayload()) as any;
+
+      expect(
+        result.updateEligibility.blockers.some(
+          (b: { reason: string }) => b.reason === 'active-operation',
+        ),
+      ).toBe(true);
+      // byName must NOT have been called because byId was truthy
+      expect(mockGetActiveOperationByContainerName).not.toHaveBeenCalled();
+    });
+
+    test('byId returns undefined, byName returns valid queued operation → active-operation blocker added', () => {
+      mockGetActiveOperationByContainerId.mockReturnValueOnce(undefined);
+      mockGetActiveOperationByContainerName.mockReturnValueOnce({
+        id: 'op-2',
+        status: 'queued',
+        updatedAt: '2026-04-26T00:00:00Z',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = enrichContainerLifecyclePayloadWithEligibility(updatePayload()) as any;
+
+      expect(
+        result.updateEligibility.blockers.some(
+          (b: { reason: string }) => b.reason === 'active-operation',
+        ),
+      ).toBe(true);
+    });
+
+    test('both byId and byName return undefined → no active-operation blocker', () => {
+      mockGetActiveOperationByContainerId.mockReturnValueOnce(undefined);
+      mockGetActiveOperationByContainerName.mockReturnValueOnce(undefined);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = enrichContainerLifecyclePayloadWithEligibility(updatePayload()) as any;
+
+      expect(
+        result.updateEligibility.blockers.some(
+          (b: { reason: string }) => b.reason === 'active-operation',
+        ),
+      ).toBe(false);
+    });
+
+    test('byId returns a non-object (string) → falls through typeof guard → no active-operation blocker', () => {
+      mockGetActiveOperationByContainerId.mockReturnValueOnce('not-an-object');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = enrichContainerLifecyclePayloadWithEligibility(updatePayload()) as any;
+
+      expect(
+        result.updateEligibility.blockers.some(
+          (b: { reason: string }) => b.reason === 'active-operation',
+        ),
+      ).toBe(false);
+    });
+
+    test('operation has invalid id (not a string) → no active-operation blocker', () => {
+      mockGetActiveOperationByContainerId.mockReturnValueOnce({ id: 42, status: 'queued' });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = enrichContainerLifecyclePayloadWithEligibility(updatePayload()) as any;
+
+      expect(
+        result.updateEligibility.blockers.some(
+          (b: { reason: string }) => b.reason === 'active-operation',
+        ),
+      ).toBe(false);
+    });
+
+    test('operation has invalid status (completed) → no active-operation blocker', () => {
+      mockGetActiveOperationByContainerId.mockReturnValueOnce({
+        id: 'op-3',
+        status: 'completed',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = enrichContainerLifecyclePayloadWithEligibility(updatePayload()) as any;
+
+      expect(
+        result.updateEligibility.blockers.some(
+          (b: { reason: string }) => b.reason === 'active-operation',
+        ),
+      ).toBe(false);
+    });
+
+    test('operation has no updatedAt → blocker still attached, updatedAt absent', () => {
+      mockGetActiveOperationByContainerId.mockReturnValueOnce({
+        id: 'op-4',
+        status: 'in-progress',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = enrichContainerLifecyclePayloadWithEligibility(updatePayload()) as any;
+
+      expect(
+        result.updateEligibility.blockers.some(
+          (b: { reason: string }) => b.reason === 'active-operation',
+        ),
+      ).toBe(true);
+    });
+
+    test('operation has non-string updatedAt (number) → blocker still attached, updatedAt falls through to undefined', () => {
+      mockGetActiveOperationByContainerId.mockReturnValueOnce({
+        id: 'op-5',
+        status: 'in-progress',
+        updatedAt: 123,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = enrichContainerLifecyclePayloadWithEligibility(updatePayload()) as any;
+
+      expect(
+        result.updateEligibility.blockers.some(
+          (b: { reason: string }) => b.reason === 'active-operation',
+        ),
+      ).toBe(true);
+    });
+  });
 });

--- a/app/api/sse-container-enrichment.test.ts
+++ b/app/api/sse-container-enrichment.test.ts
@@ -1,0 +1,104 @@
+var { mockGetState, mockGetActiveOperationByContainerId, mockGetActiveOperationByContainerName } =
+  vi.hoisted(() => {
+    return {
+      mockGetState: vi.fn(() => ({ trigger: {} })),
+      mockGetActiveOperationByContainerId: vi.fn(() => undefined),
+      mockGetActiveOperationByContainerName: vi.fn(() => undefined),
+    };
+  });
+
+vi.mock('../registry/index.js', () => ({
+  getState: mockGetState,
+}));
+
+vi.mock('../store/update-operation.js', () => ({
+  getActiveOperationByContainerId: mockGetActiveOperationByContainerId,
+  getActiveOperationByContainerName: mockGetActiveOperationByContainerName,
+}));
+
+import { enrichContainerLifecyclePayloadWithEligibility } from './sse-container-enrichment.js';
+
+describe('enrichContainerLifecyclePayloadWithEligibility', () => {
+  beforeEach(() => {
+    mockGetState.mockReturnValue({ trigger: {} });
+    mockGetActiveOperationByContainerId.mockReturnValue(undefined);
+    mockGetActiveOperationByContainerName.mockReturnValue(undefined);
+  });
+
+  describe('malformed payload guard', () => {
+    test('returns null unchanged', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(enrichContainerLifecyclePayloadWithEligibility(null as any)).toBeNull();
+    });
+
+    test('returns undefined unchanged', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(enrichContainerLifecyclePayloadWithEligibility(undefined as any)).toBeUndefined();
+    });
+
+    test('returns payload unchanged when id field is missing', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const payload = { name: 'my-container' } as any;
+      expect(enrichContainerLifecyclePayloadWithEligibility(payload)).toBe(payload);
+    });
+
+    test('returns payload unchanged when id is not a string', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const payload = { id: 123, name: 'my-container' } as any;
+      expect(enrichContainerLifecyclePayloadWithEligibility(payload)).toBe(payload);
+    });
+  });
+
+  describe('happy path', () => {
+    test('attaches updateEligibility with no-update-available when container has no raw update', () => {
+      // A minimal container with id+name but no image/result — hasRawTagOrDigestUpdate returns
+      // false, so computeUpdateEligibility short-circuits with no-update-available.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const payload = { id: 'c1', name: 'my-container' } as any;
+      const result = enrichContainerLifecyclePayloadWithEligibility(payload);
+
+      expect(result).not.toBe(payload);
+      expect(result).toMatchObject({
+        id: 'c1',
+        name: 'my-container',
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const enriched = result as any;
+      expect(enriched.updateEligibility).toBeDefined();
+      expect(enriched.updateEligibility.eligible).toBe(false);
+      expect(enriched.updateEligibility.blockers).toHaveLength(1);
+      expect(enriched.updateEligibility.blockers[0].reason).toBe('no-update-available');
+      expect(typeof enriched.updateEligibility.evaluatedAt).toBe('string');
+    });
+
+    test('preserves all original payload fields alongside updateEligibility', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const payload = { id: 'c2', name: 'redis', status: 'running', extra: 42 } as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = enrichContainerLifecyclePayloadWithEligibility(payload) as any;
+
+      expect(result.id).toBe('c2');
+      expect(result.name).toBe('redis');
+      expect(result.status).toBe('running');
+      expect(result.extra).toBe(42);
+      expect(result.updateEligibility).toBeDefined();
+    });
+  });
+
+  describe('error resilience', () => {
+    test('returns original payload when computeUpdateEligibility throws', async () => {
+      // Force registry.getState to throw so buildEligibilityContext propagates an error
+      mockGetState.mockImplementation(() => {
+        throw new Error('registry exploded');
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const payload = { id: 'c3', name: 'broken' } as any;
+      const result = enrichContainerLifecyclePayloadWithEligibility(payload);
+
+      // Must return the original object, not throw
+      expect(result).toBe(payload);
+    });
+  });
+});

--- a/app/api/sse-container-enrichment.ts
+++ b/app/api/sse-container-enrichment.ts
@@ -1,0 +1,49 @@
+import type { ContainerLifecycleEventPayload } from '../event/index.js';
+import type { Container } from '../model/container.js';
+import {
+  computeUpdateEligibility,
+  type UpdateEligibilityContext,
+} from '../model/update-eligibility.js';
+import * as registry from '../registry/index.js';
+import {
+  getActiveOperationByContainerId,
+  getActiveOperationByContainerName,
+} from '../store/update-operation.js';
+
+function buildEligibilityContext(): UpdateEligibilityContext {
+  return {
+    triggers: registry.getState().trigger,
+    getActiveOperation: (container: Container) => {
+      const byId = getActiveOperationByContainerId(container.id);
+      const byName = byId ? undefined : getActiveOperationByContainerName(container.name);
+      const matched = byId ?? byName;
+      if (!matched || typeof matched !== 'object') return undefined;
+      const m = matched as Record<string, unknown>;
+      const id = typeof m.id === 'string' ? m.id : undefined;
+      const status = m.status === 'queued' || m.status === 'in-progress' ? m.status : undefined;
+      if (!id || !status) return undefined;
+      return {
+        id,
+        status,
+        updatedAt: typeof m.updatedAt === 'string' ? m.updatedAt : undefined,
+      };
+    },
+  };
+}
+
+export function enrichContainerLifecyclePayloadWithEligibility(
+  payload: ContainerLifecycleEventPayload,
+): ContainerLifecycleEventPayload {
+  if (!payload || typeof payload !== 'object' || typeof payload.id !== 'string') {
+    return payload;
+  }
+  try {
+    const eligibility = computeUpdateEligibility(
+      payload as unknown as Container,
+      buildEligibilityContext(),
+    );
+    return { ...payload, updateEligibility: eligibility };
+  } catch {
+    return payload;
+  }
+}

--- a/app/api/sse.test.ts
+++ b/app/api/sse.test.ts
@@ -121,6 +121,10 @@ vi.mock('../event/index', () => ({
   registerAgentDisconnected: mockRegisterAgentDisconnected,
 }));
 
+vi.mock('./sse-container-enrichment.js', () => ({
+  enrichContainerLifecyclePayloadWithEligibility: (payload) => payload,
+}));
+
 vi.mock('../log', () => ({
   default: {
     child: vi.fn(() => ({

--- a/app/api/sse.ts
+++ b/app/api/sse.ts
@@ -1,7 +1,10 @@
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import type { Request, Response } from 'express';
 import express from 'express';
-import type { SelfUpdateStartingEventPayload } from '../event/index.js';
+import type {
+  ContainerLifecycleEventPayload,
+  SelfUpdateStartingEventPayload,
+} from '../event/index.js';
 import {
   registerAgentConnected,
   registerAgentDisconnected,
@@ -20,6 +23,7 @@ import {
   createActiveSseClientRegistryTestAdapter,
   type FlushableResponse,
 } from './sse-active-client-registry.js';
+import { enrichContainerLifecyclePayloadWithEligibility } from './sse-container-enrichment.js';
 import { bootId, SseEventBuffer } from './sse-event-buffer.js';
 import { createSelfUpdateAckProtocol } from './sse-self-update-ack-protocol.js';
 
@@ -420,13 +424,19 @@ export function init(): express.Router {
     }),
   );
   trackEventListenerDeregistration(
-    registerContainerAdded((payload: unknown) => {
-      broadcastContainerEvent('dd:container-added', payload);
+    registerContainerAdded((payload: ContainerLifecycleEventPayload) => {
+      broadcastContainerEvent(
+        'dd:container-added',
+        enrichContainerLifecyclePayloadWithEligibility(payload),
+      );
     }),
   );
   trackEventListenerDeregistration(
-    registerContainerUpdated((payload: unknown) => {
-      broadcastContainerEvent('dd:container-updated', payload);
+    registerContainerUpdated((payload: ContainerLifecycleEventPayload) => {
+      broadcastContainerEvent(
+        'dd:container-updated',
+        enrichContainerLifecyclePayloadWithEligibility(payload),
+      );
     }),
   );
   trackEventListenerDeregistration(

--- a/ui/src/utils/container-mapper.ts
+++ b/ui/src/utils/container-mapper.ts
@@ -22,6 +22,9 @@ import type {
   ContainerSecurityDelta,
   ContainerSecuritySummary,
   ContainerUpdateOperation,
+  UpdateBlocker,
+  UpdateBlockerReason,
+  UpdateEligibility,
 } from '../types/container';
 import {
   isActiveContainerUpdateOperationPhaseForStatus,
@@ -105,6 +108,21 @@ interface ApiContainerSecurityScan {
   summary?: ApiContainerSecuritySummary | null;
 }
 
+interface ApiContainerUpdateBlocker {
+  reason?: unknown;
+  message?: unknown;
+  actionable?: unknown;
+  actionHint?: unknown;
+  liftableAt?: unknown;
+  details?: unknown;
+}
+
+interface ApiContainerUpdateEligibility {
+  eligible?: unknown;
+  blockers?: unknown;
+  evaluatedAt?: unknown;
+}
+
 type SecurityScanType = 'scan' | 'updateScan';
 
 /**
@@ -137,6 +155,7 @@ export interface ApiContainerInput {
   updateDetectedAt?: unknown;
   updateOperation?: ApiContainerUpdateOperation | null;
   updatePolicy?: ApiContainerUpdatePolicy | null;
+  updateEligibility?: ApiContainerUpdateEligibility | null;
   details?: ApiContainerDetails | null;
   tagFamily?: unknown;
   includeTags?: unknown;
@@ -605,6 +624,59 @@ function deriveReleaseNotes(apiContainer: ApiContainerInput): ContainerReleaseNo
   return { title, body, url, publishedAt, provider };
 }
 
+const VALID_UPDATE_BLOCKER_REASONS: ReadonlySet<UpdateBlockerReason> = new Set([
+  'no-update-available',
+  'rollback-container',
+  'active-operation',
+  'security-scan-blocked',
+  'snoozed',
+  'skip-tag',
+  'skip-digest',
+  'maturity-not-reached',
+  'threshold-not-reached',
+  'trigger-excluded',
+  'trigger-not-included',
+  'agent-mismatch',
+  'no-update-trigger-configured',
+]);
+
+function isUpdateBlockerReason(value: unknown): value is UpdateBlockerReason {
+  return (
+    typeof value === 'string' && VALID_UPDATE_BLOCKER_REASONS.has(value as UpdateBlockerReason)
+  );
+}
+
+function deriveUpdateBlocker(blocker: unknown): UpdateBlocker | null {
+  if (!blocker || typeof blocker !== 'object') return null;
+  const b = blocker as ApiContainerUpdateBlocker;
+  if (!isUpdateBlockerReason(b.reason)) return null;
+  const message = asNonEmptyString(b.message);
+  if (!message) return null;
+  const actionable = typeof b.actionable === 'boolean' ? b.actionable : false;
+  const result: UpdateBlocker = { reason: b.reason, message, actionable };
+  const actionHint = asNonEmptyString(b.actionHint);
+  if (actionHint) result.actionHint = actionHint;
+  const liftableAt = asNonEmptyString(b.liftableAt);
+  if (liftableAt) result.liftableAt = liftableAt;
+  if (b.details && typeof b.details === 'object') {
+    result.details = b.details as Record<string, unknown>;
+  }
+  return result;
+}
+
+function deriveUpdateEligibility(apiContainer: ApiContainerInput): UpdateEligibility | undefined {
+  const eligibility = apiContainer.updateEligibility;
+  if (!eligibility || typeof eligibility !== 'object') return undefined;
+  if (typeof eligibility.eligible !== 'boolean') return undefined;
+  const evaluatedAt = asNonEmptyString(eligibility.evaluatedAt);
+  if (!evaluatedAt) return undefined;
+  const rawBlockers = Array.isArray(eligibility.blockers) ? eligibility.blockers : [];
+  const blockers = rawBlockers
+    .map(deriveUpdateBlocker)
+    .filter((b): b is UpdateBlocker => b !== null);
+  return { eligible: eligibility.eligible, blockers, evaluatedAt };
+}
+
 function deriveUpdateOperation(
   apiContainer: ApiContainerInput,
 ): ContainerUpdateOperation | undefined {
@@ -688,6 +760,7 @@ export function mapApiContainer(apiContainer: ApiContainerInput): Container {
     updateOperation: deriveUpdateOperation(apiContainer),
     updateMaturity: getUpdateMaturity(detectedAt, !!apiContainer.updateAvailable),
     updateMaturityTooltip: formatUpdateAge(detectedAt, !!apiContainer.updateAvailable),
+    updateEligibility: deriveUpdateEligibility(apiContainer),
     updatePolicyState,
     suppressedUpdateTag: deriveSuppressedUpdateTag(apiContainer, updatePolicyState),
     status: apiContainer.status === 'running' ? 'running' : 'stopped',

--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -1129,6 +1129,33 @@ onMounted(() => {
 const openActionsMenu = ref<string | null>(null);
 const actionsMenuStyle = ref<Record<string, string>>({});
 
+// Estimated max menu heights — used so popovers flip above the trigger when
+// available room below the viewport is shorter than the menu would render at.
+// Slightly generous to bias toward correct behavior on the boundary.
+const ACTIONS_MENU_ESTIMATED_HEIGHT_PX = 320;
+const COLUMN_PICKER_ESTIMATED_HEIGHT_PX = 360;
+const POPOVER_GAP_PX = 4;
+
+type PopoverHorizontalAnchor = { right: number } | { left: number };
+
+function buildPopoverStyle(
+  rect: DOMRect,
+  horizontalAnchor: PopoverHorizontalAnchor,
+  estimatedHeightPx: number,
+): Record<string, string> {
+  const spaceBelow = window.innerHeight - rect.bottom;
+  const spaceAbove = rect.top;
+  const flipUp = spaceBelow < estimatedHeightPx && spaceAbove > spaceBelow;
+  const verticalAnchor = flipUp
+    ? { bottom: `${window.innerHeight - rect.top + POPOVER_GAP_PX}px` }
+    : { top: `${rect.bottom + POPOVER_GAP_PX}px` };
+  const horizontal =
+    'right' in horizontalAnchor
+      ? { right: `${horizontalAnchor.right}px` }
+      : { left: `${horizontalAnchor.left}px` };
+  return { position: 'fixed', ...verticalAnchor, ...horizontal };
+}
+
 function toggleActionsMenu(name: string, event: MouseEvent) {
   if (openActionsMenu.value === name) {
     openActionsMenu.value = null;
@@ -1137,11 +1164,11 @@ function toggleActionsMenu(name: string, event: MouseEvent) {
   openActionsMenu.value = name;
   const button = event.currentTarget as HTMLElement;
   const rect = button.getBoundingClientRect();
-  actionsMenuStyle.value = {
-    position: 'fixed',
-    top: `${rect.bottom + 4}px`,
-    right: `${window.innerWidth - rect.right}px`,
-  };
+  actionsMenuStyle.value = buildPopoverStyle(
+    rect,
+    { right: window.innerWidth - rect.right },
+    ACTIONS_MENU_ESTIMATED_HEIGHT_PX,
+  );
 }
 
 function closeActionsMenu() {
@@ -1154,17 +1181,27 @@ function toggleColumnPicker(event: MouseEvent) {
   if (showColumnPicker.value) {
     const button = event.currentTarget as HTMLElement;
     const rect = button.getBoundingClientRect();
-    columnPickerStyle.value = {
-      position: 'fixed',
-      top: `${rect.bottom + 4}px`,
-      left: `${rect.left}px`,
-    };
+    columnPickerStyle.value = buildPopoverStyle(
+      rect,
+      { left: rect.left },
+      COLUMN_PICKER_ESTIMATED_HEIGHT_PX,
+    );
   }
 }
 
 function handleGlobalClick() {
   openActionsMenu.value = null;
   showColumnPicker.value = false;
+}
+
+// Popovers are position:fixed and anchored at click-time via getBoundingClientRect;
+// scrolling moves the trigger button while the popover stays put. Close on scroll
+// to keep the popover from drifting away from its visual anchor.
+function handleGlobalScroll() {
+  if (openActionsMenu.value !== null || showColumnPicker.value) {
+    openActionsMenu.value = null;
+    showColumnPicker.value = false;
+  }
 }
 
 // Refreshes container list and security detail data. Used on (re)connect and resync-required
@@ -1375,6 +1412,7 @@ const sseContainerRemovedListener = ((event: Event) => {
 }) as EventListener;
 onMounted(() => {
   document.addEventListener('click', handleGlobalClick);
+  document.addEventListener('scroll', handleGlobalScroll, true);
   globalThis.addEventListener('dd:sse-scan-completed', sseScanCompletedListener);
   globalThis.addEventListener('dd:sse-container-added', sseContainerAddedListener);
   globalThis.addEventListener('dd:sse-container-updated', sseContainerUpdatedListener);
@@ -1386,6 +1424,7 @@ onMounted(() => {
 onUnmounted(() => {
   clearAllOperationDisplayHolds();
   document.removeEventListener('click', handleGlobalClick);
+  document.removeEventListener('scroll', handleGlobalScroll, true);
   globalThis.removeEventListener('dd:sse-scan-completed', sseScanCompletedListener);
   globalThis.removeEventListener('dd:sse-container-added', sseContainerAddedListener);
   globalThis.removeEventListener('dd:sse-container-updated', sseContainerUpdatedListener);

--- a/ui/tests/utils/container-mapper.spec.ts
+++ b/ui/tests/utils/container-mapper.spec.ts
@@ -1580,6 +1580,23 @@ describe('container-mapper', () => {
       expect(c.updateEligibility).toBeUndefined();
     });
 
+    it('treats non-array blockers as empty list', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: true,
+            evaluatedAt: '2026-04-25T12:00:00.000Z',
+            blockers: 'not-an-array',
+          },
+        }),
+      );
+      expect(c.updateEligibility).toEqual({
+        eligible: true,
+        evaluatedAt: '2026-04-25T12:00:00.000Z',
+        blockers: [],
+      });
+    });
+
     it('filters out blockers with an invalid reason string', () => {
       const c = mapApiContainer(
         makeApiContainer({

--- a/ui/tests/utils/container-mapper.spec.ts
+++ b/ui/tests/utils/container-mapper.spec.ts
@@ -1476,4 +1476,230 @@ describe('container-mapper', () => {
       expect(c.releaseNotes).toBeNull();
     });
   });
+
+  describe('mapApiContainer — updateEligibility', () => {
+    it('maps a complete eligibility object with all fields populated', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: false,
+            evaluatedAt: '2026-04-25T12:00:00.000Z',
+            blockers: [
+              {
+                reason: 'snoozed',
+                message: 'Snoozed until May 1.',
+                actionable: true,
+                actionHint: 'Clear snooze from the container menu.',
+                liftableAt: '2026-05-01T00:00:00.000Z',
+                details: { snoozeUntil: '2026-05-01T00:00:00.000Z' },
+              },
+            ],
+          },
+        }),
+      );
+
+      expect(c.updateEligibility).toEqual({
+        eligible: false,
+        evaluatedAt: '2026-04-25T12:00:00.000Z',
+        blockers: [
+          {
+            reason: 'snoozed',
+            message: 'Snoozed until May 1.',
+            actionable: true,
+            actionHint: 'Clear snooze from the container menu.',
+            liftableAt: '2026-05-01T00:00:00.000Z',
+            details: { snoozeUntil: '2026-05-01T00:00:00.000Z' },
+          },
+        ],
+      });
+    });
+
+    it('maps eligibility with eligible:true and empty blockers', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: true,
+            evaluatedAt: '2026-04-25T12:00:00.000Z',
+            blockers: [],
+          },
+        }),
+      );
+
+      expect(c.updateEligibility).toEqual({
+        eligible: true,
+        evaluatedAt: '2026-04-25T12:00:00.000Z',
+        blockers: [],
+      });
+    });
+
+    it('returns undefined when updateEligibility is absent', () => {
+      const c = mapApiContainer(makeApiContainer());
+      expect(c.updateEligibility).toBeUndefined();
+    });
+
+    it('returns undefined when updateEligibility is null', () => {
+      const c = mapApiContainer(makeApiContainer({ updateEligibility: null }));
+      expect(c.updateEligibility).toBeUndefined();
+    });
+
+    it('returns undefined when eligible is not a boolean', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: 'yes',
+            evaluatedAt: '2026-04-25T12:00:00.000Z',
+            blockers: [],
+          },
+        }),
+      );
+      expect(c.updateEligibility).toBeUndefined();
+    });
+
+    it('returns undefined when evaluatedAt is missing', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: false,
+            blockers: [],
+          },
+        }),
+      );
+      expect(c.updateEligibility).toBeUndefined();
+    });
+
+    it('returns undefined when evaluatedAt is not a string', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: false,
+            evaluatedAt: 1745582400000,
+            blockers: [],
+          },
+        }),
+      );
+      expect(c.updateEligibility).toBeUndefined();
+    });
+
+    it('filters out blockers with an invalid reason string', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: false,
+            evaluatedAt: '2026-04-25T12:00:00.000Z',
+            blockers: [
+              { reason: 'not-a-real-reason', message: 'Bad.', actionable: false },
+              { reason: 'snoozed', message: 'Snoozed.', actionable: true },
+            ],
+          },
+        }),
+      );
+
+      expect(c.updateEligibility?.blockers).toHaveLength(1);
+      expect(c.updateEligibility?.blockers[0].reason).toBe('snoozed');
+    });
+
+    it('filters out blockers with a missing message', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: false,
+            evaluatedAt: '2026-04-25T12:00:00.000Z',
+            blockers: [
+              { reason: 'skip-tag', actionable: true },
+              { reason: 'threshold-not-reached', message: 'Threshold not met.', actionable: true },
+            ],
+          },
+        }),
+      );
+
+      expect(c.updateEligibility?.blockers).toHaveLength(1);
+      expect(c.updateEligibility?.blockers[0].reason).toBe('threshold-not-reached');
+    });
+
+    it('filters out non-object blocker entries without dropping valid ones', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: false,
+            evaluatedAt: '2026-04-25T12:00:00.000Z',
+            blockers: [
+              null,
+              'invalid-string-entry',
+              42,
+              { reason: 'agent-mismatch', message: 'Agent mismatch.', actionable: true },
+            ],
+          },
+        }),
+      );
+
+      expect(c.updateEligibility?.blockers).toHaveLength(1);
+      expect(c.updateEligibility?.blockers[0].reason).toBe('agent-mismatch');
+    });
+
+    it('defaults actionable to false when not a boolean', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: false,
+            evaluatedAt: '2026-04-25T12:00:00.000Z',
+            blockers: [{ reason: 'rollback-container', message: 'Rollback.', actionable: 'yes' }],
+          },
+        }),
+      );
+
+      expect(c.updateEligibility?.blockers[0].actionable).toBe(false);
+    });
+
+    it('omits optional blocker fields when absent', () => {
+      const c = mapApiContainer(
+        makeApiContainer({
+          updateEligibility: {
+            eligible: false,
+            evaluatedAt: '2026-04-25T12:00:00.000Z',
+            blockers: [
+              { reason: 'no-update-trigger-configured', message: 'No trigger.', actionable: true },
+            ],
+          },
+        }),
+      );
+
+      const blocker = c.updateEligibility?.blockers[0];
+      expect(blocker).toBeDefined();
+      expect(blocker?.actionHint).toBeUndefined();
+      expect(blocker?.liftableAt).toBeUndefined();
+      expect(blocker?.details).toBeUndefined();
+    });
+
+    const ALL_VALID_REASONS = [
+      'no-update-available',
+      'rollback-container',
+      'active-operation',
+      'security-scan-blocked',
+      'snoozed',
+      'skip-tag',
+      'skip-digest',
+      'maturity-not-reached',
+      'threshold-not-reached',
+      'trigger-excluded',
+      'trigger-not-included',
+      'agent-mismatch',
+      'no-update-trigger-configured',
+    ] as const;
+
+    for (const reason of ALL_VALID_REASONS) {
+      it(`accepts valid UpdateBlockerReason "${reason}"`, () => {
+        const c = mapApiContainer(
+          makeApiContainer({
+            updateEligibility: {
+              eligible: false,
+              evaluatedAt: '2026-04-25T12:00:00.000Z',
+              blockers: [{ reason, message: 'Test message.', actionable: false }],
+            },
+          }),
+        );
+        expect(c.updateEligibility?.blockers).toHaveLength(1);
+        expect(c.updateEligibility?.blockers[0].reason).toBe(reason);
+      });
+    }
+  });
 });

--- a/ui/tests/views/ContainersView.spec.ts
+++ b/ui/tests/views/ContainersView.spec.ts
@@ -2352,6 +2352,109 @@ describe('ContainersView', () => {
       }
     });
 
+    it('actions menu flips up when trigger is near the bottom of the viewport', async () => {
+      const c = makeContainer({ id: 'c1', name: 'nginx' });
+      const wrapper = await mountContainersView(
+        [c],
+        [{ id: 'c1', name: 'nginx', displayName: 'nginx' }],
+      );
+      const vm = wrapper.vm as any;
+
+      // bottom: 700, top: 680 → spaceBelow = 768 - 700 = 68 < 320 (ACTIONS_MENU_ESTIMATED_HEIGHT_PX)
+      // spaceAbove = 680 > 68 → flip up
+      // bottom style = 768 - 680 + 4 = 92px
+      const event = {
+        currentTarget: {
+          getBoundingClientRect: () => ({ bottom: 700, top: 680, right: 400, left: 80 }),
+        },
+      } as unknown as MouseEvent;
+
+      vm.toggleActionsMenu('nginx', event);
+      expect(vm.openActionsMenu).toBe('nginx');
+      expect(vm.actionsMenuStyle.bottom).toBe('92px');
+      expect(vm.actionsMenuStyle.top).toBeUndefined();
+    });
+
+    it('column picker flips up when trigger is near the bottom of the viewport', async () => {
+      const c = makeContainer({ id: 'c1', name: 'nginx' });
+      const wrapper = await mountContainersView(
+        [c],
+        [{ id: 'c1', name: 'nginx', displayName: 'nginx' }],
+      );
+      const vm = wrapper.vm as any;
+
+      // bottom: 700, top: 680 → spaceBelow = 68 < 360 (COLUMN_PICKER_ESTIMATED_HEIGHT_PX)
+      // spaceAbove = 680 > 68 → flip up
+      // bottom style = 768 - 680 + 4 = 92px
+      const event = {
+        currentTarget: {
+          getBoundingClientRect: () => ({ bottom: 700, top: 680, right: 400, left: 80 }),
+        },
+      } as unknown as MouseEvent;
+
+      vm.toggleColumnPicker(event);
+      expect(vm.showColumnPicker).toBe(true);
+      expect(vm.columnPickerStyle.bottom).toBe('92px');
+      expect(vm.columnPickerStyle.top).toBeUndefined();
+    });
+
+    it('global scroll closes the actions menu', async () => {
+      const c = makeContainer({ id: 'c1', name: 'nginx' });
+      const wrapper = await mountContainersView(
+        [c],
+        [{ id: 'c1', name: 'nginx', displayName: 'nginx' }],
+      );
+      const vm = wrapper.vm as any;
+
+      vm.openActionsMenu = 'nginx';
+      document.dispatchEvent(new Event('scroll', { bubbles: false }));
+      await flushPromises();
+      expect(vm.openActionsMenu).toBeNull();
+    });
+
+    it('global scroll closes the column picker', async () => {
+      const c = makeContainer({ id: 'c1', name: 'nginx' });
+      const wrapper = await mountContainersView(
+        [c],
+        [{ id: 'c1', name: 'nginx', displayName: 'nginx' }],
+      );
+      const vm = wrapper.vm as any;
+
+      vm.showColumnPicker = true;
+      document.dispatchEvent(new Event('scroll', { bubbles: false }));
+      await flushPromises();
+      expect(vm.showColumnPicker).toBe(false);
+    });
+
+    it('global scroll is a no-op when nothing is open', async () => {
+      const c = makeContainer({ id: 'c1', name: 'nginx' });
+      const wrapper = await mountContainersView(
+        [c],
+        [{ id: 'c1', name: 'nginx', displayName: 'nginx' }],
+      );
+      const vm = wrapper.vm as any;
+
+      expect(vm.openActionsMenu).toBeNull();
+      expect(vm.showColumnPicker).toBe(false);
+      // Dispatching scroll when nothing is open should not throw or change state
+      document.dispatchEvent(new Event('scroll', { bubbles: false }));
+      await flushPromises();
+      expect(vm.openActionsMenu).toBeNull();
+      expect(vm.showColumnPicker).toBe(false);
+    });
+
+    it('scroll listener is removed on unmount', async () => {
+      const c = makeContainer({ id: 'c1', name: 'nginx' });
+      const wrapper = await mountContainersView(
+        [c],
+        [{ id: 'c1', name: 'nginx', displayName: 'nginx' }],
+      );
+      // Unmounting should call removeEventListener for the scroll handler without throwing
+      expect(() => wrapper.unmount()).not.toThrow();
+      // After unmount, dispatching scroll should not throw (listener is gone)
+      expect(() => document.dispatchEvent(new Event('scroll', { bubbles: false }))).not.toThrow();
+    });
+
     it('registers granular container lifecycle listeners and triggers load on connected', async () => {
       vi.useFakeTimers();
       const addEventListenerSpy = vi.spyOn(globalThis, 'addEventListener');


### PR DESCRIPTION
## Summary

rc.14 ships two fixes for issues reported against rc.13:

### 1. Update-eligibility blocker pill never rendered (#307)

The blocker pills shipped in rc.13 (`Trigger filtered`, `Below threshold`, `Maturing`, etc.) silently rendered nothing for every container in every view (table rows, side panel, full-page detail, dashboard widget). The backend computed eligibility correctly and serialised it in the API response, but the UI's `mapApiContainer()` didn't declare or pass through the `updateEligibility` field — TypeScript's structural typing dropped the unknown JSON property at the boundary.

**Two-part fix:**
- **UI mapper** (`ui/src/utils/container-mapper.ts`) — `ApiContainerInput` now declares `updateEligibility`, and `mapApiContainer` passes it through with a `deriveUpdateEligibility` validator that rejects malformed eligibility objects and filters out malformed individual blockers. One change lights up every consumer.
- **Backend SSE enrichment** (`app/api/sse-container-enrichment.ts`) — the store broadcasts raw container objects on `dd:container-added` / `dd:container-updated`, but `updateEligibility` is computed on-demand in the list handler and never persisted. Without enrichment, live SSE patches would deliver containers with eligibility undefined, flickering the pill on every update. New helper computes eligibility from registry triggers + active operations and attaches it to each lifecycle payload before broadcast.

**Manual verification:** built `drydock:dev` with `DD_ACTION_DOCKER_LOCAL_AUTO=oninclude`, confirmed 23 backend `trigger-not-included` blockers render as 23 amber **"Trigger filtered"** pills in the Kind column.

### 2. Containers list popovers off-screen + sticky on scroll (#323)

The "More" actions menu and the column picker both used `position: fixed` with coordinates from `getBoundingClientRect()` and unconditionally opened *below* the trigger. When the trigger sat near the bottom of the viewport (e.g. the last container row), the menu was clipped off-screen and inaccessible. The popovers also stayed at their captured pixel coordinates while the table scrolled, drifting away from the trigger.

**Fix:** added `buildPopoverStyle` helper that measures available space below vs above and flips the popover upward when there's not enough room below. Added a global `scroll` listener (capture phase) that closes both popovers since their fixed coordinates can't track a scrolling anchor.

**Manual verification:** scrolled the last container row to the viewport bottom, opened its More menu — menu rendered fully within the viewport (anchored bottom: 48px from viewport top) instead of clipping off-screen.

## Versions

`package.json` files intentionally left at `1.5.0` per the rc.13 lesson — `release-from-tag.yml` asserts BASE version match, which broke last cycle when versions were bumped to the rc string (fixed in PR #322).

## Tests

- 13 new mapper unit tests + 15 SSE enrichment tests + 6 popover positioning tests.
- All 7,165 backend + 2,852 UI existing tests still pass.
- 100% coverage on new files (`sse-container-enrichment.ts`, mapper additions, popover helper).

## Test plan

- [x] Unit tests pass (UI + backend)
- [x] Lint clean (biome on both workspaces)
- [x] Manual verification — eligibility pill renders for blocked containers
- [x] Manual verification — More menu flips up on viewport-bottom row
- [x] Pre-push gate (clean-tree → ts-nocheck → biome → qlty → coverage 100% → build → e2e → playwright → zizmor) green
- [ ] CI Verify on PR
- [ ] 2 approvals + code owner review
- [ ] After merge: tag `v1.5.0-rc.14` → `release-from-tag.yml` publishes Docker image + GH release

Closes report in #307. Closes report in #323.