### PR TITLE
🔧 chore(ci): pin qlty shellcheck plugin to runner version

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -94,6 +94,10 @@ mode = "comment"
 
 [[plugin]]
 name = "shellcheck"
+# Pinned to the version GitHub Actions ubuntu-latest pre-installs.
+# qlty otherwise resolves to the latest (0.11.0) and rejects the runner's
+# 0.9.0 binary with "Invalid tool version", failing the lint job.
+version = "0.9.0"
 
 [[plugin]]
 name = "shfmt"


### PR DESCRIPTION
## Summary

CI Verify lint job started failing on the rc.17 merge commit (`dd6c4ae3`) because qlty resolves the shellcheck plugin to the latest version (0.11.0) but GitHub Actions ubuntu-latest pre-installs 0.9.0, and qlty rejects the version mismatch.

```
Error installing shellcheck@0.11.0.
Caused by: Invalid tool version: shellcheck --version: 0.9.0 does not match version "0.11.0"
```

Pin shellcheck to 0.9.0 in `.qlty/qlty.toml` so the plugin install matches the runner's binary.

This is the only thing keeping `release-cut` from being dispatchable for v1.5.0-rc.17 — it polls CI Verify on main and waits for green. Lint failed → Build/DAST/E2E/Playwright all skipped → run conclusion is failure → release-cut would time out.

## Test plan

- [x] Same pin applied locally; `npm run lint` continues to pass (no behavior change)
- [ ] CI Verify on this PR passes the Lint step
- [ ] After merge, CI Verify on main passes; release-cut for v1.5.0-rc.17 can be dispatched