### PR TITLE
🐛 fix(release): lowercase GHCR repo in release-cut tags

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -59,13 +59,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Resolve target SHA
+      - name: Resolve target SHA and lowercase repository
         id: target
         run: |
           set -euo pipefail
           sha="$(git rev-parse HEAD)"
-          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          # Docker registries reject uppercase repository names. ${GITHUB_REPOSITORY}
+          # preserves the org casing (e.g. "CodesWhat/drydock") so we expose a
+          # pre-lowered value for every step that builds an image reference.
+          repo_lower="$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')"
+          {
+            echo "sha=${sha}"
+            echo "repo_lower=${repo_lower}"
+          } >> "$GITHUB_OUTPUT"
           echo "Target SHA: ${sha}"
+          echo "Repository (lowercase): ${repo_lower}"
 
       - name: Wait for successful branch CI on target SHA
         uses: ./.github/actions/wait-for-successful-branch-ci
@@ -174,10 +182,11 @@ jobs:
         env:
           VERSION: ${{ steps.next.outputs.next_version }}
           IS_PRERELEASE: ${{ steps.tag.outputs.is_prerelease }}
+          GHCR_REPO: ${{ steps.target.outputs.repo_lower }}
         run: |
           set -euo pipefail
 
-          registries=("ghcr.io/${GITHUB_REPOSITORY}" "docker.io/codeswhat/drydock" "quay.io/codeswhat/drydock")
+          registries=("ghcr.io/${GHCR_REPO}" "docker.io/codeswhat/drydock" "quay.io/codeswhat/drydock")
           suffixes=("${VERSION}")
 
           if [ "${IS_PRERELEASE}" = "false" ]; then
@@ -234,7 +243,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ steps.target.outputs.repo_lower }}
           # The tags input is required. We pass the full tag list to
           # build-push-action via steps.image_tags; this single raw tag
           # exists only to drive the OCI label values
@@ -263,6 +272,7 @@ jobs:
         env:
           BUILD_DIGEST: ${{ steps.build.outputs.digest }}
           TAGS: ${{ steps.image_tags.outputs.tags }}
+          GHCR_REPO: ${{ steps.target.outputs.repo_lower }}
         run: |
           set -euo pipefail
 
@@ -272,7 +282,7 @@ jobs:
           fi
 
           source_candidates=(
-            "ghcr.io/${GITHUB_REPOSITORY}@${BUILD_DIGEST}"
+            "ghcr.io/${GHCR_REPO}@${BUILD_DIGEST}"
             "docker.io/codeswhat/drydock@${BUILD_DIGEST}"
             "quay.io/codeswhat/drydock@${BUILD_DIGEST}"
           )
@@ -381,7 +391,7 @@ jobs:
         if: steps.digest.outputs.value
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
-          subject-name: ghcr.io/${{ github.repository }}
+          subject-name: ghcr.io/${{ steps.target.outputs.repo_lower }}
           subject-digest: ${{ steps.digest.outputs.value }}
           push-to-registry: true
 


### PR DESCRIPTION
## Summary

The first dispatch of `release-cut` for `v1.5.0-rc.17` (run [25347439989](https://github.com/CodesWhat/drydock/actions/runs/25347439989)) failed at Docker build:

```
ERROR: failed to build: invalid tag "ghcr.io/CodesWhat/drydock:1.5.0-rc.17":
repository name must be lowercase
```

`${GITHUB_REPOSITORY}` preserves the org's display casing (`CodesWhat/drydock`), but Docker/OCI registries reject uppercase characters in repository names.

Compute a lowercased value once in the early "Resolve target SHA" step and reference it everywhere a Docker image path is built. The two cosign `identity_regex` references that match the OIDC subject URL keep `${GITHUB_REPOSITORY}` unchanged because the OIDC subject preserves casing and must match exactly.

## Test plan

- [ ] CI Verify on this PR passes
- [ ] After merge, dispatch `release-cut` with `release_tag=v1.5.0-rc.17`; build step succeeds with `ghcr.io/codeswhat/drydock:1.5.0-rc.17`
- [ ] Resulting image is pushed to GHCR + Docker Hub + Quay
- [ ] Tag `v1.5.0-rc.17` exists on the repo and a prerelease GitHub Release is created