### PR TITLE
🔧 chore(lint): enable noUnusedVariables and clear all open code-scanning alerts

### DIFF
--- a/app/api/agent.ts
+++ b/app/api/agent.ts
@@ -183,7 +183,7 @@ async function getAgentLogEntries(
     const since = req.query.since ? Number.parseInt(req.query.since, 10) : undefined;
     const entries = await agent.getLogEntries({ level, component, tail, since });
     res.json(normalizeAgentLogEntries(entries));
-  } catch (error: unknown) {
+  } catch {
     sendErrorResponse(res, 502, AGENT_LOG_FETCH_ERROR_MESSAGE);
   }
 }

--- a/app/api/container/log-stream.ts
+++ b/app/api/container/log-stream.ts
@@ -63,23 +63,6 @@ interface LogStreamContainerApi {
   getContainer: (id: string) => Container | undefined;
 }
 
-interface LocalDockerContainerApi {
-  logs: (options: {
-    follow: boolean;
-    stdout: boolean;
-    stderr: boolean;
-    tail: number;
-    since: number;
-    timestamps: boolean;
-  }) => Promise<Buffer | string | Uint8Array | Readable>;
-}
-
-interface LocalDockerWatcherApi {
-  dockerApi?: {
-    getContainer: (containerName: string) => LocalDockerContainerApi;
-  };
-}
-
 interface ContainerLogStreamGatewayDependencies {
   getContainer: LogStreamContainerApi['getContainer'];
   getWatchers: () => Record<string, unknown>;

--- a/app/registries/Registry.ts
+++ b/app/registries/Registry.ts
@@ -7,10 +7,6 @@ import Component, { type ComponentConfiguration } from '../registry/Component.js
 import { getErrorMessage } from '../util/error.js';
 import { getRegistryRequestTimeoutMs } from './configuration.js';
 
-interface RegistryImage extends ContainerImage {
-  // Add registry-specific properties if needed
-}
-
 interface RegistryManifest {
   digest?: string;
   version?: number;

--- a/app/registry/index.test.ts
+++ b/app/registry/index.test.ts
@@ -94,7 +94,7 @@ afterEach(async () => {
     await registry.testable_deregisterTriggers();
     await registry.testable_deregisterWatchers();
     await registry.testable_deregisterAuthentications();
-  } catch (e) {
+  } catch {
     // ignore error
   }
 });

--- a/app/triggers/providers/dockercompose/Dockercompose.comments-and-pruning.test.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.comments-and-pruning.test.ts
@@ -97,11 +97,10 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 
 describe('Dockercompose Trigger', () => {
   let trigger;
-  let mockLog;
   let mockDockerApi;
 
   beforeEach(() => {
-    ({ trigger, mockLog, mockDockerApi } = setupDockercomposeTestContext({
+    ({ trigger, mockDockerApi } = setupDockercomposeTestContext({
       DockercomposeCtor: Dockercompose,
       watchMock: watch,
       getStateMock: getState,

--- a/app/triggers/providers/dockercompose/Dockercompose.file-ops-and-trigger-batch.test.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.file-ops-and-trigger-batch.test.ts
@@ -96,10 +96,9 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 describe('Dockercompose Trigger', () => {
   let trigger;
   let mockLog;
-  let mockDockerApi;
 
   beforeEach(() => {
-    ({ trigger, mockLog, mockDockerApi } = setupDockercomposeTestContext({
+    ({ trigger, mockLog } = setupDockercomposeTestContext({
       DockercomposeCtor: Dockercompose,
       watchMock: watch,
       getStateMock: getState,

--- a/app/updates/request-update.test.ts
+++ b/app/updates/request-update.test.ts
@@ -416,8 +416,7 @@ describe('request-update', () => {
       trigger,
     };
 
-    const result = dispatchAccepted([entry]);
-    expect(result).toBeUndefined();
+    dispatchAccepted([entry]);
 
     await flushAsyncWork();
     expect(trigger.trigger).toHaveBeenCalledWith(entry.container, {

--- a/app/watchers/providers/docker/Docker.containers.additional-coverage-core.test.ts
+++ b/app/watchers/providers/docker/Docker.containers.additional-coverage-core.test.ts
@@ -43,9 +43,6 @@ import {
 describe('Docker Watcher', () => {
   let docker;
   let mockDockerApi;
-  let mockSchedule;
-  let mockContainer;
-  let mockImage;
   // Helper-scoped mock references (populated in beforeEach)
   let hRegistry: any;
   let hMockTag: any;
@@ -54,9 +51,6 @@ describe('Docker Watcher', () => {
   setupDockerWatcherContainerSuite((state) => {
     docker = state.docker;
     mockDockerApi = state.mockDockerApi;
-    mockSchedule = state.mockSchedule;
-    mockContainer = state.mockContainer;
-    mockImage = state.mockImage;
   });
 
   beforeEach(async () => {

--- a/app/watchers/providers/docker/Docker.containers.additional-coverage-helpers.test.ts
+++ b/app/watchers/providers/docker/Docker.containers.additional-coverage-helpers.test.ts
@@ -64,16 +64,10 @@ import {
 describe('Docker Watcher', () => {
   let docker;
   let mockDockerApi;
-  let mockSchedule;
-  let mockContainer;
-  let mockImage;
 
   setupDockerWatcherContainerSuite((state) => {
     docker = state.docker;
     mockDockerApi = state.mockDockerApi;
-    mockSchedule = state.mockSchedule;
-    mockContainer = state.mockContainer;
-    mockImage = state.mockImage;
   });
 
   describe('Additional Coverage - Docker helper functions', () => {

--- a/app/watchers/providers/docker/Docker.containers.details.test.ts
+++ b/app/watchers/providers/docker/Docker.containers.details.test.ts
@@ -9,8 +9,6 @@ import {
 
 describe('Docker Watcher', () => {
   let docker;
-  let mockDockerApi;
-  let mockSchedule;
   let mockContainer;
   let mockImage;
   // Helper-scoped mock references (populated in beforeEach)
@@ -20,8 +18,6 @@ describe('Docker Watcher', () => {
 
   setupDockerWatcherContainerSuite((state) => {
     docker = state.docker;
-    mockDockerApi = state.mockDockerApi;
-    mockSchedule = state.mockSchedule;
     mockContainer = state.mockContainer;
     mockImage = state.mockImage;
   });

--- a/app/watchers/providers/docker/Docker.containers.labels-version-finding.test.ts
+++ b/app/watchers/providers/docker/Docker.containers.labels-version-finding.test.ts
@@ -4,18 +4,12 @@ import { testable_getLabel } from './Docker.js';
 describe('Docker Watcher', () => {
   let docker;
   let mockDockerApi;
-  let mockSchedule;
-  let mockContainer;
-  let mockImage;
   let hRegistry: any;
   let hMockTag: any;
 
   setupDockerWatcherContainerSuite((state) => {
     docker = state.docker;
     mockDockerApi = state.mockDockerApi;
-    mockSchedule = state.mockSchedule;
-    mockContainer = state.mockContainer;
-    mockImage = state.mockImage;
   });
 
   beforeEach(async () => {

--- a/app/watchers/providers/docker/Docker.containers.processing-retrieval.test.ts
+++ b/app/watchers/providers/docker/Docker.containers.processing-retrieval.test.ts
@@ -10,18 +10,12 @@ import {
 describe('Docker Watcher', () => {
   let docker;
   let mockDockerApi;
-  let mockSchedule;
-  let mockContainer;
-  let mockImage;
   let hEvent: any;
   let hStoreContainer: any;
 
   setupDockerWatcherContainerSuite((state) => {
     docker = state.docker;
     mockDockerApi = state.mockDockerApi;
-    mockSchedule = state.mockSchedule;
-    mockContainer = state.mockContainer;
-    mockImage = state.mockImage;
   });
 
   beforeEach(async () => {

--- a/app/watchers/providers/docker/Docker.containers.reporting-utility-coverage.test.ts
+++ b/app/watchers/providers/docker/Docker.containers.reporting-utility-coverage.test.ts
@@ -7,17 +7,9 @@ let hStoreContainer: any;
 
 describe('Docker Watcher', () => {
   let docker;
-  let mockDockerApi;
-  let mockSchedule;
-  let mockContainer;
-  let mockImage;
 
   setupDockerWatcherContainerSuite((state) => {
     docker = state.docker;
-    mockDockerApi = state.mockDockerApi;
-    mockSchedule = state.mockSchedule;
-    mockContainer = state.mockContainer;
-    mockImage = state.mockImage;
   });
 
   beforeEach(async () => {

--- a/app/watchers/providers/docker/Docker.test.ts
+++ b/app/watchers/providers/docker/Docker.test.ts
@@ -1227,9 +1227,7 @@ describe('Docker Watcher', () => {
       mockDockerApi.listContainers.mockResolvedValue([]);
 
       // First call sequence: device flow
-      let postCallCount = 0;
       mockAxios.post.mockImplementation((url) => {
-        postCallCount++;
         if (url === 'https://idp.example.com/oauth/device/code') {
           return Promise.resolve({
             data: createDeviceCodeResponse({

--- a/app/watchers/providers/docker/docker-helpers.ts
+++ b/app/watchers/providers/docker/docker-helpers.ts
@@ -454,7 +454,7 @@ function hasMeaningfulDigestComparisonTag(currentTag?: string) {
 }
 
 function shouldWatchDigestForUnlabeledImage(context: DigestWatchContext) {
-  const { parsedImage, isSemver, tagPrecision, currentTag, summaryImageReference } = context;
+  const { isSemver, tagPrecision, currentTag, summaryImageReference } = context;
 
   // Specific semver releases (1.4.5) — immutable, no digest watching needed
   if (isSemver && tagPrecision === 'specific') {

--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,7 @@
       },
       "correctness": {
         "noUnusedFunctionParameters": "off",
-        "noUnusedVariables": "off"
+        "noUnusedVariables": "error"
       },
       "suspicious": {
         "noAssignInExpressions": "off",
@@ -72,7 +72,8 @@
       "linter": {
         "rules": {
           "correctness": {
-            "noUnusedImports": "off"
+            "noUnusedImports": "off",
+            "noUnusedVariables": "off"
           }
         }
       },
@@ -80,6 +81,16 @@
         "actions": {
           "source": {
             "organizeImports": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["docs/audit-findings.html"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedVariables": "off"
           }
         }
       }

--- a/ui/src/views/security/securityViewTypes.d.ts
+++ b/ui/src/views/security/securityViewTypes.d.ts
@@ -18,22 +18,6 @@ export interface SeveritySummaryCounts {
   low: number;
 }
 
-interface SecurityDelta {
-  fixed: number;
-  new: number;
-  fixedCritical: number;
-  fixedHigh: number;
-  newCritical: number;
-  newHigh: number;
-}
-
-interface ImageSummary extends SeveritySummaryCounts {
-  image: string;
-  total: number;
-  fixable: number;
-  delta?: SecurityDelta;
-}
-
 export type SbomFormat = 'spdx-json' | 'cyclonedx-json';
 
 export interface SecurityRuntimeToolStatus {
@@ -57,10 +41,6 @@ export interface SecurityRuntimeStatus {
     formats: string[];
   };
   requirements: string[];
-}
-
-interface UpdateScanSummary extends SeveritySummaryCounts {
-  unknown: number;
 }
 
 export interface SecurityEmptyState {

--- a/ui/tests/views/ContainersView.applyContainerPatch.spec.ts
+++ b/ui/tests/views/ContainersView.applyContainerPatch.spec.ts
@@ -874,17 +874,12 @@ describe('ContainersView — applyContainerPatch', () => {
         name: 'vaultwarden',
         updateOperation: activeOp,
       });
-      const wrapper = await mountContainersView([existing]);
-      const vm = wrapper.vm as any;
+      await mountContainersView([existing]);
 
       // Seed the hold map via the operation composable so reconcile has something to check
       const { useOperationDisplayHold } = await import('@/composables/useOperationDisplayHold');
-      const {
-        holdOperationDisplay,
-        heldOperations,
-        clearAllOperationDisplayHolds,
-        scheduleHeldOperationRelease,
-      } = useOperationDisplayHold();
+      const { holdOperationDisplay, heldOperations, clearAllOperationDisplayHolds } =
+        useOperationDisplayHold();
 
       holdOperationDisplay({
         operationId: activeOp.id,

--- a/ui/tests/views/DashboardView.spec.ts
+++ b/ui/tests/views/DashboardView.spec.ts
@@ -2865,9 +2865,6 @@ describe('DashboardView', () => {
         const addEventListenerSpy = vi.spyOn(globalThis, 'addEventListener');
         const c = makeContainer({ id: 'c1', name: 'nginx' });
         const wrapper = await mountDashboard([c], []);
-        const updateAppliedListener = addEventListenerSpy.mock.calls.findLast(
-          ([eventName]) => eventName === 'dd:sse-update-applied',
-        )?.[1] as EventListener | undefined;
 
         const { toasts } = useToast();
         const maxIdBefore = Math.max(-1, ...toasts.value.map((t) => t.id));
@@ -2904,9 +2901,6 @@ describe('DashboardView', () => {
         const addEventListenerSpy = vi.spyOn(globalThis, 'addEventListener');
         const c = makeContainer({ id: 'c1', name: 'nginx' });
         const wrapper = await mountDashboard([c], []);
-        const updateFailedListener = addEventListenerSpy.mock.calls.findLast(
-          ([eventName]) => eventName === 'dd:sse-update-failed',
-        )?.[1] as EventListener | undefined;
 
         const { toasts } = useToast();
         const maxIdBefore = Math.max(-1, ...toasts.value.map((t) => t.id));
@@ -2947,12 +2941,6 @@ describe('DashboardView', () => {
         const addEventListenerSpy = vi.spyOn(globalThis, 'addEventListener');
         const c = makeContainer({ id: 'c1', name: 'nginx' });
         const wrapper = await mountDashboard([c], []);
-        const operationListener = addEventListenerSpy.mock.calls.findLast(
-          ([eventName]) => eventName === 'dd:sse-update-operation-changed',
-        )?.[1] as EventListener | undefined;
-        const updateAppliedListener = addEventListenerSpy.mock.calls.findLast(
-          ([eventName]) => eventName === 'dd:sse-update-applied',
-        )?.[1] as EventListener | undefined;
         const { toasts } = useToast();
         const maxIdBefore = Math.max(-1, ...toasts.value.map((t) => t.id));
 


### PR DESCRIPTION
## Summary
- Closes the 8 open CodeQL alerts (#305–#312) — 7 unused variables + 1 returnless-function in tests.
- Flips biome `noUnusedVariables` from `off` to `error` so future regressions fail at lint time instead of slipping into a post-merge code-scanning report.
- Adds `**/*.vue` and `docs/audit-findings.html` overrides because biome's script-only parser can't see template-side identifiers in SFCs (would false-positive ~860 hits otherwise).

## What changed
- biome.json — `noUnusedVariables: error` + Vue/HTML overrides
- removed dead interfaces in `app/api/container/log-stream.ts`, `app/registries/Registry.ts`, `ui/src/views/security/securityViewTypes.d.ts`
- dropped unused `mockSchedule`/`mockContainer`/`mockImage`/`mockLog`/`mockDockerApi` declarations across docker + dockercompose test suites
- dropped unused listener captures and `vm` shims in Dashboard/Containers view specs
- dropped unused `parsedImage` from `shouldWatchDigestForUnlabeledImage`
- replaced `catch (e/error)` with bare `catch` where the binding was unused
- removed unused `result` capture in `dispatchAccepted` test (function returns void) — addresses the `js/use-of-returnless-function` alert
- removed dead `postCallCount` counter in Docker oauth refresh test

## Companion follow-up
After this merges, also make **CodeQL** a required status check on `main`'s branch protection. CodeQL already runs per-PR via default-setup; promoting it to required is the gate that catches the security-tier rules biome doesn't see (e.g. the returnless-function rule).

## Test plan
- [x] `biome check .` clean (was 899 errors)
- [x] `tsc --noEmit` clean
- [x] Affected app suites pass (596/596)
- [x] Affected UI suites pass (167/167)
- [x] Local pre-push gates all green: clean-tree, ts-nocheck, biome, qlty, coverage 100%, build