### PR TITLE
🐛 fix(release): harden rc18 ci fallout

### DIFF
--- a/.github/workflows/i18n-crowdin.yml
+++ b/.github/workflows/i18n-crowdin.yml
@@ -33,11 +33,11 @@ jobs:
           download_translations: true
           localization_branch_name: l10n_crowdin
           create_pull_request: true
-          pull_request_title: "i18n: sync translations from Crowdin"
+          pull_request_title: "🔧 chore(i18n): sync translations from Crowdin"
           pull_request_body: "Automated sync from Crowdin. Review wording, then merge."
           pull_request_labels: "translations,crowdin"
           pull_request_base_branch_name: main
-          commit_message: "i18n: sync translations from Crowdin"
+          commit_message: "🔧 chore(i18n): sync translations from Crowdin"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/app/model/container.test.ts
+++ b/app/model/container.test.ts
@@ -2186,6 +2186,20 @@ test('getLink should handle transformed tag in link', () => {
   ).toEqual('https://v1.2.3');
 });
 
+test('getLink should fall back to the original tag when transform regex is invalid', () => {
+  const { testable_getLink: getLink } = container;
+  expect(
+    getLink(
+      {
+        linkTemplate: 'https://v${transformed}',
+        transformTags: '[=>',
+        image: { tag: { semver: false } },
+      },
+      '1.2.3',
+    ),
+  ).toEqual('https://v1.2.3');
+});
+
 test('getLink should handle empty prerelease', () => {
   const { testable_getLink: getLink } = container;
   const result = getLink(

--- a/app/model/container.ts
+++ b/app/model/container.ts
@@ -632,12 +632,19 @@ function getLink(container: Container, originalTagValue: string) {
     return undefined;
   }
 
+  let transformedTagValue = originalTagValue;
+  if (container.transformTags) {
+    try {
+      transformedTagValue = transformTag(container.transformTags, originalTagValue);
+    } catch {
+      transformedTagValue = originalTagValue;
+    }
+  }
+
   const vars: Record<string, string> = {};
   vars.raw = originalTagValue; // deprecated, kept for backward compatibility
   vars.original = originalTagValue;
-  vars.transformed = container.transformTags
-    ? transformTag(container.transformTags, originalTagValue)
-    : originalTagValue;
+  vars.transformed = transformedTagValue;
   vars.major = '';
   vars.minor = '';
   vars.patch = '';


### PR DESCRIPTION
## Summary

- keep container link rendering from throwing when transform-tags contains invalid regex config
- add regression coverage for the failing fuzz case
- make Crowdin-generated PR titles and commits pass the commit-message policy

## Verification

- npm exec -- vitest run model/container.test.ts model/container.fuzz.test.ts --maxWorkers=1 --fileParallelism=false
- npm exec -- vitest run ' .fuzz.test.ts ' --maxWorkers=1 --fileParallelism=false\n- npm run lint (app)\n- npm run build (app)\n- pre-push gate: qlty, coverage, build, zizmor\n\n## Release note\n\nCancels the previous rc18 cut tied to the failing main SHA; rerun release-cut after this lands.