### PR TITLE
🐛 fix(i18n): align Crowdin locale exports

### DIFF
--- a/.github/workflows/i18n-crowdin.yml
+++ b/.github/workflows/i18n-crowdin.yml
@@ -31,6 +31,17 @@ jobs:
           upload_sources: true
           upload_translations: true
           download_translations: true
+          download_translations_args: >-
+            --language=de
+            --language=es-ES
+            --language=fr
+            --language=it
+            --language=nl
+            --language=pl
+            --language=pt-BR
+            --language=tr
+            --language=zh-CN
+            --language=zh-TW
           localization_branch_name: l10n_crowdin
           create_pull_request: true
           pull_request_title: "🔧 chore(i18n): sync translations from Crowdin"

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -15,4 +15,16 @@ pull_request_labels:
 files:
   - source: /ui/src/locales/en/**/*.json
     translation: /ui/src/locales/%locale%/**/%original_file_name%
+    languages_mapping:
+      locale:
+        de: de
+        es-ES: es
+        fr: fr
+        it: it
+        nl: nl
+        pl: pl
+        pt-BR: pt-BR
+        tr: tr
+        zh-CN: zh-CN
+        zh-TW: zh-TW
     update_option: update_as_unapproved

--- a/ui/tests/boot/crowdin-config.spec.ts
+++ b/ui/tests/boot/crowdin-config.spec.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse } from 'yaml';
+import { SUPPORTED_LOCALES } from '@/i18n/locales';
+
+const repoRoot = resolve(import.meta.dirname, '../../..');
+const supportedTranslationLocales = SUPPORTED_LOCALES.filter((locale) => locale !== 'en').sort();
+
+const expectedCrowdinLocaleMapping = {
+  de: 'de',
+  'es-ES': 'es',
+  fr: 'fr',
+  it: 'it',
+  nl: 'nl',
+  pl: 'pl',
+  'pt-BR': 'pt-BR',
+  tr: 'tr',
+  'zh-CN': 'zh-CN',
+  'zh-TW': 'zh-TW',
+} as const;
+
+function readYaml(path: string): unknown {
+  return parse(readFileSync(resolve(repoRoot, path), 'utf8'));
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  expect(value).toBeTruthy();
+  expect(typeof value).toBe('object');
+  expect(Array.isArray(value)).toBe(false);
+  return value as Record<string, unknown>;
+}
+
+function firstCrowdinFileSet(): Record<string, unknown> {
+  const config = asRecord(readYaml('crowdin.yml'));
+  const files = config.files;
+  expect(Array.isArray(files)).toBe(true);
+  expect(files).toHaveLength(1);
+  return asRecord(files[0]);
+}
+
+describe('Crowdin locale export config', () => {
+  it('maps Crowdin language codes to the locale folder IDs supported by the app', () => {
+    const fileSet = firstCrowdinFileSet();
+
+    expect(fileSet.translation).toBe('/ui/src/locales/%locale%/**/%original_file_name%');
+    const localeMapping = asRecord(asRecord(fileSet.languages_mapping).locale);
+    expect(localeMapping).toEqual(expectedCrowdinLocaleMapping);
+    expect(Object.values(localeMapping).sort()).toEqual(supportedTranslationLocales);
+  });
+
+  it('downloads only the Crowdin languages exposed in the app locale picker', () => {
+    const workflow = asRecord(readYaml('.github/workflows/i18n-crowdin.yml'));
+    const jobs = asRecord(workflow.jobs);
+    const sync = asRecord(jobs.sync);
+    const steps = sync.steps;
+    expect(Array.isArray(steps)).toBe(true);
+
+    const crowdinStep = steps
+      .map((step) => asRecord(step))
+      .find((step) => String(step.uses ?? '').startsWith('crowdin/github-action@'));
+    expect(crowdinStep).toBeTruthy();
+
+    const withConfig = asRecord(crowdinStep?.with);
+    const args = String(withConfig.download_translations_args ?? '');
+    const downloadedLanguages = Array.from(args.matchAll(/--language=(\S+)/g), (match) => match[1]);
+    const downloadedLocales = downloadedLanguages.map(
+      (language) =>
+        expectedCrowdinLocaleMapping[language as keyof typeof expectedCrowdinLocaleMapping],
+    );
+
+    expect(downloadedLanguages.sort()).toEqual(Object.keys(expectedCrowdinLocaleMapping).sort());
+    expect(downloadedLocales.sort()).toEqual(supportedTranslationLocales);
+  });
+});


### PR DESCRIPTION
## Summary
- map Crowdin language codes to the locale folder IDs supported by the app
- limit Crowdin downloads to the languages currently exposed in the locale picker
- add a guard test so future Crowdin config drift is caught before generated sync PRs add ignored locale folders

## Verification
- node ./node_modules/vitest/vitest.mjs run tests/boot/crowdin-config.spec.ts --maxWorkers=1 --fileParallelism=false
- /Users/sbenson/code/drydock/node_modules/.bin/biome check .github/workflows/i18n-crowdin.yml crowdin.yml ui/tests/boot/crowdin-config.spec.ts

Supersedes generated Crowdin sync PR #348, which exported unsupported region-coded locale folders.