### PR TITLE
⚡ chore(release): bulletproof CI + share docker cache before rc.18 cut

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -512,8 +512,8 @@ jobs:
           load: true
           tags: drydock:dev
           build-args: DD_VERSION=ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=drydock
+          cache-to: type=gha,mode=max,scope=drydock,ignore-error=true
 
       - name: Set up QEMU (multi-arch smoke build)
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
@@ -525,8 +525,8 @@ jobs:
           push: false
           platforms: linux/amd64,linux/arm64
           build-args: DD_VERSION=ci-multiarch-smoke
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=drydock
+          cache-to: type=gha,mode=max,scope=drydock,ignore-error=true
 
       - name: Export QA image artifact
         run: |

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -430,12 +430,20 @@ jobs:
           package-manager-cache: false
 
       - name: Install app dependencies
-        run: npm ci
-        working-directory: app
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd app && npm ci
 
       - name: Install ui dependencies
-        run: npm ci
-        working-directory: ui
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd ui && npm ci
 
       - name: Run app tests
         run: npm test
@@ -482,8 +490,12 @@ jobs:
           package-manager-cache: false
 
       - name: Install ui dependencies
-        run: npm ci
-        working-directory: ui
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd ui && npm ci
 
       - name: Build ui
         run: npm run build
@@ -501,7 +513,7 @@ jobs:
           tags: drydock:dev
           build-args: DD_VERSION=ci
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Set up QEMU (multi-arch smoke build)
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
@@ -514,7 +526,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: DD_VERSION=ci-multiarch-smoke
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Export QA image artifact
         run: |
@@ -838,8 +850,12 @@ jobs:
           package-manager-cache: false
 
       - name: Install e2e dependencies
-        run: npm ci
-        working-directory: e2e
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd e2e && npm ci
 
       - name: Setup test containers
         run: ./scripts/setup-test-containers.sh
@@ -898,12 +914,20 @@ jobs:
         run: docker load < artifacts/qa/drydock-dev-image.tar.gz
 
       - name: Install e2e dependencies
-        run: npm ci
-        working-directory: e2e
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd e2e && npm ci
 
       - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
-        working-directory: e2e
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd e2e && npx playwright install --with-deps chromium
 
       - name: Start QA stack
         run: docker compose -p drydock-playwright -f test/qa-compose.yml up -d

--- a/.github/workflows/i18n-crowdin.yml
+++ b/.github/workflows/i18n-crowdin.yml
@@ -22,11 +22,13 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706  # v2.16.2
+        continue-on-error: true
         with:
           upload_sources: true
           upload_translations: true

--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -150,8 +150,12 @@ jobs:
           package-manager-cache: false
 
       - name: Install dependencies
-        run: npm ci
-        working-directory: ${{ matrix.package }}
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: cd ${{ matrix.package }} && npm ci
 
       - name: Restore Stryker incremental cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
@@ -256,13 +260,15 @@ jobs:
           REPO_SLUG: ${{ github.repository }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          curl \
-            --fail-with-body \
-            --request PUT \
-            --header "X-Api-Key: ${STRYKER_DASHBOARD_API_KEY}" \
-            --header "Content-Type: application/json" \
-            --data @artifacts/aggregate/mutation-score.json \
-            "https://dashboard.stryker-mutator.io/api/reports/github.com/${REPO_SLUG}/${REF_NAME}"
+          for attempt in 1 2 3; do
+            curl \
+              --fail-with-body \
+              --request PUT \
+              --header "X-Api-Key: ${STRYKER_DASHBOARD_API_KEY}" \
+              --header "Content-Type: application/json" \
+              --data @artifacts/aggregate/mutation-score.json \
+              "https://dashboard.stryker-mutator.io/api/reports/github.com/${REPO_SLUG}/${REF_NAME}" && break || (rc=$?; if [ $attempt -eq 3 ]; then exit $rc; fi; sleep $((5*attempt)))
+          done
 
       - name: Upload aggregate mutation summary
         if: always()

--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -261,13 +261,20 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           for attempt in 1 2 3; do
-            curl \
+            if curl \
               --fail-with-body \
               --request PUT \
               --header "X-Api-Key: ${STRYKER_DASHBOARD_API_KEY}" \
               --header "Content-Type: application/json" \
               --data @artifacts/aggregate/mutation-score.json \
-              "https://dashboard.stryker-mutator.io/api/reports/github.com/${REPO_SLUG}/${REF_NAME}" && break || (rc=$?; if [ $attempt -eq 3 ]; then exit $rc; fi; sleep $((5*attempt)))
+              "https://dashboard.stryker-mutator.io/api/reports/github.com/${REPO_SLUG}/${REF_NAME}"; then
+              break
+            fi
+            rc=$?
+            if [ "$attempt" -eq 3 ]; then
+              exit "$rc"
+            fi
+            sleep $((5*attempt))
           done
 
       - name: Upload aggregate mutation summary

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -220,6 +220,8 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Log in to GHCR
+        id: login_ghcr
+        continue-on-error: true
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
           registry: ghcr.io
@@ -227,17 +229,51 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
+        id: login_dockerhub
+        continue-on-error: true
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to Quay.io
+        id: login_quay
+        continue-on-error: true
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Retry registry logins on failure
+        if: steps.login_ghcr.outcome == 'failure' || steps.login_dockerhub.outcome == 'failure' || steps.login_quay.outcome == 'failure'
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          GHCR_OUTCOME: ${{ steps.login_ghcr.outcome }}
+          DOCKERHUB_OUTCOME: ${{ steps.login_dockerhub.outcome }}
+          QUAY_OUTCOME: ${{ steps.login_quay.outcome }}
+        run: |
+          set -euo pipefail
+          if [ "${GHCR_OUTCOME}" = "failure" ]; then
+            for i in 1 2 3; do
+              echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin && break || sleep $((5*i))
+            done
+          fi
+          if [ "${DOCKERHUB_OUTCOME}" = "failure" ]; then
+            for i in 1 2 3; do
+              echo "${DOCKERHUB_TOKEN}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin && break || sleep $((5*i))
+            done
+          fi
+          if [ "${QUAY_OUTCOME}" = "failure" ]; then
+            for i in 1 2 3; do
+              echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin && break || sleep $((5*i))
+            done
+          fi
 
       - name: Docker metadata labels
         id: meta
@@ -412,12 +448,21 @@ jobs:
         run: |
           set -euo pipefail
           artifact="dist/drydock-${RELEASE_TAG}.tar.gz"
-          cosign sign-blob --yes \
-            --bundle "${artifact}.bundle" \
-            --new-bundle-format=false \
-            --output-signature "${artifact}.sig" \
-            --output-certificate "${artifact}.pem" \
-            "${artifact}"
+          for attempt in 1 2 3; do
+            if cosign sign-blob --yes \
+              --bundle "${artifact}.bundle" \
+              --new-bundle-format=false \
+              --output-signature "${artifact}.sig" \
+              --output-certificate "${artifact}.pem" \
+              "${artifact}"; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "::error::cosign sign-blob failed after 3 attempts"
+              exit 1
+            fi
+            sleep $((5*attempt))
+          done
 
           # Cosign v3 may only emit bundle output in some keyless flows.
           # Materialize legacy signature/cert files from the bundle when needed.
@@ -544,16 +589,30 @@ jobs:
             prerelease_flag="--prerelease"
           fi
 
-          gh release view "${RELEASE_TAG}" >/dev/null 2>&1 || gh release create "${RELEASE_TAG}" --title "${RELEASE_TAG}" --notes-file "${RELEASE_NOTES_PATH}" ${prerelease_flag}
-          gh release edit "${RELEASE_TAG}" --title "${RELEASE_TAG}" --notes-file "${RELEASE_NOTES_PATH}" ${prerelease_flag}
-          gh release upload "${RELEASE_TAG}" \
-            "dist/drydock-${RELEASE_TAG}.tar.gz" \
-            "dist/drydock-${RELEASE_TAG}.tar.gz.sha256" \
-            "dist/drydock-${RELEASE_TAG}.tar.gz.bundle" \
-            "dist/drydock-${RELEASE_TAG}.tar.gz.sig" \
-            "dist/drydock-${RELEASE_TAG}.tar.gz.intoto.jsonl" \
-            "dist/drydock-${RELEASE_TAG}.tar.gz.pem" \
-            --clobber
+          for attempt in 1 2 3; do
+            if gh release view "${RELEASE_TAG}" >/dev/null 2>&1 || gh release create "${RELEASE_TAG}" --title "${RELEASE_TAG}" --notes-file "${RELEASE_NOTES_PATH}" ${prerelease_flag}; then :; else
+              if [ "${attempt}" -eq 3 ]; then exit 1; fi
+              sleep $((5*attempt))
+              continue
+            fi
+            if gh release edit "${RELEASE_TAG}" --title "${RELEASE_TAG}" --notes-file "${RELEASE_NOTES_PATH}" ${prerelease_flag}; then :; else
+              if [ "${attempt}" -eq 3 ]; then exit 1; fi
+              sleep $((5*attempt))
+              continue
+            fi
+            if gh release upload "${RELEASE_TAG}" \
+              "dist/drydock-${RELEASE_TAG}.tar.gz" \
+              "dist/drydock-${RELEASE_TAG}.tar.gz.sha256" \
+              "dist/drydock-${RELEASE_TAG}.tar.gz.bundle" \
+              "dist/drydock-${RELEASE_TAG}.tar.gz.sig" \
+              "dist/drydock-${RELEASE_TAG}.tar.gz.intoto.jsonl" \
+              "dist/drydock-${RELEASE_TAG}.tar.gz.pem" \
+              --clobber; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then exit 1; fi
+            sleep $((5*attempt))
+          done
 
       - name: Release summary
         env:

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -299,8 +299,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: DD_VERSION=${{ steps.next.outputs.next_version }}
           sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=drydock
+          cache-to: type=gha,mode=max,scope=drydock,ignore-error=true
 
       - name: Retry manifest publish on transient registry failure
         id: manifest-retry

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -261,17 +261,26 @@ jobs:
           set -euo pipefail
           if [ "${GHCR_OUTCOME}" = "failure" ]; then
             for i in 1 2 3; do
-              echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin && break || sleep $((5*i))
+              if echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin; then
+                break
+              fi
+              sleep $((5*i))
             done
           fi
           if [ "${DOCKERHUB_OUTCOME}" = "failure" ]; then
             for i in 1 2 3; do
-              echo "${DOCKERHUB_TOKEN}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin && break || sleep $((5*i))
+              if echo "${DOCKERHUB_TOKEN}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin; then
+                break
+              fi
+              sleep $((5*i))
             done
           fi
           if [ "${QUAY_OUTCOME}" = "failure" ]; then
             for i in 1 2 3; do
-              echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin && break || sleep $((5*i))
+              if echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin; then
+                break
+              fi
+              sleep $((5*i))
             done
           fi
 

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Run analysis
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        timeout-minutes: 15
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/security-snyk-weekly.yml
+++ b/.github/workflows/security-snyk-weekly.yml
@@ -109,12 +109,22 @@ jobs:
           snyk-version: v${{ env.SNYK_CLI_VERSION }}
 
       - name: Run Snyk Open Source scans
+        id: snyk_open_source
+        continue-on-error: true
         run: |
           set -euo pipefail
           ./scripts/snyk-deps-gate.sh --file=package-lock.json --package-manager=npm
           ./scripts/snyk-deps-gate.sh --file=app/package-lock.json --package-manager=npm
           ./scripts/snyk-deps-gate.sh --file=ui/package-lock.json --package-manager=npm
           ./scripts/snyk-deps-gate.sh --file=e2e/package-lock.json --package-manager=npm
+
+      - name: Fail if any Snyk scan errored
+        if: always()
+        run: |
+          if [ "${{ steps.snyk_open_source.outcome }}" = "failure" ]; then
+            echo "::error::Snyk Open Source scan failed"
+            exit 1
+          fi
 
   code:
     name: "🧠 Security: Snyk Code"
@@ -145,7 +155,17 @@ jobs:
           snyk-version: v${{ env.SNYK_CLI_VERSION }}
 
       - name: Run Snyk Code scan
+        id: snyk_code
+        continue-on-error: true
         run: ./scripts/snyk-code-gate.sh
+
+      - name: Fail if any Snyk scan errored
+        if: always()
+        run: |
+          if [ "${{ steps.snyk_code.outcome }}" = "failure" ]; then
+            echo "::error::Snyk Code scan failed"
+            exit 1
+          fi
 
   container:
     name: "🐳 Security: Snyk Container"
@@ -186,10 +206,20 @@ jobs:
           tags: ${{ env.SNYK_CONTAINER_IMAGE }}
           build-args: DD_VERSION=snyk
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Run Snyk Container scan
+        id: snyk_container
+        continue-on-error: true
         run: ./scripts/snyk-container-gate.sh "${SNYK_CONTAINER_IMAGE}" --file=Dockerfile
+
+      - name: Fail if any Snyk scan errored
+        if: always()
+        run: |
+          if [ "${{ steps.snyk_container.outcome }}" = "failure" ]; then
+            echo "::error::Snyk Container scan failed"
+            exit 1
+          fi
 
   iac:
     name: "🏗️ Security: Snyk IaC"
@@ -219,7 +249,17 @@ jobs:
           snyk-version: v${{ env.SNYK_CLI_VERSION }}
 
       - name: Run Snyk IaC scan
+        id: snyk_iac
+        continue-on-error: true
         run: ./scripts/snyk-iac-gate.sh .
+
+      - name: Fail if any Snyk scan errored
+        if: always()
+        run: |
+          if [ "${{ steps.snyk_iac.outcome }}" = "failure" ]; then
+            echo "::error::Snyk IaC scan failed"
+            exit 1
+          fi
 
   skipped:
     name: "⏭️ Security: Snyk Scans Skipped"

--- a/.github/workflows/security-snyk-weekly.yml
+++ b/.github/workflows/security-snyk-weekly.yml
@@ -120,8 +120,10 @@ jobs:
 
       - name: Fail if any Snyk scan errored
         if: always()
+        env:
+          OUTCOME: ${{ steps.snyk_open_source.outcome }}
         run: |
-          if [ "${{ steps.snyk_open_source.outcome }}" = "failure" ]; then
+          if [ "$OUTCOME" = "failure" ]; then
             echo "::error::Snyk Open Source scan failed"
             exit 1
           fi
@@ -161,8 +163,10 @@ jobs:
 
       - name: Fail if any Snyk scan errored
         if: always()
+        env:
+          OUTCOME: ${{ steps.snyk_code.outcome }}
         run: |
-          if [ "${{ steps.snyk_code.outcome }}" = "failure" ]; then
+          if [ "$OUTCOME" = "failure" ]; then
             echo "::error::Snyk Code scan failed"
             exit 1
           fi
@@ -215,8 +219,10 @@ jobs:
 
       - name: Fail if any Snyk scan errored
         if: always()
+        env:
+          OUTCOME: ${{ steps.snyk_container.outcome }}
         run: |
-          if [ "${{ steps.snyk_container.outcome }}" = "failure" ]; then
+          if [ "$OUTCOME" = "failure" ]; then
             echo "::error::Snyk Container scan failed"
             exit 1
           fi
@@ -255,8 +261,10 @@ jobs:
 
       - name: Fail if any Snyk scan errored
         if: always()
+        env:
+          OUTCOME: ${{ steps.snyk_iac.outcome }}
         run: |
-          if [ "${{ steps.snyk_iac.outcome }}" = "failure" ]; then
+          if [ "$OUTCOME" = "failure" ]; then
             echo "::error::Snyk IaC scan failed"
             exit 1
           fi

--- a/.github/workflows/security-snyk-weekly.yml
+++ b/.github/workflows/security-snyk-weekly.yml
@@ -209,8 +209,8 @@ jobs:
           load: true
           tags: ${{ env.SNYK_CONTAINER_IMAGE }}
           build-args: DD_VERSION=snyk
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          cache-from: type=gha,scope=drydock
+          cache-to: type=gha,mode=max,scope=drydock,ignore-error=true
 
       - name: Run Snyk Container scan
         id: snyk_container

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ WORKDIR /home/node/app
 LABEL maintainer="CodesWhat"
 EXPOSE 3000
 
-ARG DD_VERSION=unknown
-
 ENV WORKDIR=/home/node/app
 ENV DD_LOG_FORMAT=text
-ENV DD_VERSION=$DD_VERSION
+# DD_VERSION intentionally omitted from base stage so the heavy install/
+# build layers stay cacheable across release tags. The release stage at
+# the bottom of this file reintroduces ARG/ENV DD_VERSION as the final
+# layer, where only the metadata changes per build.
 
 HEALTHCHECK --interval=30s --timeout=5s CMD ["sh", "-c", "if [ -n \"$DD_SERVER_ENABLED\" ] && [ \"$DD_SERVER_ENABLED\" != 'true' ]; then exit 0; fi; /bin/healthcheck ${DD_SERVER_PORT:-3000}"]
 
@@ -92,3 +93,8 @@ COPY --from=app-build /home/node/app/package.json ./package.json
 
 # Copy ui
 COPY --from=ui-build /home/node/ui/dist/ ./ui
+
+# DD_VERSION is the only per-build-tag layer — keep it last so every
+# layer above remains cache-hittable across rc.N → rc.N+1 builds.
+ARG DD_VERSION=unknown
+ENV DD_VERSION=$DD_VERSION

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,6 +24,11 @@
 # Biome runs directly (not via qlty) because qlty's biome integration
 # does not reliably apply fixes. Qlty handles all other linters.
 
+commit-msg:
+  commands:
+    validate:
+      run: node scripts/validate-commit-msg.mjs {1}
+
 pre-commit:
   piped: true
   commands:
@@ -75,6 +80,10 @@ pre-push:
       run: ./scripts/qlty-check-gate.sh all
       priority: 4
       timeout: 4m
+    qlty-smells:
+      run: node scripts/qlty-smells-gate.mjs --scope=all || true
+      priority: 5
+      timeout: 2m
 
     # ── Coverage: sharded app+ui parallel, 100% threshold ────────────
     # Runs tests with coverage. On failure, writes .coverage-gaps.json
@@ -82,15 +91,25 @@ pre-push:
     # Honors DD_COVERAGE_FAIL_FAST=1 for sequential first-failure mode.
     coverage:
       run: ./scripts/pre-push-coverage.sh
-      priority: 5
+      priority: 6
       timeout: 6m
 
     # ── Build: sharded app+ui parallel, no tests ─────────────────────
     # Tests already ran in the coverage step, so this is tsc/vite only.
     build:
       run: ./scripts/pre-push-build.sh
-      priority: 6
+      priority: 7
       timeout: 4m
+
+    # ── Docker build (opt-in via DD_LOCAL_DOCKER=1) ───────────────────
+    # Set DD_LOCAL_DOCKER=1 to catch Dockerfile bugs locally before push.
+    docker-build:
+      run: docker build --build-arg DD_VERSION=local -t drydock:local .
+      skip:
+        - run: '[ -z "$DD_LOCAL_DOCKER" ]'
+      priority: 8
+      timeout: 10m
+      fail_text: "Docker QA build failed — fix Dockerfile before push"
 
     # ── Zizmor: GitHub Actions security scanner (blocking) ───────────
     zizmor:
@@ -98,5 +117,5 @@ pre-push:
       run: zizmor .github/workflows/
       skip:
         - run: '! command -v zizmor >/dev/null 2>&1'
-      priority: 7
+      priority: 9
       timeout: 30s

--- a/ui/src/locales/de/containerComponents.json
+++ b/ui/src/locales/de/containerComponents.json
@@ -182,7 +182,11 @@
       "emptyState": "Keine Container passen zu deinen Filtern",
       "currentLabel": "Aktuell",
       "latestLabel": "Neueste",
-      "blockedByBouncer": "Durch Bouncer blockiert"
+      "blockedByBouncer": "Durch Bouncer blockiert",
+      "registryErrorRateLimited": "Rate limited",
+      "registryErrorAuth": "Auth failed",
+      "registryErrorNotFound": "Not found",
+      "registryErrorCheckFailed": "Check failed"
     },
     "groupHeader": {
       "ungrouped": "Nicht gruppiert",
@@ -246,6 +250,8 @@
       "collapseAll": "Alle einklappen",
       "recheckTooltip": "Erneut auf Updates prüfen",
       "columnsHeader": "Spalten",
+      "narrowViewportSuffix": "(narrow viewport)",
+      "autoHiddenBadgeTooltip": "{count} columns auto-hidden because the window is narrow. Widen the window or hide other columns to free space.",
       "filterSearch": "Suche: {value}",
       "filterStatus": "Status: {value}",
       "filterBouncer": "Bouncer: {value}",

--- a/ui/src/locales/es/containerComponents.json
+++ b/ui/src/locales/es/containerComponents.json
@@ -182,7 +182,11 @@
       "emptyState": "Ningún contenedor coincide con tus filtros",
       "currentLabel": "Actual",
       "latestLabel": "Última",
-      "blockedByBouncer": "Bloqueado por Bouncer"
+      "blockedByBouncer": "Bloqueado por Bouncer",
+      "registryErrorRateLimited": "Rate limited",
+      "registryErrorAuth": "Auth failed",
+      "registryErrorNotFound": "Not found",
+      "registryErrorCheckFailed": "Check failed"
     },
     "groupHeader": {
       "ungrouped": "Sin agrupar",
@@ -246,6 +250,8 @@
       "collapseAll": "Contraer todo",
       "recheckTooltip": "Volver a comprobar actualizaciones",
       "columnsHeader": "Columnas",
+      "narrowViewportSuffix": "(narrow viewport)",
+      "autoHiddenBadgeTooltip": "{count} columns auto-hidden because the window is narrow. Widen the window or hide other columns to free space.",
       "filterSearch": "Búsqueda: {value}",
       "filterStatus": "Estado: {value}",
       "filterBouncer": "Bouncer: {value}",

--- a/ui/src/locales/fr/containerComponents.json
+++ b/ui/src/locales/fr/containerComponents.json
@@ -182,7 +182,11 @@
       "emptyState": "Aucun conteneur ne correspond à vos filtres",
       "currentLabel": "Actuel",
       "latestLabel": "Dernier",
-      "blockedByBouncer": "Bloqué par Bouncer"
+      "blockedByBouncer": "Bloqué par Bouncer",
+      "registryErrorRateLimited": "Rate limited",
+      "registryErrorAuth": "Auth failed",
+      "registryErrorNotFound": "Not found",
+      "registryErrorCheckFailed": "Check failed"
     },
     "groupHeader": {
       "ungrouped": "Non groupé",
@@ -246,6 +250,8 @@
       "collapseAll": "Tout réduire",
       "recheckTooltip": "Revérifier les mises à jour",
       "columnsHeader": "Colonnes",
+      "narrowViewportSuffix": "(narrow viewport)",
+      "autoHiddenBadgeTooltip": "{count} columns auto-hidden because the window is narrow. Widen the window or hide other columns to free space.",
       "filterSearch": "Recherche : {value}",
       "filterStatus": "État : {value}",
       "filterBouncer": "Bouncer : {value}",

--- a/ui/src/locales/it/containerComponents.json
+++ b/ui/src/locales/it/containerComponents.json
@@ -182,7 +182,11 @@
       "emptyState": "Nessun container corrisponde ai filtri",
       "currentLabel": "Corrente",
       "latestLabel": "Ultima",
-      "blockedByBouncer": "Bloccato da Bouncer"
+      "blockedByBouncer": "Bloccato da Bouncer",
+      "registryErrorRateLimited": "Rate limited",
+      "registryErrorAuth": "Auth failed",
+      "registryErrorNotFound": "Not found",
+      "registryErrorCheckFailed": "Check failed"
     },
     "groupHeader": {
       "ungrouped": "Non raggruppati",
@@ -246,6 +250,8 @@
       "collapseAll": "Comprimi tutto",
       "recheckTooltip": "Ricontrolla aggiornamenti",
       "columnsHeader": "Colonne",
+      "narrowViewportSuffix": "(narrow viewport)",
+      "autoHiddenBadgeTooltip": "{count} columns auto-hidden because the window is narrow. Widen the window or hide other columns to free space.",
       "filterSearch": "Ricerca: {value}",
       "filterStatus": "Stato: {value}",
       "filterBouncer": "Bouncer: {value}",

--- a/ui/src/locales/nl/containerComponents.json
+++ b/ui/src/locales/nl/containerComponents.json
@@ -182,7 +182,11 @@
       "emptyState": "Er zijn geen containers die overeenkomen met uw filters",
       "currentLabel": "Huidig",
       "latestLabel": "Nieuwste",
-      "blockedByBouncer": "Geblokkeerd door Bouncer"
+      "blockedByBouncer": "Geblokkeerd door Bouncer",
+      "registryErrorRateLimited": "Rate limited",
+      "registryErrorAuth": "Auth failed",
+      "registryErrorNotFound": "Not found",
+      "registryErrorCheckFailed": "Check failed"
     },
     "groupHeader": {
       "ungrouped": "Niet gegroepeerd",
@@ -246,6 +250,8 @@
       "collapseAll": "Alles samenvouwen",
       "recheckTooltip": "Controleer opnieuw op updates",
       "columnsHeader": "Kolommen",
+      "narrowViewportSuffix": "(narrow viewport)",
+      "autoHiddenBadgeTooltip": "{count} columns auto-hidden because the window is narrow. Widen the window or hide other columns to free space.",
       "filterSearch": "Zoeken: {value}",
       "filterStatus": "Status: {value}",
       "filterBouncer": "Bouncer: {value}",

--- a/ui/src/locales/pl/containerComponents.json
+++ b/ui/src/locales/pl/containerComponents.json
@@ -182,7 +182,11 @@
       "emptyState": "Żadne kontenery nie pasują do wybranych filtrów",
       "currentLabel": "Aktualny",
       "latestLabel": "Najnowsze",
-      "blockedByBouncer": "Zablokowany przez Bouncera"
+      "blockedByBouncer": "Zablokowany przez Bouncera",
+      "registryErrorRateLimited": "Rate limited",
+      "registryErrorAuth": "Auth failed",
+      "registryErrorNotFound": "Not found",
+      "registryErrorCheckFailed": "Check failed"
     },
     "groupHeader": {
       "ungrouped": "Rozgrupowane",
@@ -246,6 +250,8 @@
       "collapseAll": "Zwiń wszystko",
       "recheckTooltip": "Sprawdź ponownie dostępność aktualizacji",
       "columnsHeader": "Kolumny",
+      "narrowViewportSuffix": "(narrow viewport)",
+      "autoHiddenBadgeTooltip": "{count} columns auto-hidden because the window is narrow. Widen the window or hide other columns to free space.",
       "filterSearch": "Szukaj: {value}",
       "filterStatus": "Stan: {value}",
       "filterBouncer": "Bouncer: {value}",

--- a/ui/src/locales/pt-BR/containerComponents.json
+++ b/ui/src/locales/pt-BR/containerComponents.json
@@ -182,7 +182,11 @@
       "emptyState": "Nenhum contêiner corresponde aos filtros",
       "currentLabel": "Atual",
       "latestLabel": "Mais recente",
-      "blockedByBouncer": "Bloqueado pelo Bouncer"
+      "blockedByBouncer": "Bloqueado pelo Bouncer",
+      "registryErrorRateLimited": "Rate limited",
+      "registryErrorAuth": "Auth failed",
+      "registryErrorNotFound": "Not found",
+      "registryErrorCheckFailed": "Check failed"
     },
     "groupHeader": {
       "ungrouped": "Sem grupo",
@@ -246,6 +250,8 @@
       "collapseAll": "Recolher tudo",
       "recheckTooltip": "Verificar atualizações novamente",
       "columnsHeader": "Colunas",
+      "narrowViewportSuffix": "(narrow viewport)",
+      "autoHiddenBadgeTooltip": "{count} columns auto-hidden because the window is narrow. Widen the window or hide other columns to free space.",
       "filterSearch": "Busca: {value}",
       "filterStatus": "Status: {value}",
       "filterBouncer": "Bouncer: {value}",

--- a/ui/src/locales/tr/containerComponents.json
+++ b/ui/src/locales/tr/containerComponents.json
@@ -182,7 +182,11 @@
       "emptyState": "Filtrelerinizle eşleşen kapsayıcı yok",
       "currentLabel": "Mevcut",
       "latestLabel": "En son",
-      "blockedByBouncer": "Bouncer tarafından engellendi"
+      "blockedByBouncer": "Bouncer tarafından engellendi",
+      "registryErrorRateLimited": "Rate limited",
+      "registryErrorAuth": "Auth failed",
+      "registryErrorNotFound": "Not found",
+      "registryErrorCheckFailed": "Check failed"
     },
     "groupHeader": {
       "ungrouped": "Gruplandırılmamış",
@@ -246,6 +250,8 @@
       "collapseAll": "Tümünü daralt",
       "recheckTooltip": "Güncellemeleri tekrar kontrol edin",
       "columnsHeader": "Sütunlar",
+      "narrowViewportSuffix": "(narrow viewport)",
+      "autoHiddenBadgeTooltip": "{count} columns auto-hidden because the window is narrow. Widen the window or hide other columns to free space.",
       "filterSearch": "Arama: {value}",
       "filterStatus": "Durum: {value}",
       "filterBouncer": "Bouncer: {value}",

--- a/ui/src/locales/zh-CN/agentsView.json
+++ b/ui/src/locales/zh-CN/agentsView.json
@@ -60,8 +60,8 @@
         "reset": "重置",
         "refresh": "刷新",
         "emptyMessage": "当前筛选条件下没有日志条目。",
-        "lastFetched": "上次获取：{time}",
-        "entries": "{count} 条日志",
+        "lastFetched": "最后获取时间：{time}",
+        "entries": "{count} 条记录",
         "statusLive": "在线",
         "statusOffline": "离线"
       },
@@ -78,7 +78,7 @@
         "agentVersion": "代理版本",
         "logLevel": "日志级别",
         "pollInterval": "轮询间隔",
-        "dockerSocket": "Docker 套接字",
+        "dockerSocket": "Docker Socket",
         "lastSeen": "最后活跃",
         "never": "从未"
       },

--- a/ui/src/locales/zh-CN/appShell.json
+++ b/ui/src/locales/zh-CN/appShell.json
@@ -5,12 +5,12 @@
     },
     "logViewer": {
       "toolbar": {
-        "resume": "继续",
+        "resume": "恢复",
         "pause": "暂停",
         "unpinAutoScroll": "取消固定自动滚动",
         "pinAutoScroll": "固定自动滚动",
         "newestFirst": "最新在前",
-        "oldestFirst": "最早在前",
+        "oldestFirst": "最旧在前",
         "regexToggle": ".* 正则",
         "showMatchesOnly": "仅显示匹配项",
         "showingMatchesOnly": "仅显示匹配项",
@@ -36,7 +36,7 @@
       "tooltip": "通知",
       "header": "通知",
       "clear": "清除",
-      "loading": "正在加载...",
+      "loading": "加载中...",
       "empty": "暂无通知",
       "markAllRead": "全部标记为已读",
       "openAuditLog": "打开审计日志",
@@ -56,7 +56,7 @@
         "systemLogs": "系统日志",
         "manageGroup": "管理",
         "hosts": "主机",
-        "registries": "镜像仓库",
+        "registries": "仓库",
         "watchers": "监视器",
         "settingsGroup": "设置",
         "general": "通用",
@@ -97,9 +97,9 @@
         "refreshing": "正在刷新搜索索引...",
         "noMatches": "没有找到 \"{query}\" 的匹配项。",
         "hint": "输入以搜索页面、容器、代理、触发器、监视器和设置。",
-        "prefixScopeHint": "前缀范围已启用；使用 ",
+        "prefixScopeHint": "前缀作用域已激活",
         "typeHint": "输入",
-        "useTab": " 切换范围",
+        "useTab": " 以更改作用域",
         "moveHint": "移动",
         "openHint": "打开"
       },
@@ -107,7 +107,7 @@
         "lostTitle": "连接丢失",
         "applyingUpdateTitle": "正在应用更新",
         "lostMessage": "服务器无法访问。正在等待其重新上线...",
-        "restartingMessage": "Drydock 自更新后正在重启{opId}。服务恢复后将重新连接...",
+        "restartingMessage": "Drydock 正在重新启动{opId}。服务恢复后将重新连接...",
         "reconnecting": "重新连接中",
         "restartingService": "重启服务中"
       }
@@ -124,8 +124,8 @@
       "oidcHttpTitle": "检测到 HTTP OIDC 发现",
       "legacyHashTitle": "检测到旧版密码哈希",
       "curlHealthcheckTitle": "检测到自定义 curl 健康检查覆盖",
-      "envKeysLabel": "环境变量键 ({count}): {keys}",
-      "labelKeysLabel": "标签键 ({count}): {keys}",
+      "envKeysLabel": "环境变量密钥 ({count}): {keys}",
+      "labelKeysLabel": "标签 ({count}): {keys}",
       "apiPathsLabel": "API 路径 ({count}): {keys}",
       "healthcheckCommandLabel": "健康检查命令：{command}"
     }

--- a/ui/src/locales/zh-CN/authView.json
+++ b/ui/src/locales/zh-CN/authView.json
@@ -1,15 +1,15 @@
 {
   "authView": {
-    "loadingProviders": "正在加载身份验证提供方...",
-    "loadError": "无法加载身份验证提供方",
+    "loadingProviders": "正在加载身份验证提供者...",
+    "loadError": "无法加载身份验证提供者",
     "filterPlaceholder": "按名称筛选...",
     "clearFilter": "清除",
-    "emptyFiltered": "没有提供方符合筛选条件",
+    "emptyFiltered": "没有匹配筛选条件的提供者",
     "detailRefreshing": "正在刷新身份验证详情...",
     "detailLoadError": "无法加载最新的身份验证详情",
     "noConfig": "无配置属性",
     "columns": {
-      "provider": "提供方",
+      "provider": "提供者",
       "type": "类型",
       "status": "状态"
     },
@@ -17,7 +17,7 @@
       "status": "状态"
     },
     "badge": {
-      "basic": "Basic",
+      "basic": "基本",
       "oidc": "OIDC"
     }
   }

--- a/ui/src/locales/zh-CN/common.json
+++ b/ui/src/locales/zh-CN/common.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "loading": "正在加载…",
+    "loading": "加载中...",
     "back": "返回",
     "cancel": "取消",
     "save": "保存",

--- a/ui/src/locales/zh-CN/configView.json
+++ b/ui/src/locales/zh-CN/configView.json
@@ -7,7 +7,7 @@
     },
     "general": {
       "application": {
-        "title": "应用",
+        "title": "应用程序",
         "loadingServerInfo": "正在加载服务器信息"
       },
       "store": {
@@ -17,7 +17,7 @@
         "title": "Webhook API",
         "enabled": "已启用",
         "disabled": "已禁用",
-        "description": "使用这些端点通过 HTTP 触发监视周期和更新。所有请求都需要在 Authorization 标头中携带 Bearer 令牌。",
+        "description": "使用这些端点通过 HTTP 触发监视周期和更新。所有请求都需要在 Authorization 头中携带 Bearer 令牌。",
         "disabledMessage": "Webhook API 已禁用。请设置",
         "disabledHint": "Webhook API 已禁用。请设置 {envEnabled} 并配置至少一个令牌（{envToken} 或 {envTokens}）以启用它。",
         "table": {
@@ -35,7 +35,7 @@
         "title": "网络",
         "internetlessMode": {
           "label": "离线模式",
-          "description": "阻止所有出站请求（容器图标、外部请求）"
+          "description": "阻止所有出站请求（容器图标、外部获取）"
         }
       },
       "iconCache": {
@@ -51,8 +51,8 @@
         "title": "诊断",
         "debugDump": {
           "label": "诊断调试转储",
-          "description": "下载用于故障排查的运行时状态脱敏 JSON 快照",
-          "preparing": "正在准备...",
+          "description": "下载用于故障排除的运行时状态精简 JSON 快照",
+          "preparing": "准备中...",
           "download": "下载调试转储"
         }
       },
@@ -126,7 +126,7 @@
         "username": "用户名",
         "email": "邮箱",
         "role": "角色",
-        "provider": "提供方",
+        "provider": "提供者",
         "lastLogin": "上次登录",
         "activeSessions": "活跃会话"
       }
@@ -150,7 +150,7 @@
         "500": "末尾 500 条",
         "1000": "末尾 1000 条"
       },
-      "logLevelBadge": "服务器日志级别：{level}。仅捕获该级别及以上的消息。"
+      "logLevelBadge": "服务器日志级别：{level}。仅捕获此级别及更高级别的消息。"
     }
   }
 }

--- a/ui/src/locales/zh-CN/containerComponents.json
+++ b/ui/src/locales/zh-CN/containerComponents.json
@@ -15,8 +15,8 @@
       "snoozeUntil": "推迟至",
       "unsnooze": "取消推迟",
       "maturityGroup": "成熟度",
-      "allowNewMature": "允许新版本和成熟版本",
-      "matureOnly": "仅成熟版本",
+      "allowNewMature": "允许新的 + 成熟",
+      "matureOnly": "仅成熟",
       "applyMaturity": "应用成熟度",
       "clearMaturity": "清除成熟度",
       "resetGroup": "重置",
@@ -24,16 +24,16 @@
       "clearPolicy": "清除策略",
       "snoozedUntil": "推迟至：",
       "maturityMode": "成熟度模式：",
-      "matureOnlyMinimum": "仅成熟版本（至少 {days} 天）",
+      "matureOnlyMinimum": "仅成熟（{days} 天最低）",
       "allowAllUpdates": "允许所有更新",
       "skippedTags": "跳过的标签：",
       "skippedDigests": "跳过的摘要：",
       "noActivePolicy": "无活动更新策略。",
-      "removeSkip": "取消跳过",
+      "removeSkip": "移除跳过",
       "previewSection": "预览",
       "generatingPreview": "正在生成预览...",
       "currentLabel": "当前：",
-      "newLabel": "新版：",
+      "newLabel": "新：",
       "updateKindLabel": "更新类型：",
       "runningLabel": "运行中：",
       "networksLabel": "网络：",
@@ -41,7 +41,7 @@
       "composeFilesLabel": "Compose 文件：",
       "composeServiceLabel": "Compose 服务：",
       "writableFileLabel": "可写文件：",
-      "writesComposeFileLabel": "写入 Compose 文件：",
+      "writesComposeFileLabel": "写入 compose 文件：",
       "patchPreviewLabel": "补丁预览：",
       "previewEmptyState": "运行预览以检查计划的更新操作。",
       "associatedTriggers": "关联的触发器",
@@ -51,7 +51,7 @@
       "noTriggersAssociated": "此容器没有关联的触发器",
       "backupsRollback": "备份与回滚",
       "rollingBack": "回滚中...",
-      "rollbackLatest": "回滚到最新备份",
+      "rollbackLatest": "回滚到最新",
       "loadingBackups": "正在加载备份...",
       "rollingButton": "回滚中...",
       "useButton": "使用",
@@ -61,7 +61,7 @@
       "phaseLabel": "阶段：",
       "versionLabel": "版本：",
       "rollbackReasonLabel": "回滚原因：",
-      "lastErrorLabel": "上次错误：",
+      "lastErrorLabel": "最后错误：",
       "noUpdateOperations": "暂无更新操作记录"
     },
     "fullPageDetail": {
@@ -157,7 +157,7 @@
       "statusScanningPhase": "扫描中…",
       "statusGeneratingSbom": "生成 SBOM 中…",
       "statusHealthChecking": "健康检查中…",
-      "statusFinalizing": "收尾中…",
+      "statusFinalizing": "完成中…",
       "statusRollingBack": "回滚中…",
       "lastUpdateFailed": "上次更新失败：{reason}",
       "stopAction": "停止",
@@ -182,7 +182,11 @@
       "emptyState": "没有容器匹配您的筛选条件",
       "currentLabel": "当前",
       "latestLabel": "最新",
-      "blockedByBouncer": "被 Bouncer 阻止"
+      "blockedByBouncer": "被 Bouncer 阻止",
+      "registryErrorRateLimited": "速率限制",
+      "registryErrorAuth": "验证失败",
+      "registryErrorNotFound": "未找到",
+      "registryErrorCheckFailed": "检查失败"
     },
     "groupHeader": {
       "ungrouped": "未分组",
@@ -246,6 +250,8 @@
       "collapseAll": "全部折叠",
       "recheckTooltip": "重新检查更新",
       "columnsHeader": "列",
+      "narrowViewportSuffix": "(窄视图)",
+      "autoHiddenBadgeTooltip": "因窗口宽度不足，自动隐藏了 ({count}) 列。请拉宽窗口，或隐藏其他列以腾出空间。",
       "filterSearch": "搜索：{value}",
       "filterStatus": "状态：{value}",
       "filterBouncer": "Bouncer：{value}",
@@ -259,7 +265,7 @@
     "stats": {
       "paused": "已暂停",
       "live": "实时",
-      "heartbeatActive": "心跳正常",
+      "heartbeatActive": "心跳活动中",
       "resume": "恢复",
       "pause": "暂停",
       "loadingStats": "正在加载容器统计信息...",
@@ -267,19 +273,19 @@
       "cpu": "CPU",
       "memory": "内存",
       "networkRxTx": "网络 RX/TX",
-      "blockIo": "块设备 I/O"
+      "blockIo": "块 I/O"
     },
     "updateDialog": {
       "title": "更新容器",
       "confirmTagChange": "更新 {name}？这将把镜像标签从 :{currentTag} 更改为 :{newTag}{kind}。",
-      "confirmDigestChange": "更新 {name}？:{currentTag} 有较新的构建可用（摘要变更）。",
-      "confirmLatest": "立即更新 {name}？这将应用最新检测到的镜像。",
+      "confirmDigestChange": "更新 {name}？:{currentTag} 有更新的构建版本可用（摘要变更）。",
+      "confirmLatest": "立即更新 {name}？这将应用最新发现的镜像。",
       "updating": "更新中...",
       "update": "更新"
     },
     "floatingTag": {
       "badgeText": "浮动标签",
-      "tooltip": "镜像仓库可能会直接更新此标签。启用 dd.watch.digest=true 或使用完整的 semver 标签以完整检测更新。"
+      "tooltip": "此标签可能会被仓库就地更新。启用 dd.watch.digest=true 或使用完整 semver 标签以完整检测更新。"
     },
     "projectLink": {
       "viewProject": "查看项目"
@@ -292,20 +298,20 @@
     },
     "suggestedTag": {
       "badgeText": "建议",
-      "tooltip": "可用的最佳稳定 semver 标签 — 建议固定到该标签"
+      "tooltip": "可用的最佳稳定 semver 标签 — 建议固定使用"
     },
     "eligibilityBadges": {
-      "securityBlocked": "因安全检查被阻止",
+      "securityBlocked": "安全阻止",
       "rolledBack": "已回滚",
       "snoozed": "已推迟",
-      "tagSkipped": "已跳过标签",
-      "digestSkipped": "已跳过摘要",
+      "tagSkipped": "标签已跳过",
+      "digestSkipped": "摘要已跳过",
       "maturing": "成熟中",
       "belowThreshold": "低于阈值",
       "rollback": "回滚",
       "inProgress": "进行中",
-      "triggerExcluded": "触发器已排除",
-      "triggerFiltered": "触发器已筛除",
+      "triggerExcluded": "触发器排除",
+      "triggerFiltered": "触发器筛选",
       "agentMismatch": "代理不匹配",
       "noTrigger": "无触发器",
       "liftsLabel": "解除条件："

--- a/ui/src/locales/zh-CN/containerLogs.json
+++ b/ui/src/locales/zh-CN/containerLogs.json
@@ -3,7 +3,7 @@
     "backTooltip": "返回容器列表",
     "title": "容器日志",
     "loading": "正在加载容器...",
-    "notFound": "未找到容器“{name}”",
+    "notFound": "未找到容器 \"{name}\"",
     "loadFailed": "无法加载容器信息"
   }
 }

--- a/ui/src/locales/zh-CN/containersView.json
+++ b/ui/src/locales/zh-CN/containersView.json
@@ -14,8 +14,8 @@
       "updateAlreadyInProgress": "此组中部分容器已有更新进行中",
       "batchUpdated": "已更新 {group} 中的 {count} 个容器",
       "batchUpdatedNoGroup": "已更新 {count} 个容器",
-      "batchPartial": "{group} 中已更新 {succeeded}/{total} 个容器；{failed} 个失败",
-      "batchPartialNoGroup": "已更新 {succeeded}/{total} 个容器；{failed} 个失败",
+      "batchPartial": "已更新 {group} 中 {total} 个容器中的 {succeeded} 个；{failed} 个失败",
+      "batchPartialNoGroup": "已更新 {total} 个容器中的 {succeeded} 个；{failed} 个失败",
       "batchFailed": "无法更新 {group} 中的 {count} 个容器",
       "batchFailedNoGroup": "无法更新 {count} 个容器",
       "unknownGroup": "未知组"

--- a/ui/src/locales/zh-CN/dashboardView.json
+++ b/ui/src/locales/zh-CN/dashboardView.json
@@ -2,7 +2,7 @@
   "dashboardView": {
     "loading": "正在加载仪表盘...",
     "loadFailed": "无法加载仪表盘",
-    "dragToReorder": "拖动重新排序",
+    "dragToReorder": "拖动以重新排序",
     "viewAll": "查看全部 →",
     "editToggle": {
       "showWidgetPanel": "显示小部件面板",
@@ -12,17 +12,17 @@
     "widgetPanel": {
       "title": "小部件",
       "closePanel": "关闭面板",
-      "resetToDefault": "恢复默认"
+      "resetToDefault": "重置为默认"
     },
     "confirm": {
       "updateContainer": {
         "header": "更新容器",
-        "message": "立即更新 {name}？这会应用最新发现的镜像。",
+        "message": "立即更新 {name}？这将应用最新发现的镜像。",
         "accept": "更新"
       },
       "updateAll": {
         "header": "更新所有容器",
-        "message": "将更新 {count} 个容器。要继续吗？",
+        "message": "{count} 个容器将被更新。继续吗？",
         "accept": "全部更新"
       }
     },
@@ -41,7 +41,7 @@
       "updateAll": "全部更新",
       "noUpdates": "没有可用更新",
       "releaseNotes": "发布说明",
-      "securityBlocked": "安全策略已阻止",
+      "securityBlocked": "被安全机制阻止",
       "updateContainer": "更新容器",
       "compactSingle": "{count} 个可用更新",
       "compactPlural": "{count} 个可用更新",
@@ -64,13 +64,13 @@
     },
     "resourceUsage": {
       "title": "资源使用",
-      "totalUsage": "总使用量（监视 {watched} 个容器）",
-      "cpu": "平均 CPU",
+      "totalUsage": "总使用量（监视 {watched} 个）",
+      "cpu": "CPU",
       "memory": "内存",
-      "topCpu": "CPU 占用最高",
-      "topMemory": "内存占用最高",
-      "noCpuData": "暂无实时 CPU 数据",
-      "noMemoryData": "暂无实时内存数据"
+      "topCpu": "CPU 最高",
+      "topMemory": "内存最高",
+      "noCpuData": "无实时 CPU 数据",
+      "noMemoryData": "无实时内存数据"
     },
     "securityOverview": {
       "title": "安全概览",
@@ -84,7 +84,7 @@
       "medium": "{count} 个中危",
       "low": "{count} 个低危",
       "topVulnerabilities": "主要漏洞",
-      "noVulnerabilities": "未报告漏洞"
+      "noVulnerabilities": "未报告任何漏洞"
     },
     "updateBreakdown": {
       "title": "更新分布",

--- a/ui/src/locales/zh-CN/listViews.json
+++ b/ui/src/locales/zh-CN/listViews.json
@@ -14,7 +14,7 @@
       "previousPage": "上一页",
       "nextPage": "下一页"
     },
-    "emptyFiltered": "没有审计记录符合筛选条件",
+    "emptyFiltered": "没有审计记录匹配您的筛选条件",
     "columns": {
       "time": "时间",
       "event": "事件",
@@ -30,8 +30,8 @@
       "timestamp": "时间戳",
       "event": "事件",
       "image": "镜像",
-      "fromVersion": "原版本",
-      "toVersion": "目标版本",
+      "fromVersion": "从版本",
+      "toVersion": "到版本",
       "trigger": "触发器",
       "details": "详情"
     }
@@ -49,17 +49,17 @@
       "triggers": "触发器"
     },
     "toggleAriaLabel": "切换通知规则",
-    "emptyFiltered": "没有通知规则符合筛选条件",
+    "emptyFiltered": "没有通知规则匹配您的筛选条件",
     "detail": {
       "ruleStatusLabel": "规则状态",
       "ruleStatusAriaLabel": "规则状态",
       "enabledText": "已启用：此事件可以触发通知。",
-      "disabledText": "已禁用：此事件不会发送通知。",
-      "assignedTriggersLabel": "已分配的触发器",
+      "disabledText": "已禁用：此事件的通知被抑制。",
+      "assignedTriggersLabel": "分配的触发器",
       "noTriggersConfigured": "未配置触发器。请在",
       "triggersPageLink": "触发器页面",
-      "helpTextImplicitAll": "留空会将此事件发送给所有通知触发器。选择任何触发器后，此规则会变为允许列表。",
-      "helpTextExplicit": "只有选定的触发器会收到此事件。留空会禁止向所有触发器发送此事件。",
+      "helpTextImplicitAll": "留空将此事件发送到所有通知触发器。选择任何触发器会将此规则转为允许列表。",
+      "helpTextExplicit": "只有选定的触发器会接收此事件。留空会抑制此事件对所有触发器的通知。",
       "saving": "保存中...",
       "saveChanges": "保存更改",
       "reset": "重置",
@@ -81,7 +81,7 @@
       "severityHigh": "高危",
       "severityMedium": "中危",
       "severityLow": "低危",
-      "fixAvailable": "有可用修复",
+      "fixAvailable": "修复可用",
       "fixYes": "是",
       "fixNo": "否",
       "clearAll": "清除全部"
@@ -97,9 +97,9 @@
     },
     "card": {
       "vulnerabilities": "个漏洞",
-      "vsUpdate": "与更新相比",
+      "vsUpdate": "对比更新",
       "fixable": "可修复",
-      "noFixesAvailable": "无可用修复",
+      "noFixesAvailable": "没有可用修复",
       "total": "总计"
     },
     "badge": {
@@ -137,13 +137,13 @@
     }
   },
   "registriesView": {
-    "loadingRegistries": "正在加载镜像仓库...",
-    "loadError": "无法加载镜像仓库",
+    "loadingRegistries": "正在加载仓库...",
+    "loadError": "无法加载仓库",
     "filterPlaceholder": "按名称或类型筛选...",
     "clear": "清除",
-    "emptyFiltered": "没有镜像仓库符合筛选条件",
+    "emptyFiltered": "没有仓库匹配您的筛选条件",
     "columns": {
-      "registry": "镜像仓库",
+      "registry": "仓库",
       "type": "类型",
       "status": "状态",
       "url": "URL"
@@ -157,7 +157,7 @@
       "status": "状态"
     },
     "detail": {
-      "refreshing": "正在刷新镜像仓库详情...",
+      "refreshing": "正在刷新仓库详情...",
       "status": "状态",
       "authentication": "认证",
       "url": "URL"

--- a/ui/src/locales/zh-CN/loginView.json
+++ b/ui/src/locales/zh-CN/loginView.json
@@ -15,13 +15,13 @@
     },
     "separator": "或使用以下方式继续",
     "rememberMe": "记住我",
-    "noMethods": "未配置身份验证方式。",
+    "noMethods": "未配置任何身份验证方法。",
     "errors": {
-      "loadFailed": "无法加载身份验证方式",
+      "loadFailed": "无法加载身份验证方法",
       "invalidCredentials": "用户名或密码无效",
       "oidcFailed": "无法连接到 {name}",
-      "providerBasic": "基本身份验证 '{name}'：{error}",
-      "providerOidc": "OIDC 提供方 '{name}'：{error}",
+      "providerBasic": "基本认证 '{name}'：{error}",
+      "providerOidc": "OIDC 提供者 '{name}'：{error}",
       "providerNamed": "{type} '{name}'：{error}",
       "providerGeneric": "{provider}：{error}"
     },

--- a/ui/src/locales/zh-CN/logsView.json
+++ b/ui/src/locales/zh-CN/logsView.json
@@ -1,5 +1,5 @@
 {
   "logsView": {
-    "loadFailed": "无法加载应用日志"
+    "loadFailed": "无法加载应用程序日志"
   }
 }

--- a/ui/src/locales/zh-CN/sharedComponents.json
+++ b/ui/src/locales/zh-CN/sharedComponents.json
@@ -45,10 +45,10 @@
     },
     "securityEmptyState": {
       "noDataTitle": "暂无漏洞数据",
-      "noDataBody": "运行扫描以检查容器是否存在已知漏洞",
-      "filteredTitle": "没有镜像符合筛选条件",
+      "noDataBody": "运行扫描以检查您的容器的已知漏洞",
+      "filteredTitle": "没有镜像匹配您的筛选条件",
       "clearFilters": "清除所有筛选",
-      "setupGuide": "配置指南",
+      "setupGuide": "设置指南",
       "scanNow": "立即扫描"
     }
   }

--- a/ui/src/locales/zh-TW/agentsView.json
+++ b/ui/src/locales/zh-TW/agentsView.json
@@ -66,7 +66,7 @@
         "statusOffline": "離線"
       },
       "fields": {
-        "cpus": "CPUs",
+        "cpus": "CPU",
         "memory": "記憶體",
         "images": "映像檔",
         "uptime": "執行時間",

--- a/ui/src/locales/zh-TW/appShell.json
+++ b/ui/src/locales/zh-TW/appShell.json
@@ -125,7 +125,7 @@
       "legacyHashTitle": "偵測到舊版密碼雜湊",
       "curlHealthcheckTitle": "偵測到自訂 curl 健康檢查覆蓋",
       "envKeysLabel": "環境變數金鑰 ({count}): {keys}",
-      "labelKeysLabel": "Label keys ({count}): {keys}",
+      "labelKeysLabel": "標籤 ({count}): {keys}",
       "apiPathsLabel": "API 路徑 ({count}): {keys}",
       "healthcheckCommandLabel": "健康檢查命令：{command}"
     }

--- a/ui/src/locales/zh-TW/containerComponents.json
+++ b/ui/src/locales/zh-TW/containerComponents.json
@@ -182,7 +182,11 @@
       "emptyState": "沒有容器匹配您的篩選條件",
       "currentLabel": "目前",
       "latestLabel": "最新",
-      "blockedByBouncer": "被 Bouncer 阻止"
+      "blockedByBouncer": "被 Bouncer 阻止",
+      "registryErrorRateLimited": "速率限制",
+      "registryErrorAuth": "認證失敗",
+      "registryErrorNotFound": "未找到",
+      "registryErrorCheckFailed": "檢查失敗"
     },
     "groupHeader": {
       "ungrouped": "未分組",
@@ -246,6 +250,8 @@
       "collapseAll": "全部摺疊",
       "recheckTooltip": "重新檢查更新",
       "columnsHeader": "列",
+      "narrowViewportSuffix": "(窄視圖)",
+      "autoHiddenBadgeTooltip": "視窗寬度不足，已自動隱藏 ({count}) 欄。請拉寬視窗，或隱藏其他欄位以釋放空間。",
       "filterSearch": "搜尋：{value}",
       "filterStatus": "狀態：{value}",
       "filterBouncer": "Bouncer：{value}",


### PR DESCRIPTION
## Summary
Pre-rc.18 fixes that need to land **before** the next release-cut so rc.18 ships in single-digit minutes instead of hanging on multi-arch arm64 build:

1. **🔧 CI bulletproofing** — retry wrappers + cache `ignore-error=true` across ci-verify, release-cut, snyk-weekly, scorecard, mutation-monthly. Lefthook now gates commit-msg + opt-in docker-build.
2. **🔒 zizmor cleanup** — moves `${{ steps.X.outcome }}` references to env to clear template-injection findings introduced by the new Snyk per-scan gates.
3. **⚡ Cross-workflow Docker layer cache** — relocates `ARG/ENV DD_VERSION` from the `base` stage to the final `release` stage, and pins explicit `scope=drydock` on every `cache-{from,to}: type=gha` so ci-verify, release-cut, and snyk-container all share layer cache.
4. **🐛 shellcheck SC2015 fixes** — replaces `A && break || sleep` antipattern with explicit `if ! cmd; then sleep` in the new retry loops.
5. **🌍 Crowdin sync** — translation updates that previously lived in PR #352 / #353 (now closed/superseded).

## Why
rc.18 release-cut today hung 70+ min on `Build and push` step at `[linux/arm64 ui-build] vite build` — DD_VERSION change cache-busted the npm-ci/build layers, forcing a cold arm64 emulated rebuild. With this PR merged, ci-verify primes the shared `scope=drydock` cache, and release-cut hits cache for every heavy layer → no cold arm64 rebuild → ships in ~5 min.

## Test plan
- [ ] CI Verify green on this PR
- [ ] After merge, dispatch release-cut for v1.5.0-rc.18 and confirm Build-and-push completes in single-digit minutes (vs the 70+ min hang)