### PR TITLE
Fix rc.21 Playwright outbox empty-state capitalization

### DIFF
--- a/ui/src/locales/en/notificationOutboxView.json
+++ b/ui/src/locales/en/notificationOutboxView.json
@@ -24,7 +24,11 @@
       "pending": "Pending",
       "delivered": "Delivered"
     },
-    "empty": "No {status} entries",
+    "empty": {
+      "dead-letter": "No dead-letter entries",
+      "pending": "No pending entries",
+      "delivered": "No delivered entries"
+    },
     "toast": {
       "requeued": "Requeued: {name}",
       "discarded": "Discarded: {name}",

--- a/ui/src/views/NotificationOutboxView.vue
+++ b/ui/src/views/NotificationOutboxView.vue
@@ -312,7 +312,7 @@ onMounted(() => {
         </div>
       </template>
       <template #empty>
-        <EmptyState icon="notifications" :message="t('notificationOutboxView.empty', { status: t(`notificationOutboxView.tabs.${status}`) })" />
+        <EmptyState icon="notifications" :message="t(`notificationOutboxView.empty.${status}`)" />
       </template>
     </DataTable>
   </DataViewLayout>


### PR DESCRIPTION
## Summary

The rc.21 tail PR (#366) extracted the notification outbox empty-state into the i18n catalog as a single template `"No {status} entries"` interpolating the tab label. Tab labels are capitalized (`"Dead-letter"`), so the interpolated message rendered `"No Dead-letter entries"` — breaking 4 existing Playwright scenarios that assert the lowercase noun form `"No dead-letter entries"`.

This was the blocker that failed the rc.21 release-cut on commit `9d877d63` (post-merge CI Verify).

### Fixed
- 🐛 Splits `notificationOutboxView.empty` into a per-status map (`dead-letter`, `pending`, `delivered`) so the empty-state copy uses the lowercase noun while tab labels keep their capitalized display form. Vue template now reads `t(\`notificationOutboxView.empty.\${status}\`)` directly.

## Test plan
- [ ] CI Verify passes (Playwright outbox scenarios were the blocker)
- [ ] After merge: dispatch `release-cut.yml` from main with `release_tag=v1.5.0-rc.21` (3rd attempt)