### PR TITLE
🐛 fix(quality): repair UI mutation slices and dashboard publish visibility

### DIFF
--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -264,6 +264,10 @@ jobs:
           REPO_SLUG: ${{ github.repository }}
           REF_NAME: ${{ github.ref_name }}
         run: |
+          # Each attempt's exit code must come from curl directly. The previous
+          # `rc=$?` ran after the `if` compound command, which is always 0 when
+          # the condition is false — so a failed publish (e.g. HTTP 401) was
+          # silently reported as success. Exit explicitly per outcome instead.
           for attempt in 1 2 3; do
             if curl \
               --fail-with-body \
@@ -272,14 +276,16 @@ jobs:
               --header "Content-Type: application/json" \
               --data @artifacts/aggregate/mutation-score.json \
               "https://dashboard.stryker-mutator.io/api/reports/github.com/${REPO_SLUG}/${REF_NAME}"; then
-              break
+              echo "Published mutation score to Stryker dashboard."
+              exit 0
             fi
-            rc=$?
-            if [ "$attempt" -eq 3 ]; then
-              exit "$rc"
+            echo "::warning::Dashboard publish attempt ${attempt} failed."
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((5 * attempt))
             fi
-            sleep $((5*attempt))
           done
+          echo "::error::Failed to publish mutation score to Stryker dashboard after 3 attempts."
+          exit 1
 
       - name: Upload aggregate mutation summary
         if: always()

--- a/ui/stryker.conf.mjs
+++ b/ui/stryker.conf.mjs
@@ -6,7 +6,7 @@ const config = {
   testRunner: 'vitest',
   checkers: ['typescript'],
   tsconfigFile: 'tsconfig.json',
-  coverageAnalysis: 'perTest',
+  coverageAnalysis: 'off',
   reporters: [
     'clear-text',
     'progress',
@@ -30,7 +30,7 @@ const config = {
       }
     : {}),
   vitest: {
-    configFile: 'vitest.config.ts',
+    configFile: 'vitest.stryker.config.ts',
     related: false,
   },
   incremental: true,

--- a/ui/vitest.stryker.config.ts
+++ b/ui/vitest.stryker.config.ts
@@ -1,0 +1,32 @@
+/**
+ * Vitest config used exclusively by Stryker mutation testing.
+ *
+ * Stryker copies `ui/` source files into a sandbox directory (under
+ * `.stryker-tmp/`) and sets the worker-process cwd to that sandbox.
+ * Two test files cannot run in that environment:
+ *
+ * 1. tests/vitest.coverage-provider.spec.ts — imports the custom coverage
+ *    provider (`../vitest.coverage-provider.js`) which in turn does a
+ *    cross-workspace import (`../app/vitest.coverage-provider.shared.js`).
+ *    The sandbox only contains `ui/` files, so `../app/` does not exist
+ *    relative to the sandbox root, causing "Failed to resolve import".
+ *
+ * 2. tests/boot/crowdin-config.spec.ts — resolves the repo root via
+ *    `resolve(import.meta.dirname, '../../..')` and reads `crowdin.yml` /
+ *    `.github/workflows/i18n-crowdin.yml`.  Inside the sandbox that path
+ *    lands at `.stryker-tmp/`, not the actual repo root, so the files are
+ *    missing.
+ *
+ * Both tests are purely infrastructure/config validation — they do not cover
+ * application source code, so excluding them here does not hide any mutants.
+ * The real `vitest.config.ts` (used by `npm run test:unit`) is unchanged.
+ */
+
+import { mergeConfig } from 'vitest/config';
+import vitestConfig from './vitest.config';
+
+export default mergeConfig(vitestConfig, {
+  test: {
+    exclude: ['tests/vitest.coverage-provider.spec.ts', 'tests/boot/crowdin-config.spec.ts'],
+  },
+});


### PR DESCRIPTION
Follow-up to #376. With the TypeScript dry-run crash fixed there, the next mutation run ([26010877013](https://github.com/CodesWhat/drydock/actions/runs/26010877013)) exposed two further bugs.

## Bug B — UI slices crash with `No tests were found`

`fix(ui): repair Stryker vitest dry run so UI mutation slices run`

Stryker runs the dry run from a sandbox (`ui/.stryker-tmp/sandbox-XXXXX/`). Two infrastructure test files break there due to relative-path resolution:
- `tests/vitest.coverage-provider.spec.ts` — imports `../app/vitest.coverage-provider.shared.js`, which resolves outside the sandbox.
- `tests/boot/crowdin-config.spec.ts` — resolves the repo root via `../../..`, which lands inside `.stryker-tmp`.

Both throw during the dry run, so Stryker reports `No tests were found` and aborts.

**Fix:** a Stryker-specific `ui/vitest.stryker.config.ts` that extends `vitest.config.ts` and excludes those two infra tests (they cover no `src/` code, so no mutants are hidden); `stryker.conf.mjs` points at it and uses `coverageAnalysis: 'off'` to match the working `app/` config. Verified with a scoped Stryker run — dry run succeeds (3,534 tests) and mutation testing proceeds. `npm run test:unit` and `npm run typecheck` still pass (the regular config is unchanged).

## Bug C — dashboard publish failures reported as success

`fix(ci): surface mutation dashboard publish failures`

The publish retry loop captured `rc=$?` *after* an `if curl ...; fi` compound command — which is always `0` when the condition is false. A failed publish was reported as a successful step. Run 26010877013's publish step "succeeded" while curl actually returned **HTTP 401** on all 3 attempts. Now the step exits 0 only on a real publish, exits 1 after 3 failures, and emits an error annotation.

## ⚠️ Still needed (not in this PR)

The 401 means `STRYKER_DASHBOARD_API_KEY` is invalid/stale and must be regenerated from https://dashboard.stryker-mutator.io. Until then the badge stays `"unknown"` even with these fixes.

## Verification
- Full pre-push gate green (biome, qlty, typecheck-ui, coverage, build, zizmor)
- UI: `typecheck` clean, `test:unit` 3,536 tests pass