### PR TITLE
🐛 fix(quality): unblock ui-shell-and-data mutation slice + rotate cache key

### DIFF
--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -161,8 +161,14 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: ${{ matrix.package }}/${{ matrix.incremental_file }}
-          key: stryker-incremental-${{ matrix.name }}-${{ github.ref_name }}
+          # Append the run number so every run writes a fresh cache entry
+          # (actions/cache never overwrites an existing key). Without this the
+          # incremental baseline froze at the first run and the speedup decayed
+          # as the project drifted from that stale snapshot. restore-keys still
+          # warm-restores the most recent prior baseline by prefix.
+          key: stryker-incremental-${{ matrix.name }}-${{ github.ref_name }}-${{ github.run_number }}
           restore-keys: |
+            stryker-incremental-${{ matrix.name }}-${{ github.ref_name }}-
             stryker-incremental-${{ matrix.name }}-
 
       - name: Run Stryker

--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -124,8 +124,11 @@ jobs:
           - name: ui-shell-and-data
             package: ui
             incremental_file: reports/stryker-incremental-ui-shell-and-data.json
+            # src/boot/i18n.ts is excluded: it uses import.meta.glob(), a Vite
+            # compile-time macro whose argument must stay a literal. Stryker
+            # instrumentation breaks Vite's glob parser and aborts the dry run.
             mutate: >-
-              src/boot/**/*.ts,src/components/**/*.ts,src/composables/**/*.ts,src/i18n/**/*.ts,src/layouts/**/*.ts,src/preferences/**/*.ts,src/services/**/*.ts,src/stores/**/*.ts,src/theme/**/*.ts,src/types/**/*.ts,src/utils/**/*.ts,src/main.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+              src/boot/**/*.ts,src/components/**/*.ts,src/composables/**/*.ts,src/i18n/**/*.ts,src/layouts/**/*.ts,src/preferences/**/*.ts,src/services/**/*.ts,src/stores/**/*.ts,src/theme/**/*.ts,src/types/**/*.ts,src/utils/**/*.ts,src/main.ts,!src/boot/i18n.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
           - name: ui-views-and-navigation
             package: ui
             incremental_file: reports/stryker-incremental-ui-views-and-navigation.json

--- a/ui/stryker.conf.mjs
+++ b/ui/stryker.conf.mjs
@@ -2,7 +2,18 @@ const dashboardReporterEnabled = Boolean(process.env.STRYKER_DASHBOARD_API_KEY);
 
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 const config = {
-  mutate: ['src/**/*.ts', '!src/**/*.typecheck.ts', '!src/**/*.d.ts', '!dist/**', '!coverage/**'],
+  // src/boot/i18n.ts uses import.meta.glob(), a Vite compile-time macro whose
+  // argument must stay a string literal. Stryker instrumentation rewrites that
+  // literal into a mutant switch, which breaks Vite's glob parser and fails
+  // every test that imports the i18n bootstrap. Exclude it from mutation.
+  mutate: [
+    'src/**/*.ts',
+    '!src/boot/i18n.ts',
+    '!src/**/*.typecheck.ts',
+    '!src/**/*.d.ts',
+    '!dist/**',
+    '!coverage/**',
+  ],
   testRunner: 'vitest',
   checkers: ['typescript'],
   tsconfigFile: 'tsconfig.json',


### PR DESCRIPTION
Follow-up to #376 and #377. Run [26028808485](https://github.com/CodesWhat/drydock/actions/runs/26028808485) confirmed `ui-views-and-navigation` now mutates successfully, but `ui-shell-and-data` still aborted. Reproduced in a Linux container and root-caused.

## Bug — `ui-shell-and-data` aborts with `No tests were found`

`🐛 fix(ci): exclude i18n bootstrap from UI mutation scope`

`src/boot/i18n.ts` calls `import.meta.glob()` — a Vite compile-time macro whose argument **must remain a string literal**. Stryker instruments that file (it's in the `src/boot/**` mutate glob), rewriting the literal into a `stryMutAct_*` mutant switch. Vite's `import-glob` plugin can then no longer parse it:

```
RolldownError: Parse failed — Expected `)` but found `EOF`
1: import.meta.glob(stryMutAct_9fa48("0")
File: src/boot/i18n.ts
```

The parse error cascades to **every test that imports the i18n bootstrap** → 192 test files fail to load → the vitest dry run collects zero tests → Stryker aborts.

Only `ui-shell-and-data` is affected — `ui-views-and-navigation`'s mutate glob doesn't include `src/boot/`. (That earlier `--mutate src/main.ts` repros passed for the same reason — `src/boot/` was out of scope.)

**Fix:** exclude `src/boot/i18n.ts` from the mutate scope in both `ui/stryker.conf.mjs` and the `ui-shell-and-data` workflow matrix entry. Verified in a Linux container — the dry run now succeeds and mutation testing proceeds (reached "7% — 567/9272 tested").

## Cache key rotation

`🔧 chore(ci): rotate Stryker incremental cache key per run`

`actions/cache` never overwrites an existing key, so the incremental baseline froze at the first run and the speedup decayed as the project drifted from that stale snapshot. Append `github.run_number` to the cache key so each run saves a fresh baseline; `restore-keys` still warm-restores the most recent prior one by prefix.

## Verification
- Linux-container repro: dry run succeeds, mutation testing proceeds
- Full pre-push gate green (biome, qlty, typecheck-ui, coverage, build, zizmor)