### PR TITLE
⚡ perf(ci): speed up mutation testing — perTest + balanced UI slices

### DIFF
--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -121,19 +121,42 @@ jobs:
             incremental_file: reports/stryker-incremental-app-ops-registries-remote.json
             mutate: >-
               registries/providers/acr/**/*.ts,registries/providers/alicr/**/*.ts,registries/providers/artifactory/**/*.ts,registries/providers/codeberg/**/*.ts,registries/providers/dhi/**/*.ts,registries/providers/docr/**/*.ts,registries/providers/ecr/**/*.ts,registries/providers/forgejo/**/*.ts,registries/providers/gar/**/*.ts,registries/providers/gcr/**/*.ts,registries/providers/ghcr/**/*.ts,registries/providers/gitea/**/*.ts,registries/providers/gitlab/**/*.ts,registries/providers/harbor/**/*.ts,registries/providers/hub/**/*.ts,registries/providers/ibmcr/**/*.ts,registries/providers/lscr/**/*.ts,registries/providers/mau/**/*.ts,registries/providers/nexus/**/*.ts,registries/providers/ocir/**/*.ts,registries/providers/quay/**/*.ts,registries/providers/trueforge/**/*.ts,stats/**/*.ts,prometheus/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!test/**,!dist/**,!coverage/**
-          - name: ui-shell-and-data
+          # The UI source is split into 6 slices sized to match the app slices
+          # (~2k mutants each). A single all-of-ui slice runs past the 6h job
+          # timeout. src/boot/i18n.ts is excluded everywhere it appears: it
+          # uses import.meta.glob(), a Vite compile-time macro whose argument
+          # must stay a literal — Stryker instrumentation breaks the glob
+          # parser and aborts the dry run.
+          - name: ui-views-containers
             package: ui
-            incremental_file: reports/stryker-incremental-ui-shell-and-data.json
-            # src/boot/i18n.ts is excluded: it uses import.meta.glob(), a Vite
-            # compile-time macro whose argument must stay a literal. Stryker
-            # instrumentation breaks Vite's glob parser and aborts the dry run.
+            incremental_file: reports/stryker-incremental-ui-views-containers.json
             mutate: >-
-              src/boot/**/*.ts,src/components/**/*.ts,src/composables/**/*.ts,src/i18n/**/*.ts,src/layouts/**/*.ts,src/preferences/**/*.ts,src/services/**/*.ts,src/stores/**/*.ts,src/theme/**/*.ts,src/types/**/*.ts,src/utils/**/*.ts,src/main.ts,!src/boot/i18n.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
-          - name: ui-views-and-navigation
+              src/views/containers/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+          - name: ui-views-dashboard
             package: ui
-            incremental_file: reports/stryker-incremental-ui-views-and-navigation.json
+            incremental_file: reports/stryker-incremental-ui-views-dashboard.json
             mutate: >-
-              src/views/**/*.ts,src/directives/**/*.ts,src/router/**/*.ts,src/icons.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+              src/views/dashboard/**/*.ts,src/views/security/**/*.ts,src/views/*.ts,src/directives/**/*.ts,src/router/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+          - name: ui-composables
+            package: ui
+            incremental_file: reports/stryker-incremental-ui-composables.json
+            mutate: >-
+              src/composables/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+          - name: ui-services
+            package: ui
+            incremental_file: reports/stryker-incremental-ui-services.json
+            mutate: >-
+              src/services/**/*.ts,src/types/**/*.ts,src/theme/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+          - name: ui-utils
+            package: ui
+            incremental_file: reports/stryker-incremental-ui-utils.json
+            mutate: >-
+              src/utils/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+          - name: ui-shell
+            package: ui
+            incremental_file: reports/stryker-incremental-ui-shell.json
+            mutate: >-
+              src/stores/**/*.ts,src/preferences/**/*.ts,src/components/**/*.ts,src/boot/**/*.ts,src/layouts/**/*.ts,src/i18n/**/*.ts,src/main.ts,src/icons.ts,!src/boot/i18n.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
 
     steps:
       - name: Harden Runner
@@ -247,7 +270,7 @@ jobs:
           # the summary records how many shards were missing.
           node scripts/aggregate-stryker-score.mjs \
             --input artifacts/mutation \
-            --expected-count 20 \
+            --expected-count 24 \
             --allow-missing \
             --summary-out artifacts/aggregate/summary.json \
             --score-out artifacts/aggregate/mutation-score.json

--- a/app/mutation-workflow.test.ts
+++ b/app/mutation-workflow.test.ts
@@ -90,15 +90,15 @@ function splitMutateEntry(entry: WorkflowMatrixEntry): string[] {
     .filter(Boolean);
 }
 
-test('mutation workflow runs monthly with 20 logical slices and aggregate count parity', () => {
+test('mutation workflow runs monthly with 24 logical slices and aggregate count parity', () => {
   const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
 
   expect(workflow.on?.schedule).toStrictEqual([{ cron: '15 6 1 * *' }]);
 
   const matrixEntries = workflow.jobs?.stryker?.strategy?.matrix?.include ?? [];
 
-  expect(matrixEntries).toHaveLength(20);
-  expect(new Set(matrixEntries.map((entry) => entry.name)).size).toBe(20);
+  expect(matrixEntries).toHaveLength(24);
+  expect(new Set(matrixEntries.map((entry) => entry.name)).size).toBe(24);
   expect(new Set(matrixEntries.map((entry) => entry.package))).toStrictEqual(
     new Set(['app', 'ui']),
   );
@@ -107,7 +107,7 @@ test('mutation workflow runs monthly with 20 logical slices and aggregate count 
     (step) => step.name === 'Aggregate shard scores',
   )?.run;
 
-  expect(aggregateRunScript).toContain('--expected-count 20');
+  expect(aggregateRunScript).toContain('--expected-count 24');
 });
 
 test('mutation workflow slices cover the app and ui Stryker targets without overlap', () => {

--- a/app/stryker.conf.mjs
+++ b/app/stryker.conf.mjs
@@ -15,7 +15,11 @@ const config = {
   testRunner: 'vitest',
   checkers: ['typescript'],
   tsconfigFile: 'tsconfig.json',
-  coverageAnalysis: 'off',
+  // perTest: each mutant runs only the tests that cover it, instead of
+  // re-running the whole suite per mutant. Stryker's recommended default —
+  // same mutation score, far less wall-clock time. Coverage is collected
+  // via Stryker's own instrumentation, independent of the vitest provider.
+  coverageAnalysis: 'perTest',
   reporters: [
     'clear-text',
     'progress',

--- a/ui/stryker.conf.mjs
+++ b/ui/stryker.conf.mjs
@@ -17,7 +17,12 @@ const config = {
   testRunner: 'vitest',
   checkers: ['typescript'],
   tsconfigFile: 'tsconfig.json',
-  coverageAnalysis: 'off',
+  // perTest: each mutant runs only the tests that cover it. 'off' (which
+  // re-runs the whole jsdom suite per mutant) made a single UI slice take
+  // ~8h and inflated the timeout rate. Stryker collects per-test coverage
+  // via its own instrumentation — independent of the vitest coverage
+  // provider — so this works inside the mutation sandbox.
+  coverageAnalysis: 'perTest',
   reporters: [
     'clear-text',
     'progress',


### PR DESCRIPTION
## Why

The `ui-views-and-navigation` mutation slice projected **~8h** against the 6h
job timeout and inflated the timeout rate. Root cause: PR #377 flipped
`ui/stryker.conf.mjs` `coverageAnalysis` to `'off'`, which re-runs the entire
jsdom suite for *every* mutant instead of only the covering tests.

## What

- **Restore `coverageAnalysis: 'perTest'` in `ui/stryker.conf.mjs`.** `perTest`
  runs only the tests that cover each mutant — Stryker's recommended default.
  Same mutation score, far less wall-clock time. Stryker collects per-test
  coverage via its own instrumentation, independent of the vitest coverage
  provider, so it works inside the mutation sandbox.
- **Align `app/stryker.conf.mjs` to `'perTest'` too** — it was `'off'` with no
  documented reason. Both configs now match what is correct.
- **Split the 2 oversized UI matrix slices into 6 balanced ones**
  (`ui-views-containers`, `ui-views-dashboard`, `ui-composables`,
  `ui-services`, `ui-utils`, `ui-shell`) so each finishes well under the 6h
  job timeout. `--expected-count` bumped 20 → 24.
- **Update `app/mutation-workflow.test.ts`** to expect 24 slices. Its
  coverage/overlap assertion confirms the 6 UI slices cover every UI mutate
  target exactly once with no gaps or overlap.

## Verification

- `perTest` confirmed working in a Linux Stryker sandbox (composables slice
  ran clean).
- `mutation-workflow.test.ts` passes both assertions (count + coverage/overlap).
- Full pre-push gate green: coverage 100%, build, zizmor.