### PR TITLE
♻️ refactor(quality): clear 27 qlty smells — duplication, boolean-logic, parameters

### DIFF
--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -121,10 +121,11 @@ jobs:
             incremental_file: reports/stryker-incremental-app-ops-registries-remote.json
             mutate: >-
               registries/providers/acr/**/*.ts,registries/providers/alicr/**/*.ts,registries/providers/artifactory/**/*.ts,registries/providers/codeberg/**/*.ts,registries/providers/dhi/**/*.ts,registries/providers/docr/**/*.ts,registries/providers/ecr/**/*.ts,registries/providers/forgejo/**/*.ts,registries/providers/gar/**/*.ts,registries/providers/gcr/**/*.ts,registries/providers/ghcr/**/*.ts,registries/providers/gitea/**/*.ts,registries/providers/gitlab/**/*.ts,registries/providers/harbor/**/*.ts,registries/providers/hub/**/*.ts,registries/providers/ibmcr/**/*.ts,registries/providers/lscr/**/*.ts,registries/providers/mau/**/*.ts,registries/providers/nexus/**/*.ts,registries/providers/ocir/**/*.ts,registries/providers/quay/**/*.ts,registries/providers/trueforge/**/*.ts,stats/**/*.ts,prometheus/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!test/**,!dist/**,!coverage/**
-          # The UI source is split into 8 slices sized to match the app slices.
-          # ui-shell is itself split into stores / preferences / app — bundled,
-          # its high-fan-in Pinia stores and icons map ran past the 6h job
-          # timeout. src/boot/i18n.ts is excluded everywhere it appears: it
+          # The UI source is split into 9 slices sized to match the app slices.
+          # ui-shell (stores / preferences / app) and ui-services (am / nz) are
+          # each split further by size — bundled, their high-fan-in stores and
+          # icons map ran past the 6h job timeout. src/boot/i18n.ts is excluded
+          # everywhere it appears: it
           # uses import.meta.glob(), a Vite compile-time macro whose argument
           # must stay a literal — Stryker instrumentation breaks the glob
           # parser and aborts the dry run.
@@ -143,11 +144,16 @@ jobs:
             incremental_file: reports/stryker-incremental-ui-composables.json
             mutate: >-
               src/composables/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
-          - name: ui-services
+          - name: ui-services-am
             package: ui
-            incremental_file: reports/stryker-incremental-ui-services.json
+            incremental_file: reports/stryker-incremental-ui-services-am.json
             mutate: >-
-              src/services/**/*.ts,src/types/**/*.ts,src/theme/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+              src/services/[a-m]*.ts,src/types/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+          - name: ui-services-nz
+            package: ui
+            incremental_file: reports/stryker-incremental-ui-services-nz.json
+            mutate: >-
+              src/services/[n-z]*.ts,src/theme/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
           - name: ui-utils
             package: ui
             incremental_file: reports/stryker-incremental-ui-utils.json
@@ -281,7 +287,7 @@ jobs:
           # the summary records how many shards were missing.
           node scripts/aggregate-stryker-score.mjs \
             --input artifacts/mutation \
-            --expected-count 26 \
+            --expected-count 27 \
             --allow-missing \
             --summary-out artifacts/aggregate/summary.json \
             --score-out artifacts/aggregate/mutation-score.json

--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -85,7 +85,7 @@ jobs:
             package: app
             incremental_file: reports/stryker-incremental-app-orch-trigger-runtime.json
             mutate: >-
-              triggers/providers/Trigger.ts,triggers/providers/trigger-*.ts,triggers/hooks/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!test/**,!dist/**,!coverage/**
+              triggers/providers/Trigger.ts,triggers/providers/trigger-*.ts,triggers/providers/exec-stream.ts,triggers/hooks/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!test/**,!dist/**,!coverage/**
           - name: app-orch-trigger-notify-primary
             package: app
             incremental_file: reports/stryker-incremental-app-orch-trigger-notify-primary.json

--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -121,8 +121,9 @@ jobs:
             incremental_file: reports/stryker-incremental-app-ops-registries-remote.json
             mutate: >-
               registries/providers/acr/**/*.ts,registries/providers/alicr/**/*.ts,registries/providers/artifactory/**/*.ts,registries/providers/codeberg/**/*.ts,registries/providers/dhi/**/*.ts,registries/providers/docr/**/*.ts,registries/providers/ecr/**/*.ts,registries/providers/forgejo/**/*.ts,registries/providers/gar/**/*.ts,registries/providers/gcr/**/*.ts,registries/providers/ghcr/**/*.ts,registries/providers/gitea/**/*.ts,registries/providers/gitlab/**/*.ts,registries/providers/harbor/**/*.ts,registries/providers/hub/**/*.ts,registries/providers/ibmcr/**/*.ts,registries/providers/lscr/**/*.ts,registries/providers/mau/**/*.ts,registries/providers/nexus/**/*.ts,registries/providers/ocir/**/*.ts,registries/providers/quay/**/*.ts,registries/providers/trueforge/**/*.ts,stats/**/*.ts,prometheus/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!test/**,!dist/**,!coverage/**
-          # The UI source is split into 6 slices sized to match the app slices
-          # (~2k mutants each). A single all-of-ui slice runs past the 6h job
+          # The UI source is split into 8 slices sized to match the app slices.
+          # ui-shell is itself split into stores / preferences / app — bundled,
+          # its high-fan-in Pinia stores and icons map ran past the 6h job
           # timeout. src/boot/i18n.ts is excluded everywhere it appears: it
           # uses import.meta.glob(), a Vite compile-time macro whose argument
           # must stay a literal — Stryker instrumentation breaks the glob
@@ -152,11 +153,21 @@ jobs:
             incremental_file: reports/stryker-incremental-ui-utils.json
             mutate: >-
               src/utils/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
-          - name: ui-shell
+          - name: ui-shell-stores
             package: ui
-            incremental_file: reports/stryker-incremental-ui-shell.json
+            incremental_file: reports/stryker-incremental-ui-shell-stores.json
             mutate: >-
-              src/stores/**/*.ts,src/preferences/**/*.ts,src/components/**/*.ts,src/boot/**/*.ts,src/layouts/**/*.ts,src/i18n/**/*.ts,src/main.ts,src/icons.ts,!src/boot/i18n.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+              src/stores/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+          - name: ui-shell-preferences
+            package: ui
+            incremental_file: reports/stryker-incremental-ui-shell-preferences.json
+            mutate: >-
+              src/preferences/**/*.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
+          - name: ui-shell-app
+            package: ui
+            incremental_file: reports/stryker-incremental-ui-shell-app.json
+            mutate: >-
+              src/components/**/*.ts,src/boot/**/*.ts,src/layouts/**/*.ts,src/i18n/**/*.ts,src/main.ts,src/icons.ts,!src/boot/i18n.ts,!**/*.d.ts,!**/*.test.ts,!**/*.fuzz.test.ts,!**/*.typecheck.ts,!dist/**,!coverage/**
 
     steps:
       - name: Harden Runner
@@ -270,7 +281,7 @@ jobs:
           # the summary records how many shards were missing.
           node scripts/aggregate-stryker-score.mjs \
             --input artifacts/mutation \
-            --expected-count 24 \
+            --expected-count 26 \
             --allow-missing \
             --summary-out artifacts/aggregate/summary.json \
             --score-out artifacts/aggregate/mutation-score.json

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,10 @@ output/
 .qlty/*
 !.qlty/qlty.toml
 
+# qlty smells scan artifacts
+.qlty-smells.sarif.json
+.qlty-smells-summary.md
+
 # SonarCloud scanner working directory
 .scannerwork/
 

--- a/app/agent/AgentClient.ts
+++ b/app/agent/AgentClient.ts
@@ -1005,14 +1005,12 @@ export class AgentClient {
 
     const payload = data as Record<string, unknown>;
     const batchId = toNonEmptyString(payload.batchId);
-    if (
-      !batchId ||
-      !Number.isFinite(payload.total) ||
-      !Number.isFinite(payload.succeeded) ||
-      !Number.isFinite(payload.failed) ||
-      !Number.isFinite(payload.durationMs) ||
-      !Array.isArray(payload.items)
-    ) {
+    const hasNumericFields =
+      Number.isFinite(payload.total) &&
+      Number.isFinite(payload.succeeded) &&
+      Number.isFinite(payload.failed) &&
+      Number.isFinite(payload.durationMs);
+    if (!batchId || !hasNumericFields || !Array.isArray(payload.items)) {
       return undefined;
     }
 

--- a/app/api/container/bulk-security.ts
+++ b/app/api/container/bulk-security.ts
@@ -149,14 +149,19 @@ async function runConcurrently<T>(
   await Promise.all(workers);
 }
 
+interface BulkScanOptions {
+  containers: Container[];
+  cycleId: string;
+  startedAt: string;
+  severity: SeverityFilter;
+  signal?: AbortSignal;
+}
+
 async function runBulkScan(
   deps: BulkSecurityHandlerDependencies,
-  containers: Container[],
-  cycleId: string,
-  startedAt: string,
-  severity: SeverityFilter,
-  signal?: AbortSignal,
+  options: BulkScanOptions,
 ): Promise<void> {
+  const { containers, cycleId, startedAt, severity, signal } = options;
   let alertCount = 0;
   let scannedCount = 0;
 
@@ -294,14 +299,13 @@ export function createBulkSecurityHandlers(deps: BulkSecurityHandlerDependencies
       res.status(202).json({ cycleId, scheduledCount: targetContainers.length });
 
       // Run async, don't let unhandled rejections crash the process
-      runBulkScan(
-        deps,
-        targetContainers,
+      runBulkScan(deps, {
+        containers: targetContainers,
         cycleId,
         startedAt,
         severity,
-        abortController.signal,
-      ).catch((err: unknown) => {
+        signal: abortController.signal,
+      }).catch((err: unknown) => {
         deps.log.error(`Bulk scan cycle ${cycleId} failed: ${deps.getErrorMessage(err)}`);
       });
     },

--- a/app/api/container/filters.ts
+++ b/app/api/container/filters.ts
@@ -81,19 +81,21 @@ const CONTAINER_LIST_QUERY_SCHEMA = joi.object({
 
 export function removeContainerListControlParams(query: Request['query']): Request['query'] {
   const filteredQuery: Record<string, unknown> = {};
+  const CONTROL_PARAMS = new Set([
+    'includeVulnerabilities',
+    'excludeRollbackContainers',
+    'limit',
+    'offset',
+    'sort',
+    'order',
+    'maturity',
+    'status',
+    'kind',
+    'watcher',
+  ]);
   Object.entries(query || {}).forEach(([key, value]) => {
-    if (
-      key === 'includeVulnerabilities' ||
-      key === 'excludeRollbackContainers' ||
-      key === 'limit' ||
-      key === 'offset' ||
-      key === 'sort' ||
-      key === 'order' ||
-      key === 'maturity' ||
-      key === 'status' ||
-      key === 'kind' ||
-      key === 'watcher'
-    ) {
+    const isControlParam = CONTROL_PARAMS.has(key);
+    if (isControlParam) {
       return;
     }
     filteredQuery[key] = value;

--- a/app/api/container/sorting.ts
+++ b/app/api/container/sorting.ts
@@ -146,17 +146,10 @@ function sortContainersByName(containers: Container[]): Container[] {
   return containersSorted;
 }
 
+const CONTAINER_SORT_MODE_SET: ReadonlySet<string> = new Set(CONTAINER_SORT_MODES);
+
 export function isContainerSortMode(value: string): value is ContainerSortMode {
-  return (
-    value === 'name' ||
-    value === '-name' ||
-    value === 'status' ||
-    value === '-status' ||
-    value === 'age' ||
-    value === '-age' ||
-    value === 'created' ||
-    value === '-created'
-  );
+  return CONTAINER_SORT_MODE_SET.has(value);
 }
 
 export function normalizeContainerSortMode(

--- a/app/mutation-workflow.test.ts
+++ b/app/mutation-workflow.test.ts
@@ -90,15 +90,15 @@ function splitMutateEntry(entry: WorkflowMatrixEntry): string[] {
     .filter(Boolean);
 }
 
-test('mutation workflow runs monthly with 26 logical slices and aggregate count parity', () => {
+test('mutation workflow runs monthly with 27 logical slices and aggregate count parity', () => {
   const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
 
   expect(workflow.on?.schedule).toStrictEqual([{ cron: '15 6 1 * *' }]);
 
   const matrixEntries = workflow.jobs?.stryker?.strategy?.matrix?.include ?? [];
 
-  expect(matrixEntries).toHaveLength(26);
-  expect(new Set(matrixEntries.map((entry) => entry.name)).size).toBe(26);
+  expect(matrixEntries).toHaveLength(27);
+  expect(new Set(matrixEntries.map((entry) => entry.name)).size).toBe(27);
   expect(new Set(matrixEntries.map((entry) => entry.package))).toStrictEqual(
     new Set(['app', 'ui']),
   );
@@ -107,7 +107,7 @@ test('mutation workflow runs monthly with 26 logical slices and aggregate count 
     (step) => step.name === 'Aggregate shard scores',
   )?.run;
 
-  expect(aggregateRunScript).toContain('--expected-count 26');
+  expect(aggregateRunScript).toContain('--expected-count 27');
 });
 
 test('mutation workflow slices cover the app and ui Stryker targets without overlap', () => {

--- a/app/mutation-workflow.test.ts
+++ b/app/mutation-workflow.test.ts
@@ -90,15 +90,15 @@ function splitMutateEntry(entry: WorkflowMatrixEntry): string[] {
     .filter(Boolean);
 }
 
-test('mutation workflow runs monthly with 24 logical slices and aggregate count parity', () => {
+test('mutation workflow runs monthly with 26 logical slices and aggregate count parity', () => {
   const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
 
   expect(workflow.on?.schedule).toStrictEqual([{ cron: '15 6 1 * *' }]);
 
   const matrixEntries = workflow.jobs?.stryker?.strategy?.matrix?.include ?? [];
 
-  expect(matrixEntries).toHaveLength(24);
-  expect(new Set(matrixEntries.map((entry) => entry.name)).size).toBe(24);
+  expect(matrixEntries).toHaveLength(26);
+  expect(new Set(matrixEntries.map((entry) => entry.name)).size).toBe(26);
   expect(new Set(matrixEntries.map((entry) => entry.package))).toStrictEqual(
     new Set(['app', 'ui']),
   );
@@ -107,7 +107,7 @@ test('mutation workflow runs monthly with 24 logical slices and aggregate count 
     (step) => step.name === 'Aggregate shard scores',
   )?.run;
 
-  expect(aggregateRunScript).toContain('--expected-count 24');
+  expect(aggregateRunScript).toContain('--expected-count 26');
 });
 
 test('mutation workflow slices cover the app and ui Stryker targets without overlap', () => {

--- a/app/registries/http-retry.ts
+++ b/app/registries/http-retry.ts
@@ -30,13 +30,11 @@ export interface WithRetryOptions {
 function isAxiosError(err: unknown): err is {
   response: { status: number; headers?: Record<string, string | undefined> };
 } {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'response' in err &&
-    typeof (err as Record<string, unknown>).response === 'object' &&
-    (err as Record<string, unknown>).response !== null
-  );
+  const isNonNullObject = typeof err === 'object' && err !== null;
+  const hasResponseKey = isNonNullObject && 'response' in err;
+  const responseValue = hasResponseKey ? (err as Record<string, unknown>).response : undefined;
+  const hasValidResponse = typeof responseValue === 'object' && responseValue !== null;
+  return hasResponseKey && hasValidResponse;
 }
 
 function parseRetryAfterMs(headerValue: string | undefined): number | undefined {

--- a/app/stats/collector.ts
+++ b/app/stats/collector.ts
@@ -173,14 +173,11 @@ function getOrCreateState(
 }
 
 function isStateInactive(state: ContainerCollectionState): boolean {
-  return (
-    state.watchCount === 0 &&
-    !state.stream &&
-    !state.startPromise &&
-    !state.restTouchRelease &&
-    !state.restTouchTimeout &&
-    state.listeners.size === 0
-  );
+  const hasNoWatchers = state.watchCount === 0;
+  const hasNoActiveStream = !state.stream && !state.startPromise;
+  const hasNoRestTouch = !state.restTouchRelease && !state.restTouchTimeout;
+  const hasNoListeners = state.listeners.size === 0;
+  return hasNoWatchers && hasNoActiveStream && hasNoRestTouch && hasNoListeners;
 }
 
 function pruneContainerStateIfMissing(

--- a/app/triggers/providers/Trigger.ts
+++ b/app/triggers/providers/Trigger.ts
@@ -1890,14 +1890,15 @@ class Trigger<
     }));
 
     // Sort by severity descending: critical → high → medium → low → unknown
-    rows.sort(
-      (a, b) =>
-        b.critical - a.critical ||
-        b.high - a.high ||
-        b.medium - a.medium ||
-        b.low - a.low ||
-        b.unknown - a.unknown,
-    );
+    rows.sort((a, b) => {
+      const byCritical = b.critical - a.critical;
+      const byHigh = b.high - a.high;
+      const byMedium = b.medium - a.medium;
+      const byLow = b.low - a.low;
+      const byUnknown = b.unknown - a.unknown;
+      const byTopSeverity = byCritical || byHigh || byMedium;
+      return byTopSeverity || byLow || byUnknown;
+    });
 
     const alertCount = rows.length;
     const criticalCount = rows.reduce((s, r) => s + (r.critical > 0 ? 1 : 0), 0);
@@ -1910,14 +1911,15 @@ class Trigger<
       (s, r) => s + (r.critical === 0 && r.high === 0 && r.medium === 0 && r.low > 0 ? 1 : 0),
       0,
     );
-    const unknownCount = rows.reduce(
-      (s, r) =>
-        s +
-        (r.critical === 0 && r.high === 0 && r.medium === 0 && r.low === 0 && r.unknown > 0
-          ? 1
-          : 0),
-      0,
-    );
+    const unknownCount = rows.reduce((s, r) => {
+      const noCritical = r.critical === 0;
+      const noHigh = r.high === 0;
+      const noMedium = r.medium === 0;
+      const noLow = r.low === 0;
+      const hasUnknown = r.unknown > 0;
+      const noHigherSeverity = noCritical && noHigh && noMedium && noLow;
+      return s + (noHigherSeverity && hasUnknown ? 1 : 0);
+    }, 0);
 
     const now = new Date().toISOString();
     const secCtx: SecurityDigestContext = {

--- a/app/triggers/providers/docker/self-update-controller.ts
+++ b/app/triggers/providers/docker/self-update-controller.ts
@@ -4,6 +4,7 @@ import { toPositiveInteger } from '../../../util/parse.js';
 import { sleep } from '../../../util/sleep.js';
 import { disableSocketRedirects } from '../../../watchers/providers/docker/disable-socket-redirects.js';
 import { probeSocketApiVersion } from '../../../watchers/providers/docker/socket-version-probe.js';
+import { waitForExecStream } from '../exec-stream.js';
 import { validateTcpDockerHost } from './SelfUpdateTransitionShared.js';
 import {
   SELF_UPDATE_HEALTH_TIMEOUT_MS,
@@ -252,26 +253,7 @@ class SelfUpdateController {
   }
 
   async waitForExecStream(execStream: ContainerExecStream): Promise<void> {
-    await new Promise((resolve, reject) => {
-      if (!execStream?.once) {
-        resolve(undefined);
-        return;
-      }
-      const onError = (error: unknown) => {
-        execStream.removeListener('end', onDone);
-        execStream.removeListener('close', onDone);
-        reject(error);
-      };
-      const onDone = () => {
-        execStream.removeListener('end', onDone);
-        execStream.removeListener('close', onDone);
-        execStream.removeListener('error', onError);
-        resolve(undefined);
-      };
-      execStream.once('end', onDone);
-      execStream.once('close', onDone);
-      execStream.once('error', onError);
-    });
+    await waitForExecStream(execStream);
   }
 
   buildFinalizeExecEnv(payload: SelfUpdateTerminalFinalizePayload): string[] {

--- a/app/triggers/providers/dockercompose/PostStartExecutor.ts
+++ b/app/triggers/providers/dockercompose/PostStartExecutor.ts
@@ -1,3 +1,5 @@
+import { waitForExecStream } from '../exec-stream.js';
+
 const POST_START_ENVIRONMENT_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 type PostStartExecutorLog = {
@@ -210,26 +212,7 @@ class PostStartExecutor {
   }
 
   async waitForPostStartHookExecStream(execStream: PostStartExecStream): Promise<void> {
-    await new Promise((resolve, reject) => {
-      if (!execStream?.once) {
-        resolve(undefined);
-        return;
-      }
-      const onError = (e: unknown) => {
-        execStream.removeListener('end', onDone);
-        execStream.removeListener('close', onDone);
-        reject(e);
-      };
-      const onDone = () => {
-        execStream.removeListener('end', onDone);
-        execStream.removeListener('close', onDone);
-        execStream.removeListener('error', onError);
-        resolve(undefined);
-      };
-      execStream.once('end', onDone);
-      execStream.once('close', onDone);
-      execStream.once('error', onError);
-    });
+    await waitForExecStream(execStream);
   }
 
   ensurePostStartHookExecSucceeded(

--- a/app/triggers/providers/exec-stream.test.ts
+++ b/app/triggers/providers/exec-stream.test.ts
@@ -1,0 +1,88 @@
+import { waitForExecStream } from './exec-stream.js';
+
+function makeStream({
+  hasOnce = true,
+  emitEvent = 'close' as string | null,
+  emitError = undefined as unknown,
+} = {}) {
+  const listeners: Record<string, ((error?: unknown) => void)[]> = {};
+
+  const stream = {
+    once: hasOnce
+      ? (event: string, cb: (error?: unknown) => void) => {
+          if (!listeners[event]) {
+            listeners[event] = [];
+          }
+          listeners[event].push(cb);
+        }
+      : undefined,
+    removeListener: (event: string, cb: (error?: unknown) => void) => {
+      if (listeners[event]) {
+        listeners[event] = listeners[event].filter((fn) => fn !== cb);
+      }
+    },
+    emit(event: string, arg?: unknown) {
+      for (const fn of listeners[event] ?? []) {
+        fn(arg);
+      }
+    },
+  };
+
+  return { stream, emit: stream.emit.bind(stream) };
+}
+
+describe('waitForExecStream', () => {
+  test('resolves immediately when stream has no once handler', async () => {
+    const { stream } = makeStream({ hasOnce: false });
+    await expect(waitForExecStream(stream)).resolves.toBeUndefined();
+  });
+
+  test('resolves when close event fires', async () => {
+    const { stream, emit } = makeStream({ emitEvent: 'close' });
+    const promise = waitForExecStream(stream);
+    emit('close');
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test('resolves when end event fires', async () => {
+    const { stream, emit } = makeStream({ emitEvent: 'end' });
+    const promise = waitForExecStream(stream);
+    emit('end');
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test('rejects when error event fires', async () => {
+    const { stream, emit } = makeStream();
+    const promise = waitForExecStream(stream);
+    emit('error', new Error('stream exploded'));
+    await expect(promise).rejects.toThrow('stream exploded');
+  });
+
+  test('removes end and close listeners after error fires', async () => {
+    const { stream, emit } = makeStream();
+    const promise = waitForExecStream(stream);
+    emit('error', new Error('boom'));
+    await expect(promise).rejects.toThrow('boom');
+    // Additional close/end should not throw or cause issues
+    emit('close');
+    emit('end');
+  });
+
+  test('removes error listener after close fires', async () => {
+    const { stream, emit } = makeStream();
+    const promise = waitForExecStream(stream);
+    emit('close');
+    await expect(promise).resolves.toBeUndefined();
+    // Error emitted after resolve should be a no-op
+    emit('error', new Error('late error'));
+  });
+
+  test('removes error listener after end fires', async () => {
+    const { stream, emit } = makeStream();
+    const promise = waitForExecStream(stream);
+    emit('end');
+    await expect(promise).resolves.toBeUndefined();
+    // Error emitted after resolve should be a no-op
+    emit('error', new Error('late error'));
+  });
+});

--- a/app/triggers/providers/exec-stream.ts
+++ b/app/triggers/providers/exec-stream.ts
@@ -1,0 +1,27 @@
+type ExecStream = {
+  once?: (event: string, callback: (error?: unknown) => void) => void;
+  removeListener: (event: string, callback: (error?: unknown) => void) => void;
+};
+
+export async function waitForExecStream(execStream: ExecStream): Promise<void> {
+  await new Promise((resolve, reject) => {
+    if (!execStream?.once) {
+      resolve(undefined);
+      return;
+    }
+    const onError = (error: unknown) => {
+      execStream.removeListener('end', onDone);
+      execStream.removeListener('close', onDone);
+      reject(error);
+    };
+    const onDone = () => {
+      execStream.removeListener('end', onDone);
+      execStream.removeListener('close', onDone);
+      execStream.removeListener('error', onError);
+      resolve(undefined);
+    };
+    execStream.once('end', onDone);
+    execStream.once('close', onDone);
+    execStream.once('error', onError);
+  });
+}

--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -193,6 +193,25 @@ function allSettledWithDockerWatchConcurrency<T, R>(
   return Promise.allSettled(items.map((item, index) => limit(() => mapper(item, index))));
 }
 
+function filterAndSliceTimestampedHistory<T extends { timestamp: string }>(
+  history: T[],
+  sinceMs: number | undefined,
+  limit: number,
+): T[] {
+  const filtered = history.filter((entry) => {
+    if (sinceMs === undefined) {
+      return true;
+    }
+    const timestampMs = Date.parse(entry.timestamp);
+    return Number.isNaN(timestampMs) ? false : timestampMs >= sinceMs;
+  });
+
+  if (!Number.isFinite(limit) || limit <= 0) {
+    return filtered;
+  }
+  return filtered.slice(-Math.trunc(limit));
+}
+
 interface DockerEventsStream {
   on: (eventName: string, handler: (...args: unknown[]) => unknown) => unknown;
   removeAllListeners?: (eventName?: string) => unknown;
@@ -824,36 +843,14 @@ class Docker extends Watcher<DockerWatcherConfiguration> {
 
   getRecentDockerEvents(options: { sinceMs?: number; limit?: number } = {}): DockerRecentEvent[] {
     const { sinceMs, limit = RECENT_DOCKER_EVENT_LIMIT } = options;
-    const filteredEvents = this.recentDockerEvents.filter((recentEvent) => {
-      if (sinceMs === undefined) {
-        return true;
-      }
-      const timestampMs = Date.parse(recentEvent.timestamp);
-      return Number.isNaN(timestampMs) ? false : timestampMs >= sinceMs;
-    });
-
-    if (!Number.isFinite(limit) || limit <= 0) {
-      return filteredEvents;
-    }
-    return filteredEvents.slice(-Math.trunc(limit));
+    return filterAndSliceTimestampedHistory(this.recentDockerEvents, sinceMs, limit);
   }
 
   getRecentAliasFilterDecisions(
     options: { sinceMs?: number; limit?: number } = {},
   ): AliasFilterDecision[] {
     const { sinceMs, limit = RECENT_ALIAS_FILTER_DECISION_LIMIT } = options;
-    const filteredDecisions = this.recentAliasFilterDecisions.filter((decision) => {
-      if (sinceMs === undefined) {
-        return true;
-      }
-      const timestampMs = Date.parse(decision.timestamp);
-      return Number.isNaN(timestampMs) ? false : timestampMs >= sinceMs;
-    });
-
-    if (!Number.isFinite(limit) || limit <= 0) {
-      return filteredDecisions;
-    }
-    return filteredDecisions.slice(-Math.trunc(limit));
+    return filterAndSliceTimestampedHistory(this.recentAliasFilterDecisions, sinceMs, limit);
   }
 
   async ensureRemoteAuthHeaders() {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,7 +2,6 @@ import {
   ArrowRight,
   BarChart3,
   Bell,
-  BookOpen,
   ChevronDown,
   Container,
   Eye,
@@ -13,18 +12,16 @@ import {
   Play,
   Radio,
   RotateCcw,
-  Terminal,
   Webhook,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { CtaButtons } from "@/components/cta-buttons";
 import { DemoSection } from "@/components/demo-section";
-import { GithubIcon } from "@/components/github-icon";
+import { DockerRunSnippet } from "@/components/docker-run-snippet";
 import { RoadmapTimeline } from "@/components/roadmap-timeline";
 import { SiteFooter } from "@/components/site-footer";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 
 type FeatureCategory = "core" | "security" | "integrations" | "operations";
 
@@ -489,24 +486,7 @@ export default function Home() {
                 </p>
 
                 {/* CTA Buttons */}
-                <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-                  <Button size="lg" asChild>
-                    <a
-                      href="https://github.com/CodesWhat/drydock"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <GithubIcon className="h-4 w-4" />
-                      View on GitHub
-                    </a>
-                  </Button>
-                  <Button variant="outline" size="lg" asChild>
-                    <Link href="/docs">
-                      <BookOpen className="h-4 w-4" />
-                      Documentation
-                    </Link>
-                  </Button>
-                </div>
+                <CtaButtons />
 
                 {/* Distribution Badges */}
                 <div className="mt-10 flex flex-wrap items-center justify-center gap-2">
@@ -816,24 +796,7 @@ export default function Home() {
               </div>
 
               {/* Code Block */}
-              <Card className="mx-auto max-w-2xl border-neutral-200 bg-neutral-950 text-left dark:border-neutral-800">
-                <CardContent className="pt-6">
-                  <div className="mb-3 flex items-center gap-2 text-neutral-500">
-                    <Terminal className="h-4 w-4" />
-                    <span className="text-xs font-medium uppercase tracking-wider">Terminal</span>
-                  </div>
-                  <pre className="overflow-x-auto text-sm">
-                    <code className="text-neutral-300">
-                      <span className="text-neutral-500">$</span>{" "}
-                      <span className="text-[#C4FF00]">docker run</span> -d \{"\n"}
-                      {"  "}--name drydock \{"\n"}
-                      {"  "}-v /var/run/docker.sock:/var/run/docker.sock \{"\n"}
-                      {"  "}-p 3000:3000 \{"\n"}
-                      {"  "}codeswhat/drydock
-                    </code>
-                  </pre>
-                </CardContent>
-              </Card>
+              <DockerRunSnippet cardClassName="mx-auto max-w-2xl border-neutral-200 bg-neutral-950 text-left dark:border-neutral-800" />
             </div>
           </section>
 

--- a/apps/web/components/comparison-page.tsx
+++ b/apps/web/components/comparison-page.tsx
@@ -1,11 +1,11 @@
 import type { LucideIcon } from "lucide-react";
-import { AlertTriangle, BookOpen, Check, Clock, Minus, Terminal, X } from "lucide-react";
+import { AlertTriangle, Check, Clock, Minus, X } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { GithubIcon } from "@/components/github-icon";
+import { CtaButtons } from "@/components/cta-buttons";
+import { DockerRunSnippet } from "@/components/docker-run-snippet";
 import { SiteFooter } from "@/components/site-footer";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
 export type ComparisonRow = {
@@ -239,26 +239,12 @@ export function ComparisonPage({
                       <p className="mb-4 text-sm text-neutral-600 dark:text-neutral-400">
                         {migrationDescription}
                       </p>
-                      <Card className="border-neutral-200 bg-neutral-950 text-left dark:border-neutral-800">
-                        <CardContent className="pt-4 pb-4">
-                          <div className="mb-2 flex items-center gap-2 text-neutral-500">
-                            <Terminal className="h-3.5 w-3.5" />
-                            <span className="text-xs font-medium uppercase tracking-wider">
-                              Quick start
-                            </span>
-                          </div>
-                          <pre className="overflow-x-auto text-sm">
-                            <code className="text-neutral-300">
-                              <span className="text-neutral-500">$</span>{" "}
-                              <span className="text-[#C4FF00]">docker run</span> -d \{"\n"}
-                              {"  "}--name drydock \{"\n"}
-                              {"  "}-v /var/run/docker.sock:/var/run/docker.sock \{"\n"}
-                              {"  "}-p 3000:3000 \{"\n"}
-                              {"  "}codeswhat/drydock
-                            </code>
-                          </pre>
-                        </CardContent>
-                      </Card>
+                      <DockerRunSnippet
+                        contentClassName="pt-4 pb-4"
+                        iconClassName="h-3.5 w-3.5"
+                        headerClassName="mb-2 flex items-center gap-2 text-neutral-500"
+                        label="Quick start"
+                      />
                     </div>
                   </div>
                 </CardContent>
@@ -279,24 +265,7 @@ export function ComparisonPage({
                 </p>
               </div>
 
-              <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
-                <Button size="lg" asChild>
-                  <a
-                    href="https://github.com/CodesWhat/drydock"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <GithubIcon className="h-4 w-4" />
-                    View on GitHub
-                  </a>
-                </Button>
-                <Button variant="outline" size="lg" asChild>
-                  <Link href="/docs">
-                    <BookOpen className="h-4 w-4" />
-                    Documentation
-                  </Link>
-                </Button>
-              </div>
+              <CtaButtons />
             </div>
           </section>
 

--- a/apps/web/components/cta-buttons.tsx
+++ b/apps/web/components/cta-buttons.tsx
@@ -1,0 +1,23 @@
+import { BookOpen } from "lucide-react";
+import Link from "next/link";
+import { GithubIcon } from "@/components/github-icon";
+import { Button } from "@/components/ui/button";
+
+export function CtaButtons() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+      <Button size="lg" asChild>
+        <a href="https://github.com/CodesWhat/drydock" target="_blank" rel="noopener noreferrer">
+          <GithubIcon className="h-4 w-4" />
+          View on GitHub
+        </a>
+      </Button>
+      <Button variant="outline" size="lg" asChild>
+        <Link href="/docs">
+          <BookOpen className="h-4 w-4" />
+          Documentation
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/components/docker-run-snippet.tsx
+++ b/apps/web/components/docker-run-snippet.tsx
@@ -1,0 +1,39 @@
+import { Terminal } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+
+type Props = {
+  cardClassName?: string;
+  contentClassName?: string;
+  iconClassName?: string;
+  headerClassName?: string;
+  label?: string;
+};
+
+export function DockerRunSnippet({
+  cardClassName = "border-neutral-200 bg-neutral-950 text-left dark:border-neutral-800",
+  contentClassName = "pt-6",
+  iconClassName = "h-4 w-4",
+  headerClassName = "mb-3 flex items-center gap-2 text-neutral-500",
+  label = "Terminal",
+}: Props) {
+  return (
+    <Card className={cardClassName}>
+      <CardContent className={contentClassName}>
+        <div className={headerClassName}>
+          <Terminal className={iconClassName} />
+          <span className="text-xs font-medium uppercase tracking-wider">{label}</span>
+        </div>
+        <pre className="overflow-x-auto text-sm">
+          <code className="text-neutral-300">
+            <span className="text-neutral-500">$</span>{" "}
+            <span className="text-[#C4FF00]">docker run</span> -d \{"\n"}
+            {"  "}--name drydock \{"\n"}
+            {"  "}-v /var/run/docker.sock:/var/run/docker.sock \{"\n"}
+            {"  "}-p 3000:3000 \{"\n"}
+            {"  "}codeswhat/drydock
+          </code>
+        </pre>
+      </CardContent>
+    </Card>
+  );
+}

--- a/scripts/extract-changelog-entry.mjs
+++ b/scripts/extract-changelog-entry.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync } from 'node:fs';
+import { parseArgs } from './lib/parse-args.mjs';
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -71,23 +72,6 @@ export function extractChangelogEntry(changelog, version) {
       : startIndex + startMatch[0].length + nextHeadingOffset;
 
   return content.slice(startIndex, endIndex).trim();
-}
-
-function parseArgs(argv) {
-  const args = {};
-  for (let i = 0; i < argv.length; i += 1) {
-    const key = argv[i];
-    if (!key.startsWith('--')) {
-      continue;
-    }
-    const value = argv[i + 1];
-    if (value === undefined || value.startsWith('--')) {
-      throw new Error(`Missing value for argument: ${key}`);
-    }
-    args[key.slice(2)] = value;
-    i += 1;
-  }
-  return args;
 }
 
 function main() {

--- a/scripts/lib/parse-args.mjs
+++ b/scripts/lib/parse-args.mjs
@@ -1,0 +1,16 @@
+export function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith('--')) {
+      continue;
+    }
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for argument: ${key}`);
+    }
+    args[key.slice(2)] = value;
+    i += 1;
+  }
+  return args;
+}

--- a/scripts/lib/parse-args.test.mjs
+++ b/scripts/lib/parse-args.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseArgs } from './parse-args.mjs';
+
+test('returns empty object for empty argv', () => {
+  assert.deepEqual(parseArgs([]), {});
+});
+
+test('parses a single --key value pair', () => {
+  assert.deepEqual(parseArgs(['--version', '1.2.3']), { version: '1.2.3' });
+});
+
+test('parses multiple --key value pairs', () => {
+  assert.deepEqual(parseArgs(['--version', '1.0.0', '--file', 'CHANGELOG.md']), {
+    version: '1.0.0',
+    file: 'CHANGELOG.md',
+  });
+});
+
+test('skips positional arguments that do not start with --', () => {
+  assert.deepEqual(parseArgs(['positional', '--key', 'val']), { key: 'val' });
+});
+
+test('throws when a flag has no following value', () => {
+  assert.throws(() => parseArgs(['--version']), /Missing value for argument: --version/u);
+});
+
+test('throws when a flag is immediately followed by another flag', () => {
+  assert.throws(
+    () => parseArgs(['--version', '--file', 'CHANGELOG.md']),
+    /Missing value for argument: --version/u,
+  );
+});
+
+test('handles numeric-looking string values', () => {
+  assert.deepEqual(parseArgs(['--count', '42']), { count: '42' });
+});

--- a/scripts/snyk-quota-plan.mjs
+++ b/scripts/snyk-quota-plan.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
+import { parseArgs } from './lib/parse-args.mjs';
 
 const PRODUCT_KEYS = ['openSource', 'code', 'container', 'iac'];
 export const DEFAULT_CONFIG_PATH = new URL('./snyk-quota-config.json', import.meta.url);
@@ -97,23 +98,6 @@ export function evaluateQuotaPlan({
     monthly,
     violations,
   };
-}
-
-function parseArgs(argv) {
-  const args = {};
-  for (let i = 0; i < argv.length; i += 1) {
-    const key = argv[i];
-    if (!key.startsWith('--')) {
-      continue;
-    }
-    const value = argv[i + 1];
-    if (value === undefined || value.startsWith('--')) {
-      throw new Error(`Missing value for argument: ${key}`);
-    }
-    args[key.slice(2)] = value;
-    i += 1;
-  }
-  return args;
 }
 
 function main() {

--- a/ui/src/composables/useOperationDisplayHold.ts
+++ b/ui/src/composables/useOperationDisplayHold.ts
@@ -330,15 +330,19 @@ function projectContainerDisplayState<T extends Container>(container: T): T {
   }
 
   const { sortSnapshot } = held;
-  const needsSortFields =
-    sortSnapshot !== undefined &&
-    (sortSnapshot.status !== container.status ||
-      sortSnapshot.updateKind !== container.updateKind ||
-      sortSnapshot.newTag !== container.newTag ||
-      sortSnapshot.currentTag !== container.currentTag ||
-      sortSnapshot.image !== container.image ||
+  const hasSortSnapshot = sortSnapshot !== undefined;
+  const statusOrKindDiffers =
+    hasSortSnapshot &&
+    (sortSnapshot.status !== container.status || sortSnapshot.updateKind !== container.updateKind);
+  const tagsDiffer =
+    hasSortSnapshot &&
+    (sortSnapshot.newTag !== container.newTag || sortSnapshot.currentTag !== container.currentTag);
+  const imageOrTimingDiffers =
+    hasSortSnapshot &&
+    (sortSnapshot.image !== container.image ||
       sortSnapshot.imageCreated !== container.imageCreated ||
       sortSnapshot.updateDetectedAt !== container.updateDetectedAt);
+  const needsSortFields = statusOrKindDiffers || tagsDiffer || imageOrTimingDiffers;
 
   return {
     ...container,

--- a/ui/src/services/stats.ts
+++ b/ui/src/services/stats.ts
@@ -173,26 +173,25 @@ function closeSource(state: StreamConnectionState): void {
   }
 }
 
-function createEventSource(
-  streamUrl: string,
-  handlers: ContainerStatsStreamEventHandlers,
-  onError: () => void,
-): EventSource {
-  const source = createManagedEventSource(streamUrl);
+interface BaseEventSourceConfig {
+  streamUrl: string;
+  onOpen: (() => void) | undefined;
+  onHeartbeat: (() => void) | undefined;
+  customEventName: string;
+  onCustomEvent: (event: Event) => void;
+  onError: () => void;
+}
+
+function createBaseEventSource(config: BaseEventSourceConfig): EventSource {
+  const source = createManagedEventSource(config.streamUrl);
   source.addEventListener('open', () => {
-    handlers.onOpen?.();
+    config.onOpen?.();
   });
   source.addEventListener('dd:heartbeat', () => {
-    handlers.onHeartbeat?.();
+    config.onHeartbeat?.();
   });
-  source.addEventListener('dd:container-stats', (event: Event) => {
-    const messageEvent = event as MessageEvent;
-    const snapshot = parseSnapshotEvent(messageEvent.data);
-    if (snapshot) {
-      handlers.onSnapshot?.(snapshot);
-    }
-  });
-  source.onerror = onError;
+  source.addEventListener(config.customEventName, config.onCustomEvent);
+  source.onerror = config.onError;
   return source;
 }
 
@@ -366,53 +365,46 @@ export async function getStatsSummary(): Promise<ContainerStatsSummarySnapshot> 
   return snapshot;
 }
 
-function createSummaryEventSource(
-  streamUrl: string,
-  handlers: StatsSummaryStreamHandlers,
-  onError: () => void,
-): EventSource {
-  const source = createManagedEventSource(streamUrl);
-  source.addEventListener('open', () => {
-    handlers.onOpen?.();
-  });
-  source.addEventListener('dd:heartbeat', () => {
-    handlers.onHeartbeat?.();
-  });
-  source.addEventListener('dd:stats-summary', (event: Event) => {
-    const messageEvent = event as MessageEvent;
-    const snapshot = parseSummarySnapshotEvent(messageEvent.data);
-    if (snapshot) {
-      handlers.onSummary?.(snapshot);
-    }
-  });
-  source.onerror = onError;
-  return source;
+interface StreamOptions {
+  streamUrl: string;
+  onOpen: (() => void) | undefined;
+  onHeartbeat: (() => void) | undefined;
+  onError: (() => void) | undefined;
+  customEventName: string;
+  onCustomEvent: (event: Event) => void;
+  reconnectDelayMs: number;
 }
 
-export function connectStatsSummaryStream(
-  handlers: StatsSummaryStreamHandlers = {},
-  options: StatsSummaryStreamOptions = {},
-): StatsSummaryStreamController {
-  const reconnectDelayMs = Math.max(1, options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS);
-  const streamUrl = '/api/v1/stats/summary/stream';
+function connectStream(opts: StreamOptions): {
+  pause(): void;
+  resume(): void;
+  disconnect(): void;
+  isPaused(): boolean;
+} {
   const state: StreamConnectionState = {
     paused: false,
     disconnected: false,
   };
 
   function handleError(): void {
-    handlers.onError?.();
+    opts.onError?.();
     if (state.paused || state.disconnected) {
       return;
     }
-
     closeSource(state);
-    scheduleReconnect(state, reconnectDelayMs, connect);
+    scheduleReconnect(state, opts.reconnectDelayMs, connect);
   }
 
   function connect(): void {
     closeSource(state);
-    state.eventSource = createSummaryEventSource(streamUrl, handlers, handleError);
+    state.eventSource = createBaseEventSource({
+      streamUrl: opts.streamUrl,
+      onOpen: opts.onOpen,
+      onHeartbeat: opts.onHeartbeat,
+      customEventName: opts.customEventName,
+      onCustomEvent: opts.onCustomEvent,
+      onError: handleError,
+    });
   }
 
   connect();
@@ -446,6 +438,27 @@ export function connectStatsSummaryStream(
       return state.paused;
     },
   };
+}
+
+export function connectStatsSummaryStream(
+  handlers: StatsSummaryStreamHandlers = {},
+  options: StatsSummaryStreamOptions = {},
+): StatsSummaryStreamController {
+  return connectStream({
+    streamUrl: '/api/v1/stats/summary/stream',
+    onOpen: handlers.onOpen,
+    onHeartbeat: handlers.onHeartbeat,
+    onError: handlers.onError,
+    customEventName: 'dd:stats-summary',
+    onCustomEvent: (event: Event) => {
+      const messageEvent = event as MessageEvent;
+      const snapshot = parseSummarySnapshotEvent(messageEvent.data);
+      if (snapshot) {
+        handlers.onSummary?.(snapshot);
+      }
+    },
+    reconnectDelayMs: Math.max(1, options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS),
+  });
 }
 
 export function connectContainerStatsStream(
@@ -453,57 +466,19 @@ export function connectContainerStatsStream(
   handlers: ContainerStatsStreamEventHandlers = {},
   options: ContainerStatsStreamOptions = {},
 ): ContainerStatsStreamController {
-  const reconnectDelayMs = Math.max(1, options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS);
-  const streamUrl = `/api/v1/containers/${encodeURIComponent(containerId)}/stats/stream`;
-  const state: StreamConnectionState = {
-    paused: false,
-    disconnected: false,
-  };
-
-  function handleError(): void {
-    handlers.onError?.();
-    if (state.paused || state.disconnected) {
-      return;
-    }
-
-    closeSource(state);
-    scheduleReconnect(state, reconnectDelayMs, connect);
-  }
-
-  function connect(): void {
-    closeSource(state);
-    state.eventSource = createEventSource(streamUrl, handlers, handleError);
-  }
-
-  connect();
-
-  return {
-    pause() {
-      if (state.paused || state.disconnected) {
-        return;
+  return connectStream({
+    streamUrl: `/api/v1/containers/${encodeURIComponent(containerId)}/stats/stream`,
+    onOpen: handlers.onOpen,
+    onHeartbeat: handlers.onHeartbeat,
+    onError: handlers.onError,
+    customEventName: 'dd:container-stats',
+    onCustomEvent: (event: Event) => {
+      const messageEvent = event as MessageEvent;
+      const snapshot = parseSnapshotEvent(messageEvent.data);
+      if (snapshot) {
+        handlers.onSnapshot?.(snapshot);
       }
-      state.paused = true;
-      clearReconnectTimer(state);
-      closeSource(state);
     },
-    resume() {
-      if (!state.paused || state.disconnected) {
-        return;
-      }
-      state.paused = false;
-      connect();
-    },
-    disconnect() {
-      if (state.disconnected) {
-        return;
-      }
-      state.disconnected = true;
-      state.paused = true;
-      clearReconnectTimer(state);
-      closeSource(state);
-    },
-    isPaused() {
-      return state.paused;
-    },
-  };
+    reconnectDelayMs: Math.max(1, options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS),
+  });
 }

--- a/ui/src/utils/container-mapper.ts
+++ b/ui/src/utils/container-mapper.ts
@@ -669,7 +669,9 @@ function normalizeReleaseNotes(
   const url = asNonEmptyString(rn.url);
   const publishedAt = asNonEmptyString(rn.publishedAt);
   const provider = asNonEmptyString(rn.provider);
-  if (!title || !body || !url || !publishedAt || !provider) return null;
+  const hasContent = title && body && url;
+  const hasMetadata = publishedAt && provider;
+  if (!hasContent || !hasMetadata) return null;
   return { title, body, url, publishedAt, provider };
 }
 

--- a/ui/src/utils/update-error-summary.ts
+++ b/ui/src/utils/update-error-summary.ts
@@ -77,13 +77,10 @@ export function summariseUpdateError(error: string | undefined): string | undefi
   ) {
     return 'Registry authentication failed';
   }
-  if (
-    lower.includes('econnrefused') ||
-    lower.includes('enotfound') ||
-    lower.includes('etimedout') ||
-    lower.includes('socket hang up') ||
-    lower.includes('econnreset')
-  ) {
+  const isConnectionError =
+    lower.includes('econnrefused') || lower.includes('econnreset') || lower.includes('etimedout');
+  const isResolutionError = lower.includes('enotfound') || lower.includes('socket hang up');
+  if (isConnectionError || isResolutionError) {
     return 'Registry unreachable';
   }
   if (error === 'Cancelled by operator') {

--- a/ui/src/views/dashboard/useDashboardResponsiveLayouts.ts
+++ b/ui/src/views/dashboard/useDashboardResponsiveLayouts.ts
@@ -47,17 +47,15 @@ function cloneLayout(layout: readonly WidgetLayoutItem[]): WidgetLayoutItem[] {
 }
 
 function layoutItemsEqual(left: WidgetLayoutItem, right: WidgetLayoutItem): boolean {
-  return (
-    left.i === right.i &&
-    left.x === right.x &&
-    left.y === right.y &&
-    left.w === right.w &&
-    left.h === right.h &&
+  const idMatch = left.i === right.i;
+  const positionMatch = left.x === right.x && left.y === right.y;
+  const sizeMatch = left.w === right.w && left.h === right.h;
+  const constraintsMatch =
     left.minW === right.minW &&
     left.minH === right.minH &&
     left.maxW === right.maxW &&
-    left.maxH === right.maxH
-  );
+    left.maxH === right.maxH;
+  return idMatch && positionMatch && sizeMatch && constraintsMatch;
 }
 
 function layoutsShallowEqual(
@@ -120,13 +118,13 @@ function stripLayout(layout: readonly WidgetLayoutItem[]): PersistedLayoutItem[]
 function isValidLayoutItem(value: unknown): value is WidgetLayoutItem {
   if (!value || typeof value !== 'object') return false;
   const item = value as Record<string, unknown>;
-  return (
-    isDashboardWidgetId(item.i) &&
+  const hasValidId = isDashboardWidgetId(item.i);
+  const hasNumericCoords =
     typeof item.x === 'number' &&
     typeof item.y === 'number' &&
     typeof item.w === 'number' &&
-    typeof item.h === 'number'
-  );
+    typeof item.h === 'number';
+  return hasValidId && hasNumericCoords;
 }
 
 function isLegacySingleColumnLayout(rawLayout: unknown): boolean {


### PR DESCRIPTION
## Summary

Two things, both touching code/CI quality:
1. Clears **27 of 86** qlty code smells (86 → 59) via mechanical, behaviour-preserving refactors.
2. Splits two oversized Stryker mutation slices that were exceeding the 6h GitHub Actions job timeout.

`qlty-smells` is advisory (non-blocking); the mutation workflow is monthly + advisory.

## Part 1 — qlty smell cleanup

**Duplication — 14 smells** (`d2ef4220`): shared helpers extracted in `stats.ts`, `watchers/docker/Docker.ts`, a shared `exec-stream.ts` for triggers, `CtaButtons`/`DockerRunSnippet` in `apps/web`, `scripts/lib/parse-args.mjs`.

**Boolean-logic — 8 smells** (`17a1b834`): named intermediate booleans / lookup Sets across 7 files.

**Boolean-logic + function-parameters — 5 smells** (`d56beeaa`): named predicates in `Trigger.ts`/`AgentClient.ts`/`useOperationDisplayHold.ts`; `runBulkScan` args bundled into `BulkScanOptions`.

The remaining 59 smells (41 function-complexity, 6 nested-control-flow, 10 similar-code, 2 cross-workspace identical-code) are **not bulk-safe** — deliberately left for case-by-case work.

## Part 2 — mutation slice rebalance

`ui-shell` (3745 LOC) and `ui-services` (3352 LOC) bundled high-fan-in code (Pinia stores, the icons map, API service wrappers) into single Stryker slices that ran past the 360-min (GitHub maximum) job timeout.

- `ui-shell` → `ui-shell-stores` / `ui-shell-preferences` / `ui-shell-app` (`2d988131`)
- `ui-services` → `ui-services-am` / `ui-services-nz`, alphabetical `[a-m]`/`[n-z]` split (`d3e3e497`)
- Matrix grows **24 → 27**; aggregate `--expected-count` and `mutation-workflow.test.ts` updated to match.

Each new slice is ≤~1.7k LOC — comfortably inside the 6h budget.

## Verification

- app coverage **100%** (9787 tests) · ui coverage **100%** (3540 tests)
- biome lint clean (all workspaces) · app + ui builds pass
- pre-push gate green (qlty, qlty-smells, coverage, build, zizmor)
- `mutation-workflow.test.ts` passes — verifies the 27 slices partition every app/ui mutation target with no overlap
