### PR TITLE
🔧 chore(ci): run Playwright in official container — fix runner-image regression

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -80,10 +80,17 @@ jobs:
     name: "🎭 E2E: Playwright"
     if: needs.changes.outputs.runtime == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 35  # UI build + Docker build + browser install + QA stack startup + UI flow tests
+    timeout-minutes: 35  # UI build + Docker build + QA stack startup + Playwright pull + UI flow tests
     needs: [changes]
     permissions:
       contents: read
+    env:
+      # Pinned to match @playwright/test in e2e/package.json. Ships with
+      # the matching chromium build pre-installed at /ms-playwright, which
+      # eliminates the cdn.playwright.dev runtime dependency that used to
+      # cause cold-cache install failures whenever the GitHub Actions
+      # runner image rotated and dropped its pre-baked browser.
+      PLAYWRIGHT_IMAGE: mcr.microsoft.com/playwright:v1.58.2-noble
 
     steps:
       - name: Harden Runner
@@ -130,49 +137,13 @@ jobs:
           cache-from: type=gha,scope=drydock
           cache-to: type=gha,mode=max,scope=drydock,ignore-error=true
 
-      # Cache Playwright's browser binary directory across runs.
-      # The @playwright/browser-chromium devDep runs a 167-MiB postinstall
-      # download against cdn.playwright.dev during `npm ci`. CDN throttling
-      # has been making that 9-10 min per attempt and three jobs in a row
-      # blew past even a 10-min retry timeout. With a warm cache the
-      # postinstall short-circuits and npm ci finishes in seconds.
-      # Per-ref key matches the cache-scoping pattern in
-      # quality-mutation-monthly.yml: each branch (main, release/**, PR
-      # heads) gets its own cache namespace so an untrusted PR cannot
-      # poison main's chromium binary. restore-keys lets a fresh branch
-      # warm-start from any prior cache by lockfile-hash prefix.
-      # The workflow runs on push:main/PR/merge_group, which triggers
-      # zizmor's cache-poisoning audit on any actions/cache usage. The
-      # ref-scoped key (github.ref_name) gives each branch its own
-      # cache namespace so an untrusted PR cannot overwrite main's
-      # binary, and the cached payload is just the chromium binary
-      # (verified by its own integrity check at runtime). No runtime
-      # artifact is being published from this cache.
-      - name: Cache Playwright browsers
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # zizmor: ignore[cache-poisoning] v4.2.3
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ github.ref_name }}-${{ hashFiles('e2e/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-${{ github.ref_name }}-
-            ${{ runner.os }}-playwright-main-
-            ${{ runner.os }}-playwright-
-
-      - name: Install e2e dependencies
+      - name: Pull Playwright container
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
         with:
-          timeout_minutes: 15  # Cold-cache cushion: chromium download has been clocking 9-10 min per attempt under CDN throttling
+          timeout_minutes: 5
           max_attempts: 3
           retry_wait_seconds: 30
-          command: cd e2e && npm ci
-
-      - name: Install Playwright Chromium
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 30
-          command: cd e2e && npx playwright install --with-deps chromium
+          command: docker pull "$PLAYWRIGHT_IMAGE"
 
       - name: Start QA stack
         run: docker compose -p drydock-playwright -f test/qa-compose.yml up -d
@@ -192,9 +163,25 @@ jobs:
           docker compose -p drydock-playwright -f test/qa-compose.yml ps
           exit 1
 
+      # Run npm ci + playwright test inside the official Playwright
+      # container so the chromium build is sourced from the image
+      # (pre-installed at /ms-playwright, version-matched to
+      # @playwright/test) instead of cdn.playwright.dev at runtime.
+      # PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 keeps the transitive
+      # @playwright/browser-chromium postinstall from racing the same
+      # download. --network host lets Playwright reach the QA stack on
+      # localhost:3333. --ipc=host avoids Chrome /dev/shm OOMs.
       - name: Run Playwright tests
-        run: npm run test:playwright
-        working-directory: e2e
+        run: |
+          docker run --rm \
+            --network host \
+            --ipc=host \
+            -e PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+            -e HOME=/tmp \
+            -v "${{ github.workspace }}:/work" \
+            -w /work/e2e \
+            "$PLAYWRIGHT_IMAGE" \
+            sh -c "npm ci --no-audit --no-fund && npm run test:playwright"
 
       - name: Upload Playwright HTML report
         if: failure()


### PR DESCRIPTION
## Summary

Switches the E2E Playwright job to the official `mcr.microsoft.com/playwright:v1.58.2-noble` container so the chromium binary is sourced from the image (pre-installed at `/ms-playwright`, version-matched to `@playwright/test`) instead of `cdn.playwright.dev` at runtime.

## Root cause

The May-25 `ubuntu-24.04` runner image rotation (`20260518.149` → `20260525.161`) dropped the pre-baked Playwright chromium build that rc.27 and every earlier release had been relying on. On rc.27 (run `26336406444`) the entire browser install pipeline took **51 seconds**:

- `Install e2e dependencies` (`npm ci`): 37s — zero mention of `browser-chromium` / `Downloading Chrome`
- `Install Playwright Chromium` (`npx playwright install --with-deps chromium`): 14s — just apt-get for system deps, no binary fetch

Post-rotation, the same steps tried to fetch the 167 MiB Chrome-for-Testing binary from `cdn.playwright.dev` and SIGTERMed at every per-attempt timeout, blocking the rc.28 release-cut and consuming three CI escalations (`7dc8b2d3`, `cac1793d`, the now-superseded `38cc8a5a`) that all chased the timeout instead of the regression.

## Why this fix

The official Playwright container ships chromium pre-installed at `/ms-playwright` for the exact `@playwright/test` version it's tagged with. Running tests inside it eliminates the `cdn.playwright.dev` runtime dependency entirely — no cache to seed, no postinstall race, no per-attempt retry budget to blow.

## Changes

- Job still runs on `ubuntu-latest` (kept for Docker compose access to bring up the QA stack)
- New `PLAYWRIGHT_IMAGE` env pin → `mcr.microsoft.com/playwright:v1.58.2-noble`
- Drop `actions/cache` for `~/.cache/ms-playwright`
- Drop host-side `Install e2e dependencies` + dedicated `Install Playwright Chromium` steps
- Add `Pull Playwright container` step (retry budget preserved)
- `Run Playwright tests` is now `docker run` inside the official container:
  - `--network host` → reach QA stack on `localhost:3333`
  - `--ipc=host` → avoid Chrome `/dev/shm` OOMs
  - `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` → keep transitive `@playwright/browser-chromium` postinstall from racing the same download
  - `npm ci` + `npm run test:playwright` run inside container; node_modules + reports written back to mounted workspace for artifact upload
- Job `timeout-minutes` back to 35 (was 50, accommodating the runaway CDN download)

## Test plan

- [ ] E2E Playwright check passes on this PR
- [ ] After merge to main, push-event E2E run on main goes green
- [ ] `release-cut.yml` dispatched for `v1.5.0-rc.28` passes its "Wait for successful E2E Playwright on target SHA" gate

## Supersedes

`38cc8a5a` (the `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` approach) which was force-pushed off this branch — it addressed the npm-ci postinstall download but left the dedicated `npx playwright install` step facing the same CDN. Container approach removes both download paths at once.