### PR TITLE
🐛 fix(ci): wait for auth strategies in DAST health gate

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -564,9 +564,12 @@ jobs:
       - name: Wait for QA health
         run: |
           set -euo pipefail
+          # /health flips true before auth strategies finish registering, so
+          # poll /auth/strategies too — that's the gate the scanners hit next.
           for _ in $(seq 1 60); do
-            if curl -sf http://localhost:3333/health >/dev/null 2>&1; then
-              echo "Drydock is healthy"
+            if curl -sf http://localhost:3333/health >/dev/null 2>&1 \
+               && curl -sf http://localhost:3333/auth/strategies | jq -e '.strategies | length > 0' >/dev/null 2>&1; then
+              echo "Drydock is healthy and auth is ready"
               exit 0
             fi
             sleep 2


### PR DESCRIPTION
## Summary
- DAST's ZAP/Nuclei auth steps were getting 401 on `/auth/login` because `/health` flips true before auth strategies finish registering.
- Cucumber dodged it because its first scenario polls `/auth/strategies`; DAST went straight to `/auth/login`.
- Extend the wait gate to also require `/auth/strategies` to return a populated array before declaring the stack ready.

This blocked the rc.28 release-cut (CI Verify on main at `ca65eb1f` failed). Once this merges, re-run release-cut.

## Test plan
- [ ] DAST: ZAP + Nuclei job goes green on the merge-to-main push
- [ ] After merge: \`gh workflow run release-cut.yml --ref main -f release_tag=v1.5.0-rc.28\`