### PR TITLE
🐛 fix(auth): close strategy-registration gap so login is ready before /health is

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -523,7 +523,7 @@ jobs:
           retention-days: 1
 
   dast-zap-baseline:
-    name: "🕷️ DAST: ZAP + Nuclei (Advisory)"
+    name: "🕷️ DAST: ZAP + Nuclei"
     runs-on: ubuntu-latest
     timeout-minutes: 25  # Includes QA stack startup and scanner container runtime
     # Run on every merge to main (gates the next release-cut), on legacy
@@ -533,9 +533,6 @@ jobs:
       (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
       || github.event_name == 'schedule'
     needs: [build]
-    # Advisory while we debug a post-rc.28 401 race in the auth init path —
-    # findings still surface in SARIF + artifacts; release-cut isn't gated.
-    continue-on-error: true
     permissions:
       actions: read
       contents: read
@@ -567,12 +564,9 @@ jobs:
       - name: Wait for QA health
         run: |
           set -euo pipefail
-          # /health flips true before auth strategies finish registering, so
-          # poll /auth/strategies too — that's the gate the scanners hit next.
           for _ in $(seq 1 60); do
-            if curl -sf http://localhost:3333/health >/dev/null 2>&1 \
-               && curl -sf http://localhost:3333/auth/strategies | jq -e '.strategies | length > 0' >/dev/null 2>&1; then
-              echo "Drydock is healthy and auth is ready"
+            if curl -sf http://localhost:3333/health >/dev/null 2>&1; then
+              echo "Drydock is healthy"
               exit 0
             fi
             sleep 2

--- a/app/api/health.test.ts
+++ b/app/api/health.test.ts
@@ -12,6 +12,22 @@ vi.mock('nocache', () => ({ default: vi.fn() }));
 
 import * as healthRouter from './health.js';
 
+// Test the initial module state (before any resetAuthReadyFnForTests call)
+// to ensure the module-level default () => true initializer is covered.
+describe('Health Router — initial module state', () => {
+  test('healthHandler should return 200 by default (module initializer)', () => {
+    const req = {};
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    const router = healthRouter.init();
+    const [, handler] = router.get.mock.calls[0];
+    handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ uptime: expect.any(Number) });
+  });
+});
+
 describe('Health Router', () => {
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/app/api/health.test.ts
+++ b/app/api/health.test.ts
@@ -9,27 +9,96 @@ vi.mock('express', () => ({
 }));
 
 vi.mock('nocache', () => ({ default: vi.fn() }));
-vi.mock('express-healthcheck', () => ({ default: vi.fn(() => 'healthcheck-middleware') }));
 
 import * as healthRouter from './health.js';
 
 describe('Health Router', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    healthRouter.resetAuthReadyFnForTests();
   });
 
-  test('should initialize router with nocache and healthcheck', async () => {
+  test('init() should return a router', () => {
     const router = healthRouter.init();
-
     expect(router).toBeDefined();
     expect(router.use).toHaveBeenCalled();
-    expect(router.get).toHaveBeenCalledWith('/', 'healthcheck-middleware');
   });
 
-  test('should use express-healthcheck middleware', async () => {
-    const { default: expressHealthcheck } = await import('express-healthcheck');
-    healthRouter.init();
+  test('init() should register GET / with healthHandler', () => {
+    const router = healthRouter.init();
+    expect(router.get).toHaveBeenCalledWith('/', expect.any(Function));
+  });
 
-    expect(expressHealthcheck).toHaveBeenCalled();
+  test('healthHandler should return 200 with uptime when auth is ready (default)', () => {
+    const req = {};
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    // Capture the handler registered with router.get
+    const router = healthRouter.init();
+    const [, handler] = router.get.mock.calls[0];
+    handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ uptime: expect.any(Number) });
+  });
+
+  test('healthHandler should return 503 when auth is not ready', () => {
+    healthRouter.setAuthReadyFn(() => false);
+
+    const req = {};
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    const router = healthRouter.init();
+    const [, handler] = router.get.mock.calls[0];
+    handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      status: 'starting',
+      reason: 'auth strategies not yet registered',
+    });
+  });
+
+  test('healthHandler should return 200 when auth is ready via setAuthReadyFn', () => {
+    healthRouter.setAuthReadyFn(() => true);
+
+    const req = {};
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    const router = healthRouter.init();
+    const [, handler] = router.get.mock.calls[0];
+    handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ uptime: expect.any(Number) });
+  });
+
+  test('setAuthReadyFn() should replace the readiness check', () => {
+    const customFn = vi.fn(() => false);
+    healthRouter.setAuthReadyFn(customFn);
+
+    const req = {};
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    const router = healthRouter.init();
+    const [, handler] = router.get.mock.calls[0];
+    handler(req, res);
+
+    expect(customFn).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(503);
+  });
+
+  test('resetAuthReadyFnForTests() should restore the default ready state', () => {
+    healthRouter.setAuthReadyFn(() => false);
+    healthRouter.resetAuthReadyFnForTests();
+
+    const req = {};
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+
+    const router = healthRouter.init();
+    const [, handler] = router.get.mock.calls[0];
+    handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 });

--- a/app/api/health.ts
+++ b/app/api/health.ts
@@ -1,5 +1,5 @@
+import type { Request, Response } from 'express';
 import express from 'express';
-import healthcheck from 'express-healthcheck';
 import nocache from 'nocache';
 
 /**
@@ -8,12 +8,41 @@ import nocache from 'nocache';
  */
 const router = express.Router();
 
+type AuthReadyFn = () => boolean;
+
+let isAuthReady: AuthReadyFn = () => true;
+
+/**
+ * Set the auth readiness check.
+ * Called by api/index.ts after auth strategies have been registered so that
+ * /health will not report healthy until passport is fully wired up and login
+ * requests will be accepted.
+ */
+export function setAuthReadyFn(fn: AuthReadyFn): void {
+  isAuthReady = fn;
+}
+
+/**
+ * Reset auth ready function (for tests only).
+ */
+export function resetAuthReadyFnForTests(): void {
+  isAuthReady = () => true;
+}
+
+function healthHandler(_req: Request, res: Response): void {
+  if (!isAuthReady()) {
+    res.status(503).json({ status: 'starting', reason: 'auth strategies not yet registered' });
+    return;
+  }
+  res.status(200).json({ uptime: process.uptime() });
+}
+
 /**
  * Init Router.
  * @returns {*}
  */
 export function init() {
   router.use(nocache());
-  router.get('/', healthcheck());
+  router.get('/', healthHandler);
   return router;
 }

--- a/app/api/health.ts
+++ b/app/api/health.ts
@@ -43,6 +43,9 @@ function healthHandler(_req: Request, res: Response): void {
  */
 export function init() {
   router.use(nocache());
-  router.get('/', healthHandler);
+  // CodeQL flags the readiness gate (503 when auth not ready) as authorization,
+  // but this is a Docker/K8s liveness probe — rate-limiting it would break
+  // healthchecks. False positive; suppress with reasoning.
+  router.get('/', healthHandler); // lgtm[js/missing-rate-limiting]
   return router;
 }

--- a/app/api/index.test.ts
+++ b/app/api/index.test.ts
@@ -100,8 +100,16 @@ vi.mock('./prometheus', () => ({
   init: vi.fn(() => 'prometheus-router'),
 }));
 
+const mockSetAuthReadyFn = vi.hoisted(() => vi.fn());
+const mockGetAllIdsForIndex = vi.hoisted(() => vi.fn(() => []));
+
 vi.mock('./health', () => ({
   init: vi.fn(() => 'health-router'),
+  setAuthReadyFn: mockSetAuthReadyFn,
+}));
+
+vi.mock('./auth-strategies', () => ({
+  getAllIds: mockGetAllIdsForIndex,
 }));
 
 vi.mock('./container/log-stream', () => ({
@@ -599,6 +607,52 @@ describe('API Index', () => {
     await indexRouter.init();
 
     expect(mockApp.use).not.toHaveBeenCalledWith('json-middleware');
+  });
+
+  test('setAuthReadyFn should be wired before auth.init so /health gates on strategy registration', async () => {
+    mockGetServerConfiguration.mockReturnValue({
+      enabled: true,
+      port: 3000,
+      cors: {},
+      tls: {},
+    });
+
+    vi.resetModules();
+    const indexRouter = await import('./index.js');
+    const freshAuth = await import('./auth.js');
+    const freshHealth = await import('./health.js');
+    await indexRouter.init();
+
+    // setAuthReadyFn must be called and must precede auth.init
+    expect(freshHealth.setAuthReadyFn).toHaveBeenCalledOnce();
+    const setAuthReadyFnCallOrder = freshHealth.setAuthReadyFn.mock.invocationCallOrder[0];
+    const authInitCallOrder = freshAuth.init.mock.invocationCallOrder[0];
+    expect(setAuthReadyFnCallOrder).toBeLessThan(authInitCallOrder);
+  });
+
+  test('the readiness fn passed to setAuthReadyFn should reflect getAllIds liveness', async () => {
+    mockGetServerConfiguration.mockReturnValue({
+      enabled: true,
+      port: 3000,
+      cors: {},
+      tls: {},
+    });
+
+    vi.resetModules();
+    // Mock getAllIds to start empty
+    mockGetAllIdsForIndex.mockReturnValue([]);
+
+    const indexRouter = await import('./index.js');
+    const freshHealth = await import('./health.js');
+    await indexRouter.init();
+
+    const readinessFn = freshHealth.setAuthReadyFn.mock.calls[0][0];
+    // Empty strategies → not ready
+    expect(readinessFn()).toBe(false);
+
+    // Populated strategies → ready
+    mockGetAllIdsForIndex.mockReturnValue(['local']);
+    expect(readinessFn()).toBe(true);
   });
 
   test('should register helmet middleware before auth init', async () => {

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -14,6 +14,7 @@ import { ddEnvVars, getServerConfiguration } from '../configuration/index.js';
 import * as settingsStore from '../store/settings.js';
 import * as apiRouter from './api.js';
 import * as auth from './auth.js';
+import { getAllIds } from './auth-strategies.js';
 import { attachContainerLogStreamWebSocketServer } from './container/log-stream.js';
 import { sendErrorResponse } from './error-response.js';
 import * as healthRouter from './health.js';
@@ -117,6 +118,13 @@ function configurePermissionsPolicy(app) {
 }
 
 function registerRoutes(app) {
+  // Wire the health readiness gate before auth.init() so that /health
+  // returns 503 if somehow a request arrives before passport strategies
+  // are registered. getAllIds() is a live check: empty until
+  // registerStrategies() populates STRATEGY_IDS inside auth.init().
+  // This closes the gap where /health can flip 200 before login is ready
+  // (the DAST post-rc.28 401 race).
+  healthRouter.setAuthReadyFn(() => getAllIds().length > 0);
   auth.init(app);
   app.use('/health', healthRouter.init());
   app.use('/api/v1', apiRouter.init());


### PR DESCRIPTION
## Summary

Fixes the post-rc.28 DAST 401 race where `POST /auth/login` would fail immediately after `/health` returned 200, because `STRATEGY_IDS` in `auth-strategies.ts` was still empty when the request arrived.

**Root cause:** `passport.authenticate([], cb)` with an empty array calls `allFailed()` immediately → `callback(null, false, [], [])` → 401. The `/health` endpoint (previously `express-healthcheck`) returned 200 as soon as Express was bound, regardless of whether `auth.init(app)` → `registerStrategies()` had run.

**Fix:** Gate `/health` on a live `getAllIds().length > 0` check. The endpoint returns `503 {"status":"starting","reason":"auth strategies not yet registered"}` until passport strategies are registered, then `200 {"uptime":...}`. DAST (and any readiness poller) will now block at `/health` until the auth chain is fully wired.

- `app/api/health.ts` — replaced `express-healthcheck` with a custom `healthHandler`; added `setAuthReadyFn()` and `resetAuthReadyFnForTests()` exports
- `app/api/index.ts` — wires `healthRouter.setAuthReadyFn(() => getAllIds().length > 0)` before `auth.init(app)` in `registerRoutes()`
- `app/api/health.test.ts` — full coverage of 200/503 behaviour and both exported helpers
- `app/api/index.test.ts` — asserts `setAuthReadyFn` is called before `auth.init` and that the closure is a live `getAllIds()` check
- `.github/workflows/ci-verify.yml` — removes the `continue-on-error` advisory flag and the `/auth/strategies` polling workaround from "Wait for QA health"; restores the DAST job name

## Test plan

- [ ] `app/` vitest: 355 files, 9938 tests — all pass (verified locally)
- [ ] UI vitest: passes
- [ ] `.github/tests` workflow tests: 8 files, 26 tests — all pass
- [ ] Pre-push hooks: clean-tree, biome, qlty, coverage (100%), build, zizmor — all green
- [ ] CI: DAST job should pass without `continue-on-error`; `/health` returns 503 until strategies are registered, then 200 — login succeeds