### PR TITLE
🐛 fix(ci): use admin:admin in DAST auth to match qa-compose hash

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -584,7 +584,10 @@ jobs:
           cookie_jar="$(mktemp)"
           trap 'rm -f "${cookie_jar}"' EXIT
 
-          basic_auth="$(printf 'admin:password' | base64 | tr -d '\n')"
+          # qa-compose.yml DD_AUTH_BASIC_ADMIN_HASH verifies 'admin' (matches
+          # Playwright DD_PASSWORD default in e2e/playwright/helpers/test-helpers.ts).
+          # ci-compose.yml uses a different hash that verifies 'password'.
+          basic_auth="$(printf 'admin:admin' | base64 | tr -d '\n')"
           echo "::add-mask::${basic_auth}"
           curl -fsS \
             -c "${cookie_jar}" \
@@ -700,7 +703,10 @@ jobs:
           cookie_jar="$(mktemp)"
           trap 'rm -f "${cookie_jar}"' EXIT
 
-          basic_auth="$(printf 'admin:password' | base64 | tr -d '\n')"
+          # qa-compose.yml DD_AUTH_BASIC_ADMIN_HASH verifies 'admin' (matches
+          # Playwright DD_PASSWORD default in e2e/playwright/helpers/test-helpers.ts).
+          # ci-compose.yml uses a different hash that verifies 'password'.
+          basic_auth="$(printf 'admin:admin' | base64 | tr -d '\n')"
           echo "::add-mask::${basic_auth}"
           curl -fsS \
             -c "${cookie_jar}" \


### PR DESCRIPTION
## Summary

The recurring DAST 401 we've been chasing was caused by **invalid credentials**, not the readiness race PR #402 fixed.

- `test/qa-compose.yml` `DD_AUTH_BASIC_ADMIN_HASH` verifies the plaintext **\`admin\`**, not \`password\`
- `test/ci-compose.yml` (used by Load Tests) uses a *different* hash that verifies \`password\`
- Playwright already defaults to \`admin:admin\` via \`e2e/playwright/helpers/test-helpers.ts:19-22\` and passes against the same qa-compose
- Only DAST hardcoded \`admin:password\` against qa-compose — only DAST failed with 401

PR #402's readiness gate is still correct and required: the CI log for run 26611307727 shows \`Wait for QA health\` passed at 01:13:10.207Z and Basic strategy registered at 01:13:09.763Z — strategies were registered before the failed request. The 401 was just bad credentials.

## Changes
- \`.github/workflows/ci-verify.yml:587,703\` — change \`admin:password\` → \`admin:admin\` in both DAST auth steps
- Inline comment explains the qa-compose vs ci-compose hash divergence

## Test plan
- [ ] CI Verify runs green, DAST job succeeds
- [ ] Load Tests still pass (they use ci-compose, unrelated)
- [ ] Playwright still passes (already used admin:admin)