### PR TITLE
🔧 chore(release): v1.5.0-rc.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0-rc.35] — 2026-06-10
+
 ### Fixed
 
 - **False "update failed" notification when concurrent update requests race ([#421](https://github.com/CodesWhat/drydock/issues/421)).** When a duplicate update request was rejected with HTTP 409 ("update already in progress") while the winning update was still in flight, the controller classified the conflict as a genuine failure — firing an "update failed" notification immediately followed by "updated successfully". The duplicate classifier now recognizes three benign signals instead of one: a recently-succeeded operation (as before), a 409 response whose body explicitly carries the active-update lock message ("Container update already queued/in progress" — authoritative even before the winner's state has propagated from a remote agent over SSE), and another active (queued or in-progress) operation for the same container and agent+watcher identity. The same reclassification now also covers the Docker-native rename path in `ContainerUpdateExecutor`, which previously marked the duplicate failed before the outer classifier could run.


### PR DESCRIPTION
Release candidate **v1.5.0-rc.35** — CHANGELOG heading for the release-cut validator.

This RC ships (already merged to main via #422 and #419):
- **#421** duplicate-409 race closed end to end (classifier + rename path + deferred reconciliation)
- **#408** suppression hardening (dual-key, batch retry, startup re-seed, TTL pruning)
- **#290** toast status gap (success waits for the replacement container)
- **#418** trust-proxy startup warning + `TRUSTPROXY=0` fix
- 3 security fixes: command env allowlist, hooks binary allowlist, HTTP metadata guard (incl. IPv4-mapped IPv6 bypass)
- perf: RE2 transform cache, deep-clone removal, indexed retention pruning
- openssl apk pin bump (3.5.7-r0)

Full local gate green. Cut via `release-cut.yml` after merge.