### PR TITLE
🐛 fix(store): normalise empty-string identity fields in insertOperation

### DIFF
--- a/app/agent/AgentClient.test.ts
+++ b/app/agent/AgentClient.test.ts
@@ -4841,6 +4841,54 @@ describe('AgentClient', () => {
       expect(result).toBe(row);
       expect(storeContainer.getContainers).toHaveBeenCalledWith({ agent: 'test-agent' });
     });
+
+    test('returns undefined when two agent-owned containers share the same name (ambiguous match)', () => {
+      // Two containers both named 'nginx' on this agent — cannot determine which
+      // identity to stamp, so the function must return undefined rather than
+      // picking one arbitrarily.
+      vi.mocked(storeContainer.getContainer).mockReturnValue(undefined);
+      vi.mocked(storeContainer.getContainers).mockReturnValue([
+        { id: 'nginx-1', name: 'nginx', agent: 'test-agent', watcher: 'local' },
+        { id: 'nginx-2', name: 'nginx', agent: 'test-agent', watcher: 'local' },
+      ] as any);
+
+      const result = (client as any).getStoredContainerForAgentOperation({
+        containerName: 'nginx',
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    test('ambiguous two-name: buildAgentOperationBase omits container snapshot and watcher when store is ambiguous', async () => {
+      // When two same-named containers exist on the agent, getStoredContainerForAgentOperation
+      // returns undefined, so buildAgentOperationBase must not stamp a container or watcher.
+      vi.mocked(storeContainer.getContainer).mockReturnValue(undefined);
+      vi.mocked(storeContainer.getContainers).mockReturnValue([
+        { id: 'nginx-1', name: 'nginx', agent: 'test-agent', watcher: 'local' },
+        { id: 'nginx-2', name: 'nginx', agent: 'test-agent', watcher: 'local' },
+      ] as any);
+
+      await client.handleEvent('dd:update-operation-changed', {
+        operationId: 'remote-op-ambiguous',
+        containerName: 'nginx',
+        status: 'in-progress',
+        phase: 'pulling',
+      });
+
+      expect(updateOperationStore.insertOperation).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          container: expect.anything(),
+          watcher: expect.anything(),
+        }),
+      );
+      expect(updateOperationStore.insertOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'agent-test-agent-remote-op-ambiguous',
+          containerName: 'nginx',
+          agent: 'test-agent',
+        }),
+      );
+    });
   });
 
   describe('applyAgentUpdateOperationChanged — controller-issued row reuse (#289)', () => {

--- a/app/store/update-operation.test.ts
+++ b/app/store/update-operation.test.ts
@@ -402,6 +402,87 @@ describe('Update Operation Store', () => {
     expect(inserted.updatedAt).toBeDefined();
   });
 
+  test('insertOperation normalises empty-string agent to undefined', () => {
+    const inserted = updateOperation.insertOperation({
+      containerName: 'web',
+      agent: '',
+    });
+
+    expect((inserted as unknown as Record<string, unknown>).agent).toBeUndefined();
+  });
+
+  test('insertOperation normalises empty-string watcher to undefined', () => {
+    const inserted = updateOperation.insertOperation({
+      containerName: 'web',
+      watcher: '',
+    });
+
+    expect((inserted as unknown as Record<string, unknown>).watcher).toBeUndefined();
+  });
+
+  test('insertOperation normalises empty-string agent/watcher inside container snapshot to undefined', () => {
+    const inputContainer = { id: 'c1', name: 'web', agent: '', watcher: '' } as any;
+    const inserted = updateOperation.insertOperation({
+      containerName: 'web',
+      container: inputContainer,
+    });
+
+    const container = (inserted as unknown as Record<string, unknown>).container as Record<
+      string,
+      unknown
+    >;
+    expect(container.agent).toBeUndefined();
+    expect(container.watcher).toBeUndefined();
+    // The stored container must be a clone — the caller's object must not be mutated.
+    expect(container).not.toBe(inputContainer);
+    expect(inputContainer.agent).toBe('');
+    expect(inputContainer.watcher).toBe('');
+  });
+
+  test('insertOperation normalises empty-string agent but preserves non-empty watcher in container snapshot', () => {
+    const inserted = updateOperation.insertOperation({
+      containerName: 'web',
+      container: { id: 'c1', name: 'web', agent: '', watcher: 'local' } as any,
+    });
+
+    const container = (inserted as unknown as Record<string, unknown>).container as Record<
+      string,
+      unknown
+    >;
+    expect(container.agent).toBeUndefined();
+    expect(container.watcher).toBe('local');
+  });
+
+  test('insertOperation normalises empty-string watcher but preserves non-empty agent in container snapshot', () => {
+    const inserted = updateOperation.insertOperation({
+      containerName: 'web',
+      container: { id: 'c1', name: 'web', agent: 'agent-A', watcher: '' } as any,
+    });
+
+    const container = (inserted as unknown as Record<string, unknown>).container as Record<
+      string,
+      unknown
+    >;
+    expect(container.agent).toBe('agent-A');
+    expect(container.watcher).toBeUndefined();
+  });
+
+  test('insertOperation preserves non-empty agent and watcher strings unchanged', () => {
+    const inserted = updateOperation.insertOperation({
+      containerName: 'web',
+      agent: 'agent-A',
+      watcher: 'local',
+      container: { id: 'c1', name: 'web', agent: 'agent-A', watcher: 'local' } as any,
+    });
+
+    const op = inserted as unknown as Record<string, unknown>;
+    const container = op.container as Record<string, unknown>;
+    expect(op.agent).toBe('agent-A');
+    expect(op.watcher).toBe('local');
+    expect(container.agent).toBe('agent-A');
+    expect(container.watcher).toBe('local');
+  });
+
   test('updateOperation should merge patch and refresh updatedAt', () => {
     const inserted = updateOperation.insertOperation({
       containerName: 'web',
@@ -2776,6 +2857,51 @@ describe('Update Operation Store', () => {
           watcher: 'local',
         }),
       ).toBe(true);
+    });
+
+    test('returns false and expires the winner op when it is past the active TTL', async () => {
+      // Verify that a stale in-progress "winner" op (past DD_UPDATE_OPERATION_ACTIVE_TTL_MS)
+      // is not counted as active: hasOtherActiveOperationByContainerName must return false
+      // and the freshness check inside it must terminalize the winner op as expired.
+      vi.resetModules();
+      const previousActiveTtlMs = process.env.DD_UPDATE_OPERATION_ACTIVE_TTL_MS;
+      process.env.DD_UPDATE_OPERATION_ACTIVE_TTL_MS = '60000';
+      vi.useFakeTimers();
+
+      try {
+        const fresh = await import('./update-operation.js');
+        fresh.createCollections(createDb());
+
+        vi.setSystemTime(new Date('2026-02-23T00:00:00.000Z'));
+        const winner = fresh.insertOperation({
+          containerName: 'web',
+          status: 'in-progress',
+          phase: 'pulling',
+          container: { id: 'c-winner', name: 'web', watcher: 'local', agent: 'agent-A' } as any,
+        });
+
+        // Advance past the 60 s TTL so the winner op is stale.
+        vi.setSystemTime(new Date('2026-02-23T00:01:01.000Z'));
+
+        const result = fresh.hasOtherActiveOperationByContainerName('web', 'loser-op-id', {
+          agent: 'agent-A',
+          watcher: 'local',
+        });
+
+        expect(result).toBe(false);
+
+        // The freshness check inside hasOtherActiveOperationByContainerName must have
+        // terminalized the stale winner op as expired.
+        const winnerAfter = fresh.getOperationById(winner.id);
+        expect(winnerAfter?.status).toBe('expired');
+      } finally {
+        vi.useRealTimers();
+        if (previousActiveTtlMs === undefined) {
+          delete process.env.DD_UPDATE_OPERATION_ACTIVE_TTL_MS;
+        } else {
+          process.env.DD_UPDATE_OPERATION_ACTIVE_TTL_MS = previousActiveTtlMs;
+        }
+      }
     });
   });
 

--- a/app/store/update-operation.ts
+++ b/app/store/update-operation.ts
@@ -617,6 +617,27 @@ export function insertOperation(
     updatedAt: now,
   } as UpdateOperation;
 
+  // Normalise empty-string identity fields to undefined after building the
+  // operation object.  `getOperationIdentity` and `matchesStrictIdentityFilter`
+  // treat '' and undefined identically via `?? ''`, so leaving '' in the store
+  // would make the identity-matching invariant depend on every caller being
+  // careful.  Doing it here makes the guarantee unconditional.
+  const op = operationToSave as unknown as Record<string, unknown>;
+  if (op.agent === '') op.agent = undefined;
+  if (op.watcher === '') op.watcher = undefined;
+  const savedContainer = op.container;
+  if (savedContainer && typeof savedContainer === 'object') {
+    const c = savedContainer as Record<string, unknown>;
+    if (c.agent === '' || c.watcher === '') {
+      // Clone rather than mutate in place: the container snapshot belongs to the
+      // caller and may be a live store document; mutating it would corrupt shared state.
+      const cloned = { ...c };
+      if (cloned.agent === '') cloned.agent = undefined;
+      if (cloned.watcher === '') cloned.watcher = undefined;
+      op.container = cloned;
+    }
+  }
+
   if (updateOperationCollection) {
     updateOperationCollection.insert({ data: operationToSave });
     maybePruneOperationsForRetention(updateOperationCollection);

--- a/app/updates/request-update.test.ts
+++ b/app/updates/request-update.test.ts
@@ -1402,5 +1402,108 @@ describe('request-update', () => {
         expect.objectContaining({ status: 'failed' }),
       );
     });
+
+    test('winner fails after loser was expired: one failed + one expired, update-failed fires exactly once', async () => {
+      // Sequence:
+      //   (1) Winner op is accepted and running (in-progress).
+      //   (2) Loser op gets a 409 active-lock conflict while the winner is still
+      //       in flight → classified as `expired` (no update-failed).
+      //   (3) Winner's trigger subsequently fails → classified as `failed`
+      //       (exactly ONE update-failed-worthy terminal transition).
+      //
+      // The test operates at the markOperationTerminal seam: we verify it is
+      // called exactly twice — once with { status: 'expired' } for the loser,
+      // once with { status: 'failed' } for the winner — proving the loser's
+      // expiry cannot retroactively become a second failure event.
+      const winnerPull = deferred();
+      const loserConflict409 = Object.assign(new Error('Container update already in progress'), {
+        response: { status: 409, data: { error: 'Container update already in progress' } },
+      });
+
+      const winnerTrigger = {
+        type: 'docker',
+        trigger: vi.fn(() => winnerPull.promise),
+      };
+      const loserTrigger = {
+        type: 'docker',
+        trigger: vi.fn().mockRejectedValue(loserConflict409),
+      };
+
+      // Winner op: queued with agent+watcher identity.
+      let winnerOpId: string | undefined;
+      mockInsertOperation.mockImplementationOnce(
+        (operation: { id?: string; [k: string]: unknown }) => {
+          const row = { id: operation.id || 'winner-op-id', ...operation };
+          winnerOpId = row.id;
+          return row;
+        },
+      );
+      mockGetOperationById.mockImplementation((id: string) => {
+        if (id === winnerOpId) {
+          return {
+            id: winnerOpId,
+            containerName: 'nginx',
+            status: 'queued',
+            phase: 'queued',
+            container: { id: 'c-winner', name: 'nginx', watcher: 'local', agent: 'agent-A' },
+          };
+        }
+        return {
+          id,
+          containerName: 'nginx',
+          status: 'queued',
+          phase: 'queued',
+          container: { id: 'c-loser', name: 'nginx', watcher: 'local', agent: 'agent-A' },
+        };
+      });
+
+      // (1) Enqueue winner — runs in background.
+      const winnerAccepted = await requestContainerUpdate(
+        createContainer({ name: 'nginx', watcher: 'local', agent: 'agent-A' }),
+        { trigger: winnerTrigger },
+      );
+      // Winner is now in-flight (promise unresolved).
+
+      // (2) Loser: active-lock 409 arrives while winner is in flight.
+      // hasOtherActiveOperationByContainerName returns true to classify as expired.
+      mockGetRecentTerminalSucceededOperationByContainerName.mockReturnValue(undefined);
+      mockHasOtherActiveOperationByContainerName.mockReturnValue(true);
+      mockGetActiveOperationByContainerId.mockReturnValue(undefined);
+      mockGetActiveOperationByContainerName.mockReturnValue(undefined);
+
+      const loserAccepted = await requestContainerUpdate(
+        createContainer({ name: 'nginx', watcher: 'local', agent: 'agent-A' }),
+        { trigger: loserTrigger },
+      );
+      await flushAsyncWork();
+
+      // Loser must be expired; winner is still running.
+      expect(mockMarkOperationTerminal).toHaveBeenCalledWith(
+        loserAccepted.operationId,
+        expect.objectContaining({ status: 'expired' }),
+      );
+      const callsAfterLoser = mockMarkOperationTerminal.mock.calls.length;
+      expect(callsAfterLoser).toBe(1);
+
+      // (3) Winner now fails.
+      winnerPull.reject(new Error('pull failed for winner'));
+      await flushAsyncWork();
+
+      // Final state: two markOperationTerminal calls total.
+      expect(mockMarkOperationTerminal).toHaveBeenCalledTimes(2);
+      expect(mockMarkOperationTerminal).toHaveBeenCalledWith(
+        winnerAccepted.operationId,
+        expect.objectContaining({ status: 'failed' }),
+      );
+      // The loser's expired terminal status is unchanged — only one call used 'expired'.
+      const expiredCalls = mockMarkOperationTerminal.mock.calls.filter(
+        ([, patch]) => (patch as { status?: string }).status === 'expired',
+      );
+      const failedCalls = mockMarkOperationTerminal.mock.calls.filter(
+        ([, patch]) => (patch as { status?: string }).status === 'failed',
+      );
+      expect(expiredCalls).toHaveLength(1);
+      expect(failedCalls).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Hardening batch from today's v1.5.0 release-readiness review of the rc.33→rc.35 delta. No behavior changes for any current caller — this makes the duplicate-409 race fix's identity-matching invariant unconditional and closes the three test gaps the review flagged around #421/#422.

### Fix

- **`insertOperation` now normalises `''` → `undefined`** for `agent` and `watcher`, both top-level and inside the `container` snapshot. Previously the comment in `matchesStrictIdentityFilter` claimed this normalization existed, but it didn't — the invariant only held because every current caller filters empty strings before insert. A future caller passing `agent: ''` would have silently broken strict identity matching (the cross-agent guard in the 409-race classification). The container snapshot is **cloned on normalize**, never mutated in place, since it belongs to the caller and may be a live store document.

### Tests added

- **TTL-expired winner** (`store/update-operation.test.ts`): a racing "winner" op stored as `in-progress` but past `DD_UPDATE_OPERATION_ACTIVE_TTL_MS` — `hasOtherActiveOperationByContainerName` returns `false` and the freshness check terminalizes the stale op as `expired`.
- **Ambiguous same-name containers** (`agent/AgentClient.test.ts`): two agent-owned containers sharing a name — `getStoredContainerForAgentOperation` returns `undefined` and `buildAgentOperationBase` stamps no container/watcher identity, instead of picking one arbitrarily.
- **Winner fails after loser expired** (`updates/request-update.test.ts`): sequences loser-409→`expired` then winner→`failed`; asserts the final store state is exactly one `failed` + one `expired` and the update-failed terminal transition happens exactly once — the exact observable behavior #410's reporter will judge rc.35 by.
- **Normalization coverage** (`store/update-operation.test.ts`): empty-string/mixed/preserved identity cases, plus an assertion that the caller's container object is not mutated.

## Verification

- Full pre-push gate passed: 100% coverage thresholds met (app + ui), tsc clean, biome clean, qlty clean, builds clean.
- 663 tests passing across the three affected suites.