### PR TITLE
🔧 config(codeowners): normalize code owners across CodesWhat repos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @biggest-littlest @ALARGECOMPANY
+* @scttbnsn @ALARGECOMPANY @biggest-littlest


### PR DESCRIPTION
Normalize `.github/CODEOWNERS` to the canonical trusted-approver set `@scttbnsn @ALARGECOMPANY @biggest-littlest`, matching lookout. For `drydock` this adds `@scttbnsn` (previously omitted).

Part of cross-repo governance normalization (lookout / drydock / sockguard).