### PR TITLE
✨ feat(agents): declare lookout runtime info fields in ack payload (M4)

### DIFF
--- a/app/agent/AgentClient.test.ts
+++ b/app/agent/AgentClient.test.ts
@@ -4467,6 +4467,35 @@ describe('AgentClient', () => {
       // Should not throw — optional chaining prevents it
       expect(result).toBeDefined();
     });
+
+    test('applies logLevel and pollInterval from ack payload', () => {
+      const internal = client as any;
+      client.info = { logLevel: 'info', pollInterval: '300' };
+
+      const result = internal.buildRuntimeInfoFromAck({
+        logLevel: 'debug',
+        pollInterval: '60',
+      });
+      expect(result.logLevel).toBe('debug');
+      expect(result.pollInterval).toBe('60');
+    });
+
+    test('falls back to existing logLevel and pollInterval when absent from ack payload', () => {
+      const internal = client as any;
+      client.info = { logLevel: 'warn', pollInterval: '120' };
+
+      const result = internal.buildRuntimeInfoFromAck({});
+      expect(result.logLevel).toBe('warn');
+      expect(result.pollInterval).toBe('120');
+    });
+
+    test('falls back to existing logLevel when ack payload logLevel is empty string', () => {
+      const internal = client as any;
+      client.info = { logLevel: 'error' };
+
+      const result = internal.buildRuntimeInfoFromAck({ logLevel: '' });
+      expect(result.logLevel).toBe('error');
+    });
   });
 
   describe('handleWatcherSnapshotEvent optional chaining', () => {

--- a/app/agent/AgentClient.ts
+++ b/app/agent/AgentClient.ts
@@ -86,6 +86,8 @@ interface AgentRuntimeAckPayload {
   memoryGb?: unknown;
   uptimeSeconds?: unknown;
   lastSeen?: unknown;
+  logLevel?: unknown;
+  pollInterval?: unknown;
 }
 
 interface AgentSsePayload {
@@ -759,6 +761,14 @@ export class AgentClient {
         typeof runtimeData?.lastSeen === 'string' && runtimeData.lastSeen
           ? runtimeData.lastSeen
           : new Date().toISOString(),
+      logLevel:
+        typeof runtimeData?.logLevel === 'string' && runtimeData.logLevel
+          ? runtimeData.logLevel
+          : this.info.logLevel,
+      pollInterval:
+        typeof runtimeData?.pollInterval === 'string' && runtimeData.pollInterval
+          ? runtimeData.pollInterval
+          : this.info.pollInterval,
     };
   }
 


### PR DESCRIPTION
## Summary

Implements the drydock half of milestone **M4**: declares the `logLevel` and `pollInterval` runtime-info fields in `AgentRuntimeAckPayload` and threads them into the agent info surface. Resolves integration gap **G4** (a symmetric omission — both sides previously dropped these fields).

Paired with lookout PR **`feat/agent-info-fields`**, which populates the same fields on the wire. The contract is locked field-for-field:

| Field | lookout (Go json tag) | drydock (TS) |
|-------|----------------------|--------------|
| `logLevel` | `json:"logLevel"` (string) | `logLevel?: unknown` |
| `pollInterval` | `json:"pollInterval"` (string, seconds) | `pollInterval?: unknown` |
| `memoryGb` | `json:"memoryGb"` (float64, GiB) | `memoryGb?` (already existed) |

`buildRuntimeInfoFromAck` threads both new fields with the same string-guard / non-empty / fallback pattern as sibling fields. UI surfacing reuses the existing detail-field pattern in `AgentsView.vue`.

## Validation

```
all tests pass · 100% line/branch/function/statement coverage maintained
```

A cross-repo pairing review confirmed the JSON field names, types, and units match exactly on both sides (no ms/s mismatch on `pollInterval`; `memoryGb` is GiB on both).

## ⚠️ Merge note

This branch and **`feat/lookout-edge`** (M5) both modify `app/agent/AgentClient.ts` — whichever merges second needs a trivial rebase.

🎯 Target: `main`
