### PR TITLE
🐛 fix(docs): strip HTML comments from generated changelog MDX

### DIFF
--- a/apps/web/scripts/sync-docs.mjs
+++ b/apps/web/scripts/sync-docs.mjs
@@ -27,7 +27,15 @@ title: "Changelog"
 description: "All notable changes to this project will be documented in this file."
 ---`;
 
-const body = changelogMd.replace(/^# Changelog\n/, "");
+// Strip HTML comments (<!-- ... -->) before emitting MDX. They are valid in the
+// GitHub-rendered CHANGELOG (used for maintainer-only notes) but MDX v3 rejects
+// them ("use {/* */}"), which fails the fumadocs/Turbopack build. They are not
+// published-docs content, so drop them, then collapse the blank-line gap left
+// behind so the generated MDX stays tidy.
+const body = changelogMd
+  .replace(/^# Changelog\n/, "")
+  .replace(/<!--[\s\S]*?-->/g, "")
+  .replace(/\n{3,}/g, "\n\n");
 
 // Write changelog into the current (v1.5) source dir so it gets copied
 const changelogDir = join(repoRoot, "content", "docs", "current", "changelog");


### PR DESCRIPTION
## Problem

Every `drydock-website` Vercel deploy (production + preview) has failed since ~2026-06-13:

```
./apps/web/content/docs/v1.5/changelog/index.mdx
16:2: Unexpected character `!` (U+0021) before name ... (note: to create a comment in MDX, use {/* text */})
Error: Turbopack build failed
```

`sync-docs.mjs` copies `CHANGELOG.md` verbatim into the fumadocs MDX source. The `<!-- ... -->` upgrade-notes maintainer note in the `[Unreleased]` section is valid in the GitHub-rendered CHANGELOG but MDX v3 rejects HTML comments, failing the build. getdrydock.com production has been stuck on the last good build for ~2 days.

## Fix

Strip HTML comments during MDX generation (they are maintainer-only notes, not published-docs content) and collapse the blank-line gap. **`CHANGELOG.md` stays GitHub-valid and unchanged.** Root-cause fix in the generator, so future CHANGELOG comments can't break the build.

## Verification

- `node apps/web/scripts/sync-docs.mjs` → generated `v1.5/changelog/index.mdx` has 0 `<!--`.
- Full `npm run build` in `apps/web` passes (240+ docs pages generated incl. changelog).

1 file changed, 9 insertions(+), 1 deletion(-).