### PR TITLE
🔒 security: patch transitive CVEs in apps/web (js-yaml) and e2e (@opentelemetry/core)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ scheme restriction) live in `UPGRADE-NOTES.md` and are auto-appended to every
 1.4.6+ / 1.5.x release's notes by `scripts/append-upgrade-notes.mjs` (wired into
 `release-cut.yml`). Update that file — not this comment — when the notes change. -->
 
+### Security
+
+- **Documentation site (`apps/web`) js-yaml pinned to 4.2.0 ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68)).** `fumadocs-mdx` pulled js-yaml 4.1.1 transitively; an override forces the patched 4.2.0. Build-time dependency of the website only — not part of the shipped drydock image.
+
 ## [1.5.0-rc.37] — 2026-06-15
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ scheme restriction) live in `UPGRADE-NOTES.md` and are auto-appended to every
 
 - **Documentation site (`apps/web`) js-yaml pinned to 4.2.0 ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68)).** `fumadocs-mdx` pulled js-yaml 4.1.1 transitively; an override forces the patched 4.2.0. Build-time dependency of the website only — not part of the shipped drydock image.
 
+- **E2E load-test harness `@opentelemetry/core` pinned to 2.8.0 ([CVE-2026-54285](https://github.com/advisories/GHSA-8988-4f7v-96qf)).** artillery pulled `@opentelemetry/core` 2.7.1 transitively, vulnerable to unbounded memory allocation in W3C Baggage propagation; an override forces the patched 2.8.0. Test-only dependency — not part of the shipped drydock image.
+
 ## [1.5.0-rc.37] — 2026-06-15
 
 ### Security

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -3976,9 +3976,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,6 +50,7 @@
   },
   "overrides": {
     "postcss": "8.5.10",
-    "esbuild": "0.28.1"
+    "esbuild": "0.28.1",
+    "js-yaml": "4.2.0"
   }
 }

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -2423,9 +2423,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -46,6 +46,7 @@
     "ws": "8.21.0",
     "yaml": "2.8.3",
     "form-data": "4.0.6",
-    "protobufjs": "7.6.3"
+    "protobufjs": "7.6.3",
+    "@opentelemetry/core": "2.8.0"
   }
 }


### PR DESCRIPTION
Post-rc.37 dependency hygiene for two transitive CVEs flagged after the cut. Both are **build/test-time only — neither is in the shipped drydock container image.**

- **apps/web** — `fumadocs-mdx` pulled `js-yaml@4.1.1` (GHSA-h67p-54hq-rp68, fixed 4.2.0). Override → 4.2.0; postinstall docs-sync/MDX frontmatter generation runs clean. Clears Dependabot #139.
- **e2e** — artillery pulled `@opentelemetry/core@2.7.1` (CVE-2026-54285, unbounded memory in W3C Baggage propagation, fixed 2.8.0). Override → 2.8.0, a drop-in minor bump.

Full `qlty check --all --filter=osv-scanner` is clean after both. CHANGELOG `[Unreleased]` notes added for traceability into the next RC.

Not bundling the remaining e2e `js-yaml@3.14.2` (artillery): its only fix removes the `safeLoad()` API artillery calls, so it's triaged in `.qlty/qlty.toml` and the Dependabot alert (#140) is dismissed as tolerable_risk (test-only, trusted input).