### PR TITLE
🔒 security(scripts): use execFileSync in gen-banner to clear CodeQL shell-injection

### DIFF
--- a/scripts/gen-banner.mjs
+++ b/scripts/gen-banner.mjs
@@ -9,7 +9,7 @@
  *   node scripts/gen-banner.mjs
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -28,7 +28,7 @@ const RESET = `${ESC}[0m`;
 // ---------------------------------------------------------------------------
 // 1. Dump pixels via ImageMagick
 // ---------------------------------------------------------------------------
-const raw = execSync(`magick ${PNG} -resize ${TARGET_WIDTH}x -depth 8 txt:-`, {
+const raw = execFileSync('magick', [PNG, '-resize', `${TARGET_WIDTH}x`, '-depth', '8', 'txt:-'], {
   encoding: 'utf8',
   maxBuffer: 10 * 1024 * 1024,
 });
@@ -143,7 +143,7 @@ writeFileSync(OUT, tsContent, 'utf8');
 // 5. Lint/format the generated file
 // ---------------------------------------------------------------------------
 try {
-  execSync(`npx @biomejs/biome check --write ${OUT}`, {
+  execFileSync('npx', ['@biomejs/biome', 'check', '--write', OUT], {
     cwd: ROOT,
     encoding: 'utf8',
     stdio: 'pipe',


### PR DESCRIPTION
## What

`scripts/gen-banner.mjs` built its `magick` and `npx @biomejs/biome` invocations via template-string interpolation passed to `execSync`, which CodeQL flags as `js/shell-command-injection-from-environment`:

- [#378](https://github.com/CodesWhat/drydock/security/code-scanning/378) — line 31 (`magick ... txt:-`)
- [#379](https://github.com/CodesWhat/drydock/security/code-scanning/379) — line 146 (`npx @biomejs/biome check --write`)

Both are switched to `execFileSync(file, argsArray)` so the binaries run without a shell — the injection sink is gone.

## Why it's safe / behavior-preserving

`gen-banner.mjs` is a build-time dev script (run by hand, not shipped in the image), and the interpolated paths come from `__dirname`, not user input — so real exploitability was nil. But it's our own code sitting as two open mediums in the Security tab, and the fix is mechanical. Verified behavior-identical: re-running the script with ImageMagick available regenerates a **byte-identical** `app/banner/art.ts` (no diff). Biome clean, full pre-push gate green (qlty, coverage 100%, build).

Clearing these keeps the Security tab clean for the 1.5.0 GA cut.

## Scope

One file, 3 lines (`execSync` → `execFileSync` import + the two call sites). No other changes.