### PR TITLE
🐛 fix(portwing): complete edge wire-contract integration with portwing agent

### DIFF
--- a/app/agent/AgentClient.ts
+++ b/app/agent/AgentClient.ts
@@ -67,6 +67,15 @@ interface AgentClientRuntimeInfo {
   lastSeen?: string;
   logLevel?: string;
   pollInterval?: string;
+  cpuUsage?: number;
+  cpuCores?: number;
+  memoryUsed?: number;
+  memoryFree?: number;
+  diskTotal?: number;
+  diskUsed?: number;
+  diskFree?: number;
+  networkRxBytes?: number;
+  networkTxBytes?: number;
 }
 
 interface AgentComponentDescriptor {

--- a/app/agent/EdgeAgentAdapter.test.ts
+++ b/app/agent/EdgeAgentAdapter.test.ts
@@ -368,6 +368,9 @@ describe('EdgeAgentAdapter — frame dispatch', () => {
   });
 
   test('exec start when limit reached rejects with session-limit error and sends NO exec_end frame', async () => {
+    // When the session limit is reached, startExec rejects before registering any session,
+    // so no exec_end should be sent for the rejected call. exec_end is only sent by the
+    // close() closure of successfully-registered sessions (O5 fix).
     const { adapter, ws } = createAdapter();
     adapter.activate();
 
@@ -390,7 +393,9 @@ describe('EdgeAgentAdapter — frame dispatch', () => {
 
     await expect(adapter.startExec('c1', ['/bin/bash'])).rejects.toThrow('session limit reached');
 
-    // No new frame should have been sent — the exec_end send is spurious and has been removed
+    // No new frame should have been sent — the session was never registered so
+    // no exec_end is generated (exec_end is only sent from the close() closure of a
+    // successfully-registered session, which this rejected call never created).
     expect(ws.sentMessages.length).toBe(sentCountBefore);
     expect(ws.close).not.toHaveBeenCalled();
   });
@@ -425,12 +430,15 @@ describe('EdgeAgentAdapter — disconnect cleanup', () => {
     expect(await p1).toMatch(/connection closed/);
   });
 
-  test('onDisconnect clears all exec sessions', async () => {
+  test('onDisconnect clears all exec sessions and sends exec_end for each (O5)', async () => {
+    // O5 fix: onDisconnect calls session.close() for each live session, which now
+    // sends exec_end to the edge before deleting the map entry.
     const { adapter, ws } = createAdapter();
     adapter.activate();
 
-    sendFrame(ws, 'exec_ready', { execId: 'exec-99' });
-    await new Promise((r) => setTimeout(r, 0));
+    // Register a session via startExec so the close closure includes sendExecEnd
+    const execId = await adapter.startExec('c1', ['/bin/bash']);
+    ws.sentMessages.length = 0; // clear exec_start frame
 
     const adapterInternal = adapter as unknown as { execSessions: Map<string, unknown> };
     expect(adapterInternal.execSessions.size).toBe(1);
@@ -438,6 +446,14 @@ describe('EdgeAgentAdapter — disconnect cleanup', () => {
     await adapter.onDisconnect();
 
     expect(adapterInternal.execSessions.size).toBe(0);
+
+    // exec_end must have been sent to the edge for the live session (O5)
+    expect(
+      ws.sentMessages.some((m) => {
+        const parsed = JSON.parse(m) as { type: string; data: { execId: string } };
+        return parsed.type === 'exec_end' && parsed.data.execId === execId;
+      }),
+    ).toBe(true);
   });
 
   test('onDisconnect calls removeAgent', async () => {
@@ -1169,11 +1185,14 @@ describe('EdgeAgentAdapter — startExec close closure and send error', () => {
     vi.clearAllMocks();
   });
 
-  test('exec_end after startExec invokes the startExec close closure', async () => {
+  test('exec_end after startExec invokes the startExec close closure and sends exec_end to edge (O5)', async () => {
+    // O5 fix: session.close() now sends exec_end to the edge BEFORE deleting the map
+    // entry, so the edge can tear down Docker exec processes / goroutines.
     const { adapter, ws } = createAdapter();
     adapter.activate();
 
     const execId = await adapter.startExec('c1', ['/bin/bash']);
+    ws.sentMessages.length = 0; // clear exec_start frame
 
     const adapterInternal = adapter as unknown as {
       execSessions: Map<string, unknown>;
@@ -1181,11 +1200,19 @@ describe('EdgeAgentAdapter — startExec close closure and send error', () => {
     expect(adapterInternal.execSessions.has(execId)).toBe(true);
 
     // Send exec_end with the execId returned by startExec
-    // This hits the startExec close closure (line 589)
+    // This hits the startExec close closure which now calls sendExecEnd(execId)
     sendFrame(ws, 'exec_end', { execId });
     await new Promise((r) => setTimeout(r, 0));
 
     expect(adapterInternal.execSessions.has(execId)).toBe(false);
+
+    // Verify exec_end was sent outbound to the edge agent (O5)
+    expect(
+      ws.sentMessages.some((m) => {
+        const parsed = JSON.parse(m) as { type: string; data: { execId: string } };
+        return parsed.type === 'exec_end' && parsed.data.execId === execId;
+      }),
+    ).toBe(true);
   });
 
   test('startExec rejects when ws.send throws', async () => {
@@ -1465,6 +1492,347 @@ describe('EdgeAgentAdapter — branch coverage for uncovered paths', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     expect(ws.close).not.toHaveBeenCalled();
+  });
+});
+
+describe('EdgeAgentAdapter — O4: stream inactivity timeout resets on chunk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('stream chunks arriving within 30s reset the timer so the promise does not time out', async () => {
+    vi.useFakeTimers();
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const streamPromise = adapter.sendStreamRequest('GET', '/containers/c1/logs?follow=1');
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      data: { requestId: string };
+    };
+    const { requestId } = sentFrame.data;
+
+    // Advance 25s — no timeout yet (timer is 30s)
+    vi.advanceTimersByTime(25_000);
+
+    // A chunk arrives — this resets the 30s inactivity timer
+    sendFrame(ws, 'stream', { requestId, data: Buffer.from('chunk').toString('base64') });
+
+    // Advance another 25s — without the reset this would have timed out (25+25=50>30)
+    vi.advanceTimersByTime(25_000);
+
+    // Stream ends now — should still resolve (total 50s but timer was reset at 25s)
+    sendFrame(ws, 'stream_end', { requestId, reason: 'done' });
+
+    vi.useRealTimers();
+    const result = await streamPromise;
+    expect((result as { complete: boolean }).complete).toBe(true);
+  });
+
+  test('stream times out when no chunk arrives within 30s of the last activity', async () => {
+    vi.useFakeTimers();
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const streamPromise = adapter.sendStreamRequest('GET', '/containers/c1/logs?follow=1');
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      data: { requestId: string };
+    };
+    const { requestId } = sentFrame.data;
+
+    // Advance 25s and send a chunk (resets timer)
+    vi.advanceTimersByTime(25_000);
+    sendFrame(ws, 'stream', { requestId, data: Buffer.from('chunk').toString('base64') });
+
+    // Now advance 31s with NO new chunk — should time out
+    vi.advanceTimersByTime(31_000);
+
+    await expect(streamPromise).rejects.toThrow(/timed out/);
+    vi.useRealTimers();
+  });
+});
+
+describe('EdgeAgentAdapter — O7: metrics reads all 11 fields', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('metrics frame populates all 11 camelCase fields on client.info', async () => {
+    const { adapter, ws, client } = createAdapter();
+    adapter.activate();
+
+    sendFrame(ws, 'metrics', {
+      cpuUsage: 0.75,
+      cpuCores: 8,
+      memoryTotal: 16 * 1e9,
+      memoryUsed: 8 * 1e9,
+      memoryFree: 8 * 1e9,
+      diskTotal: 500 * 1e9,
+      diskUsed: 200 * 1e9,
+      diskFree: 300 * 1e9,
+      networkRxBytes: 1_000_000,
+      networkTxBytes: 500_000,
+      uptime: 7200,
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(client.info.memoryGb).toBeCloseTo(16, 1);
+    expect(client.info.uptimeSeconds).toBe(7200);
+    expect(client.info.cpuUsage).toBe(0.75);
+    expect(client.info.cpuCores).toBe(8);
+    expect(client.info.memoryUsed).toBe(8 * 1e9);
+    expect(client.info.memoryFree).toBe(8 * 1e9);
+    expect(client.info.diskTotal).toBe(500 * 1e9);
+    expect(client.info.diskUsed).toBe(200 * 1e9);
+    expect(client.info.diskFree).toBe(300 * 1e9);
+    expect(client.info.networkRxBytes).toBe(1_000_000);
+    expect(client.info.networkTxBytes).toBe(500_000);
+  });
+
+  test('metrics frame with missing optional fields leaves them absent from client.info', async () => {
+    const { adapter, ws, client } = createAdapter();
+    adapter.activate();
+
+    sendFrame(ws, 'metrics', { memoryTotal: 8 * 1e9, uptime: 3600 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(client.info.cpuUsage).toBeUndefined();
+    expect(client.info.cpuCores).toBeUndefined();
+    expect(client.info.memoryUsed).toBeUndefined();
+  });
+});
+
+describe('EdgeAgentAdapter — O9: response isStream=true stashes headers/statusCode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('response frame with isStream=true stashes statusCode/headers and does not resolve', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    let resolved = false;
+    const streamPromise = adapter.sendStreamRequest('GET', '/containers/c1/archive');
+    streamPromise
+      .then(() => {
+        resolved = true;
+      })
+      .catch(() => {});
+
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      data: { requestId: string };
+    };
+    const { requestId } = sentFrame.data;
+
+    // Portwing sends initial response frame before stream chunks
+    sendFrame(ws, 'response', {
+      requestId,
+      isStream: true,
+      statusCode: 200,
+      headers: { 'content-type': 'application/x-tar' },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Must NOT have resolved yet (stream chunks still pending)
+    expect(resolved).toBe(false);
+
+    // Resolve with stream_end — statusCode/headers must appear in resolved value
+    sendFrame(ws, 'stream_end', { requestId, reason: 'done' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const result = await streamPromise;
+    const res = result as {
+      complete: boolean;
+      statusCode?: number;
+      headers?: Record<string, string>;
+      body: Buffer;
+    };
+    expect(res.complete).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers?.['content-type']).toBe('application/x-tar');
+  });
+
+  test('response with isStream=true that receives no chunks times out and rejects (covers stream-response inactivity timer)', async () => {
+    vi.useFakeTimers();
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const streamPromise = adapter.sendStreamRequest('GET', '/containers/c1/archive');
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      data: { requestId: string };
+    };
+    const { requestId } = sentFrame.data;
+
+    sendFrame(ws, 'response', {
+      requestId,
+      isStream: true,
+      statusCode: 200,
+      headers: { 'content-type': 'application/x-tar' },
+    });
+    vi.advanceTimersByTime(31_000);
+
+    await expect(streamPromise).rejects.toThrow(/timed out/);
+    vi.useRealTimers();
+  });
+
+  test('isStream=true response without statusCode/headers leaves them unset (covers false guards)', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const streamPromise = adapter.sendStreamRequest('GET', '/containers/c1/archive');
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      data: { requestId: string };
+    };
+    const { requestId } = sentFrame.data;
+
+    sendFrame(ws, 'response', { requestId, isStream: true });
+    await new Promise((r) => setTimeout(r, 0));
+
+    sendFrame(ws, 'stream_end', { requestId, reason: 'done' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const result = await streamPromise;
+    const res = result as {
+      complete: boolean;
+      statusCode?: number;
+      headers?: Record<string, string>;
+    };
+    expect(res.complete).toBe(true);
+    expect(res.statusCode).toBeUndefined();
+    expect(res.headers).toBeUndefined();
+  });
+
+  test('stream frame with non-string data is ignored (covers false branch of typeof check)', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const streamPromise = adapter.sendStreamRequest('GET', '/containers/c1/archive');
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      data: { requestId: string };
+    };
+    const { requestId } = sentFrame.data;
+
+    sendFrame(ws, 'stream', { requestId });
+    await new Promise((r) => setTimeout(r, 0));
+
+    sendFrame(ws, 'stream_end', { requestId, reason: 'done' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const result = await streamPromise;
+    const res = result as { complete: boolean; body: Buffer };
+    expect(res.complete).toBe(true);
+    expect(res.body.length).toBe(0);
+  });
+});
+
+describe('EdgeAgentAdapter — O10: stream chunks assembled into body', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('stream chunks are base64-decoded and concatenated; body appears in resolved value', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const streamPromise = adapter.sendStreamRequest('GET', '/containers/c1/archive');
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      data: { requestId: string };
+    };
+    const { requestId } = sentFrame.data;
+
+    const part1 = Buffer.from('hello ');
+    const part2 = Buffer.from('world');
+
+    sendFrame(ws, 'stream', { requestId, data: part1.toString('base64') });
+    sendFrame(ws, 'stream', { requestId, data: part2.toString('base64') });
+    await new Promise((r) => setTimeout(r, 0));
+
+    sendFrame(ws, 'stream_end', { requestId, reason: 'done' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const result = await streamPromise;
+    const res = result as { complete: boolean; body: Buffer };
+    expect(res.complete).toBe(true);
+    expect(res.body.toString()).toBe('hello world');
+  });
+
+  test('stream_end with no preceding chunks resolves with empty body', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const streamPromise = adapter.sendStreamRequest('GET', '/containers/c1/archive');
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      data: { requestId: string };
+    };
+    const { requestId } = sentFrame.data;
+
+    sendFrame(ws, 'stream_end', { requestId, reason: 'done' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const result = await streamPromise;
+    const res = result as { complete: boolean; body: Buffer };
+    expect(res.complete).toBe(true);
+    expect(res.body.length).toBe(0);
+  });
+});
+
+describe('EdgeAgentAdapter — O12: startExec includes tty field', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('startExec sends tty: true by default', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    await adapter.startExec('c1', ['/bin/bash']);
+
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      type: string;
+      data: { tty: boolean };
+    };
+    expect(sentFrame.type).toBe('exec_start');
+    expect(sentFrame.data.tty).toBe(true);
+  });
+
+  test('startExec sends tty: false when explicitly set', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    await adapter.startExec('c1', ['/bin/sh', '-c', 'ls'], { tty: false });
+
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      type: string;
+      data: { tty: boolean };
+    };
+    expect(sentFrame.type).toBe('exec_start');
+    expect(sentFrame.data.tty).toBe(false);
+  });
+});
+
+describe('EdgeAgentAdapter — O5: startExec close sends exec_end outbound', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('calling session.close() directly sends exec_end to edge', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const execId = await adapter.startExec('c1', ['/bin/bash']);
+    ws.sentMessages.length = 0; // clear exec_start
+
+    // Call close() directly (simulates caller-side teardown)
+    const adapterInternal = adapter as unknown as {
+      execSessions: Map<string, { close: () => void }>;
+    };
+    adapterInternal.execSessions.get(execId)?.close();
+
+    const execEndSent = ws.sentMessages.some((m) => {
+      const parsed = JSON.parse(m) as { type: string; data: { execId: string } };
+      return parsed.type === 'exec_end' && parsed.data.execId === execId;
+    });
+    expect(execEndSent).toBe(true);
   });
 });
 

--- a/app/agent/EdgeAgentAdapter.ts
+++ b/app/agent/EdgeAgentAdapter.ts
@@ -49,6 +49,10 @@ interface PendingRequest {
   resolve: (value: unknown) => void;
   reject: (reason: unknown) => void;
   timer: ReturnType<typeof setTimeout>;
+  // Stream accumulation fields (set by handleResponse / handleStream for stream: keys)
+  statusCode?: number;
+  headers?: Record<string, string>;
+  chunks?: Buffer[];
 }
 
 interface AgentComponentDescriptor {
@@ -252,11 +256,32 @@ export class EdgeAgentAdapter {
     const memoryTotal = typeof data.memoryTotal === 'number' ? data.memoryTotal : 0;
     const uptime = typeof data.uptime === 'number' ? data.uptime : 0;
 
+    const cpuUsage = typeof data.cpuUsage === 'number' ? data.cpuUsage : undefined;
+    const cpuCores = typeof data.cpuCores === 'number' ? data.cpuCores : undefined;
+    const memoryUsed = typeof data.memoryUsed === 'number' ? data.memoryUsed : undefined;
+    const memoryFree = typeof data.memoryFree === 'number' ? data.memoryFree : undefined;
+    const diskTotal = typeof data.diskTotal === 'number' ? data.diskTotal : undefined;
+    const diskUsed = typeof data.diskUsed === 'number' ? data.diskUsed : undefined;
+    const diskFree = typeof data.diskFree === 'number' ? data.diskFree : undefined;
+    const networkRxBytes =
+      typeof data.networkRxBytes === 'number' ? data.networkRxBytes : undefined;
+    const networkTxBytes =
+      typeof data.networkTxBytes === 'number' ? data.networkTxBytes : undefined;
+
     this.client.info = {
       ...this.client.info,
       memoryGb: memoryTotal > 0 ? memoryTotal / 1e9 : this.client.info.memoryGb,
       uptimeSeconds: uptime > 0 ? uptime : this.client.info.uptimeSeconds,
       lastSeen: new Date().toISOString(),
+      ...(cpuUsage !== undefined ? { cpuUsage } : {}),
+      ...(cpuCores !== undefined ? { cpuCores } : {}),
+      ...(memoryUsed !== undefined ? { memoryUsed } : {}),
+      ...(memoryFree !== undefined ? { memoryFree } : {}),
+      ...(diskTotal !== undefined ? { diskTotal } : {}),
+      ...(diskUsed !== undefined ? { diskUsed } : {}),
+      ...(diskFree !== undefined ? { diskFree } : {}),
+      ...(networkRxBytes !== undefined ? { networkRxBytes } : {}),
+      ...(networkTxBytes !== undefined ? { networkTxBytes } : {}),
     };
     this.client.scheduleStatsChangedPublic();
   }
@@ -288,13 +313,38 @@ export class EdgeAgentAdapter {
     if (!requestId) {
       return;
     }
+
+    // Check bare key first (non-stream requests)
     const pending = this.pendingRequests.get(requestId);
-    if (!pending) {
+    if (pending) {
+      clearTimeout(pending.timer);
+      this.pendingRequests.delete(requestId);
+      pending.resolve(data);
       return;
     }
-    clearTimeout(pending.timer);
-    this.pendingRequests.delete(requestId);
-    pending.resolve(data);
+
+    // O9: portwing sends a response frame with isStream=true BEFORE stream chunks.
+    // sendStreamRequest registers the entry under `stream:${requestId}`, so the bare
+    // lookup above misses. Fall back to the stream: key; stash statusCode/headers and
+    // do NOT resolve — handleStreamEnd will resolve once all chunks are received.
+    const streamKey = `stream:${requestId}`;
+    const streamPending = this.pendingRequests.get(streamKey);
+    if (streamPending && data.isStream === true) {
+      if (typeof data.statusCode === 'number') {
+        streamPending.statusCode = data.statusCode;
+      }
+      if (data.headers && typeof data.headers === 'object' && !Array.isArray(data.headers)) {
+        streamPending.headers = data.headers as Record<string, string>;
+      }
+      // Reset the inactivity timer (O4) — initial response counts as activity
+      clearTimeout(streamPending.timer);
+      streamPending.timer = setTimeout(() => {
+        this.pendingRequests.delete(streamKey);
+        streamPending.reject(
+          new Error(`Stream request ${requestId} timed out after ${REQUEST_TIMEOUT_MS}ms`),
+        );
+      }, REQUEST_TIMEOUT_MS);
+    }
   }
 
   private handleStream(data: Record<string, unknown>): void {
@@ -310,10 +360,32 @@ export class EdgeAgentAdapter {
     // Confirm the stream is known; do NOT resolve the promise here.
     // Resolution is deferred to handleStreamEnd so that callers of
     // sendStreamRequest receive the complete event, not individual chunks.
-    const pending = this.pendingRequests.get(`stream:${requestId}`);
-    if (pending) {
-      log.debug(`${this.agentName}: stream chunk for ${requestId}`);
+    const streamKey = `stream:${requestId}`;
+    const pending = this.pendingRequests.get(streamKey);
+    if (!pending) {
+      return;
     }
+
+    log.debug(`${this.agentName}: stream chunk for ${requestId}`);
+
+    // O10: accumulate base64-decoded chunk on the pending entry
+    if (typeof data.data === 'string') {
+      const chunk = Buffer.from(data.data, 'base64');
+      if (!pending.chunks) {
+        pending.chunks = [];
+      }
+      pending.chunks.push(chunk);
+    }
+
+    // O4: reset the inactivity timer so a stream lasting >30s is not rejected
+    // as long as chunks keep arriving within 30s of each other.
+    clearTimeout(pending.timer);
+    pending.timer = setTimeout(() => {
+      this.pendingRequests.delete(streamKey);
+      pending.reject(
+        new Error(`Stream request ${requestId} timed out after ${REQUEST_TIMEOUT_MS}ms`),
+      );
+    }, REQUEST_TIMEOUT_MS);
   }
 
   private handleStreamEnd(data: Record<string, unknown>): void {
@@ -330,7 +402,19 @@ export class EdgeAgentAdapter {
     if (pending) {
       clearTimeout(pending.timer);
       this.pendingRequests.delete(`stream:${requestId}`);
-      pending.resolve({ complete: true, reason: data.reason });
+      // O10: assemble accumulated chunks into a single body Buffer (O9 stashed
+      // statusCode/headers on the pending entry from the initial response frame).
+      const body =
+        pending.chunks && pending.chunks.length > 0
+          ? Buffer.concat(pending.chunks)
+          : Buffer.alloc(0);
+      pending.resolve({
+        complete: true,
+        reason: data.reason,
+        body,
+        statusCode: pending.statusCode,
+        headers: pending.headers,
+      });
     }
   }
 
@@ -548,6 +632,7 @@ export class EdgeAgentAdapter {
       user?: string;
       cols?: number;
       rows?: number;
+      tty?: boolean;
       outputCallback?: (data: Buffer) => void;
     },
   ): Promise<string> {
@@ -564,6 +649,8 @@ export class EdgeAgentAdapter {
       execId,
       outputHandler: outputCallback,
       close: () => {
+        // O5: notify the edge so it can tear down the Docker exec process/goroutine.
+        this.sendExecEnd(execId);
         this.execSessions.delete(execId);
       },
     };
@@ -580,6 +667,7 @@ export class EdgeAgentAdapter {
             user: options?.user,
             cols: options?.cols ?? 80,
             rows: options?.rows ?? 24,
+            tty: options?.tty ?? true,
           },
         }),
       );
@@ -589,6 +677,19 @@ export class EdgeAgentAdapter {
     }
 
     return Promise.resolve(execId);
+  }
+
+  /**
+   * Notify the edge agent that an exec session has ended.
+   * Portwing handles inbound exec_end by tearing down the Docker exec process;
+   * without this the edge leaks goroutines and Docker exec processes (O5).
+   */
+  private sendExecEnd(execId: string): void {
+    try {
+      this.ws.send(JSON.stringify({ type: 'exec_end', data: { execId } }));
+    } catch {
+      // connection may be closing
+    }
   }
 
   /**
@@ -642,7 +743,7 @@ export class EdgeAgentAdapter {
       this.pendingRequests.delete(requestId);
     }
 
-    // Close all exec sessions
+    // Close all exec sessions — session.close() sends exec_end before deleting (O5)
     for (const session of this.execSessions.values()) {
       session.close();
     }

--- a/app/api/index.test.ts
+++ b/app/api/index.test.ts
@@ -1329,4 +1329,22 @@ describe('API Index', () => {
 
     expect(mockAttachPortwingWsServer).not.toHaveBeenCalled();
   });
+
+  test('should log info that portwing endpoint is disabled when DD_EXPERIMENTAL_PORTWING is false', async () => {
+    mockGetServerConfiguration.mockReturnValue({
+      enabled: true,
+      port: 3000,
+      cors: {},
+      tls: {},
+    });
+    mockGetExperimentalPortwingEnabled.mockReturnValue(false);
+
+    vi.resetModules();
+    const indexRouter = await import('./index.js');
+    await indexRouter.init();
+
+    expect(mockLog.info).toHaveBeenCalledWith(
+      'portwing/1.0 edge endpoint is disabled — set DD_EXPERIMENTAL_PORTWING=true to enable it',
+    );
+  });
 });

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -311,5 +311,9 @@ export async function init() {
       serverConfiguration: configuration as Record<string, unknown>,
       isRateLimited,
     });
+  } else {
+    log.info(
+      'portwing/1.0 edge endpoint is disabled — set DD_EXPERIMENTAL_PORTWING=true to enable it',
+    );
   }
 }

--- a/app/configuration/index.ts
+++ b/app/configuration/index.ts
@@ -181,6 +181,16 @@ export function getExperimentalPortwingEnabled() {
   return envFlagEnabled(ddEnvVars.DD_EXPERIMENTAL_PORTWING);
 }
 
+/**
+ * Return the path configured via DD_PORTWING_AUTHORIZED_KEYS, or undefined if unset.
+ * When set, drydock loads this authorized_keys file at startup to pre-populate
+ * the agent-key registry without requiring one-by-one REST API registration.
+ */
+export function getPortwingAuthorizedKeysPath(): string | undefined {
+  const raw = ddEnvVars.DD_PORTWING_AUTHORIZED_KEYS?.trim();
+  return raw || undefined;
+}
+
 function parseWatcherMaintenanceEnvAlias(envKey: string) {
   const envKeyUpper = envKey.toUpperCase();
   const prefix = 'DD_WATCHER_';

--- a/app/store/index.test.ts
+++ b/app/store/index.test.ts
@@ -8,6 +8,7 @@ const {
   createFsMock,
   createConfigMock,
   createCollectionsMock,
+  createAgentKeysMock,
   createLogMock,
   registerCommonMocks,
 } = vi.hoisted(() => {
@@ -43,8 +44,16 @@ const {
     return { createCollections: vi.fn(), completeStartupInitialization: vi.fn() };
   }
 
+  function createAgentKeysMock() {
+    return {
+      createCollections: vi.fn(),
+      completeStartupInitialization: vi.fn(),
+      loadAuthorizedKeysFile: vi.fn(),
+    };
+  }
+
   function createLogMock() {
-    return { default: { child: vi.fn(() => ({ info: vi.fn() })) } };
+    return { default: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn() })) } };
   }
 
   /** Register the standard set of doMock calls needed after vi.resetModules. */
@@ -55,14 +64,18 @@ const {
       lokiInstance?: Parameters<typeof createLokiMock>[2];
       fs?: Record<string, unknown>;
       config?: Record<string, unknown>;
+      portwingAuthorizedKeysPath?: string | undefined;
     } = {},
   ) {
     vi.doMock('lokijs', () =>
       createLokiMock(overrides.loki, overrides.lokiSave, overrides.lokiInstance),
     );
     vi.doMock('node:fs', () => createFsMock(overrides.fs));
-    vi.doMock('../configuration', () => createConfigMock(overrides.config ?? STORE_CONFIG));
-    vi.doMock('./agent-keys', createCollectionsMock);
+    vi.doMock('../configuration', () => ({
+      ...createConfigMock(overrides.config ?? STORE_CONFIG),
+      getPortwingAuthorizedKeysPath: vi.fn(() => overrides.portwingAuthorizedKeysPath),
+    }));
+    vi.doMock('./agent-keys', createAgentKeysMock);
     vi.doMock('./app', createCollectionsMock);
     vi.doMock('./audit', createCollectionsMock);
     vi.doMock('./backup', createCollectionsMock);
@@ -82,6 +95,7 @@ const {
     createFsMock,
     createConfigMock,
     createCollectionsMock,
+    createAgentKeysMock,
     createLogMock,
     registerCommonMocks,
   };
@@ -91,14 +105,17 @@ const {
 
 vi.mock('lokijs', () => createLokiMock());
 vi.mock('node:fs', () => createFsMock());
-vi.mock('../configuration', () => createConfigMock());
+vi.mock('../configuration', () => ({
+  ...createConfigMock(),
+  getPortwingAuthorizedKeysPath: vi.fn(() => undefined),
+}));
 vi.mock('./app', createCollectionsMock);
 vi.mock('./audit', createCollectionsMock);
 vi.mock('./backup', createCollectionsMock);
 vi.mock('./container', createCollectionsMock);
 vi.mock('./notification', createCollectionsMock);
 vi.mock('./notification-history', createCollectionsMock);
-vi.mock('./agent-keys', createCollectionsMock);
+vi.mock('./agent-keys', createAgentKeysMock);
 vi.mock('./notification-outbox', createCollectionsMock);
 vi.mock('./secrets', createCollectionsMock);
 vi.mock('./settings', createCollectionsMock);
@@ -443,5 +460,92 @@ describe('Store Module', () => {
       lastPersistAt: undefined,
       collections: [{ name: 'only', documents: 1 }],
     });
+  });
+
+  test('should call loadAuthorizedKeysFile when DD_PORTWING_AUTHORIZED_KEYS is set', async () => {
+    vi.resetModules();
+    registerCommonMocks({
+      fs: { existsSync: vi.fn(() => true), mkdirSync: vi.fn(), renameSync: vi.fn() },
+      portwingAuthorizedKeysPath: '/etc/drydock/authorized_keys',
+    });
+
+    const storeWithKeys = await import('./index.js');
+    await storeWithKeys.init();
+
+    const agentKeysMod = await import('./agent-keys.js');
+    expect(agentKeysMod.loadAuthorizedKeysFile).toHaveBeenCalledWith(
+      '/etc/drydock/authorized_keys',
+    );
+  });
+
+  test('should skip loadAuthorizedKeysFile when DD_PORTWING_AUTHORIZED_KEYS is unset', async () => {
+    vi.resetModules();
+    registerCommonMocks({
+      fs: { existsSync: vi.fn(() => true), mkdirSync: vi.fn(), renameSync: vi.fn() },
+      portwingAuthorizedKeysPath: undefined,
+    });
+
+    const storeNoKeys = await import('./index.js');
+    await storeNoKeys.init();
+
+    const agentKeysMod = await import('./agent-keys.js');
+    expect(agentKeysMod.loadAuthorizedKeysFile).not.toHaveBeenCalled();
+  });
+
+  test('should warn and continue startup when loadAuthorizedKeysFile throws', async () => {
+    vi.resetModules();
+
+    const mockWarn = vi.fn();
+    vi.doMock('lokijs', () => createLokiMock());
+    vi.doMock('node:fs', () =>
+      createFsMock({ existsSync: vi.fn(() => true), mkdirSync: vi.fn(), renameSync: vi.fn() }),
+    );
+    vi.doMock('../configuration', () => ({
+      ...createConfigMock(STORE_CONFIG),
+      getPortwingAuthorizedKeysPath: vi.fn(() => '/bad/authorized_keys'),
+    }));
+    vi.doMock('./agent-keys', () => ({
+      createCollections: vi.fn(),
+      completeStartupInitialization: vi.fn(),
+      loadAuthorizedKeysFile: vi.fn(() => {
+        throw new Error('permission denied');
+      }),
+    }));
+    vi.doMock('./app', createCollectionsMock);
+    vi.doMock('./audit', createCollectionsMock);
+    vi.doMock('./backup', createCollectionsMock);
+    vi.doMock('./container', createCollectionsMock);
+    vi.doMock('./notification', createCollectionsMock);
+    vi.doMock('./notification-history', createCollectionsMock);
+    vi.doMock('./notification-outbox', createCollectionsMock);
+    vi.doMock('./secrets', createCollectionsMock);
+    vi.doMock('./settings', createCollectionsMock);
+    vi.doMock('./update-operation', createCollectionsMock);
+    vi.doMock('../log', () => ({
+      default: { child: vi.fn(() => ({ info: vi.fn(), warn: mockWarn })) },
+    }));
+
+    const storeWithBadKeys = await import('./index.js');
+    await expect(storeWithBadKeys.init()).resolves.toBeUndefined();
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/bad/authorized_keys' }),
+      expect.stringContaining('DD_PORTWING_AUTHORIZED_KEYS'),
+    );
+  });
+
+  test('should call loadAuthorizedKeysFile when DD_PORTWING_AUTHORIZED_KEYS is set in memory mode', async () => {
+    vi.resetModules();
+    registerCommonMocks({
+      fs: { renameSync: vi.fn() },
+      portwingAuthorizedKeysPath: '/etc/drydock/authorized_keys',
+    });
+
+    const storeMemoryWithKeys = await import('./index.js');
+    await storeMemoryWithKeys.init({ memory: true });
+
+    const agentKeysMod = await import('./agent-keys.js');
+    expect(agentKeysMod.loadAuthorizedKeysFile).toHaveBeenCalledWith(
+      '/etc/drydock/authorized_keys',
+    );
   });
 });

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -7,7 +7,7 @@ import { resolveConfiguredPath, resolveConfiguredPathWithinBase } from '../runti
 
 const log = logger.child({ component: 'store' });
 
-import { getStoreConfiguration } from '../configuration/index.js';
+import { getPortwingAuthorizedKeysPath, getStoreConfiguration } from '../configuration/index.js';
 
 import * as agentKeys from './agent-keys.js';
 import * as app from './app.js';
@@ -56,6 +56,25 @@ function createCollections() {
 }
 
 /**
+ * Load authorized keys from DD_PORTWING_AUTHORIZED_KEYS if set.
+ * Errors are logged and swallowed so a bad keys file does not abort startup.
+ */
+function loadAuthorizedKeysIfConfigured() {
+  const keysPath = getPortwingAuthorizedKeysPath();
+  if (!keysPath) {
+    return;
+  }
+  try {
+    agentKeys.loadAuthorizedKeysFile(keysPath);
+  } catch (error: unknown) {
+    log.warn(
+      { path: keysPath, error: String(error) },
+      'Failed to load DD_PORTWING_AUTHORIZED_KEYS — edge connections will require manual key registration',
+    );
+  }
+}
+
+/**
  * Load DB.
  * @param err
  * @param resolve
@@ -72,6 +91,7 @@ async function loadDb(
   } else {
     // Create collections
     createCollections();
+    loadAuthorizedKeysIfConfigured();
     resolve();
   }
 }
@@ -102,6 +122,7 @@ export async function init(options: { memory?: boolean } = {}) {
   if (isMemoryMode) {
     log.info('Init store in memory mode');
     createCollections();
+    loadAuthorizedKeysIfConfigured();
     return;
   }
 


### PR DESCRIPTION
## What

Completes drydock's side of the edge wire-contract so it lines up byte-for-byte with the portwing edge agent. These are the controller-side halves of the integration audit (portwing carries the matching agent-side changes in CodesWhat/portwing#31).

## Changes

- **O3 — disabled-endpoint log:** when `DD_EXPERIMENTAL_PORTWING` is off, log that the `portwing/1.0` edge endpoint is disabled instead of silently 404ing.
- **O4 — stream inactivity timeout:** the request/stream timer now resets on each chunk (inactivity timeout) rather than a single fixed deadline, so long-lived streams aren't killed mid-flight.
- **O5 — exec_end on teardown:** `session.close()` sends an `exec_end` frame to the edge before dropping the session; `onDisconnect` tears down every live session.
- **O7 — full metrics surface:** `handleMetrics` reads the 9 additional runtime fields (cpu/mem/disk/network) the agent now reports.
- **O9 — streamed responses:** a `response` frame with `isStream=true` stashes statusCode/headers and defers resolution to `stream_end`.
- **O10 — chunk assembly:** stream chunks are base64-decoded and concatenated into the response body.
- **O11 — authorized keys file:** load `DD_PORTWING_AUTHORIZED_KEYS` at startup so edge agents don't need manual key registration.
- **O12 — exec tty:** `startExec` carries a `tty` option (default true) end to end.

## Tests / coverage

drydock enforces 100% coverage (lines/branches/functions/statements). All new code is covered — added cases for the exec_end teardown path, the stream inactivity timeout, the metrics fields, the isStream response/chunk assembly, the authorized-keys load, and the false-guard branches on the stream-response path. Full gate green: `21218/21218` statements, `13391/13391` branches.

Generated with [Claude Code](https://claude.com/claude-code)
