### PR TITLE
🔧 chore(renovate): adopt shared CodesWhat Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests", ":semanticCommits"],
-  "schedule": ["before 6am on monday"],
-  "labels": ["dependencies"],
-  "prHourlyLimit": 4,
-  "prConcurrentLimit": 10,
+  "extends": ["local>CodesWhat/.github:renovate-config"],
   "packageRules": [
     {
       "description": "Group all non-major npm updates per workspace",


### PR DESCRIPTION
Converts drydock's standalone Renovate config to extend the shared org preset, while keeping everything drydock-specific.

- Extends `local>CodesWhat/.github:renovate-config` for org-wide policy: 14-day soak (`minimumReleaseAge`), `internalChecksFilter: strict`, `config:best-practices`, Monday schedule, dependency dashboard.
- **Keeps** drydock's npm-per-workspace grouping, the Playwright runner+container grouping, the Playwright Docker image custom manager, and the patch-only GitHub Actions auto-merge rule.
- `app/renovate-config.test.ts` stays green (the patch-automerge rule is still scoped to `github-actions`).

Part of the org-wide Renovate rollout.