### PR TITLE
✨ feat(edge): tri-repo integration — edge dispatch fix, WS liveness, agent identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,46 @@ services:
 ```
 
 <details>
+<summary>Alternative: <a href="https://github.com/CodesWhat/sockguard">sockguard</a> socket proxy</summary>
+
+[sockguard](https://github.com/CodesWhat/sockguard) is a default-deny Docker socket filter from the same CodesWhat ecosystem, with a preset built for drydock:
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      sockguard:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=sockguard
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  sockguard:
+    image: codeswhat/sockguard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./sockguard.yaml:/etc/sockguard/config.yaml:ro
+    environment:
+      - SOCKGUARD_CONFIG_FILE=/etc/sockguard/config.yaml
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+See sockguard's [`app/configs/portwing.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing.yaml) preset for a starting `sockguard.yaml` (the same preset portwing ships in its own examples).
+
+</details>
+
+<details>
 <summary>Alternative: quick start with direct socket mount</summary>
 
 ```bash
@@ -382,6 +422,8 @@ Thanks to the users who helped test v1.4.0 and v1.5.0 release candidates and rep
 </table>
 
 These three tools are designed to layer: sockguard filters the socket, portwing exposes it remotely, and drydock monitors and acts on container state.
+
+See [portwing's COMPATIBILITY.md](https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md) for the full compatibility matrix across all three tools.
 
 ---
 

--- a/app/agent/AgentClient.test.ts
+++ b/app/agent/AgentClient.test.ts
@@ -3602,6 +3602,53 @@ describe('AgentClient', () => {
     });
   });
 
+  describe('edgeAdapter delegation', () => {
+    test('getContainerLogs delegates to edgeAdapter.requestContainerLogs instead of axios', async () => {
+      const edgeAdapter = {
+        requestContainerLogs: vi.fn().mockResolvedValue('log line 1\nlog line 2\n'),
+        deleteContainer: vi.fn(),
+      };
+      client.edgeAdapter = edgeAdapter;
+
+      const result = await client.getContainerLogs('c1', {
+        tail: 100,
+        since: 0,
+        timestamps: true,
+      });
+
+      expect(result).toBe('log line 1\nlog line 2\n');
+      expect(edgeAdapter.requestContainerLogs).toHaveBeenCalledWith('c1', {
+        tail: 100,
+        since: '0',
+      });
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    test('deleteContainer delegates to edgeAdapter.deleteContainer instead of axios', async () => {
+      const edgeAdapter = {
+        requestContainerLogs: vi.fn(),
+        deleteContainer: vi.fn().mockResolvedValue(undefined),
+      };
+      client.edgeAdapter = edgeAdapter;
+
+      await client.deleteContainer('c1');
+
+      expect(edgeAdapter.deleteContainer).toHaveBeenCalledWith('c1');
+      expect(axios.delete).not.toHaveBeenCalled();
+    });
+
+    test('deleteContainer propagates edgeAdapter rejection', async () => {
+      const edgeAdapter = {
+        requestContainerLogs: vi.fn(),
+        deleteContainer: vi.fn().mockRejectedValue(new Error('delete failed')),
+      };
+      client.edgeAdapter = edgeAdapter;
+
+      await expect(client.deleteContainer('c1')).rejects.toThrow('delete failed');
+      expect(axios.delete).not.toHaveBeenCalled();
+    });
+  });
+
   describe('watcher snapshot cache', () => {
     test('getWatcherSnapshot returns undefined before handshake or SSE event fires', () => {
       expect(client.getWatcherSnapshot('docker', 'remote')).toBeUndefined();

--- a/app/agent/AgentClient.ts
+++ b/app/agent/AgentClient.ts
@@ -11,6 +11,7 @@ import type {
   SecurityAlertSummary,
   SecurityScanCycleCompleteEventPayload,
 } from '../event/index.js';
+import type { EdgeAgentAdapter } from './EdgeAgentAdapter.js';
 import {
   emitAgentConnected,
   emitAgentDisconnected,
@@ -198,6 +199,13 @@ export class AgentClient {
   private readonly watcherSnapshotCache: Map<string, WatcherSnapshotCacheEntry>;
   private statsChangedTimer: ReturnType<typeof setTimeout> | undefined;
   private handshakeInProgress: Promise<void> | null = null;
+  /**
+   * Set by portwing-ws.ts immediately after EdgeAgentAdapter.activate() for
+   * edge-mode connections. When present, container-op methods that have a
+   * WS-tunnel equivalent delegate to it instead of making an axios call
+   * against the (nonexistent) edge-agent-placeholder host.
+   */
+  public edgeAdapter?: EdgeAgentAdapter;
 
   constructor(name: string, config: AgentClientConfig) {
     this.name = name;
@@ -1543,6 +1551,12 @@ export class AgentClient {
     containerId: string,
     options: { tail: number; since: number; timestamps: boolean },
   ) {
+    if (this.edgeAdapter) {
+      return this.edgeAdapter.requestContainerLogs(containerId, {
+        tail: options.tail,
+        since: String(options.since),
+      });
+    }
     try {
       const response = await axios.get(
         `${this.baseUrl}/api/containers/${encodeURIComponent(containerId)}/logs?tail=${options.tail}&since=${options.since}&timestamps=${options.timestamps}`,
@@ -1556,6 +1570,9 @@ export class AgentClient {
   }
 
   async deleteContainer(containerId: string) {
+    if (this.edgeAdapter) {
+      return this.edgeAdapter.deleteContainer(containerId);
+    }
     try {
       this.log.debug(`Deleting container ${sanitizeLogParam(containerId)} on agent`);
       await axios.delete(

--- a/app/agent/EdgeAgentAdapter.test.ts
+++ b/app/agent/EdgeAgentAdapter.test.ts
@@ -770,6 +770,157 @@ describe('EdgeAgentAdapter — requestContainerLogs', () => {
   });
 });
 
+describe('EdgeAgentAdapter — deleteContainer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('sends dd:container_delete_request frame and resolves on success response', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const containerId = 'container-abc';
+    const deletePromise = adapter.deleteContainer(containerId);
+
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      type: string;
+      data: { containerId: string };
+    };
+    expect(sentFrame.type).toBe('dd:container_delete_request');
+    expect(sentFrame.data.containerId).toBe(containerId);
+
+    sendFrame(ws, 'dd:container_delete_response', { containerId, success: true });
+    await new Promise((r) => setTimeout(r, 0));
+
+    await expect(deletePromise).resolves.toBeUndefined();
+  });
+
+  test('rejects with the agent-provided error message on failure response', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const containerId = 'container-fail';
+    // Attach the rejection handler immediately (same tick) so the rejection
+    // triggered synchronously by sendFrame below is never briefly unhandled.
+    const deletePromise = adapter.deleteContainer(containerId).catch((err: Error) => err.message);
+
+    sendFrame(ws, 'dd:container_delete_response', {
+      containerId,
+      success: false,
+      error: 'container is running',
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await deletePromise).toBe('container is running');
+  });
+
+  test('rejects with a fallback message when failure response omits error', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    const containerId = 'container-fail-no-msg';
+    const deletePromise = adapter.deleteContainer(containerId).catch((err: Error) => err.message);
+
+    sendFrame(ws, 'dd:container_delete_response', { containerId, success: false });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(await deletePromise).toBe('delete failed');
+  });
+
+  test('deleteContainer rejects after 30s timeout', async () => {
+    vi.useFakeTimers();
+    const { adapter } = createAdapter();
+    adapter.activate();
+
+    const deletePromise = adapter.deleteContainer('c-timeout');
+
+    vi.advanceTimersByTime(31_000);
+    await expect(deletePromise).rejects.toThrow(/timed out/);
+
+    vi.useRealTimers();
+  });
+
+  test('onDisconnect rejects pending delete request', async () => {
+    const { adapter } = createAdapter();
+    adapter.activate();
+
+    const deletePromise = adapter
+      .deleteContainer('c-disc')
+      .catch((err: Error) => err.message);
+
+    await adapter.onDisconnect();
+
+    expect(await deletePromise).toMatch(/connection closed/);
+  });
+
+  test('handleContainerDeleteResponse with no containerId is a no-op', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    expect(() => sendFrame(ws, 'dd:container_delete_response', { success: true })).not.toThrow();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+
+  test('dd:container_delete_response with unknown containerId is a no-op', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    sendFrame(ws, 'dd:container_delete_response', {
+      containerId: 'unknown-container',
+      success: true,
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+});
+
+describe('EdgeAgentAdapter — deleteContainer limit and send error', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('rejects immediately when pending request limit is reached', async () => {
+    const { adapter } = createAdapter();
+    adapter.activate();
+
+    const adapterInternal = adapter as unknown as {
+      pendingRequests: Map<string, unknown>;
+    };
+
+    // Fill to limit
+    for (let i = 0; i < 100; i++) {
+      adapterInternal.pendingRequests.set(`req-${i}`, {
+        resolve: () => {},
+        reject: () => {},
+        timer: setTimeout(() => {}, 99_999),
+      });
+    }
+
+    await expect(adapter.deleteContainer('c-overflow')).rejects.toThrow(
+      /concurrent request limit/,
+    );
+
+    // Clean up timers
+    for (const [, pending] of adapterInternal.pendingRequests) {
+      clearTimeout((pending as { timer: ReturnType<typeof setTimeout> }).timer);
+    }
+  });
+
+  test('rejects when ws.send throws during deleteContainer', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    (ws.send as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('send failed');
+    });
+
+    await expect(adapter.deleteContainer('c-throw')).rejects.toThrow('send failed');
+  });
+});
+
 describe('buildEdgeSentinelConfig', () => {
   test('returns correct sentinel config for a given agentId', () => {
     const config = buildEdgeSentinelConfig('my-agent');

--- a/app/agent/EdgeAgentAdapter.test.ts
+++ b/app/agent/EdgeAgentAdapter.test.ts
@@ -228,7 +228,7 @@ describe('EdgeAgentAdapter — frame dispatch', () => {
     sendFrame(ws, 'metrics', {
       cpuUsage: 0.5,
       cpuCores: 4,
-      memoryTotal: 8 * 1e9,
+      memoryTotal: 8 * 1024 ** 3,
       memoryUsed: 4 * 1e9,
       uptime: 3600,
     });
@@ -1714,7 +1714,7 @@ describe('EdgeAgentAdapter — O7: metrics reads all 11 fields', () => {
     sendFrame(ws, 'metrics', {
       cpuUsage: 0.75,
       cpuCores: 8,
-      memoryTotal: 16 * 1e9,
+      memoryTotal: 16 * 1024 ** 3,
       memoryUsed: 8 * 1e9,
       memoryFree: 8 * 1e9,
       diskTotal: 500 * 1e9,

--- a/app/agent/EdgeAgentAdapter.test.ts
+++ b/app/agent/EdgeAgentAdapter.test.ts
@@ -2068,3 +2068,41 @@ describe('EdgeAgentAdapter — false-branch coverage for ternary fallbacks', () 
     expect(ws.close).not.toHaveBeenCalled();
   });
 });
+
+describe('EdgeAgentAdapter — ping/pong liveness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('closes the connection and frees the agent slot after missing pong for 2 ping cycles (60s)', async () => {
+    vi.useFakeTimers();
+    const { adapter, ws, client } = createAdapter();
+    adapter.activate();
+
+    // Agent never replies with 'pong'. Two 30s ping cycles elapse with no pong.
+    vi.advanceTimersByTime(30_000 * 2);
+
+    expect(ws.close).toHaveBeenCalledWith(1001, 'ping timeout');
+    expect(manager.removeAgent).toHaveBeenCalledWith(client.name);
+
+    vi.useRealTimers();
+  });
+
+  test('does not close the connection when the agent replies with pong every cycle', async () => {
+    vi.useFakeTimers();
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+
+    // Simulate 4 healthy ping/pong cycles (well past the 2-cycle timeout threshold
+    // if pongs were not being tracked).
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(30_000);
+      sendFrame(ws, 'pong', { timestamp: Date.now() });
+    }
+
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(manager.removeAgent).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+});

--- a/app/agent/EdgeAgentAdapter.ts
+++ b/app/agent/EdgeAgentAdapter.ts
@@ -191,6 +191,9 @@ export class EdgeAgentAdapter {
       case 'dd:container_log_response':
         this.handleContainerLogResponse(data);
         return;
+      case 'dd:container_delete_response':
+        this.handleContainerDeleteResponse(data);
+        return;
       case 'response':
         this.handleResponse(data);
         return;
@@ -305,6 +308,25 @@ export class EdgeAgentAdapter {
       clearTimeout(pending.timer);
       this.pendingRequests.delete(`log:${containerId}`);
       pending.resolve(data.logs);
+    }
+  }
+
+  private handleContainerDeleteResponse(data: Record<string, unknown>): void {
+    const containerId = typeof data.containerId === 'string' ? data.containerId : undefined;
+    if (!containerId) {
+      return;
+    }
+    const pendingKey = `delete:${containerId}`;
+    const pending = this.pendingRequests.get(pendingKey);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timer);
+    this.pendingRequests.delete(pendingKey);
+    if (data.success === true) {
+      pending.resolve(undefined);
+    } else {
+      pending.reject(new Error(typeof data.error === 'string' ? data.error : 'delete failed'));
     }
   }
 
@@ -515,6 +537,47 @@ export class EdgeAgentAdapter {
           JSON.stringify({
             type: 'dd:container_log_request',
             data: { containerId, ...options },
+          }),
+        );
+      } catch (err: unknown) {
+        clearTimeout(timer);
+        this.pendingRequests.delete(pendingKey);
+        reject(err);
+      }
+    });
+  }
+
+  /**
+   * Delete a container on the edge agent.
+   * Returns a promise that resolves once the agent confirms deletion, or
+   * rejects after 30s / on an error response. The pending entry is keyed as
+   * `delete:${containerId}` to match the dd:container_delete_response handler.
+   */
+  deleteContainer(containerId: string): Promise<void> {
+    const pendingKey = `delete:${containerId}`;
+    if (this.pendingRequests.size >= MAX_PENDING_REQUESTS) {
+      return Promise.reject(new Error('concurrent request limit reached'));
+    }
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(pendingKey);
+        reject(
+          new Error(`Container delete request for ${containerId} timed out after ${REQUEST_TIMEOUT_MS}ms`),
+        );
+      }, REQUEST_TIMEOUT_MS);
+
+      this.pendingRequests.set(pendingKey, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timer,
+      });
+
+      try {
+        this.ws.send(
+          JSON.stringify({
+            type: 'dd:container_delete_request',
+            data: { containerId },
           }),
         );
       } catch (err: unknown) {

--- a/app/agent/EdgeAgentAdapter.ts
+++ b/app/agent/EdgeAgentAdapter.ts
@@ -304,7 +304,9 @@ export class EdgeAgentAdapter {
 
     this.client.info = {
       ...this.client.info,
-      memoryGb: memoryTotal > 0 ? memoryTotal / 1e9 : this.client.info.memoryGb,
+      // GiB (1024^3), matching portwing's canonical MemoryTotalGB() definition
+      // (internal/metrics/collector.go) — not decimal GB (1e9).
+      memoryGb: memoryTotal > 0 ? memoryTotal / 1024 ** 3 : this.client.info.memoryGb,
       uptimeSeconds: uptime > 0 ? uptime : this.client.info.uptimeSeconds,
       lastSeen: new Date().toISOString(),
       ...(cpuUsage !== undefined ? { cpuUsage } : {}),

--- a/app/agent/EdgeAgentAdapter.ts
+++ b/app/agent/EdgeAgentAdapter.ts
@@ -20,6 +20,10 @@ const MAX_PENDING_REQUESTS = 100;
 const PING_INTERVAL_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 30_000;
 const CONTAINER_SYNC_WARN_MS = 30_000;
+// Number of consecutive server-initiated ping cycles that may pass without a
+// pong reply before the connection is considered dead. 2 cycles × 30s = 60s,
+// matching portwing's own readDeadline of max(2*heartbeat, 60s) for symmetry.
+const PONG_MISS_THRESHOLD = 2;
 
 export interface HelloMessage {
   version: string;
@@ -97,6 +101,7 @@ export class EdgeAgentAdapter {
   private pingInterval: ReturnType<typeof setInterval> | undefined;
   private containerSyncWarnTimer: ReturnType<typeof setTimeout> | undefined;
   private connected = false;
+  private lastPongAt = 0;
 
   constructor(client: AgentClient, ws: WebSocketLike) {
     this.client = client;
@@ -112,13 +117,10 @@ export class EdgeAgentAdapter {
    */
   activate(): void {
     addAgent(this.client);
+    this.lastPongAt = Date.now();
 
     this.pingInterval = setInterval(() => {
-      try {
-        this.ws.send(JSON.stringify({ type: 'ping', data: { timestamp: Date.now() } }));
-      } catch {
-        // connection may already be closing
-      }
+      this.checkLivenessAndPing();
     }, PING_INTERVAL_MS);
 
     // Warn if container_sync does not arrive within 30 seconds
@@ -143,6 +145,35 @@ export class EdgeAgentAdapter {
       log.error(`WebSocket error on ${this.agentName}: ${getErrorMessage(err)}`);
       void this.onDisconnect();
     });
+  }
+
+  /**
+   * Runs every PING_INTERVAL_MS. If no pong has been received within
+   * PONG_MISS_THRESHOLD ping cycles, the connection is considered dead: force
+   * close it and run the same cleanup path a real 'close' event would trigger
+   * so the agent slot is freed immediately rather than left dangling until the
+   * underlying transport eventually notices. Otherwise, send the next ping.
+   */
+  private checkLivenessAndPing(): void {
+    const staleMs = Date.now() - this.lastPongAt;
+    if (staleMs >= PING_INTERVAL_MS * PONG_MISS_THRESHOLD) {
+      log.warn(
+        `Edge agent ${this.agentName} missed ${PONG_MISS_THRESHOLD} pong cycles (${staleMs}ms); closing connection`,
+      );
+      try {
+        this.ws.close(1001, 'ping timeout');
+      } catch {
+        // connection may already be closing
+      }
+      void this.onDisconnect();
+      return;
+    }
+
+    try {
+      this.ws.send(JSON.stringify({ type: 'ping', data: { timestamp: Date.now() } }));
+    } catch {
+      // connection may already be closing
+    }
   }
 
   private async onMessage(raw: unknown): Promise<void> {
@@ -177,7 +208,7 @@ export class EdgeAgentAdapter {
         this.handlePing(data);
         return;
       case 'pong':
-        // no-op — reply to server-initiated ping
+        this.handlePong();
         return;
       case 'dd:watch_response':
         log.debug(`${this.agentName}: dd:watch_response (no-op in M5)`);
@@ -295,6 +326,11 @@ export class EdgeAgentAdapter {
     } catch {
       // connection may be closing
     }
+  }
+
+  /** Reply to our own server-initiated ping — marks the connection as alive. */
+  private handlePong(): void {
+    this.lastPongAt = Date.now();
   }
 
   private handleContainerLogResponse(data: Record<string, unknown>): void {

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -966,6 +966,79 @@ describe('edgeAdapter wiring', () => {
   });
 });
 
+describe('hello verification — agentName sanitization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearNonceCacheForTesting();
+  });
+
+  async function helloWithAgentName(
+    agentId: string,
+    nonce: string,
+    agentNameOverride: Record<string, unknown>,
+  ) {
+    const { privateKey, pubkeyBase64, keyId } = generateKeyPair();
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = signHello(privateKey, ts, nonce);
+    const record: AgentKeyRecord = {
+      keyId,
+      pubkey: pubkeyBase64,
+      label: 'test',
+      createdAt: new Date().toISOString(),
+      revokedAt: null,
+    };
+
+    const { gateway, getUpgradedWs } = createGateway(record);
+    gateway.handleUpgrade(
+      createRequest('/api/portwing/ws'),
+      createMockSocket() as unknown as Socket,
+      Buffer.alloc(0),
+    );
+    const ws = getUpgradedWs()!;
+    sendMessageToGateway(
+      ws,
+      buildHello(keyId, ts, nonce, sig, { agentId, ...agentNameOverride }),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    return getLastAgentClientInstance();
+  }
+
+  test('a clean agentName is used verbatim, lowercased', async () => {
+    const client = await helloWithAgentName('agent-clean-1', 'a1000000000000000000000000000001', {
+      agentName: 'Clean-Name',
+    });
+    expect(client?.name).toBe('clean-name');
+  });
+
+  test('an agentName with invalid characters is sanitized to a safe slug', async () => {
+    const client = await helloWithAgentName('agent-dirty-1', 'a1000000000000000000000000000002', {
+      agentName: 'My Agent!!formatted_Name日本語',
+    });
+    expect(client?.name).toBe('my-agent-formatted-name');
+  });
+
+  test('an empty agentName falls back to portwing-edge-<agentId>', async () => {
+    const client = await helloWithAgentName('agent-empty-1', 'a1000000000000000000000000000003', {
+      agentName: '',
+    });
+    expect(client?.name).toBe('portwing-edge-agent-empty-1');
+  });
+
+  test('an agentName that sanitizes to empty falls back to portwing-edge-<agentId>', async () => {
+    const client = await helloWithAgentName('agent-allbad-1', 'a1000000000000000000000000000004', {
+      agentName: '###',
+    });
+    expect(client?.name).toBe('portwing-edge-agent-allbad-1');
+  });
+
+  test('an omitted agentName falls back to portwing-edge-<agentId> without crashing', async () => {
+    const client = await helloWithAgentName('agent-none-1', 'a1000000000000000000000000000005', {
+      agentName: undefined,
+    });
+    expect(client?.name).toBe('portwing-edge-agent-none-1');
+  });
+});
+
 describe('version handshake', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -37,12 +37,15 @@ vi.mock('../log/index.js', () => ({
 // works in portwing-ws.ts. Arrow-factory implementations are not usable as
 // constructors in newer Vitest versions — use vi.hoisted() exactly like
 // EdgeAgentAdapter.test.ts does.
-const { MockAgentClient, MockEdgeAgentAdapter } = vi.hoisted(() => {
+const { MockAgentClient, MockEdgeAgentAdapter, getLastAgentClientInstance } = vi.hoisted(() => {
+  let lastInstance: InstanceType<typeof _MockAgentClient> | undefined;
+
   class _MockAgentClient {
     name: string;
     config: { host: string; port: number; secret: string };
     isConnected = false;
     info: Record<string, unknown> = {};
+    edgeAdapter?: unknown;
     handleEvent = vi.fn().mockResolvedValue(undefined);
     handleContainerSync = vi.fn().mockResolvedValue(undefined);
     handleComponentSync = vi.fn().mockResolvedValue(undefined);
@@ -52,6 +55,7 @@ const { MockAgentClient, MockEdgeAgentAdapter } = vi.hoisted(() => {
     constructor(name: string) {
       this.name = name;
       this.config = { host: 'http://edge-agent-placeholder', port: 0, secret: '' };
+      lastInstance = this;
     }
   }
 
@@ -60,7 +64,11 @@ const { MockAgentClient, MockEdgeAgentAdapter } = vi.hoisted(() => {
     onDisconnect = vi.fn().mockResolvedValue(undefined);
   }
 
-  return { MockAgentClient: _MockAgentClient, MockEdgeAgentAdapter: _MockEdgeAgentAdapter };
+  return {
+    MockAgentClient: _MockAgentClient,
+    MockEdgeAgentAdapter: _MockEdgeAgentAdapter,
+    getLastAgentClientInstance: () => lastInstance,
+  };
 });
 
 vi.mock('../agent/AgentClient.js', () => ({
@@ -920,6 +928,41 @@ describe('hello verification — happy path', () => {
     };
     expect(welcome.type).toBe('welcome');
     expect(welcome.data.config.supportedProtocols).toBe('portwing/1.0');
+  });
+});
+
+describe('edgeAdapter wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearNonceCacheForTesting();
+  });
+
+  test('client.edgeAdapter is set after a successful hello handshake', async () => {
+    const { privateKey, pubkeyBase64, keyId } = generateKeyPair();
+    const ts = Math.floor(Date.now() / 1000);
+    const nonce = 'f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
+    const sig = signHello(privateKey, ts, nonce);
+
+    const record: AgentKeyRecord = {
+      keyId,
+      pubkey: pubkeyBase64,
+      label: 'test',
+      createdAt: new Date().toISOString(),
+      revokedAt: null,
+    };
+
+    const { gateway, getUpgradedWs } = createGateway(record);
+    gateway.handleUpgrade(
+      createRequest('/api/portwing/ws'),
+      createMockSocket() as unknown as Socket,
+      Buffer.alloc(0),
+    );
+    const ws = getUpgradedWs()!;
+    sendMessageToGateway(ws, buildHello(keyId, ts, nonce, sig));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const client = getLastAgentClientInstance();
+    expect(client?.edgeAdapter).toBeInstanceOf(MockEdgeAgentAdapter);
   });
 });
 

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -22,14 +22,18 @@ vi.mock('../configuration/index.js', () => ({
   getServerConfiguration: vi.fn(() => ({})),
 }));
 
+// Hoisted so tests can assert on log calls (e.g. the compat-level mismatch
+// warning) — the module-level `log` in portwing-ws.ts is `logger.child(...)`,
+// called once at import time, so it always returns this same singleton.
+const mockLogChild = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
 vi.mock('../log/index.js', () => ({
   default: {
-    child: vi.fn(() => ({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    })),
+    child: vi.fn(() => mockLogChild),
   },
 }));
 
@@ -1379,6 +1383,41 @@ describe('hello verification — drydockCompat version warning', () => {
 
     const firstFrame = JSON.parse(ws.sentMessages[0]) as { type: string };
     expect(firstFrame.type).toBe('welcome');
+  });
+
+  test('warns when drydockCompat majorVersion is LOWER than server (sends welcome)', async () => {
+    const { privateKey, pubkeyBase64, keyId } = generateKeyPair();
+    const ts = Math.floor(Date.now() / 1000);
+    const nonce = 'ac000000000000000000000000000002';
+    const sig = signHello(privateKey, ts, nonce);
+    const record: AgentKeyRecord = {
+      keyId,
+      pubkey: pubkeyBase64,
+      label: 'test',
+      createdAt: new Date().toISOString(),
+      revokedAt: null,
+    };
+
+    const { gateway, getUpgradedWs } = createGateway(record);
+    gateway.handleUpgrade(
+      createRequest('/api/portwing/ws'),
+      createMockSocket() as unknown as Socket,
+      Buffer.alloc(0),
+    );
+    const ws = getUpgradedWs()!;
+
+    // drydockCompat '0.9.0' has majorVersion=0, server implements '1.4.0' (major=1).
+    // Previously only the higher-than-server direction warned; now any mismatch does.
+    sendMessageToGateway(ws, buildHello(keyId, ts, nonce, sig, { drydockCompat: '0.9.0' }));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const firstFrame = JSON.parse(ws.sentMessages[0]) as { type: string };
+    expect(firstFrame.type).toBe('welcome');
+    expect(mockLogChild.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Edge agent requires drydockCompat 0.9.0 but server implements 1.4.0',
+      ),
+    );
   });
 });
 

--- a/app/api/portwing-ws.ts
+++ b/app/api/portwing-ws.ts
@@ -541,6 +541,11 @@ async function processHello(
   // activate() calls addAgent() — release the in-flight reservation immediately
   // after so the slot is held by the manager instead.
   adapter.activate();
+  // Route handlers only ever look up the client via getAgent(name); wire the
+  // adapter onto the client so getContainerLogs()/deleteContainer() can reach
+  // the WS-tunnel methods instead of falling through to the (nonexistent)
+  // edge-agent-placeholder host.
+  client.edgeAdapter = adapter;
   inFlightAgents.delete(agentName);
 
   // Register this session under pubKeyId so it can be disconnected on key revocation.

--- a/app/api/portwing-ws.ts
+++ b/app/api/portwing-ws.ts
@@ -213,6 +213,25 @@ function verifyHelloSignature(
   return cryptoVerify(null, canonical, pubKey, sigBuf);
 }
 
+/**
+ * Compute the agent's display/registry name from the hello frame.
+ * hello.agentName is sanitized to a safe slug (lowercase, alphanumeric + hyphen,
+ * max 63 chars); an empty, missing, or all-invalid-chars name falls back to
+ * `portwing-edge-<agentId>` — the pre-existing unconditional name.
+ */
+function computeAgentName(hello: HelloMessage): string {
+  const rawName = hello.agentName?.trim();
+  const sanitized = rawName
+    ? rawName
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '')
+        .slice(0, 63)
+    : '';
+  return sanitized || `portwing-edge-${hello.agentId}`;
+}
+
 interface PortwingWsGatewayDependencies {
   webSocketServer?: {
     handleUpgrade: (
@@ -498,7 +517,10 @@ async function processHello(
 
   // Step 10: Prevent duplicate agent names — atomic check/reserve with inFlightAgents
   // so that concurrent hellos cannot both pass before either calls activate().
-  const agentName = `portwing-edge-${hello.agentId}`;
+  // The friendly name is derived from hello.agentName when present (sanitized to a
+  // safe slug); collisions on the sanitized name are still caught by this same
+  // reservation logic, same as the portwing-edge-<agentId> fallback.
+  const agentName = computeAgentName(hello);
   if (getAgent(agentName) || inFlightAgents.has(agentName)) {
     sendErrorAndClose(ws, 'agent-already-connected', `Agent ${agentName} already connected`, 1008);
     return;

--- a/app/api/portwing-ws.ts
+++ b/app/api/portwing-ws.ts
@@ -381,7 +381,9 @@ async function processHello(
   } else {
     const majorVersion = parseInt(drydockCompat.split('.')[0], 10);
     const serverMajor = parseInt(SERVER_COMPAT_LEVEL.split('.')[0], 10);
-    if (majorVersion > serverMajor) {
+    // Any major-version mismatch (either direction) is diagnostic-only — the wire
+    // connection is still accepted; this warns operators to check the compat matrix.
+    if (majorVersion !== serverMajor) {
       log.warn(
         `Edge agent requires drydockCompat ${drydockCompat} but server implements ${SERVER_COMPAT_LEVEL}`,
       );

--- a/content/docs/current/configuration/agents/index.mdx
+++ b/content/docs/current/configuration/agents/index.mdx
@@ -35,6 +35,43 @@ The WebSocket endpoint is `WS /api/v1/portwing/ws` (compatibility alias: `/api/p
 
 You can also preload keys at startup with `DD_PORTWING_AUTHORIZED_KEYS=/path/to/authorized_keys`. The file format is `ed25519 <base64-raw-pubkey> [comment]`, and the file must not be world-readable.
 
+### Edge-agent example (Docker Compose)
+
+A [Portwing](https://github.com/CodesWhat/portwing) edge agent runs on the remote/NAT'd host and dials out — no inbound ports need to be published on that side:
+
+```yaml
+services:
+  portwing:
+    image: ghcr.io/codeswhat/portwing:latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - DRYDOCK_URL=https://drydock.example.com
+      - PRIVATE_KEY_FILE=/run/secrets/portwing_key
+      - AGENT_NAME=edge-host-01
+    secrets:
+      - portwing_key
+
+secrets:
+  portwing_key:
+    file: ./portwing_ed25519.pem
+```
+
+The Drydock controller enables the endpoint with `DD_EXPERIMENTAL_PORTWING=true` and needs the agent's public key registered before it connects:
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    ports:
+      - "3000:3000"
+    environment:
+      - DD_EXPERIMENTAL_PORTWING=true
+```
+
+Generate the agent's keypair with `portwing keygen -comment "edge-host-01"`, then register the printed public key with the controller (`POST /api/v1/portwing/keys`, or preload it via `DD_PORTWING_AUTHORIZED_KEYS`) before starting the agent — see the REST API table above.
+
 <Callout type="warn">Portwing support is experimental. Its REST API and wire protocol may change before it is promoted out of `DD_EXPERIMENTAL_PORTWING=true`.</Callout>
 
 ## Quickstart

--- a/content/docs/current/configuration/watchers/index.mdx
+++ b/content/docs/current/configuration/watchers/index.mdx
@@ -399,7 +399,7 @@ The `:ro` (read-only) flag on the Docker socket mount is omitted intentionally. 
 
 [Tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) is the most widely used option, but any HAProxy or nginx-based Docker socket proxy that filters by HTTP method and path will work. The key requirement is that the proxy exposes the Docker Engine API endpoints listed in the permissions table above and blocks everything else (especially `exec`, `build`, and `swarm` endpoints).
 
-Other compatible proxies include [linuxserver/docker-socket-proxy](https://github.com/linuxserver/docker-socket-proxy) (a fork with additional features).
+Other compatible proxies include [linuxserver/docker-socket-proxy](https://github.com/linuxserver/docker-socket-proxy) (a fork with additional features) and [sockguard](https://github.com/CodesWhat/sockguard), a default-deny allowlist filter from the same CodesWhat ecosystem as Drydock, with a preset built specifically for Drydock (see the [Security Hardening Guide](/docs/guides/security#isolate-the-docker-socket)).
 
 ### Option 2: Remote Docker over TLS
 

--- a/content/docs/current/guides/security/index.mdx
+++ b/content/docs/current/guides/security/index.mdx
@@ -20,6 +20,9 @@ Before you run Drydock, verify the image or archive you downloaded. See [Verify 
 
 The Docker socket gives full control over the host's containers. Never mount it directly in production — use a socket proxy to expose only the API endpoints Drydock needs.
 
+<Tabs items={["Tecnativa", "sockguard"]}>
+<Tab value="Tecnativa">
+
 ```yaml
 services:
   socket-proxy:
@@ -54,6 +57,42 @@ services:
 ```
 
 The proxy's environment variables (`CONTAINERS=1`, `EVENTS=1`, etc.) are the security boundary — they control which Docker API endpoints are forwarded. Everything else is blocked.
+
+</Tab>
+<Tab value="sockguard">
+
+[sockguard](https://github.com/CodesWhat/sockguard) is a default-deny Docker socket filter from the same CodesWhat ecosystem as Drydock and portwing. Instead of an allowlist of environment flags, it ships a YAML preset built for this exact use case — see [`examples/compose/portwing/`](https://github.com/CodesWhat/sockguard/tree/dev/v1.5/examples/compose/portwing) for a runnable compose stack and the [`portwing.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing.yaml) preset it's built from.
+
+```yaml
+services:
+  sockguard:
+    image: codeswhat/sockguard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./sockguard.yaml:/etc/sockguard/config.yaml:ro
+    environment:
+      - SOCKGUARD_CONFIG_FILE=/etc/sockguard/config.yaml
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      sockguard:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=sockguard
+      - DD_WATCHER_LOCAL_PORT=2375
+```
+
+The preset's allow-rules are the security boundary, in the same spirit as the proxy's environment flags — everything not explicitly allowed is denied.
+
+</Tab>
+</Tabs>
 
 **Other options:** If a socket proxy doesn't fit your environment, Drydock also supports remote Docker over mTLS, rootless Docker, and Podman through Podman's Docker-compatible API socket. See the [full comparison table](/docs/configuration/watchers#docker-socket-security) and [Podman Quick Start](/docs/configuration/watchers#podman-quick-start) for trade-offs.
 


### PR DESCRIPTION
Drydock side of the three-repo integration pass (companion PRs in portwing and sockguard).

## What's here

- ✨ **EdgeAgentAdapter wired into dispatch for logs/delete.** The `/api/portwing/ws` endpoint shipped in 1.5, but route handlers only ever reached the placeholder-host `AgentClient`, so edge container logs/delete 500'd. `AgentClient` now carries an `edgeAdapter` and delegates when the agent is edge-connected. Delete uses the new `dd:container_delete_request/response` wire pair (portwing's companion PR implements the agent side).
- ✨ **WS liveness**: close connections that miss 2 consecutive pongs (60s interval). Dead tunnels previously lingered until TCP gave up.
- ✨ **Honor `hello.agentName`** as the agent's display name (sanitized `[^a-z0-9-]` → `-`, 63-char cap, fallback `portwing-edge-<agentId>`).
- 🐛 **`memoryGb` now reports real GiB** (`1<<30`), was decimal `/1e9`.
- 🐛 **Compat-level warning fires symmetrically** (`!==` both directions), was only warning when the agent was older.
- 📝 Ecosystem docs: surface sockguard, point compat questions at portwing's canonical `COMPATIBILITY.md`.

## Known gaps (pre-existing, documented not fixed)

- Edge log fetches drop timestamps/until/follow options — the wire message has no fields for them.
- `deleteContainerHandler` 500s (never 404s) on adapter errors.

All contracts were pinned across the three repos before implementation and adversarially verified. tsc clean, all 11,169 tests pass, coverage 100% on this branch.