### PR TITLE
🔧 config(coderabbit): adopt agent-voice tone and SYP best practices

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,15 +1,54 @@
-# CodeRabbit configuration — drydock
+# CodeRabbit configuration: drydock
 language: en-US
+early_access: true
+enable_free_tier: true
+
+tone_instructions: >-
+  Reviewing AI-agent TypeScript code. Terse and direct. State problem and fix
+  with code. Skip praise and rhetoric. Flag provider-pattern divergence,
+  missed conventions, existing utilities, DRY violations. Only actionable
+  feedback.
 
 reviews:
   profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_instructions: >-
+    This summary will be read by an AI coding agent (Claude Code), not a human.
+    Be direct and structured. Use a changelog with emojis: ✨ Added, 🔧 Changed,
+    🐛 Fixed, 🗑️ Removed, ⚠️ Breaking, 🔒 Security. After the changelog, list
+    any concerns or issues the agent should address as a flat bullet list — no
+    prose, no praise, no context the agent already knows from the diff.
+  high_level_summary_placeholder: "@coderabbitai summary"
+  high_level_summary_in_walkthrough: false
+  collapse_walkthrough: true
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  review_details: false
+  review_status: true
+  commit_status: true
+  fail_commit_status: false
+  poem: false
+  in_progress_fortune: false
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: false
+  auto_apply_labels: false
+  suggested_reviewers: false
+  auto_assign_reviewers: false
+  enable_prompt_for_ai_agents: true
+  abort_on_close: true
+
   auto_review:
     enabled: true
-  high_level_summary: true
-  collapse_walkthrough: false
-  review_status: true
-  poem: false
-  request_changes_workflow: false
+    auto_incremental_review: true
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+      - "[skip review]"
 
   path_filters:
     - "!**/node_modules/**"
@@ -45,6 +84,45 @@ reviews:
       instructions: |
         Documentation content. Review for accuracy against the code, not prose style.
 
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: true
+
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: "off"
+    description:
+      mode: "off"
+    issue_assessment:
+      mode: "warning"
+
+  tools:
+    biome:
+      enabled: true
+    shellcheck:
+      enabled: true
+    hadolint:
+      enabled: true
+    markdownlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    actionlint:
+      enabled: true
+    ast-grep:
+      essential_rules: true
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
+    languagetool:
+      enabled: false
+
 knowledge_base:
   opt_out: false
   learnings:
@@ -61,3 +139,4 @@ knowledge_base:
 
 chat:
   auto_reply: true
+  art: false


### PR DESCRIPTION
Second pass pulling in the evolved config the SYP repos converged on:

- `tone_instructions`: review comments written for an AI coding agent, terse, problem+fix, actionable only
- `high_level_summary_instructions`: emoji changelog plus flat concern list, formatted for Claude Code to consume
- Walkthrough noise stripped: collapsed walkthrough, no sequence diagrams, no effort estimate, no changed-files table, no fortune
- `auto_incremental_review` on, drafts skipped, WIP/DO NOT MERGE titles skipped
- Explicit tool enables for this stack (gitleaks, actionlint, markdownlint, yamllint, shellcheck, hadolint, ast-grep essential rules, github-checks) with languagetool off
- `pre_merge_checks`: docstring/title/description gates off, linked-issue assessment as warning
- Finishing touches (docstrings, unit tests) available on demand


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added
- Expanded `.coderabbit.yaml` with agent-voice `tone_instructions` for terse, actionable review comments.
- Added `high_level_summary_instructions` optimized for Claude Code, using an emoji changelog plus flat concern list output.
- Enabled `auto_incremental_review` behavior and support for AI-agent prompt usage.
- Added `finishing_touches` options for `docstrings` and `unit_tests`.
- Enabled tooling for `gitleaks`, `actionlint`, `markdownlint`, `yamllint`, `shellcheck`, `hadolint`, essential `ast-grep` rules, and `github-checks`.

🔧 Changed
- Updated review settings to collapse walkthrough content and remove sequence diagrams, effort estimates, changed-files tables, and fortune content.
- Adjusted auto-review filtering to skip drafts and titles containing `WIP` / `DO NOT MERGE` / `[skip review]`.
- Tweaked `pre_merge_checks` so docstring/title/description gates are disabled and linked-issue assessment is warning-only.
- Disabled `languagetool`.
- Updated chat config with `art: false`.

🗑️ Removed
- Removed walkthrough-heavy review output sections from the generated summary format.

⚠️ Breaking
- Review output format now expects a flatter, agent-oriented summary structure instead of the previous walkthrough-style format.

- Confirm the new `ignore_title_keywords` list matches all intended skip-review variants used in the repo.
- Verify `pre_merge_checks` warning-level behavior is sufficient for linked-issue validation.
- Check that disabling `languagetool` does not weaken any required language-quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->