### PR TITLE
🔧 config(greptile): on-call reviews only, skip automatic

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,3 @@
+{
+  "skipReview": "AUTOMATIC"
+}


### PR DESCRIPTION
Greptile joins as an on-call second reviewer, not an automatic one. `skipReview: "AUTOMATIC"` turns off auto-reviews on every PR; summon it when wanted by commenting `@greptileai` (optionally with a question). CodeRabbit stays the always-on reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

🔧 Changed
- Updated `greptile.json` to set `skipReview: "AUTOMATIC"`, disabling Greptile’s automatic PR review behavior.
- Configured Greptile to be invoked manually via `@greptileai` comments while leaving CodeRabbit as the always-on reviewer.

- Confirm the updated Greptile behavior matches the intended review workflow in your repository.
- Verify any docs or contributor guidance that mention automatic Greptile reviews are updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->