### PR TITLE
🐛 fix(ui): make click-to-copy work on insecure contexts and fix tooltip feedback (#472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Click to copy" did nothing and logged a TypeError on deployments served over plain HTTP** (the common self-hosted LAN setup), because the browser Clipboard API only exists in secure contexts. Copying now falls back to the legacy execCommand technique when the API is missing or rejects, covers the log viewer's Copy button too, and shows a "Copy failed" state instead of failing silently when no copy mechanism works at all. (#472)
+
 ## [1.5.1-rc.5] — 2026-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **"Click to copy" did nothing and logged a TypeError on deployments served over plain HTTP** (the common self-hosted LAN setup), because the browser Clipboard API only exists in secure contexts. Copying now falls back to the legacy execCommand technique when the API is missing or rejects, covers the log viewer's Copy button too, and shows a "Copy failed" state instead of failing silently when no copy mechanism works at all. (#472)
+- **An open tooltip whose text changed — like the copy button's "Copied" confirmation — stayed stuck on the old text until you moved the mouse away and back.** Clicking to copy hid the tooltip outright, so the "Copied"/"Copy failed" state never appeared until a re-hover. Tooltips now update their text in place while open, reposition themselves for the new content, and reappear immediately if the pointer never left. (#472)
 
 ## [1.5.1-rc.5] — 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **"Click to copy" did nothing and logged a TypeError on deployments served over plain HTTP** (the common self-hosted LAN setup), because the browser Clipboard API only exists in secure contexts. Copying now falls back to the legacy execCommand technique when the API is missing or rejects, covers the log viewer's Copy button too, and shows a "Copy failed" state instead of failing silently when no copy mechanism works at all. (#472)
 - **An open tooltip whose text changed — like the copy button's "Copied" confirmation — stayed stuck on the old text until you moved the mouse away and back.** Clicking to copy hid the tooltip outright, so the "Copied"/"Copy failed" state never appeared until a re-hover. Tooltips now update their text in place while open, reposition themselves for the new content, and reappear immediately if the pointer never left. (#472)
+- **Three call sites bound a second tooltip directly onto a copyable tag's root element** (the containers table's digest-delta tooltip and two spots in the dashboard's recent-updates widget), so it silently clobbered the tag's own copy-state tooltip — duplicate listeners and, after the content-change re-show above, occasional spurious re-shows while hovering. The informative text now flows into the tag's own tooltip via a new `idleTooltip` prop instead of stacking a second directive on the same element. (#472)
 
 ## [1.5.1-rc.5] — 2026-07-02
 

--- a/ui/src/components/AppLogViewer.vue
+++ b/ui/src/components/AppLogViewer.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onMounted, ref, shallowRef, triggerRef, watch } fro
 import { useI18n } from 'vue-i18n';
 import AppIconButton from '@/components/AppIconButton.vue';
 import StatusDot from '@/components/StatusDot.vue';
+import { writeToClipboard } from '../composables/useClipboard';
 import { useLogSearch } from '../composables/useLogSearch';
 import type { AppLogEntry } from '../types/log-entry';
 import type { AnsiColor, AnsiTextSegment } from '../utils/container-logs';
@@ -47,6 +48,7 @@ const { t } = useI18n();
 const lineElements = new Map<number, HTMLElement>();
 const logViewport = ref<HTMLElement | null>(null);
 const copySuccess = ref(false);
+const copyFailed = ref(false);
 
 function isNearEdge(element: HTMLElement): boolean {
   if (props.newestFirst) {
@@ -391,14 +393,17 @@ async function copyLogs(): Promise<void> {
     })
     .join('\n');
 
-  try {
-    await navigator.clipboard.writeText(text);
-    copySuccess.value = true;
+  const succeeded = await writeToClipboard(text);
+  copySuccess.value = succeeded;
+  copyFailed.value = !succeeded;
+  if (succeeded) {
     setTimeout(() => {
       copySuccess.value = false;
     }, 2000);
-  } catch {
-    // Clipboard API may not be available in all contexts.
+  } else {
+    setTimeout(() => {
+      copyFailed.value = false;
+    }, 2000);
   }
 }
 
@@ -516,10 +521,11 @@ function toggleSortOrder(): void {
 
     <div class="relative flex-1 min-h-[120px] flex flex-col">
       <AppIconButton
-        :icon="copySuccess ? 'check' : 'copy'"
+        :icon="copyFailed ? 'xmark' : copySuccess ? 'check' : 'copy'"
         size="xs"
         data-test="container-log-copy"
-        :tooltip="copySuccess ? t('appShell.logViewer.search.copied') : t('appShell.logViewer.search.copyLogs')"
+        :variant="copyFailed ? 'danger' : 'muted'"
+        :tooltip="copyFailed ? t('sharedComponents.copyableTag.failed') : copySuccess ? t('appShell.logViewer.search.copied') : t('appShell.logViewer.search.copyLogs')"
         class="absolute top-2 right-2 z-10 opacity-50 hover:opacity-100"
         @click="copyLogs"
       />

--- a/ui/src/components/AppLogViewer.vue
+++ b/ui/src/components/AppLogViewer.vue
@@ -49,6 +49,7 @@ const lineElements = new Map<number, HTMLElement>();
 const logViewport = ref<HTMLElement | null>(null);
 const copySuccess = ref(false);
 const copyFailed = ref(false);
+let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
 
 function isNearEdge(element: HTMLElement): boolean {
   if (props.newestFirst) {
@@ -396,15 +397,13 @@ async function copyLogs(): Promise<void> {
   const succeeded = await writeToClipboard(text);
   copySuccess.value = succeeded;
   copyFailed.value = !succeeded;
-  if (succeeded) {
-    setTimeout(() => {
-      copySuccess.value = false;
-    }, 2000);
-  } else {
-    setTimeout(() => {
-      copyFailed.value = false;
-    }, 2000);
-  }
+
+  if (copyResetTimer) clearTimeout(copyResetTimer);
+  copyResetTimer = setTimeout(() => {
+    copySuccess.value = false;
+    copyFailed.value = false;
+    copyResetTimer = null;
+  }, 2000);
 }
 
 function toggleSortOrder(): void {

--- a/ui/src/components/CopyableTag.vue
+++ b/ui/src/components/CopyableTag.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
 import { useClipboard } from '../composables/useClipboard';
+import type { BindingValue } from '../directives/tooltip';
 
 const props = defineProps<{
   tag: string;
+  // Optional informative tooltip shown in place of the default "Click to copy"
+  // hint while idle (not copied, not failed). Lets call sites fold their own
+  // outer tooltip content into this component's own tooltip instead of
+  // stacking a second v-tooltip on the same root element (#472). Accepts
+  // either a plain string or the richer { value, showDelay } shape the
+  // v-tooltip directive also supports.
+  idleTooltip?: BindingValue;
 }>();
 
 const { t } = useI18n();
@@ -13,7 +21,7 @@ const { copyToClipboard, isCopied, isFailed } = useClipboard();
 <template>
   <span
     class="cursor-pointer hover:underline"
-    v-tooltip.top="isFailed(props.tag) ? t('sharedComponents.copyableTag.failed') : isCopied(props.tag) ? t('sharedComponents.copyableTag.copied') : t('sharedComponents.copyableTag.clickToCopy')"
+    v-tooltip.top="isFailed(props.tag) ? t('sharedComponents.copyableTag.failed') : isCopied(props.tag) ? t('sharedComponents.copyableTag.copied') : (props.idleTooltip ?? t('sharedComponents.copyableTag.clickToCopy'))"
     @click.stop="copyToClipboard(props.tag)"
   ><span :style="isFailed(props.tag) ? { color: 'var(--dd-danger)' } : undefined"><slot>{{ props.tag }}</slot></span></span>
 </template>

--- a/ui/src/components/CopyableTag.vue
+++ b/ui/src/components/CopyableTag.vue
@@ -7,13 +7,13 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
-const { copyToClipboard, isCopied } = useClipboard();
+const { copyToClipboard, isCopied, isFailed } = useClipboard();
 </script>
 
 <template>
   <span
     class="cursor-pointer hover:underline"
-    v-tooltip.top="isCopied(props.tag) ? t('sharedComponents.copyableTag.copied') : t('sharedComponents.copyableTag.clickToCopy')"
+    v-tooltip.top="isFailed(props.tag) ? t('sharedComponents.copyableTag.failed') : isCopied(props.tag) ? t('sharedComponents.copyableTag.copied') : t('sharedComponents.copyableTag.clickToCopy')"
     @click.stop="copyToClipboard(props.tag)"
-  ><slot>{{ props.tag }}</slot></span>
+  ><span :style="isFailed(props.tag) ? { color: 'var(--dd-danger)' } : undefined"><slot>{{ props.tag }}</slot></span></span>
 </template>

--- a/ui/src/components/containers/ContainersGroupedViews.vue
+++ b/ui/src/components/containers/ContainersGroupedViews.vue
@@ -661,7 +661,7 @@ onScopeDispose(() => {
                regressed twice (#356 fixed it, b40d3db8 re-broke it → #370). -->
           <div v-else-if="c.updateKind === 'digest' && c.newDigest && c.currentDigest" class="container-version-query">
             <div class="container-version-flow">
-              <CopyableTag :tag="c.currentTag" class="container-version-tag container-version-tag-target text-2xs-plus font-semibold" style="color: var(--dd-primary);" v-tooltip.top="tt(`${c.currentTag} — ${formatShortDigest(c.currentDigest)} → ${formatShortDigest(c.newDigest)}`)" @click.stop>{{ c.currentTag }}</CopyableTag>
+              <CopyableTag :tag="c.currentTag" class="container-version-tag container-version-tag-target text-2xs-plus font-semibold" style="color: var(--dd-primary);" :idle-tooltip="tt(`${c.currentTag} — ${formatShortDigest(c.currentDigest)} → ${formatShortDigest(c.newDigest)}`)" @click.stop>{{ c.currentTag }}</CopyableTag>
             </div>
           </div>
           <div v-else-if="c.newTag" class="container-version-query">

--- a/ui/src/composables/useClipboard.ts
+++ b/ui/src/composables/useClipboard.ts
@@ -3,30 +3,113 @@ import { readonly, ref } from 'vue';
 const FEEDBACK_DURATION_MS = 1500;
 
 const copiedKey = ref<string | null>(null);
+const failedKey = ref<string | null>(null);
 let resetTimer: ReturnType<typeof setTimeout> | null = null;
 
 function scheduleReset() {
   if (resetTimer) clearTimeout(resetTimer);
   resetTimer = setTimeout(() => {
     copiedKey.value = null;
+    failedKey.value = null;
     resetTimer = null;
   }, FEEDBACK_DURATION_MS);
 }
 
+/**
+ * Legacy fallback for contexts where the async Clipboard API is unavailable:
+ * plain http (insecure context — the primary self-hosted LAN deployment
+ * mode), older browsers, and some cross-origin iframes. Copies via a
+ * hidden, off-screen textarea and the deprecated but still universally
+ * supported document.execCommand('copy').
+ */
+function copyWithExecCommand(text: string): boolean {
+  if (typeof document.execCommand !== 'function') {
+    return false;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '-9999px';
+  textarea.style.opacity = '0';
+
+  const previouslyFocused = document.activeElement;
+  let succeeded = false;
+
+  try {
+    document.body.appendChild(textarea);
+    textarea.select();
+    textarea.setSelectionRange(0, text.length);
+    succeeded = document.execCommand('copy');
+  } catch {
+    succeeded = false;
+  } finally {
+    // appendChild/select can throw (e.g. a sandboxed iframe denying the
+    // operation) before the textarea ever attaches — guard removeChild so
+    // cleanup itself can't throw and leak the element or the focus restore.
+    if (textarea.parentNode) {
+      textarea.parentNode.removeChild(textarea);
+    }
+    if (previouslyFocused instanceof HTMLElement) {
+      previouslyFocused.focus();
+    }
+  }
+
+  return succeeded;
+}
+
+/**
+ * Tries the modern, permission-aware async Clipboard API first, then falls
+ * back to the legacy execCommand technique both when the API is absent
+ * (insecure http contexts, older browsers) and when it rejects (e.g. a
+ * cross-origin iframe without the clipboard-write permission).
+ */
+export async function writeToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Rejected (permission denied, insecure-context inconsistency, iframe
+      // restrictions) — fall through to the legacy path below.
+    }
+  }
+
+  return copyWithExecCommand(text);
+}
+
 export function useClipboard() {
-  async function copyToClipboard(text: string, key?: string) {
-    await navigator.clipboard.writeText(text);
-    copiedKey.value = key ?? text;
+  async function copyToClipboard(text: string, key?: string): Promise<boolean> {
+    const resolvedKey = key ?? text;
+    const succeeded = await writeToClipboard(text);
+
+    if (succeeded) {
+      copiedKey.value = resolvedKey;
+      failedKey.value = null;
+    } else {
+      failedKey.value = resolvedKey;
+      copiedKey.value = null;
+    }
     scheduleReset();
+
+    return succeeded;
   }
 
   function isCopied(key: string): boolean {
     return copiedKey.value === key;
   }
 
+  function isFailed(key: string): boolean {
+    return failedKey.value === key;
+  }
+
   return {
     copyToClipboard,
     isCopied,
+    isFailed,
     copiedKey: readonly(copiedKey),
+    failedKey: readonly(failedKey),
   };
 }

--- a/ui/src/directives/tooltip.ts
+++ b/ui/src/directives/tooltip.ts
@@ -1,11 +1,11 @@
 import type { DirectiveBinding, ObjectDirective } from 'vue';
 
-interface TooltipBinding {
+export interface TooltipBinding {
   value: string;
   showDelay?: number;
 }
 
-type BindingValue = string | TooltipBinding;
+export type BindingValue = string | TooltipBinding;
 
 interface TooltipState {
   text: string;

--- a/ui/src/directives/tooltip.ts
+++ b/ui/src/directives/tooltip.ts
@@ -15,8 +15,9 @@ interface TooltipState {
   originalTitle: string | null;
   fallbackTitle: string | null;
   titleSuppressed: boolean;
-  show: () => void;
-  hide: () => void;
+  pointerInside: boolean;
+  show: (event?: Event) => void;
+  hide: (event?: Event) => void;
 }
 
 // ── Shared singleton tooltip element ──────────────────────────────
@@ -115,8 +116,11 @@ function parse(binding: DirectiveBinding<BindingValue>): { text: string; delay: 
   return { text: value.value ?? '', delay: value.showDelay ?? 0 };
 }
 
-function makeShow(el: HTMLElement, state: TooltipState): () => void {
-  return () => {
+function makeShow(el: HTMLElement, state: TooltipState): (event?: Event) => void {
+  return (event?: Event) => {
+    if (event?.type === 'mouseenter') {
+      state.pointerInside = true;
+    }
     if (!state.text) return;
 
     if (state.timer != null) {
@@ -140,8 +144,11 @@ function makeShow(el: HTMLElement, state: TooltipState): () => void {
   };
 }
 
-function makeHide(_el: HTMLElement, state: TooltipState): () => void {
-  return () => {
+function makeHide(_el: HTMLElement, state: TooltipState): (event?: Event) => void {
+  return (event?: Event) => {
+    if (event?.type === 'mouseleave') {
+      state.pointerInside = false;
+    }
     if (state.timer != null) {
       clearTimeout(state.timer);
       state.timer = null;
@@ -167,6 +174,7 @@ function bind(el: HTMLElement, binding: DirectiveBinding<BindingValue>) {
     originalTitle,
     fallbackTitle: originalTitle ?? (text || null),
     titleSuppressed: false,
+    pointerInside: false,
     show: undefined as unknown as () => void,
     hide: undefined as unknown as () => void,
   };
@@ -214,6 +222,7 @@ export const tooltip: ObjectDirective<HTMLElement, BindingValue> = {
     }
 
     const { text, delay } = parse(binding);
+    const previousText = state.text;
     state.text = text;
     state.delay = delay;
     const currentTitle = el.getAttribute('title');
@@ -226,9 +235,19 @@ export const tooltip: ObjectDirective<HTMLElement, BindingValue> = {
       state.fallbackTitle = text || null;
     }
 
-    // Update live tooltip text if currently showing for this anchor
-    if (activeAnchor === el && sharedTip) {
-      sharedTip.textContent = text;
+    // Live-update a tooltip that's already showing for this anchor, or
+    // re-show immediately (bypassing any showDelay) when the pointer never
+    // left the anchor — e.g. a click-triggered title change like the copy
+    // button's "Copied" confirmation.
+    if (text && text !== previousText) {
+      if (activeAnchor === el && sharedTip) {
+        sharedTip.textContent = text;
+        positionTooltip(el, sharedTip);
+      } else if (state.pointerInside) {
+        state.titleSuppressed = true;
+        syncTitle(el, state);
+        showTooltip(el, state);
+      }
     }
 
     if (!text) {

--- a/ui/src/locales/en/sharedComponents.json
+++ b/ui/src/locales/en/sharedComponents.json
@@ -6,7 +6,8 @@
     },
     "copyableTag": {
       "copied": "Copied!",
-      "clickToCopy": "Click to copy"
+      "clickToCopy": "Click to copy",
+      "failed": "Copy failed"
     },
     "dataCardGrid": {
       "selectItem": "Select {name}"

--- a/ui/src/views/dashboard/components/DashboardRecentUpdatesWidget.vue
+++ b/ui/src/views/dashboard/components/DashboardRecentUpdatesWidget.vue
@@ -382,14 +382,14 @@ function updateKindInitial(kind?: string): string {
               </CopyableTag>
             </div>
             <div class="flex sm:hidden flex-col items-center gap-0.5 min-w-0 max-w-full">
-              <CopyableTag :tag="row.oldVer" class="text-3xs dd-text-secondary truncate max-w-full leading-tight" v-tooltip.top="row.oldVer">
+              <CopyableTag :tag="row.oldVer" class="text-3xs dd-text-secondary truncate max-w-full leading-tight" :idle-tooltip="row.oldVer">
                 {{ row.oldVer }}
               </CopyableTag>
               <CopyableTag
                 :tag="row.newVer"
                 class="text-3xs font-semibold truncate max-w-full leading-tight"
                 :style="{ color: getUpdateKindColor(row.updateKind) }"
-                v-tooltip.top="row.newVer">
+                :idle-tooltip="row.newVer">
                 {{ row.newVer }}
               </CopyableTag>
             </div>

--- a/ui/tests/components/AppLogViewer.spec.ts
+++ b/ui/tests/components/AppLogViewer.spec.ts
@@ -351,6 +351,41 @@ describe('AppLogViewer', () => {
     expect(copyBtn.props('icon')).toBe('copy');
   });
 
+  it('shows a temporary failed state when the clipboard write does not succeed', async () => {
+    vi.useFakeTimers();
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    });
+    document.execCommand = vi.fn().mockReturnValue(false);
+
+    const wrapper = mountViewer({
+      entries: [makeEntry(1, { plainLine: 'boom' })],
+    });
+
+    await wrapper.get('[data-test="container-log-copy"]').trigger('click');
+    await flushPromises();
+
+    const copyBtn = wrapper
+      .findAllComponents({ name: 'AppIconButton' })
+      .find((component) => component.attributes('data-test') === 'container-log-copy');
+    if (!copyBtn) {
+      throw new Error('Copy button component not found');
+    }
+    expect(copyBtn.props('icon')).toBe('xmark');
+    expect(copyBtn.props('variant')).toBe('danger');
+    expect(copyBtn.props('tooltip')).toBe('Copy failed');
+
+    vi.advanceTimersByTime(2000);
+    await nextTick();
+
+    expect(copyBtn.props('icon')).toBe('copy');
+    expect(copyBtn.props('variant')).toBe('muted');
+
+    delete (document as any).execCommand;
+  });
+
   describe('search filter mode', () => {
     it('shows all entries in highlight mode (default)', async () => {
       const wrapper = mountViewer({

--- a/ui/tests/components/AppLogViewer.spec.ts
+++ b/ui/tests/components/AppLogViewer.spec.ts
@@ -386,6 +386,52 @@ describe('AppLogViewer', () => {
     delete (document as any).execCommand;
   });
 
+  it('keeps the success indicator visible through a rapid second copy instead of letting the first timer clear it early', async () => {
+    vi.useFakeTimers();
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText,
+      },
+    });
+
+    const wrapper = mountViewer({
+      entries: [makeEntry(1, { plainLine: 'ready' })],
+    });
+
+    const copyBtn = wrapper
+      .findAllComponents({ name: 'AppIconButton' })
+      .find((component) => component.attributes('data-test') === 'container-log-copy');
+    if (!copyBtn) {
+      throw new Error('Copy button component not found');
+    }
+
+    await wrapper.get('[data-test="container-log-copy"]').trigger('click');
+    await flushPromises();
+    expect(copyBtn.props('icon')).toBe('check');
+
+    // Second click 1000ms later should cancel the first timer and reset the
+    // 2s window from this click instead.
+    vi.advanceTimersByTime(1000);
+    await wrapper.get('[data-test="container-log-copy"]').trigger('click');
+    await flushPromises();
+    expect(copyBtn.props('icon')).toBe('check');
+
+    // Advance past where the FIRST timer would have fired (1000ms + 1000ms = 2000ms
+    // from the first click) — the indicator must still be set because the
+    // second click's timer replaced it.
+    vi.advanceTimersByTime(1000);
+    await nextTick();
+    expect(copyBtn.props('icon')).toBe('check');
+
+    // Advance the remaining time for the second click's own 2s window.
+    vi.advanceTimersByTime(1000);
+    await nextTick();
+    expect(copyBtn.props('icon')).toBe('copy');
+  });
+
   describe('search filter mode', () => {
     it('shows all entries in highlight mode (default)', async () => {
       const wrapper = mountViewer({

--- a/ui/tests/components/CopyableTag.spec.ts
+++ b/ui/tests/components/CopyableTag.spec.ts
@@ -1,0 +1,98 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import CopyableTag from '@/components/CopyableTag.vue';
+
+function mountTag(props: Record<string, unknown> = {}, attrs: Record<string, unknown> = {}) {
+  const tooltipValues: unknown[] = [];
+  const wrapper = mount(CopyableTag, {
+    props: { tag: 'v1.2.3', ...props },
+    attrs,
+    global: {
+      directives: {
+        tooltip: {
+          mounted(_el, binding) {
+            tooltipValues.push(binding.value);
+          },
+          updated(_el, binding) {
+            tooltipValues.push(binding.value);
+          },
+        },
+      },
+    },
+  });
+  return { wrapper, tooltipValues };
+}
+
+describe('CopyableTag', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    delete (document as any).execCommand;
+  });
+
+  it('mounts the real component template rather than the global test stub', () => {
+    // tests/setup.ts globally registers a bare `<span><slot /></span>` stub for
+    // CopyableTag (by name) so unrelated specs don't have to deal with clipboard
+    // machinery. Mounting the SFC directly bypasses that name-based stub — if it
+    // didn't, this trivially-true assertion about the real template's class
+    // would fail, since the stub renders no class at all.
+    const { wrapper } = mountTag();
+    expect(wrapper.classes()).toContain('cursor-pointer');
+  });
+
+  it('renders the tag via the default slot', () => {
+    const { wrapper } = mountTag({ tag: 'latest' });
+    expect(wrapper.text()).toBe('latest');
+  });
+
+  it('copies via the clipboard API when available (success path)', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const { wrapper, tooltipValues } = mountTag({ tag: 'success-tag' });
+    await wrapper.trigger('click');
+    await flushPromises();
+
+    expect(writeText).toHaveBeenCalledWith('success-tag');
+    expect(tooltipValues.at(-1)).toBe('Copied!');
+  });
+
+  it('falls back to execCommand when the clipboard API is unavailable (fallback path)', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockReturnValue(true);
+
+    const { wrapper, tooltipValues } = mountTag({ tag: 'fallback-tag' });
+    await wrapper.trigger('click');
+    await flushPromises();
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(tooltipValues.at(-1)).toBe('Copied!');
+  });
+
+  it('applies the danger color to the failed element even when the parent passes a conflicting static style attr', async () => {
+    // Regression test for the fallthrough-attrs bug: real call sites pass a
+    // static `style="color: var(--dd-success);"` attribute on <CopyableTag>.
+    // Vue 3 merges fallthrough attrs onto the component's root AFTER the
+    // root's own bindings, so the parent's style wins on conflicting keys. If
+    // the failed-state color were bound on the root itself, it would be
+    // silently overridden by the parent's success-green and never render.
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockReturnValue(false);
+
+    const { wrapper, tooltipValues } = mountTag(
+      { tag: 'failed-tag' },
+      { style: 'color: var(--dd-success);' },
+    );
+    await wrapper.trigger('click');
+    await flushPromises();
+
+    expect(tooltipValues.at(-1)).toBe('Copy failed');
+
+    const innerSpan = wrapper.find('span > span');
+    expect(innerSpan.exists()).toBe(true);
+    expect(innerSpan.attributes('style')).toContain('color: var(--dd-danger)');
+  });
+});

--- a/ui/tests/components/CopyableTag.spec.ts
+++ b/ui/tests/components/CopyableTag.spec.ts
@@ -95,4 +95,54 @@ describe('CopyableTag', () => {
     expect(innerSpan.exists()).toBe(true);
     expect(innerSpan.attributes('style')).toContain('color: var(--dd-danger)');
   });
+
+  it('shows the default clickToCopy text in the idle state when idleTooltip is not provided', () => {
+    const { tooltipValues } = mountTag({ tag: 'no-idle-tooltip' });
+    expect(tooltipValues.at(-1)).toBe('Click to copy');
+  });
+
+  it('shows idleTooltip in the idle state when provided', () => {
+    const { tooltipValues } = mountTag({
+      tag: 'v1.2.3',
+      idleTooltip: 'v1.2.3 — sha256:abc… → sha256:def…',
+    });
+    expect(tooltipValues.at(-1)).toBe('v1.2.3 — sha256:abc… → sha256:def…');
+  });
+
+  it('passes an object idleTooltip straight through to the tooltip binding in the idle state', () => {
+    const objectTooltip = { value: 'digest delta', showDelay: 300 };
+    const { tooltipValues } = mountTag({
+      tag: 'v1.2.3',
+      idleTooltip: objectTooltip,
+    });
+    expect(tooltipValues.at(-1)).toEqual(objectTooltip);
+  });
+
+  it('still shows the Copied! text when idleTooltip is set but the tag was just copied', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const { wrapper, tooltipValues } = mountTag({
+      tag: 'copied-with-idle-tooltip',
+      idleTooltip: 'informative text',
+    });
+    await wrapper.trigger('click');
+    await flushPromises();
+
+    expect(tooltipValues.at(-1)).toBe('Copied!');
+  });
+
+  it('still shows the Copy failed text when idleTooltip is set but the copy failed', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockReturnValue(false);
+
+    const { wrapper, tooltipValues } = mountTag({
+      tag: 'failed-with-idle-tooltip',
+      idleTooltip: 'informative text',
+    });
+    await wrapper.trigger('click');
+    await flushPromises();
+
+    expect(tooltipValues.at(-1)).toBe('Copy failed');
+  });
 });

--- a/ui/tests/composables/useClipboard.spec.ts
+++ b/ui/tests/composables/useClipboard.spec.ts
@@ -13,17 +13,26 @@ describe('useClipboard', () => {
     const { copyToClipboard } = useClipboard();
     copyToClipboard('__reset__');
     vi.advanceTimersByTime(1500);
+    writeTextMock.mockClear();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    delete (document as any).execCommand;
+    delete (document as any).activeElement;
   });
 
   it('calls navigator.clipboard.writeText with the correct text', async () => {
     const { copyToClipboard } = useClipboard();
     await copyToClipboard('hello world');
     expect(writeTextMock).toHaveBeenCalledWith('hello world');
+  });
+
+  it('resolves true on a successful async copy', async () => {
+    const { copyToClipboard } = useClipboard();
+    const result = await copyToClipboard('hello world');
+    expect(result).toBe(true);
   });
 
   it('isCopied returns true for the copied key after copying', async () => {
@@ -88,5 +97,169 @@ describe('useClipboard', () => {
     // Advance remaining 500ms to hit 1500ms from second call
     vi.advanceTimersByTime(500);
     expect(isCopied('key-2')).toBe(false);
+  });
+
+  it('falls back to execCommand when navigator.clipboard is undefined', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockReturnValue(true);
+    const { copyToClipboard, isCopied } = useClipboard();
+
+    const result = await copyToClipboard('x', 'key-undefined');
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(writeTextMock).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+    expect(isCopied('key-undefined')).toBe(true);
+  });
+
+  it('falls back to execCommand when clipboard.writeText is missing', async () => {
+    Object.assign(navigator, { clipboard: {} });
+    document.execCommand = vi.fn().mockReturnValue(true);
+    const { copyToClipboard, isCopied } = useClipboard();
+
+    const result = await copyToClipboard('x', 'key-missing-writeText');
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(writeTextMock).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+    expect(isCopied('key-missing-writeText')).toBe(true);
+  });
+
+  it('falls back to execCommand when the async clipboard write rejects', async () => {
+    writeTextMock.mockRejectedValueOnce(new Error('NotAllowedError'));
+    document.execCommand = vi.fn().mockReturnValue(true);
+    const { copyToClipboard, isCopied, isFailed } = useClipboard();
+
+    await expect(copyToClipboard('x', 'k')).resolves.toBe(true);
+
+    expect(document.execCommand).toHaveBeenCalled();
+    expect(isCopied('k')).toBe(true);
+    expect(isFailed('k')).toBe(false);
+  });
+
+  it('marks the key failed when neither clipboard API nor execCommand are available', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    const { copyToClipboard, isCopied, isFailed } = useClipboard();
+
+    const result = await copyToClipboard('x', 'k');
+
+    expect(result).toBe(false);
+    expect(isFailed('k')).toBe(true);
+    expect(isCopied('k')).toBe(false);
+  });
+
+  it('marks the key failed when execCommand returns false', async () => {
+    writeTextMock.mockRejectedValueOnce(new Error('denied'));
+    document.execCommand = vi.fn().mockReturnValue(false);
+    const { copyToClipboard, isCopied, isFailed } = useClipboard();
+
+    const result = await copyToClipboard('x', 'k');
+
+    expect(result).toBe(false);
+    expect(isFailed('k')).toBe(true);
+    expect(isCopied('k')).toBe(false);
+  });
+
+  it('marks the key failed when execCommand throws', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const { copyToClipboard, isFailed } = useClipboard();
+
+    const result = await copyToClipboard('x', 'k');
+
+    expect(result).toBe(false);
+    expect(isFailed('k')).toBe(true);
+  });
+
+  it('cleans up without leaking the textarea when appendChild throws (e.g. a sandboxed iframe)', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockReturnValue(true);
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation(() => {
+      throw new Error('denied');
+    });
+    const { copyToClipboard, isFailed } = useClipboard();
+
+    const result = await copyToClipboard('x', 'k');
+
+    expect(result).toBe(false);
+    expect(isFailed('k')).toBe(true);
+    expect(document.execCommand).not.toHaveBeenCalled();
+    expect(document.querySelectorAll('textarea')).toHaveLength(0);
+
+    appendChildSpy.mockRestore();
+  });
+
+  it('cleans up without leaking the textarea when select() throws before execCommand runs', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockReturnValue(true);
+    const selectSpy = vi.spyOn(HTMLTextAreaElement.prototype, 'select').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const { copyToClipboard, isFailed } = useClipboard();
+
+    const result = await copyToClipboard('x', 'k');
+
+    expect(result).toBe(false);
+    expect(isFailed('k')).toBe(true);
+    expect(document.execCommand).not.toHaveBeenCalled();
+    expect(document.querySelectorAll('textarea')).toHaveLength(0);
+
+    selectSpy.mockRestore();
+  });
+
+  it('restores focus to the previously focused element after a legacy copy', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockReturnValue(true);
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus');
+    const { copyToClipboard } = useClipboard();
+
+    await copyToClipboard('x');
+
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it('does not throw when there is nothing to refocus', async () => {
+    Object.defineProperty(document, 'activeElement', { value: null, configurable: true });
+    Object.assign(navigator, { clipboard: undefined });
+    document.execCommand = vi.fn().mockReturnValue(true);
+    const { copyToClipboard } = useClipboard();
+
+    await expect(copyToClipboard('x')).resolves.toBe(true);
+  });
+
+  it('isFailed returns false after 1500ms timeout', async () => {
+    Object.assign(navigator, { clipboard: undefined });
+    const { copyToClipboard, isFailed } = useClipboard();
+
+    await copyToClipboard('x', 'k');
+    expect(isFailed('k')).toBe(true);
+
+    vi.advanceTimersByTime(1500);
+    expect(isFailed('k')).toBe(false);
+  });
+
+  it('a subsequent successful copy clears a previous failedKey', async () => {
+    const { copyToClipboard, isFailed, isCopied } = useClipboard();
+    Object.assign(navigator, { clipboard: undefined });
+    await copyToClipboard('first', 'key-a');
+    expect(isFailed('key-a')).toBe(true);
+
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+    await copyToClipboard('second', 'key-b');
+    expect(isFailed('key-a')).toBe(false);
+    expect(isCopied('key-b')).toBe(true);
+  });
+
+  it('a subsequent failed copy clears a previous copiedKey', async () => {
+    const { copyToClipboard, isFailed, isCopied } = useClipboard();
+    await copyToClipboard('first', 'key-a');
+    expect(isCopied('key-a')).toBe(true);
+
+    Object.assign(navigator, { clipboard: undefined });
+    await copyToClipboard('second', 'key-b');
+    expect(isCopied('key-a')).toBe(false);
+    expect(isFailed('key-b')).toBe(true);
   });
 });

--- a/ui/tests/composables/useClipboard.spec.ts
+++ b/ui/tests/composables/useClipboard.spec.ts
@@ -3,7 +3,7 @@ import { useClipboard } from '@/composables/useClipboard';
 describe('useClipboard', () => {
   let writeTextMock: ReturnType<typeof vi.fn>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers();
     writeTextMock = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, {
@@ -11,7 +11,7 @@ describe('useClipboard', () => {
     });
     // Flush any lingering state from a previous test
     const { copyToClipboard } = useClipboard();
-    copyToClipboard('__reset__');
+    await copyToClipboard('__reset__');
     vi.advanceTimersByTime(1500);
     writeTextMock.mockClear();
   });

--- a/ui/tests/directives/tooltip.spec.ts
+++ b/ui/tests/directives/tooltip.spec.ts
@@ -376,4 +376,92 @@ describe('tooltip directive', () => {
     um?.(el);
     vi.useFakeTimers();
   });
+
+  it('repositions the shared tip when its bound text changes while visible', () => {
+    const el = createAnchor();
+    const rectSpy = vi.spyOn(el, 'getBoundingClientRect');
+    mounted?.(el, binding('Short'));
+
+    el.dispatchEvent(new Event('mouseenter'));
+    const tip = getTooltipEl()!;
+    expect(tip.textContent).toBe('Short');
+    const callsAfterShow = rectSpy.mock.calls.length;
+
+    updated?.(el, binding('A much longer replacement label'));
+
+    expect(tip.textContent).toBe('A much longer replacement label');
+    // positionTooltip() re-measures the anchor to re-center the resized tip
+    expect(rectSpy.mock.calls.length).toBeGreaterThan(callsAfterShow);
+
+    rectSpy.mockRestore();
+    beforeUnmount?.(el);
+  });
+
+  it('re-shows immediately with the new text after a click hid the tooltip while the pointer stayed put', () => {
+    const el = createAnchor();
+    mounted?.(el, binding('Copy'));
+
+    el.dispatchEvent(new Event('mouseenter'));
+    expect(getTooltipEl()!.textContent).toBe('Copy');
+
+    el.dispatchEvent(new Event('mousedown'));
+    expect(getTooltipEl()).toBeNull();
+
+    updated?.(el, binding('Copied'));
+
+    expect(getTooltipEl()).not.toBeNull();
+    expect(getTooltipEl()!.textContent).toBe('Copied');
+
+    beforeUnmount?.(el);
+  });
+
+  it('does not resurrect the tooltip when its text changes after the pointer has left', () => {
+    const el = createAnchor();
+    mounted?.(el, binding('Copy'));
+
+    el.dispatchEvent(new Event('mouseenter'));
+    el.dispatchEvent(new Event('mouseleave'));
+    expect(getTooltipEl()).toBeNull();
+
+    updated?.(el, binding('Copied'));
+
+    expect(getTooltipEl()).toBeNull();
+
+    beforeUnmount?.(el);
+  });
+
+  it('does not reappear on a re-render that leaves the text unchanged', () => {
+    const el = createAnchor();
+    mounted?.(el, binding('Copy'));
+
+    el.dispatchEvent(new Event('mouseenter'));
+    el.dispatchEvent(new Event('mousedown'));
+    expect(getTooltipEl()).toBeNull();
+
+    updated?.(el, binding('Copy'));
+
+    expect(getTooltipEl()).toBeNull();
+
+    beforeUnmount?.(el);
+  });
+
+  it('bypasses the show delay when re-showing after a content change with the pointer still present', () => {
+    const el = createAnchor();
+    mounted?.(el, binding({ value: 'Copy', showDelay: 200 }));
+
+    el.dispatchEvent(new Event('mouseenter'));
+    vi.advanceTimersByTime(200);
+    expect(getTooltipEl()!.textContent).toBe('Copy');
+
+    el.dispatchEvent(new Event('mousedown'));
+    expect(getTooltipEl()).toBeNull();
+
+    updated?.(el, binding({ value: 'Copied', showDelay: 200 }));
+
+    // Reappears immediately — no timer advance needed, unlike the initial show.
+    expect(getTooltipEl()).not.toBeNull();
+    expect(getTooltipEl()!.textContent).toBe('Copied');
+
+    beforeUnmount?.(el);
+  });
 });


### PR DESCRIPTION
Fixes #472.

Click-to-copy did nothing (and logged a TypeError) on deployments served over plain HTTP, which is the common self-hosted LAN setup, because `navigator.clipboard` only exists in secure contexts. Three commits:

- **execCommand fallback** — `useClipboard` now falls back to the legacy `document.execCommand('copy')` textarea technique when the Clipboard API is missing or rejects. The log viewer's Copy button goes through the same path, and when no copy mechanism works at all the UI shows an explicit "Copy failed" state instead of failing silently. The temp textarea teardown is wrapped in try/finally with a parentNode guard so a mid-copy DOM error can't leave it behind or skip focus restore.
- **Live tooltip updates** — an open tooltip whose text changed (like the "Copied" confirmation) stayed stuck on the old text until you moved the mouse away and back, and the click itself hid the tooltip so the feedback never appeared. The tooltip directive now updates the shared tooltip element in place when its content changes, repositions it for the new text, and re-shows immediately if the pointer never left the anchor.
- **De-duplicated tooltips on CopyableTag** — three call sites (the containers table digest-delta cell and two spots in the dashboard recent-updates widget) bound a second `v-tooltip` directly on `<CopyableTag>`, which falls through to the same root element as the component's own copy-state tooltip and clobbered its directive state. Those sites now pass their text through a new `idleTooltip` prop so one tooltip carries both the informative text and the copy feedback. Swept every `CopyableTag` usage in `ui/src` — no other double bindings.

Gate: full UI suite green at 100% coverage, build/typecheck/biome clean, e2e + playwright via pre-push hook. Manually QA'd on a LAN IP (insecure context) to exercise the fallback path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
🐛 Fixed
- Added a clipboard fallback using `document.execCommand('copy')` so click-to-copy works when `navigator.clipboard` is missing or rejects (e.g., insecure/plain HTTP contexts).
- Made `AppLogViewer`’s toolbar copy button use the same copy helper and surface explicit failure UI (“Copy failed”) when no copy method succeeds.
- Improved copy feedback timing: clears any pending copy-feedback reset timer before scheduling a new one to prevent rapid re-copy indicator glitches.

🔧 Changed
- `useClipboard()` now tracks both success (`isCopied`) and failure (`isFailed`) via `copiedKey`/`failedKey`, and `copyToClipboard()` returns `Promise<boolean>`.
- Introduced exported `writeToClipboard(text): Promise<boolean>` that tries `navigator.clipboard.writeText` first, then falls back to the `execCommand('copy')` textarea path with hardened cleanup + focus restoration.
- Tooltip directive now live-updates while open: when bound text changes it remeasures/repositions, and if the pointer is still over the anchor it re-shows immediately (bypassing the initial delay).
- `CopyableTag` now supports an optional `idleTooltip` prop to prevent duplicate/staked tooltip bindings and preserve correct copy-state tooltip precedence.
- Updated affected `CopyableTag` call sites to pass `idleTooltip` for digest/version displays.
- Added i18n strings for `sharedComponents.copyableTag.clickToCopy` and `sharedComponents.copyableTag.failed`.

✨ Added
- New/expanded tests for:
  - clipboard fallback success/failure, including missing `navigator.clipboard` and failing/throwing `document.execCommand`
  - DOM cleanup edge cases in the fallback path (append/select/throw scenarios)
  - rapid double-copy behavior and correct reset timing
  - tooltip directive dynamic update/re-show behavior
  - `CopyableTag` idleTooltip precedence and failure styling regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->