### PR TITLE
🐛 fix(mqtt): fall back to installed tag in HASS latest_version template (#491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Home Assistant `update.*` entities showed "Unknown" for both Installed and Newest version on up-to-date containers.** The MQTT HASS discovery `latest_version` template rendered an empty string whenever a container had no pending update (no `result` in the payload). Home Assistant silently discards an empty render, so the "Newest version" attribute stayed unset and, because HA blanks the whole entity state when either version is missing, the entity read `Unknown` forever instead of resolving to "up to date". The template now falls back to the installed image tag when no update result is present, and guards the digest slice so a digest-kind report that carries no digest no longer throws in HA's template engine. (#491)
+
 ## [1.5.1-rc.6] — 2026-07-05
 
 ### Fixed

--- a/app/triggers/providers/mqtt/Hass.test.ts
+++ b/app/triggers/providers/mqtt/Hass.test.ts
@@ -228,7 +228,7 @@ test('addContainerSensor must publish sensor discovery message expected by HA', 
       value_template: '{{ value_json.image_tag_value }}',
       latest_version_topic: 'topic/watcher-name/container-name',
       latest_version_template:
-        '{% if value_json.update_kind_kind == "digest" %}{{ value_json.result_digest[:15] }}{% else %}{{ value_json.result_tag }}{% endif %}',
+        '{% if value_json.update_kind_kind == "digest" %}{{ value_json.result_digest[:15] if value_json.result_digest else value_json.image_tag_value }}{% else %}{{ value_json.result_tag if value_json.result_tag else value_json.image_tag_value }}{% endif %}',
       json_attributes_topic: 'topic/watcher-name/container-name',
     }),
     { retain: true },

--- a/app/triggers/providers/mqtt/Hass.ts
+++ b/app/triggers/providers/mqtt/Hass.ts
@@ -16,8 +16,15 @@ const HASS_DEVICE_ID = 'drydock';
 const HASS_DEVICE_NAME = 'drydock';
 const HASS_MANUFACTURER = 'drydock';
 const HASS_ENTITY_VALUE_TEMPLATE = '{{ value_json.image_tag_value }}';
+// Newest version. When no update is pending, container.result is absent, so
+// result_tag/result_digest never appear in the flattened payload. Fall back to
+// the installed tag (image_tag_value) so HA resolves latest == installed ("up to
+// date") instead of rendering an empty string — which HA silently discards,
+// leaving both "Newest version" and the entity state permanently Unknown (#491).
+// The `if value_json.result_digest` guard also avoids the `Undefined[:15]` slice
+// error HA's Jinja throws when a digest-kind report carries no result_digest.
 const HASS_LATEST_VERSION_TEMPLATE =
-  '{% if value_json.update_kind_kind == "digest" %}{{ value_json.result_digest[:15] }}{% else %}{{ value_json.result_tag }}{% endif %}';
+  '{% if value_json.update_kind_kind == "digest" %}{{ value_json.result_digest[:15] if value_json.result_digest else value_json.image_tag_value }}{% else %}{{ value_json.result_tag if value_json.result_tag else value_json.image_tag_value }}{% endif %}';
 const HASS_DEFAULT_ENTITY_PICTURE =
   'https://raw.githubusercontent.com/CodesWhat/drydock/main/docs/assets/whale-logo.png';
 export const HASS_CONTAINER_STATE_TOPIC_TRACK_LIMIT = 10_000;

--- a/app/triggers/providers/mqtt/Mqtt.test.ts
+++ b/app/triggers/providers/mqtt/Mqtt.test.ts
@@ -6,7 +6,7 @@ import {
   emitContainerUpdated,
 } from '../../../event/index.js';
 import log from '../../../log/index.js';
-import { flatten } from '../../../model/container.js';
+import { flatten, validate } from '../../../model/container.js';
 
 vi.mock('mqtt');
 vi.mock('node:fs/promises', () => ({
@@ -233,6 +233,92 @@ test.each(containerData)('trigger should format json message payload as expected
   expect(mqtt.client.publish).toHaveBeenCalledWith(data.topic, JSON.stringify(flatten(container)), {
     retain: true,
   });
+});
+
+// Regression guard for #491: the HA latest_version_template reads result_tag /
+// result_digest / image_tag_value from the flattened MQTT state payload. Lock the
+// shape the template depends on — an up-to-date container carries image_tag_value
+// but NO result_* keys (the case that used to render an empty "Newest version"),
+// while tag/digest updates carry the matching result_* field.
+test('trigger should publish latest-version source fields for current, tag, and digest states', async () => {
+  mqtt.configuration = {
+    topic: 'dd/container',
+    exclude: '',
+    hass: {
+      attributes: 'full',
+      filter: {
+        include: '',
+        exclude: '',
+      },
+    },
+  };
+
+  const installedDigest = 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const remoteDigest = 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  const buildContainer = ({ id, name, digestWatch = false, result }) =>
+    validate({
+      id,
+      name,
+      watcher: 'local',
+      image: {
+        id: 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        registry: {
+          name: 'docker.io',
+          url: 'docker.io',
+        },
+        name: 'library/test',
+        tag: {
+          value: '1.25.0',
+          semver: true,
+        },
+        digest: {
+          watch: digestWatch,
+          value: installedDigest,
+        },
+        architecture: 'amd64',
+        os: 'linux',
+      },
+      ...(result ? { result } : {}),
+    });
+
+  const publishContainer = async (container) => {
+    mqtt.client.publish.mockClear();
+    await mqtt.trigger(container);
+    expect(mqtt.client.publish).toHaveBeenCalledTimes(1);
+    return JSON.parse(mqtt.client.publish.mock.calls[0][1]);
+  };
+
+  const upToDatePayload = await publishContainer(
+    buildContainer({ id: 'container-current', name: 'current' }),
+  );
+  expect(upToDatePayload).toHaveProperty('update_available', false);
+  expect(upToDatePayload).toHaveProperty('image_tag_value', '1.25.0');
+  expect(upToDatePayload).not.toHaveProperty('result_tag');
+  expect(upToDatePayload).not.toHaveProperty('result_digest');
+
+  const tagUpdatePayload = await publishContainer(
+    buildContainer({
+      id: 'container-tag-update',
+      name: 'tag-update',
+      result: { tag: '1.26.0' },
+    }),
+  );
+  expect(tagUpdatePayload).toHaveProperty('update_available', true);
+  expect(tagUpdatePayload).toHaveProperty('update_kind_kind', 'tag');
+  expect(tagUpdatePayload).toHaveProperty('result_tag', '1.26.0');
+
+  const digestUpdatePayload = await publishContainer(
+    buildContainer({
+      id: 'container-digest-update',
+      name: 'digest-update',
+      digestWatch: true,
+      result: { digest: remoteDigest },
+    }),
+  );
+  expect(digestUpdatePayload).toHaveProperty('update_available', true);
+  expect(digestUpdatePayload).toHaveProperty('update_kind_kind', 'digest');
+  expect(digestUpdatePayload).toHaveProperty('result_digest', remoteDigest);
 });
 
 test('trigger should normalize recreated alias-prefixed container names to their base topic', async () => {


### PR DESCRIPTION
## What

Fixes the Home Assistant `update.dd_container_*` entities showing **"Unknown"** for the "Newest version" attribute (and the entity state as a whole) on containers that are up to date, reported over MQTT + HASS discovery.

## Root cause

The HASS discovery `latest_version` template was:

```jinja
{% if value_json.update_kind_kind == "digest" %}{{ value_json.result_digest[:15] }}{% else %}{{ value_json.result_tag }}{% endif %}
```

When a container has no pending update, `container.result` is absent, so the flattened MQTT state payload carries **no** `result_tag` / `result_digest`. Both branches of the template then render an **empty string**. Home Assistant silently discards an empty `latest_version` render, so the "Newest version" attribute never gets set — and because HA blanks the whole `update.*` entity state when either the installed or latest version is missing, the entity reads `Unknown` forever instead of resolving to "up to date".

## Fix

Fall back to the installed image tag (`image_tag_value`) in **both** branches when no update result is present, and guard the digest slice so a digest-kind report that somehow carries no digest doesn't trip HA's `Undefined[:15]` Jinja error:

```jinja
{% if value_json.update_kind_kind == "digest" %}{{ value_json.result_digest[:15] if value_json.result_digest else value_json.image_tag_value }}{% else %}{{ value_json.result_tag if value_json.result_tag else value_json.image_tag_value }}{% endif %}
```

Now an up-to-date container reports `latest == installed`, which HA renders as "up to date".

## Tests

- **`Mqtt.test.ts`** — new payload-contract test that builds real containers through the model pipeline and locks the flattened-payload shape the template depends on: an up-to-date container carries `image_tag_value` but **no** `result_*` keys (exactly the case that used to render empty); a tag update carries `result_tag`; a digest update carries `result_digest`.
- **`Hass.test.ts`** — the existing HA-discovery-payload assertion is updated to pin the new `latest_version_template` string, so a future "simplification" can't silently regress this.

## Note on the reporter's "0 messages"

The issue log also shows `0 most recent received messages` on the state topic `dd/container/local/homeassistant`, which would independently blank **both** Installed and Newest. That half isn't reproducible from the source — `mustTrigger` passes for a plain up-to-date container and `trigger()` publishes a retained state payload on every container event regardless of update status. Confirming it needs the reporter's debug-level logs (the `Publish container result to …` line). This PR fixes the template bug that is reproducible and real; the state-delivery question is being followed up on the issue.

Fixes #491


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

🐛 Fixed
- Updated the Home Assistant MQTT discovery template for `update.dd_container_*` so up-to-date containers no longer render `Unknown` for installed/newest version fields.
- Added a fallback to `image_tag_value` when no update result is present.
- Guarded the digest slice so missing `result_digest` no longer causes template errors.

🔧 Changed
- Adjusted the Home Assistant discovery payload test to match the new template behavior.
- Added MQTT payload contract coverage for up-to-date, tag-update, and digest-update cases.

- Verify the flattened MQTT payload shape still matches all existing Home Assistant discovery consumers.
- Confirm the `latest_version_template` behavior with both tag-based and digest-based updates in Home Assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->