### PR TITLE
🐛 fix(store): retain updatePolicy across container recreates (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2-rc.1] — 2026-07-10
+
 ### Fixed
 
 - **Container update policy is no longer lost when a container is recreated** ([#496](https://github.com/CodesWhat/drydock/issues/496)). Container documents are keyed by Docker's container ID, which changes every time a container is recreated (image pull, `docker compose up -d`, or an update trigger firing). The replacement was stored as a brand-new document and the per-container update policy — maturity gate, skipped tags/digests, snooze — was silently dropped along with the old one. Because an absent policy means "no gating" rather than "default gating", affected containers then updated immediately instead of respecting their maturity soak. The policy now survives a recreate, for containers watched locally and through a remote agent alike. Present since `1.4.1`, when per-container maturity policies were introduced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Container update policy is no longer lost when a container is recreated** ([#496](https://github.com/CodesWhat/drydock/issues/496)). Container documents are keyed by Docker's container ID, which changes every time a container is recreated (image pull, `docker compose up -d`, or an update trigger firing). The replacement was stored as a brand-new document and the per-container update policy — maturity gate, skipped tags/digests, snooze — was silently dropped along with the old one. Because an absent policy means "no gating" rather than "default gating", affected containers then updated immediately instead of respecting their maturity soak. The policy now survives a recreate, for containers watched locally and through a remote agent alike. Present since `1.4.1`, when per-container maturity policies were introduced.
+- The remote-agent prune path now distinguishes a recreated container from a removed one, so a container that reappears under a new ID keeps its update policy and its Home Assistant state topic, while a genuinely deleted container still has its discovery topics cleaned up.
+
 ## [1.5.1] — 2026-07-09
 
 Consolidates the `1.5.1-rc.1` … `1.5.1-rc.6` prereleases. Users upgrading from `1.5.0`

--- a/app/agent/AgentClient.test.ts
+++ b/app/agent/AgentClient.test.ts
@@ -6408,6 +6408,42 @@ describe('AgentClient', () => {
       expect(mockLogChild.info).toHaveBeenCalledWith(expect.stringContaining('old-nginx'));
       expect(mockLogChild.info).toHaveBeenCalledWith(expect.stringContaining('Pruning'));
     });
+
+    // #496: the agent prune path deleted with no replacement signal at all, so a recreated
+    // agent-owned container lost its updatePolicy. The local watcher paths already pass this.
+    test('flags replacementExpected when a same-named container is in the new list', () => {
+      storeContainer.getContainers.mockReturnValue([
+        { id: 'old-id', name: 'nginx', agent: 'test-agent' },
+      ]);
+      (client as any).pruneOldContainers([{ id: 'new-id', name: 'nginx' }]);
+      expect(storeContainer.deleteContainer).toHaveBeenCalledWith('old-id', {
+        replacementExpected: true,
+      });
+    });
+
+    // A genuinely removed container must stay unflagged, otherwise Hass keeps its discovery
+    // state topic alive forever (Hass.ts reads replacementExpected off the removed event).
+    test('does not flag replacementExpected when the container is genuinely gone', () => {
+      storeContainer.getContainers.mockReturnValue([
+        { id: 'c2', name: 'old-nginx', agent: 'test-agent' },
+      ]);
+      (client as any).pruneOldContainers([{ id: 'other-id', name: 'something-else' }]);
+      expect(storeContainer.deleteContainer).toHaveBeenCalledWith('c2');
+    });
+
+    test('does not flag replacementExpected for an unnamed stale entry', () => {
+      storeContainer.getContainers.mockReturnValue([{ id: 'c3', agent: 'test-agent' }]);
+      (client as any).pruneOldContainers([{ id: 'new-id', name: 'nginx' }]);
+      expect(storeContainer.deleteContainer).toHaveBeenCalledWith('c3');
+    });
+
+    test('ignores unnamed containers in the authoritative list when matching names', () => {
+      storeContainer.getContainers.mockReturnValue([
+        { id: 'old-id', name: 'nginx', agent: 'test-agent' },
+      ]);
+      (client as any).pruneOldContainers([{ id: 'new-id' }, { id: 'n2', name: '' }]);
+      expect(storeContainer.deleteContainer).toHaveBeenCalledWith('old-id');
+    });
   });
 
   describe('buildContainerReport: clearPendingFreshState on updateAvailable === false', () => {

--- a/app/agent/AgentClient.ts
+++ b/app/agent/AgentClient.ts
@@ -320,9 +320,24 @@ export class AgentClient {
       (containerInStore) => !newContainerIds.has(containerInStore.id),
     );
 
+    // #496: a recreated container reappears under a fresh Docker id but keeps its name, so a
+    // stale-id entry whose name is still in the authoritative list is a replacement, not a
+    // removal. Flagging it lets the store retain the user's updatePolicy for the incoming doc
+    // (and, as before, lets Hass keep the state topic alive across the swap). A name that is
+    // genuinely gone stays unflagged so its HA discovery topics are still cleaned up.
+    const newContainerNames = new Set(
+      newContainers
+        .map((container) => container.name)
+        .filter((name): name is string => typeof name === 'string' && name !== ''),
+    );
+
     containersToRemove.forEach((c) => {
       this.log.info(`Pruning container ${c.name} (removed on Agent)`);
       this.pendingFreshStateAfterRemoteUpdate.delete(c.id);
+      if (typeof c.name === 'string' && newContainerNames.has(c.name)) {
+        storeContainer.deleteContainer(c.id, { replacementExpected: true });
+        return;
+      }
       storeContainer.deleteContainer(c.id);
     });
   }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-app",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-app",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-ecr": "3.1045.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-app",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Drydock backend — Docker container update manager",
   "engines": {
     "node": ">=24.0.0"

--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -3997,3 +3997,218 @@ describe('updateLifecycleCache carry-forward', () => {
     expect(inserted.firstSeenAt).toBe(incomingFirstSeenAt);
   });
 });
+
+// #496: a container recreate mints a new Docker container id, so ingestion falls to
+// insertContainer instead of updateContainer. updateContainer merges updatePolicy
+// forward; insertContainer historically did not, so the user's maturity gate was
+// silently dropped and isUpdateSuppressed() then failed open (no policy == no gating).
+describe('updatePolicyRetentionCache carry-forward (#496)', () => {
+  const MATURITY_POLICY = { maturityMode: 'mature', maturityMinAgeDays: 5 };
+
+  function makePolicyFixture(overrides: Record<string, unknown> = {}) {
+    return {
+      ...createContainerFixture(),
+      watcher: 'local',
+      name: 'myapp',
+      ...overrides,
+    };
+  }
+
+  function mountWith(docs: Array<{ data: unknown }>) {
+    const collection = createFilterableCollection(docs);
+    container.createCollections({ getCollection: () => collection, addCollection: () => null });
+    return collection;
+  }
+
+  test('carries updatePolicy forward across a container recreate (new id, same watcher+name)', () => {
+    const oldFixture = makePolicyFixture({
+      id: 'policy-old-1',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-old-1', { replacementExpected: true });
+    const inserted = container.insertContainer(makePolicyFixture({ id: 'policy-new-1' }));
+
+    expect(inserted.updatePolicy).toEqual(MATURITY_POLICY);
+  });
+
+  // The reported topology. insertContainer's security/lifecycle restores are gated behind
+  // isLocalContainer (#386) because runtime state is meaningless cross-agent. updatePolicy is
+  // durable controller-set config, so it must survive for agent-owned containers too.
+  test('carries updatePolicy forward for agent-owned containers', () => {
+    const oldFixture = makePolicyFixture({
+      id: 'policy-agent-old',
+      agent: 'remote1',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-agent-old', { replacementExpected: true });
+    const inserted = container.insertContainer(
+      makePolicyFixture({ id: 'policy-agent-new', agent: 'remote1' }),
+    );
+
+    expect(inserted.updatePolicy).toEqual(MATURITY_POLICY);
+  });
+
+  test('does not stash updatePolicy when the delete is not a replacement', () => {
+    const oldFixture = makePolicyFixture({
+      id: 'policy-perm-old',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-perm-old');
+    const inserted = container.insertContainer(makePolicyFixture({ id: 'policy-perm-new' }));
+
+    expect(inserted.updatePolicy).toBeUndefined();
+  });
+
+  test('does not stash when the deleted container had no updatePolicy', () => {
+    mountWith([{ data: makePolicyFixture({ id: 'policy-none-old' }) }]);
+
+    container.deleteContainer('policy-none-old', { replacementExpected: true });
+
+    expect(container._getUpdatePolicyRetentionCacheForTests().size).toBe(0);
+  });
+
+  test('does not stash for rollback containers', () => {
+    // rollback containers are named "<name>-old-<epoch>" (OLD_ROLLBACK_CONTAINER_NAME_PATTERN)
+    const oldFixture = makePolicyFixture({
+      id: 'policy-rb-old',
+      name: 'myapp-old-1752019200',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-rb-old', { replacementExpected: true });
+
+    expect(container._getUpdatePolicyRetentionCacheForTests().size).toBe(0);
+  });
+
+  test('an explicit incoming updatePolicy wins over the retained one', () => {
+    const incoming = { maturityMode: 'all', maturityMinAgeDays: 1 };
+    const oldFixture = makePolicyFixture({
+      id: 'policy-explicit-old',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-explicit-old', { replacementExpected: true });
+    const inserted = container.insertContainer(
+      makePolicyFixture({ id: 'policy-explicit-new', updatePolicy: incoming }),
+    );
+
+    expect(inserted.updatePolicy).toEqual(incoming);
+    // consumed either way, so a later unrelated insert cannot inherit it
+    expect(container._getUpdatePolicyRetentionCacheForTests().size).toBe(0);
+  });
+
+  test('does not apply a retained policy to an unrelated container name', () => {
+    const oldFixture = makePolicyFixture({
+      id: 'policy-other-old',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-other-old', { replacementExpected: true });
+    const inserted = container.insertContainer(
+      makePolicyFixture({ id: 'policy-other-new', name: 'someone-else' }),
+    );
+
+    expect(inserted.updatePolicy).toBeUndefined();
+  });
+
+  test('does not apply an expired retained policy', () => {
+    vi.useFakeTimers();
+    try {
+      const oldFixture = makePolicyFixture({
+        id: 'policy-ttl-old',
+        updatePolicy: MATURITY_POLICY,
+      });
+      mountWith([{ data: oldFixture }]);
+
+      container.deleteContainer('policy-ttl-old', { replacementExpected: true });
+      vi.advanceTimersByTime(container.UPDATE_POLICY_RETENTION_CACHE_TTL_MS + 1);
+      const inserted = container.insertContainer(makePolicyFixture({ id: 'policy-ttl-new' }));
+
+      expect(inserted.updatePolicy).toBeUndefined();
+      expect(container._getUpdatePolicyRetentionCacheForTests().size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('evicts oldest retained policies when the size cap is exceeded', () => {
+    const maxEntries = container.UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES;
+    const fixtures = [];
+    for (let i = 0; i <= maxEntries; i++) {
+      fixtures.push({
+        data: makePolicyFixture({
+          id: `policy-evict-${i}`,
+          name: `evict-app-${i}`,
+          updatePolicy: MATURITY_POLICY,
+        }),
+      });
+    }
+    mountWith(fixtures);
+
+    for (let i = 0; i <= maxEntries; i++) {
+      container.deleteContainer(`policy-evict-${i}`, { replacementExpected: true });
+    }
+
+    const cache = container._getUpdatePolicyRetentionCacheForTests();
+    expect(cache.size).toBeLessThanOrEqual(maxEntries);
+    expect(cache.has('local::evict-app-0')).toBe(false);
+  });
+
+  test('prunes expired entries before evicting live ones when the cap is hit', () => {
+    vi.useFakeTimers();
+    try {
+      const maxEntries = container.UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES;
+      const fixtures = [];
+      for (let i = 0; i <= maxEntries; i++) {
+        fixtures.push({
+          data: makePolicyFixture({
+            id: `policy-expfirst-${i}`,
+            name: `expfirst-app-${i}`,
+            updatePolicy: MATURITY_POLICY,
+          }),
+        });
+      }
+      mountWith(fixtures);
+
+      for (let i = 0; i < maxEntries; i++) {
+        container.deleteContainer(`policy-expfirst-${i}`, { replacementExpected: true });
+      }
+      const cache = container._getUpdatePolicyRetentionCacheForTests();
+      expect(cache.size).toBe(maxEntries);
+
+      vi.advanceTimersByTime(container.UPDATE_POLICY_RETENTION_CACHE_TTL_MS + 1);
+      container.deleteContainer(`policy-expfirst-${maxEntries}`, { replacementExpected: true });
+
+      expect(cache.has(`local::expfirst-app-${maxEntries}`)).toBe(true);
+      expect(cache.has('local::expfirst-app-0')).toBe(false);
+      expect(cache.size).toBeLessThanOrEqual(maxEntries);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('retained policy is consumed, so a second recreate does not resurrect it', () => {
+    const oldFixture = makePolicyFixture({
+      id: 'policy-once-old',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-once-old', { replacementExpected: true });
+    container.insertContainer(makePolicyFixture({ id: 'policy-once-new' }));
+
+    // the doc that now holds the policy is 'policy-once-new'; a fresh insert with no
+    // preceding replacement-delete must not inherit anything
+    const later = container.insertContainer(makePolicyFixture({ id: 'policy-once-later' }));
+    expect(later.updatePolicy).toBeUndefined();
+  });
+});

--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -4160,7 +4160,7 @@ describe('updatePolicyRetentionCache carry-forward (#496)', () => {
 
     const cache = container._getUpdatePolicyRetentionCacheForTests();
     expect(cache.size).toBeLessThanOrEqual(maxEntries);
-    expect(cache.has('local::evict-app-0')).toBe(false);
+    expect(cache.has('::local::evict-app-0')).toBe(false);
   });
 
   test('prunes expired entries before evicting live ones when the cap is hit', () => {
@@ -4188,12 +4188,91 @@ describe('updatePolicyRetentionCache carry-forward (#496)', () => {
       vi.advanceTimersByTime(container.UPDATE_POLICY_RETENTION_CACHE_TTL_MS + 1);
       container.deleteContainer(`policy-expfirst-${maxEntries}`, { replacementExpected: true });
 
-      expect(cache.has(`local::expfirst-app-${maxEntries}`)).toBe(true);
-      expect(cache.has('local::expfirst-app-0')).toBe(false);
+      expect(cache.has(`::local::expfirst-app-${maxEntries}`)).toBe(true);
+      expect(cache.has('::local::expfirst-app-0')).toBe(false);
       expect(cache.size).toBeLessThanOrEqual(maxEntries);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // The cache holds agent-owned containers, so it must key on the agent-scoped identity key.
+  // Keyed on watcher::name alone, two agents each running a 'local' watcher with a container
+  // named 'myapp' would share one slot and leak one deployment's policy into the other's.
+  test('does not leak a retained policy across agents with the same watcher and name', () => {
+    const oldFixture = makePolicyFixture({
+      id: 'policy-agentA-old',
+      agent: 'agent-a',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-agentA-old', { replacementExpected: true });
+    const otherAgent = container.insertContainer(
+      makePolicyFixture({ id: 'policy-agentB-new', agent: 'agent-b' }),
+    );
+
+    expect(otherAgent.updatePolicy).toBeUndefined();
+  });
+
+  test('does not leak a retained policy from an agent container to a local one', () => {
+    const oldFixture = makePolicyFixture({
+      id: 'policy-agent-leak-old',
+      agent: 'agent-a',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-agent-leak-old', { replacementExpected: true });
+    const local = container.insertContainer(makePolicyFixture({ id: 'policy-local-new' }));
+
+    expect(local.updatePolicy).toBeUndefined();
+  });
+
+  // deriveContainerIdentityKey prefers the compose project/service, which also survives a
+  // recreate, so a compose-managed container must still inherit its policy.
+  test('carries updatePolicy forward for compose-managed containers', () => {
+    const labels = {
+      'com.docker.compose.project': 'stack',
+      'com.docker.compose.service': 'web',
+    };
+    const oldFixture = makePolicyFixture({
+      id: 'policy-compose-old',
+      labels,
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-compose-old', { replacementExpected: true });
+    // compose renames the container on recreate, but project/service are stable
+    const inserted = container.insertContainer(
+      makePolicyFixture({ id: 'policy-compose-new', name: 'stack-web-2', labels }),
+    );
+
+    expect(inserted.updatePolicy).toEqual(MATURITY_POLICY);
+  });
+
+  // restoreRetainedUpdatePolicy runs before validateContainer, so it can be handed a container
+  // with no derivable identity. It must leave the cache alone rather than key off undefined.
+  test('does not consume the retained policy when the incoming identity is not derivable', () => {
+    const oldFixture = makePolicyFixture({
+      id: 'policy-noident-old',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-noident-old', { replacementExpected: true });
+    expect(container._getUpdatePolicyRetentionCacheForTests().size).toBe(1);
+
+    // an unnamed container derives no key; the schema then rejects it outright
+    expect(() =>
+      container.insertContainer(makePolicyFixture({ id: 'policy-noident-new', name: '' })),
+    ).toThrow();
+
+    // the retained entry survives for the real replacement
+    expect(container._getUpdatePolicyRetentionCacheForTests().size).toBe(1);
+    const inserted = container.insertContainer(makePolicyFixture({ id: 'policy-noident-real' }));
+    expect(inserted.updatePolicy).toEqual(MATURITY_POLICY);
   });
 
   test('retained policy is consumed, so a second recreate does not resurrect it', () => {

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -12,7 +12,11 @@ import { toPositiveInteger } from '../util/parse.js';
 const { validate: validateContainer } = container;
 
 import { emitContainerAdded, emitContainerRemoved, emitContainerUpdated } from '../event/index.js';
-import { hasRawUpdate, isRollbackContainerName } from '../model/container.js';
+import {
+  deriveContainerIdentityKey,
+  hasRawUpdate,
+  isRollbackContainerName,
+} from '../model/container.js';
 import { initCollection } from './util.js';
 
 let containers: ReturnType<typeof initCollection> | undefined;
@@ -72,6 +76,13 @@ const updateLifecycleCache = new Map<string, UpdateLifecycleCacheEntry>();
 // isLocalContainer: the #386 exclusion exists because runtime state is meaningless across
 // agents, whereas updatePolicy is set on the controller and must survive for agent-owned
 // containers too — that is precisely the topology #496 was reported against.
+//
+// Because it does hold agent-owned containers it must key on deriveContainerIdentityKey
+// (`${agent}::${watcher}::${name}`, or the compose project/service form), not on the
+// `watcher::name` toCacheKey the other two caches use. Those can get away with the shorter
+// key precisely because they only ever hold local containers; here, two agents each running
+// a `local` watcher with a container named `myapp` would otherwise share one slot and leak
+// one deployment's update policy into another's.
 type UpdatePolicyRetentionCacheEntry = {
   updatePolicy: unknown;
   expiresAt: number;
@@ -785,7 +796,12 @@ function stashUpdatePolicyForReplacement(containerRaw) {
   if (isRollbackContainerName(containerRaw?.name)) {
     return;
   }
-  const cacheKey = toCacheKey(containerRaw.watcher, containerRaw.name);
+  const cacheKey = deriveContainerIdentityKey(containerRaw);
+  /* istanbul ignore next -- unreachable: deleteContainer validates the stored document before
+     calling this, and the schema rejects an empty watcher or name, so a key always derives. */
+  if (cacheKey === undefined) {
+    return;
+  }
   updatePolicyRetentionCache.delete(cacheKey);
   updatePolicyRetentionCache.set(cacheKey, {
     updatePolicy,
@@ -814,7 +830,10 @@ function stashUpdatePolicyForReplacement(containerRaw) {
  * either way, so a stale policy can never attach to a later, unrelated container.
  */
 function restoreRetainedUpdatePolicy(container) {
-  const cacheKey = toCacheKey(container.watcher, container.name);
+  const cacheKey = deriveContainerIdentityKey(container);
+  if (cacheKey === undefined) {
+    return;
+  }
   const entry = updatePolicyRetentionCache.get(cacheKey);
   if (!entry) {
     return;

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -27,6 +27,10 @@ const DEFAULT_CACHE_MAX_ENTRIES = getDefaultCacheMaxEntries();
 const DEFAULT_CONTAINERS_QUERY_CACHE_MAX_ENTRIES = DEFAULT_CACHE_MAX_ENTRIES;
 const DEFAULT_SECURITY_STATE_CACHE_TTL_MS = 15 * 60 * 1000;
 const DEFAULT_UPDATE_LIFECYCLE_CACHE_TTL_MS = 30 * 60 * 1000;
+// Deliberately far longer than the lifecycle cache's 30 min: a maturity soak encodes
+// days-long user intent, and a replacement container can lag its predecessor by a long
+// image pull. A short TTL here would only narrow the #496 repro window, not close it.
+const DEFAULT_UPDATE_POLICY_RETENTION_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_SECURITY_STATE_CACHE_MAX_ENTRIES = DEFAULT_CACHE_MAX_ENTRIES;
 const SECURITY_STATE_CACHE_PRUNE_SCAN_BUDGET = 10;
 const CONTAINER_COLLECTION_INDICES = ['data.watcher', 'data.status', 'data.updateAvailable'];
@@ -56,6 +60,24 @@ type UpdateLifecycleCacheEntry = {
 };
 
 const updateLifecycleCache = new Map<string, UpdateLifecycleCacheEntry>();
+
+// #496: updatePolicy is durable, user-set configuration (maturity gate, skips, snooze) that
+// lives on the container document, which is keyed by Docker's ephemeral container id. A
+// recreate mints a new id, so ingestion takes insertContainer (which cannot merge from a
+// predecessor) rather than updateContainer (which can). Without this cache the policy is
+// dropped, and isUpdateSuppressed() reads an absent policy as "no gating" rather than
+// "default gating", so the very next update fires with no soak at all.
+//
+// Unlike the security-state and lifecycle caches this is deliberately NOT gated behind
+// isLocalContainer: the #386 exclusion exists because runtime state is meaningless across
+// agents, whereas updatePolicy is set on the controller and must survive for agent-owned
+// containers too — that is precisely the topology #496 was reported against.
+type UpdatePolicyRetentionCacheEntry = {
+  updatePolicy: unknown;
+  expiresAt: number;
+};
+
+const updatePolicyRetentionCache = new Map<string, UpdatePolicyRetentionCacheEntry>();
 
 interface ContainerListPaginationOptions {
   limit?: number;
@@ -93,6 +115,14 @@ export const UPDATE_LIFECYCLE_CACHE_TTL_MS = toPositiveInteger(
 );
 export const UPDATE_LIFECYCLE_CACHE_MAX_ENTRIES = toPositiveInteger(
   process.env.DD_UPDATE_LIFECYCLE_CACHE_MAX_ENTRIES,
+  DEFAULT_CACHE_MAX_ENTRIES,
+);
+export const UPDATE_POLICY_RETENTION_CACHE_TTL_MS = toPositiveInteger(
+  process.env.DD_UPDATE_POLICY_RETENTION_CACHE_TTL_MS,
+  DEFAULT_UPDATE_POLICY_RETENTION_CACHE_TTL_MS,
+);
+export const UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES = toPositiveInteger(
+  process.env.DD_UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES,
   DEFAULT_CACHE_MAX_ENTRIES,
 );
 
@@ -744,10 +774,67 @@ export function createCollections(db) {
 }
 
 /**
+ * #496: stash a soon-to-be-replaced container's updatePolicy so the replacement (which
+ * arrives under a fresh Docker id, hence via insertContainer) can inherit it.
+ */
+function stashUpdatePolicyForReplacement(containerRaw) {
+  const updatePolicy = containerRaw?.updatePolicy;
+  if (updatePolicy === undefined || updatePolicy === null) {
+    return;
+  }
+  if (isRollbackContainerName(containerRaw?.name)) {
+    return;
+  }
+  const cacheKey = toCacheKey(containerRaw.watcher, containerRaw.name);
+  updatePolicyRetentionCache.delete(cacheKey);
+  updatePolicyRetentionCache.set(cacheKey, {
+    updatePolicy,
+    expiresAt: Date.now() + UPDATE_POLICY_RETENTION_CACHE_TTL_MS,
+  });
+  if (updatePolicyRetentionCache.size > UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES) {
+    const nowMs = Date.now();
+    for (const [expiredKey, expiredEntry] of updatePolicyRetentionCache.entries()) {
+      if (expiredEntry.expiresAt <= nowMs) {
+        updatePolicyRetentionCache.delete(expiredKey);
+      }
+    }
+  }
+  while (updatePolicyRetentionCache.size > UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES) {
+    const oldestKey = updatePolicyRetentionCache.keys().next().value;
+    /* istanbul ignore next */
+    if (oldestKey === undefined) {
+      break;
+    }
+    updatePolicyRetentionCache.delete(oldestKey);
+  }
+}
+
+/**
+ * #496: restore a retained updatePolicy onto a replacement container. The entry is consumed
+ * either way, so a stale policy can never attach to a later, unrelated container.
+ */
+function restoreRetainedUpdatePolicy(container) {
+  const cacheKey = toCacheKey(container.watcher, container.name);
+  const entry = updatePolicyRetentionCache.get(cacheKey);
+  if (!entry) {
+    return;
+  }
+  updatePolicyRetentionCache.delete(cacheKey);
+  if (entry.expiresAt <= Date.now()) {
+    return;
+  }
+  // A policy carried on the incoming payload is authoritative; the cache only fills a hole.
+  if (container.updatePolicy === undefined) {
+    container.updatePolicy = entry.updatePolicy;
+  }
+}
+
+/**
  * Insert new Container.
  * @param container
  */
 export function insertContainer(container) {
+  restoreRetainedUpdatePolicy(container);
   // #386: skip the security-state cache entirely for remote-agent containers;
   // the cache is only written by the controller's local Docker trigger and is
   // meaningless (and cross-contaminating) for containers owned by an agent.
@@ -1072,6 +1159,9 @@ export function deleteContainer(id, options: DeleteContainerOptions = {}) {
       .remove();
     invalidateContainersCacheForMutation(containerRaw, undefined);
     containerSecurityStateHashCache.delete(id);
+    if (options.replacementExpected === true) {
+      stashUpdatePolicyForReplacement(containerRaw);
+    }
     if (
       options.replacementExpected === true &&
       !(typeof containerRaw?.agent === 'string' && containerRaw.agent !== '') &&
@@ -1120,6 +1210,7 @@ export function _resetContainerStoreStateForTests() {
   clearContainersQueryCacheState();
   securityStateCache.clear();
   updateLifecycleCache.clear();
+  updatePolicyRetentionCache.clear();
   pendingFreshStateAfterManualUpdate.clear();
   containerSecurityStateHashCache.clear();
   securityStateObjectHashCache = new WeakMap<object, string>();
@@ -1161,6 +1252,10 @@ export function _setContainersQueryCacheEntriesForTests(
 
 export function _getContainersQueryCacheForTests() {
   return containersQueryCache;
+}
+
+export function _getUpdatePolicyRetentionCacheForTests() {
+  return updatePolicyRetentionCache;
 }
 
 export function _invalidateContainersCacheForMutationForTests(containerBefore, containerAfter) {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-e2e",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-e2e",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@cucumber/cucumber": "12.7.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-e2e",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "drydock - e2e",
   "engines": {
     "node": ">=24.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "drydock",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.5.1",
+      "version": "1.5.2",
       "devDependencies": {
         "@biomejs/biome": "2.4.16",
         "@types/node": "25.7.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.1",
+  "version": "1.5.2",
   "scripts": {
     "prepare": "lefthook install",
     "release:precheck": "node scripts/release-precut-check.mjs",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-ui",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-ui",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "5.2.7",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-ui",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Drydock dashboard — Vue 3 + Tailwind CSS 4 SPA",
   "repository": "CodesWhat/drydock",
   "engines": {


### PR DESCRIPTION
Fixes #496.

## What's wrong

Container documents are keyed by Docker's **ephemeral container id**. A recreate — image pull, `docker compose up -d`, or one of our own action triggers firing — mints a brand-new id. Ingestion then misses the `getContainer(id)` lookup and falls to `insertContainer()` instead of `updateContainer()`.

`updateContainer()` merges the prior `updatePolicy` forward (`app/store/container.ts:826`). `insertContainer()` never has. The old document, which held the policy, is deleted with no carry-forward. So the replacement lands with `updatePolicy: undefined`, and `isUpdateSuppressed()` (`app/model/container.ts:557-561`) reads an absent policy as **no gating at all** rather than *default gating*.

The result is nasty: you get exactly one correctly-gated update, and the moment that update recreates the container your maturity gate evaporates permanently and silently. Every subsequent update fires with zero soak. The feature disables itself by working once.

That also explains the reporter's "only SOME containers reverted" — whether a container's id changed is a per-container condition. Restarted or untouched containers keep their id, hit `updateContainer`, and keep the policy.

## Provenance

**Pre-existing, not a 1.5.1 regression.** Per-container maturity policy landed in `b07195b3` (2026-03-14), first tagged **v1.4.1**. The `insertContainer`/`updateContainer` asymmetry itself dates to the initial commit `81fd6a41`. It is live in v1.4.x, v1.5.0, v1.5.1 GA, and `dev/v1.6`.

Ruled out along the way, so nobody re-litigates them: a `||`-vs-`??` falsy-coalesce bug (`resolveMaturityMinAgeDays` correctly uses `??`, and `parseMaturityMinAgeDays` rejects `0`), and any store migration (`app/store/migrate.ts` touches none of these fields).

## The fix

- **`app/store/container.ts`** — an `updatePolicyRetentionCache` keyed by `watcher::name`, stashed on `deleteContainer({replacementExpected: true})` and consumed by `insertContainer()`. It mirrors the existing `updateLifecycleCache` pattern, with two deliberate differences:
  - **Not gated behind `isLocalContainer`.** That exclusion (#386) exists because runtime *security state* is meaningless across agents. `updatePolicy` is durable controller-set config, and remote-agent containers are exactly the reported topology — they were strictly worse off before this.
  - **7-day TTL**, not the lifecycle cache's 30 minutes. A maturity soak encodes days-long user intent and a replacement container can lag its predecessor by a long image pull. A short TTL would only narrow the repro window, not close it.
  - An explicit incoming policy always wins, and the entry is consumed either way, so a stale policy can never attach to a later unrelated container.

- **`app/agent/AgentClient.ts`** — `pruneOldContainers()` deleted with **no replacement signal at all**, strictly worse than the local watcher's prune. It now mirrors that path: a stale-id entry whose name is still in the authoritative list is a replacement; anything else is a real removal.

  Worth calling out: flagging `replacementExpected` unconditionally here would have been a silent regression. `Hass.ts:477-497` reads that field off the container-removed event to decide whether to keep a state topic alive, so blanket-`true` would have orphaned Home Assistant discovery topics for genuinely deleted containers.

## Tests

Written first, and verified to fail against the unpatched source (8 of 11 store tests and the agent test fail without the fix).

- `app/store/container.test.ts` — carry-forward across a recreate; **the same test with `container.agent` set**, which is the #496 repro; no stash on a non-replacement delete; no stash without a policy; no stash for rollback containers; explicit payload wins; no cross-name leakage; TTL expiry; cap eviction; expired-first pruning; single consumption.
- `app/agent/AgentClient.test.ts` — flags a recreate, does **not** flag a genuine removal, and handles unnamed entries on both sides.

Full pre-push gate green: 100% coverage on `app` and `ui`, qlty clean, builds pass. 11,157 app tests pass.

## Release

Targeting a **`v1.5.2`** patch (RC first — the diff is small but it lands in `insertContainer`/`deleteContainer`, which every container in every deployment traverses on every scan). Forward-port to `dev/v1.6` follows the merge.

## Follow-up, not in scope here

`deriveContainerIdentityKey()` (`app/model/container.ts:937-958`) already computes a recreate-stable key and its own comment says it exists to "survive container recreates", but it is read nowhere in the store. Re-keying container documents on it is the real fix and is v1.7 debt. The retention cache is the surgical, patch-safe version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added seven-day `updatePolicyRetentionCache` keyed by agent-scoped container identity (`deriveContainerIdentityKey()`), with TTL/max entries configurable via env.
- 🔧 Changed `insertContainer` to restore and then **consume** retained `updatePolicy` for recreated containers, applying the cached policy only when the incoming container does not explicitly include `updatePolicy`.
- 🔧 Changed `deleteContainer(..., { replacementExpected: true })` to stash the deleted container’s `updatePolicy` into the retention cache (skipping rollback container names / null policies).
- 🔧 Changed pruning (`pruneOldContainers`) to set `replacementExpected: true` when an agent-owned container is being recreated (same name still present), preserving discovery cleanup behavior for genuine removals.
- 🐛 Fixed loss of per-container maturity/updatePolicy settings for remote-agent and local containers across restarts/image updates/recreations.
- ✨ Added/expanded tests covering retention carry-forward, precedence, cross-agent isolation, expiration/eviction, single-use consumption, deletion/replacement scenarios, and identity-not-derivable edge cases.

- Verify cache TTL/max env overrides and parsing (`toPositiveInteger`) behave as intended.
- Confirm eviction/expiration ordering and single-use “consume then clear” semantics match expectations under concurrency.
- Validate identity-key derivation behavior when identities can’t be derived (cache retention vs consumption paths).
- Ensure rollback container name exclusion is correct and doesn’t block legitimate retention cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->