### PR TITLE
🐛 fix(ui): wrap long tooltips and stop pin insight badge clipping (#498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2-rc.4] — 2026-07-12
+
+### Fixed
+
+- Tooltip text now wraps inside a bounded popup instead of rendering one screen-wide line — the shared tooltip directive had `white-space: nowrap` and no `max-width`, so the pinned-tag "Newer available" insight tooltip (and any other long tooltip) rendered as a single ~130-character line off the edge of the viewport ([#498](https://github.com/CodesWhat/drydock/issues/498)).
+- The pinned-tag insight badge no longer clips in the containers list. Centered with no `max-width`, it could overflow its narrow table column and get hard-clipped on both sides; it now truncates gracefully with a trailing ellipsis instead ([#498](https://github.com/CodesWhat/drydock/issues/498)).
+- Shortened the pinned-tag insight tooltip copy so it reads cleanly at the tooltip's new bounded width ([#498](https://github.com/CodesWhat/drydock/issues/498)).
+
 ## [1.5.2-rc.3] — 2026-07-11
 
 ### Added

--- a/ui/src/components/containers/SuggestedTagBadge.vue
+++ b/ui/src/components/containers/SuggestedTagBadge.vue
@@ -30,12 +30,12 @@ const colors = suggestedTagColor();
 <template>
   <span
     v-if="shouldShow"
-    class="badge text-3xs font-bold inline-flex items-center gap-1"
+    class="badge text-3xs font-bold inline-flex items-center gap-1 min-w-0 max-w-full"
     :style="{ backgroundColor: colors.bg, color: colors.text }"
     v-tooltip.top="tooltip"
     data-test="suggested-tag-badge"
   >
     <AppIcon name="tag" :size="10" class="shrink-0" />
-    <span>{{ t('containerComponents.suggestedTag.badgeText') }}</span>
+    <span class="truncate">{{ t('containerComponents.suggestedTag.badgeText') }}</span>
   </span>
 </template>

--- a/ui/src/components/containers/UpdateInsightBadge.vue
+++ b/ui/src/components/containers/UpdateInsightBadge.vue
@@ -28,12 +28,12 @@ const colors = updateInsightColor();
 <template>
   <span
     v-if="shouldShow"
-    class="badge text-3xs font-bold inline-flex items-center gap-1"
+    class="badge text-3xs font-bold inline-flex items-center gap-1 min-w-0 max-w-full"
     :style="{ backgroundColor: colors.bg, color: colors.text }"
     v-tooltip.top="tooltip"
     data-test="update-insight-badge"
   >
     <AppIcon name="info" :size="10" class="shrink-0" />
-    <span>{{ t('containerComponents.updateInsight.badgeText') }}</span>
+    <span class="truncate">{{ t('containerComponents.updateInsight.badgeText') }}</span>
   </span>
 </template>

--- a/ui/src/locales/en/containerComponents.json
+++ b/ui/src/locales/en/containerComponents.json
@@ -340,9 +340,9 @@
     },
     "updateInsight": {
       "badgeText": "Newer available",
-      "tooltipMajor": "Newer major version available: {tag}. This tag is pinned, so drydock won't act on it automatically — shown for information only.",
-      "tooltipMinor": "Newer minor version available: {tag}. This tag is pinned, so drydock won't act on it automatically — shown for information only.",
-      "tooltipPatch": "Newer patch version available: {tag}. This tag is pinned, so drydock won't act on it automatically — shown for information only."
+      "tooltipMajor": "Newer major version: {tag}. This tag is pinned — drydock won't update it automatically.",
+      "tooltipMinor": "Newer minor version: {tag}. This tag is pinned — drydock won't update it automatically.",
+      "tooltipPatch": "Newer patch version: {tag}. This tag is pinned — drydock won't update it automatically."
     },
     "eligibilityBadges": {
       "securityBlocked": "Security blocked",

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -604,7 +604,7 @@ body.dd-col-resizing {
   z-index: 9999;
   pointer-events: none;
   opacity: 0;
-  white-space: normal;
+  white-space: pre-line;
   max-width: min(var(--dd-layout-filter-max-width), calc(100vw - 16px));
   overflow-wrap: break-word;
   font-size: var(--dd-font-tooltip);

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -604,9 +604,11 @@ body.dd-col-resizing {
   z-index: 9999;
   pointer-events: none;
   opacity: 0;
-  white-space: nowrap;
+  white-space: normal;
+  max-width: min(var(--dd-layout-filter-max-width), calc(100vw - 16px));
+  overflow-wrap: break-word;
   font-size: var(--dd-font-tooltip);
-  line-height: 1.1;
+  line-height: 1.35;
   padding: var(--dd-space-4) var(--dd-space-8);
   border-radius: var(--dd-radius-sm);
   border: 1px solid var(--dd-border-strong);


### PR DESCRIPTION
Polish for the v1.5.2-rc.3 pinned-tag insight feature, based on Cesc1986's rc.3 feedback in #498 (clipped badge + screen-wide tooltip screenshots).

- The shared tooltip popup (`.dd-tooltip-popup`) had `white-space: nowrap` and no `max-width`, so the ~130-char insight tooltip rendered as a single unbroken line running off the viewport. It now wraps inside a bounded popup (reuses the 240px `--dd-layout-filter-max-width` token, clamped to the viewport) with a line-height bump for multi-line readability. App-wide fix — the floating-tag and registry-error tooltips were the next-worst offenders.
- `UpdateInsightBadge` (and `SuggestedTagBadge`, same latent bug) overflowed the narrow Update column and, being centered, got hard-clipped on **both** sides (icon cut left, letters cut right). They now shrink with a right-side ellipsis (`min-w-0 max-w-full` + inner `truncate`).
- Shortened the insight tooltip copy (~128 → ~88 chars) — it duplicated the badge text and carried two disclaimer clauses saying the same thing.

The fuller rework (stacked current→newer tag view for pinned containers, "Pinned" state label) lands separately on `dev/v1.6`.

UI suite: 3813 tests green, 100% coverage. Full pre-push gate green.

Refs #498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added viewport-clamped, multi-line tooltip rendering by updating `.dd-tooltip-popup` to use `white-space: pre-line`, a bounded `max-width`, `overflow-wrap: break-word`, and taller `line-height` for improved readability.
- 🔧 Changed `UpdateInsightBadge` and `SuggestedTagBadge` to prevent clipping in narrow columns by constraining badge width (`min-w-0 max-w-full`) and truncating badge text with `truncate`.
- 🔧 Changed pinned-tag insight tooltip wording to clarify pinned tags are not updated automatically (updated `tooltipMajor`, `tooltipMinor`, `tooltipPatch`).
- 🔧 Deferred the larger pinned-container insight rework to `dev/v1.6`.

## Validation

- UI suite and full pre-push gate pass successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->