### PR TITLE
🐛 fix(security): accept content-addressed SBOM references

### DIFF
--- a/app/model/container.test.ts
+++ b/app/model/container.test.ts
@@ -2961,6 +2961,30 @@ test.each(['trivy', 'syft'])('model should validate %s SBOM document references'
   expect(validated.security?.sbom?.documentRefs?.['spdx-json']?.bytes).toBe(123);
 });
 
+test('model should validate content-addressed SBOM document references', () => {
+  const validated = container.validate(
+    createContainerWithSecurity({
+      sbom: {
+        generator: 'trivy',
+        image: 'organization/image:1.0.1',
+        subjectDigest: `sha256:${'a'.repeat(64)}`,
+        generatedAt: '2026-07-13T15:24:28.934Z',
+        status: 'generated',
+        formats: ['spdx-json'],
+        documentRefs: {
+          'spdx-json': {
+            key: `sbom/${'b'.repeat(64)}/${'c'.repeat(64)}/spdx-json.json`,
+            sha256: 'c'.repeat(64),
+            bytes: 456,
+          },
+        },
+      },
+    }),
+  );
+
+  expect(validated.security?.sbom?.documentRefs?.['spdx-json']?.bytes).toBe(456);
+});
+
 test('model should reject invalid updateScan schema payloads', async () => {
   expect(() => {
     container.validate(

--- a/app/model/container.ts
+++ b/app/model/container.ts
@@ -302,7 +302,7 @@ const containerSecuritySbomSchema = joi
       joi.object({
         key: joi
           .string()
-          .pattern(/^sbom\/[a-f0-9]{64}\/(?:spdx-json|cyclonedx-json)\.json$/)
+          .pattern(/^sbom\/[a-f0-9]{64}(?:\/[a-f0-9]{64})?\/(?:spdx-json|cyclonedx-json)\.json$/)
           .required(),
         sha256: joi
           .string()


### PR DESCRIPTION
## Summary

- align the container validation schema with the content-addressed SBOM key layout emitted by off-heap storage
- retain compatibility with legacy digest/format references
- add a regression test for digest/document-hash/format references

## Release-blocking evidence

The Discussion #321 acceptance run generated SPDX and CycloneDX documents successfully, then POST /api/v1/containers/:id/scan returned 500 because container validation rejected the new three-segment storage key. With this fix, ten live priming scans completed and produced exactly 20 bounded off-heap files across five unique image digests.

## Verification

- red test reproduced the validation failure before the schema change
- model, container security API, and SBOM storage suites: 235 passed
- backend build and focused Biome checks passed
- complete pre-push gate passed: fresh backend/UI 100% coverage, builds, typecheck, website/workflow/script tests, Qlty baseline, and zizmor
- isolated 50-container acceptance run restarted successfully at 2026-07-13T15:27:13.689Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added regression coverage for digest, document-hash, and format SBOM references.
- 🔧 Changed container validation to accept both legacy and content-addressed three-segment SBOM storage keys.
- 🐛 Fixed validation failures for off-heap SBOM references.
- 🔒 Preserved container security validation compatibility.

## Verification

- Model, container security API, SBOM storage, build, focused checks, and complete pre-push test gate passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->