### PR TITLE
🔧 chore(release): set v1.6 RC identity

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-app",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-app",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-ecr": "3.1079.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-app",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Drydock backend — Docker container update manager",
   "engines": {
     "node": ">=24.0.0"

--- a/apps/demo/package-lock.json
+++ b/apps/demo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-demo",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-demo",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "iconify-icon": "^3.0.2",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-demo",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.5.0',
+    version: '1.6.0-rc.1',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.5.0 started',
+    details: 'Drydock v1.6.0-rc.1 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.5.0',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.1',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.5.0',
+    tag: '1.6.0-rc.1',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.5.0',
+  version: '1.6.0-rc.1',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.5.0',
+      version: '1.6.0-rc.1',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.5.0', mode: 'demo' },
+        server: { version: '1.6.0-rc.1', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-e2e",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-e2e",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@cucumber/cucumber": "12.7.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-e2e",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "drydock - e2e",
   "engines": {
     "node": ">=24.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "drydock",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "devDependencies": {
         "@biomejs/biome": "2.5.2",
         "@types/node": "25.9.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.1",
+  "version": "1.6.0",
   "scripts": {
     "prepare": "lefthook install",
     "release:precheck": "node scripts/release-precut-check.mjs",

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -4,6 +4,28 @@ import test from 'node:test';
 
 const BASE_VERSION = '1.6.0';
 const RC_VERSION = '1.6.0-rc.1';
+const DEMO_RELEASE_FIXTURES = [
+  {
+    path: 'apps/demo/src/mocks/data/server.ts',
+    valuePattern: /\bversion:\s*["']([^"']+)["']/gu,
+  },
+  {
+    path: 'apps/demo/src/mocks/data/agents.ts',
+    valuePattern: /\bversion:\s*["']([^"']+)["']/gu,
+  },
+  {
+    path: 'apps/demo/src/mocks/handlers/app.ts',
+    valuePattern: /\bversion:\s*["']([^"']+)["']/gu,
+  },
+  {
+    path: 'apps/demo/src/mocks/data/audit.ts',
+    valuePattern: /(?:Drydock v|codeswhat\/drydock:)(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/gu,
+  },
+  {
+    path: 'apps/demo/src/mocks/data/containers.ts',
+    valuePattern: /displayName:\s*["']Drydock["'][\s\S]*?\btag:\s*["']([^"']+)["']/gu,
+  },
+];
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
@@ -12,6 +34,10 @@ function readJson(path) {
 function versionPattern(version) {
   const escaped = version.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
   return new RegExp(`(?:^|[^0-9A-Za-z.-])v?${escaped}(?![0-9A-Za-z.-])`, 'u');
+}
+
+function extractVersionValues(contents, valuePattern) {
+  return [...new Set([...contents.matchAll(valuePattern)].map((match) => match[1]))].sort();
 }
 
 test('release-gated workspace packages and locks use the v1.6 base version', () => {
@@ -27,16 +53,9 @@ test('release-gated workspace packages and locks use the v1.6 base version', () 
 });
 
 test('demo runtime fixtures identify the exact v1.6.0-rc.1 candidate', () => {
-  for (const path of [
-    'apps/demo/src/mocks/data/server.ts',
-    'apps/demo/src/mocks/data/agents.ts',
-    'apps/demo/src/mocks/handlers/app.ts',
-    'apps/demo/src/mocks/data/audit.ts',
-    'apps/demo/src/mocks/data/containers.ts',
-  ]) {
+  for (const { path, valuePattern } of DEMO_RELEASE_FIXTURES) {
     const contents = readFileSync(path, 'utf8');
-    assert.match(contents, versionPattern(RC_VERSION), path);
-    assert.doesNotMatch(contents, versionPattern('1.5.0'), path);
+    assert.deepEqual(extractVersionValues(contents, valuePattern), [RC_VERSION], path);
   }
 });
 
@@ -50,4 +69,12 @@ test('release version patterns match exact optionally v-prefixed tokens', () => 
   assert.doesNotMatch('version: x1.6.0-rc.1', rcPattern);
   assert.match('version: v1.5.0', legacyPattern);
   assert.doesNotMatch('version: 1.5.0-rc.1', legacyPattern);
+});
+
+test('fixture version extraction retains mixed candidate identities', () => {
+  const contents = "version: '1.6.0-rc.1', version: '1.6.0-rc.10'";
+  assert.deepEqual(extractVersionValues(contents, /version:\s*["']([^"']+)["']/gu), [
+    '1.6.0-rc.1',
+    '1.6.0-rc.10',
+  ]);
 });

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -9,6 +9,11 @@ function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
 }
 
+function versionPattern(version) {
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  return new RegExp(`(?:^|[^0-9A-Za-z.-])v?${escaped}(?![0-9A-Za-z.-])`, 'u');
+}
+
 test('release-gated workspace packages and locks use the v1.6 base version', () => {
   for (const workspace of ['.', 'app', 'ui', 'e2e', 'apps/demo']) {
     const prefix = workspace === '.' ? '' : `${workspace}/`;
@@ -30,7 +35,19 @@ test('demo runtime fixtures identify the exact v1.6.0-rc.1 candidate', () => {
     'apps/demo/src/mocks/data/containers.ts',
   ]) {
     const contents = readFileSync(path, 'utf8');
-    assert.match(contents, new RegExp(RC_VERSION.replaceAll('.', '\\.')), path);
-    assert.doesNotMatch(contents, /\b1\.5\.0\b/u, path);
+    assert.match(contents, versionPattern(RC_VERSION), path);
+    assert.doesNotMatch(contents, versionPattern('1.5.0'), path);
   }
+});
+
+test('release version patterns match exact optionally v-prefixed tokens', () => {
+  const rcPattern = versionPattern(RC_VERSION);
+  const legacyPattern = versionPattern('1.5.0');
+
+  assert.match('version: 1.6.0-rc.1', rcPattern);
+  assert.match('version: v1.6.0-rc.1', rcPattern);
+  assert.doesNotMatch('version: 1.6.0-rc.10', rcPattern);
+  assert.doesNotMatch('version: x1.6.0-rc.1', rcPattern);
+  assert.match('version: v1.5.0', legacyPattern);
+  assert.doesNotMatch('version: 1.5.0-rc.1', legacyPattern);
 });

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const BASE_VERSION = '1.6.0';
+const RC_VERSION = '1.6.0-rc.1';
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+test('release-gated workspace packages and locks use the v1.6 base version', () => {
+  for (const workspace of ['.', 'app', 'ui', 'e2e', 'apps/demo']) {
+    const prefix = workspace === '.' ? '' : `${workspace}/`;
+    const manifest = readJson(`${prefix}package.json`);
+    const lock = readJson(`${prefix}package-lock.json`);
+
+    assert.equal(manifest.version, BASE_VERSION, `${prefix}package.json`);
+    assert.equal(lock.version, BASE_VERSION, `${prefix}package-lock.json`);
+    assert.equal(lock.packages?.['']?.version, BASE_VERSION, `${prefix}package-lock.json root`);
+  }
+});
+
+test('demo runtime fixtures identify the exact v1.6.0-rc.1 candidate', () => {
+  for (const path of [
+    'apps/demo/src/mocks/data/server.ts',
+    'apps/demo/src/mocks/data/agents.ts',
+    'apps/demo/src/mocks/handlers/app.ts',
+    'apps/demo/src/mocks/data/audit.ts',
+    'apps/demo/src/mocks/data/containers.ts',
+  ]) {
+    const contents = readFileSync(path, 'utf8');
+    assert.match(contents, new RegExp(RC_VERSION.replaceAll('.', '\\.')), path);
+    assert.doesNotMatch(contents, /\b1\.5\.0\b/u, path);
+  }
+});

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-ui",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-ui",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "5.2.7",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-ui",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Drydock dashboard — Vue 3 + Tailwind CSS 4 SPA",
   "repository": "CodesWhat/drydock",
   "engines": {


### PR DESCRIPTION
## Summary
- set release-bearing packages and lockfiles to base version `1.6.0`
- align demo fixtures with the first RC identity, `1.6.0-rc.1`
- add regression tests that require exact package, lockfile, and every release-facing demo fixture identity

## Verification
- `node --test scripts/*.test.mjs` (87/87 on the current head)
- `npx @biomejs/biome check scripts/release-identity.test.mjs`
- `node scripts/release-tag.mjs --tag v1.6.0-rc.1`
- demo production build
- complete pre-push gates on the release identity and token-boundary commits: formatting, Qlty, workflow tests, UI typecheck, 100% app/UI coverage, app/UI builds, zizmor where applicable

The final incremental commit changes only the release regression test; the full 87-test maintenance suite and focused Biome check pass.

## Scope
This is the release-identity slice only. Changelog, docs snapshots, and final cut-date metadata remain in the tracked v1.6 release-docs package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed release-bearing packages and lockfiles to version `1.6.0`.
- 🔧 Changed demo fixtures and mock responses to RC identity `1.6.0-rc.1`.
- ✨ Added regression tests enforcing exact package, lockfile, and fixture versions.
- ✨ Added version-pattern and multi-identity extraction tests.

## Concerns

- Confirm the 87-test maintenance suite, Biome checks, RC tag generation, demo production build, and pre-push gates pass.
- Keep changelog, documentation snapshots, and cut-date metadata in the tracked v1.6 release-docs package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->