### PR TITLE
🐛 fix(docs): replace realistic credential examples

### DIFF
--- a/content/docs/current/configuration/registries/acr/index.mdx
+++ b/content/docs/current/configuration/registries/acr/index.mdx
@@ -28,7 +28,7 @@ services:
     ...
     environment:
       - DD_REGISTRY_ACR_PRIVATE_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b
-      - DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=SBgHNi3zA5K.f9.f9ft~_hpqbS~.pk.t_i
+      - DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=replace-with-your-client-secret
 ```
 
 </Tab>
@@ -36,7 +36,7 @@ services:
 ```bash
 docker run \
   -e DD_REGISTRY_ACR_PRIVATE_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b \
-  -e DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=SBgHNi3zA5K.f9.f9ft~_hpqbS~.pk.t_i \
+  -e DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=replace-with-your-client-secret \
   ...
   codeswhat/drydock
 ```

--- a/content/docs/current/configuration/triggers/telegram/index.mdx
+++ b/content/docs/current/configuration/triggers/telegram/index.mdx
@@ -34,7 +34,7 @@ services:
     image: codeswhat/drydock
     ...
     environment:
-      - DD_NOTIFICATION_TELEGRAM_1_BOTTOKEN=0123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q
+      - DD_NOTIFICATION_TELEGRAM_1_BOTTOKEN=replace-with-your-telegram-bot-token
       - DD_NOTIFICATION_TELEGRAM_1_CHATID=9876543210
 ```
 
@@ -42,7 +42,7 @@ services:
 <Tab value="Docker">
 ```bash
 docker run \
-  -e DD_NOTIFICATION_TELEGRAM_1_BOTTOKEN="0123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q" \
+  -e DD_NOTIFICATION_TELEGRAM_1_BOTTOKEN="replace-with-your-telegram-bot-token" \
   -e DD_NOTIFICATION_TELEGRAM_1_CHATID="9876543210" \
   ...
   codeswhat/drydock

--- a/content/docs/v1.3/configuration/registries/acr/index.mdx
+++ b/content/docs/v1.3/configuration/registries/acr/index.mdx
@@ -28,7 +28,7 @@ services:
     ...
     environment:
       - DD_REGISTRY_ACR_PRIVATE_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b
-      - DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=SBgHNi3zA5K.f9.f9ft~_hpqbS~.pk.t_i
+      - DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=replace-with-your-client-secret
 ```
 
 </Tab>
@@ -36,7 +36,7 @@ services:
 ```bash
 docker run \
   -e DD_REGISTRY_ACR_PRIVATE_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b \
-  -e DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=SBgHNi3zA5K.f9.f9ft~_hpqbS~.pk.t_i \
+  -e DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=replace-with-your-client-secret \
   ...
   codeswhat/drydock
 ```

--- a/content/docs/v1.3/configuration/triggers/telegram/index.mdx
+++ b/content/docs/v1.3/configuration/triggers/telegram/index.mdx
@@ -34,7 +34,7 @@ services:
     image: codeswhat/drydock
     ...
     environment:
-      - DD_TRIGGER_TELEGRAM_1_BOTTOKEN=0123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q
+      - DD_TRIGGER_TELEGRAM_1_BOTTOKEN=replace-with-your-telegram-bot-token
       - DD_TRIGGER_TELEGRAM_1_CHATID=9876543210
 ```
 
@@ -42,7 +42,7 @@ services:
 <Tab value="Docker">
 ```bash
 docker run \
-  -e DD_TRIGGER_TELEGRAM_1_BOTTOKEN="0123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q" \
+  -e DD_TRIGGER_TELEGRAM_1_BOTTOKEN="replace-with-your-telegram-bot-token" \
   -e DD_TRIGGER_TELEGRAM_1_CHATID="9876543210" \
   ...
   codeswhat/drydock

--- a/content/docs/v1.4/configuration/registries/acr/index.mdx
+++ b/content/docs/v1.4/configuration/registries/acr/index.mdx
@@ -28,7 +28,7 @@ services:
     ...
     environment:
       - DD_REGISTRY_ACR_PRIVATE_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b
-      - DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=SBgHNi3zA5K.f9.f9ft~_hpqbS~.pk.t_i
+      - DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=replace-with-your-client-secret
 ```
 
 </Tab>
@@ -36,7 +36,7 @@ services:
 ```bash
 docker run \
   -e DD_REGISTRY_ACR_PRIVATE_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b \
-  -e DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=SBgHNi3zA5K.f9.f9ft~_hpqbS~.pk.t_i \
+  -e DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=replace-with-your-client-secret \
   ...
   codeswhat/drydock
 ```

--- a/content/docs/v1.4/configuration/triggers/telegram/index.mdx
+++ b/content/docs/v1.4/configuration/triggers/telegram/index.mdx
@@ -34,7 +34,7 @@ services:
     image: codeswhat/drydock
     ...
     environment:
-      - DD_TRIGGER_TELEGRAM_1_BOTTOKEN=0123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q
+      - DD_TRIGGER_TELEGRAM_1_BOTTOKEN=replace-with-your-telegram-bot-token
       - DD_TRIGGER_TELEGRAM_1_CHATID=9876543210
 ```
 
@@ -42,7 +42,7 @@ services:
 <Tab value="Docker">
 ```bash
 docker run \
-  -e DD_TRIGGER_TELEGRAM_1_BOTTOKEN="0123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q" \
+  -e DD_TRIGGER_TELEGRAM_1_BOTTOKEN="replace-with-your-telegram-bot-token" \
   -e DD_TRIGGER_TELEGRAM_1_CHATID="9876543210" \
   ...
   codeswhat/drydock

--- a/scripts/docs-secret-examples.test.mjs
+++ b/scripts/docs-secret-examples.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = fileURLToPath(new URL('..', import.meta.url));
+const documentationRoot = join(repositoryRoot, 'content', 'docs');
+const activeDocumentationVersions = readdirSync(documentationRoot, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && /^(?:current|v\d+\.\d+)$/u.test(entry.name))
+  .map((entry) => entry.name)
+  .sort();
+const deliberatePlaceholder = /^replace-with-your-(?:client-secret|telegram-bot-token)$/u;
+
+const examples = [
+  {
+    kind: 'Azure client secret',
+    relativePath: 'configuration/registries/acr/index.mdx',
+    assignment: /DD_REGISTRY_ACR_PRIVATE_CLIENTSECRET=["']?([^\s"'`]+)/gu,
+  },
+  {
+    kind: 'Telegram bot token',
+    relativePath: 'configuration/triggers/telegram/index.mdx',
+    assignment: /DD_(?:NOTIFICATION|TRIGGER)_TELEGRAM_[A-Z0-9_]+_BOTTOKEN=["']?([^\s"'`]+)/gu,
+  },
+];
+
+test('active documentation uses deliberately invalid credential placeholders', () => {
+  for (const version of activeDocumentationVersions) {
+    for (const example of examples) {
+      const relativePath = join('content', 'docs', version, example.relativePath);
+      const body = readFileSync(join(repositoryRoot, relativePath), 'utf8');
+      const matches = [...body.matchAll(example.assignment)];
+
+      assert.ok(matches.length > 0, `${relativePath} must include its ${example.kind} example`);
+
+      for (const match of matches) {
+        if (!deliberatePlaceholder.test(match[1])) {
+          const line = body.slice(0, match.index).split('\n').length;
+          assert.fail(
+            `${relativePath}:${line} contains a realistic ${example.kind} literal; use a deliberate invalid placeholder`,
+          );
+        }
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- replace realistic Azure client-secret and Telegram bot-token examples in current and versioned docs with deliberately invalid placeholders
- add a regression that scans `current` and every `vX.Y` documentation tree so future snapshots cannot reintroduce realistic literals
- preserve sanitized Telegram diagnostics in Discussion #84 without retaining the exposed token in the thread

## Verification
- complete pre-push gate: Biome, accepted Qlty baseline, 84 maintenance tests, 31 workflow tests, UI typecheck, 37 website script tests, fresh backend/UI 100% coverage, app/UI builds, zizmor
- website production build generated 262 pages during the original remediation audit

## Secret-scanning disposition
- alerts #1 and #2 are documentation-example false positives and can be resolved after this reaches `main`
- alert #3 remains open until the reporter confirms BotFather revocation; this PR does not claim that token was revoked

The future frozen v1.5 archive will run through this same regression and receive the same two deliberately invalid placeholders before the v1.6 RC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔒 Security: Replaced realistic Azure client-secret and Telegram bot-token examples across current and versioned documentation with invalid placeholders.
- ✨ Added: Regression test covering all `current` and `vX.Y` documentation trees.
- 🔧 Changed: Preserved sanitized Telegram diagnostics in Discussion `#84` without the exposed token.

## Concerns

- Two documentation-example security alerts are false positives.
- Confirm Telegram bot-token revocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->