### PR TITLE
🐛 fix(ui): harden v1.6 mobile release surfaces

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -25,9 +25,21 @@ export default defineConfig({
     {
       name: 'chromium',
       testMatch: /.*\.spec\.ts/,
-      testIgnore: /login\.spec\.ts/,
+      testIgnore: [/login\.spec\.ts/, /v16-mobile\.spec\.ts/],
       use: {
         storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
+    {
+      name: 'mobile-chromium',
+      testMatch: /v16-mobile\.spec\.ts/,
+      use: {
+        storageState: 'playwright/.auth/user.json',
+        viewport: { width: 390, height: 844 },
+        deviceScaleFactor: 3,
+        hasTouch: true,
+        isMobile: true,
       },
       dependencies: ['setup'],
     },

--- a/e2e/playwright/containers.spec.ts
+++ b/e2e/playwright/containers.spec.ts
@@ -25,7 +25,7 @@ async function openContainersView(page: Page): Promise<void> {
 
 async function switchToCardsView(page: Page): Promise<void> {
   await page.getByRole('button', { name: 'Cards view' }).click();
-  await expect(page.getByRole('button', { name: /Select / }).first()).toBeVisible({
+  await expect(page.locator('[data-test="dd-card"]').first()).toBeVisible({
     timeout: 30_000,
   });
 }
@@ -104,7 +104,7 @@ test.describe('Containers', () => {
     await expect(page.locator('th', { hasText: 'Container' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Cards view' }).click();
-    await expect(page.getByRole('button', { name: /Select / }).first()).toBeVisible();
+    await expect(page.locator('[data-test="dd-card"]').first()).toBeVisible();
     await expect(page.getByRole('button', { name: 'List view' })).toHaveCount(0);
   });
 
@@ -113,7 +113,7 @@ test.describe('Containers', () => {
     await switchToCardsView(page);
     await dismissAnnouncementBanners(page);
 
-    const allCards = page.getByRole('button', { name: /Select / });
+    const allCards = page.locator('[data-test="dd-card"]');
     const initialCount = await allCards.count();
     expect(initialCount).toBeGreaterThan(0);
 
@@ -130,7 +130,7 @@ test.describe('Containers', () => {
     await searchInput.fill('nginx');
 
     await expect(page.getByText(/nginx/i).first()).toBeVisible({ timeout: 10000 });
-    const filteredCards = page.getByRole('button', { name: /Select / });
+    const filteredCards = page.locator('[data-test="dd-card"]');
     const filteredRows = page.locator('[data-test="containers-grouped-views"] tr');
     const filteredCount = (await filteredCards.count()) + (await filteredRows.count());
     expect(filteredCount).toBeGreaterThan(0);

--- a/e2e/playwright/containers.spec.ts
+++ b/e2e/playwright/containers.spec.ts
@@ -103,8 +103,7 @@ test.describe('Containers', () => {
     await page.getByRole('button', { name: 'Table view' }).click();
     await expect(page.locator('th', { hasText: 'Container' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'Cards view' }).click();
-    await expect(page.locator('[data-test="dd-card"]').first()).toBeVisible();
+    await switchToCardsView(page);
     await expect(page.getByRole('button', { name: 'List view' })).toHaveCount(0);
   });
 

--- a/e2e/playwright/containers.spec.ts
+++ b/e2e/playwright/containers.spec.ts
@@ -97,7 +97,7 @@ function readContainerActionsFeatureFlag(payload: unknown): boolean | undefined 
 }
 
 test.describe('Containers', () => {
-  test('container list loads and supports table/cards/list view toggles', async ({ page }) => {
+  test('container list loads and supports table/cards view toggles', async ({ page }) => {
     await openContainersView(page);
 
     await page.getByRole('button', { name: 'Table view' }).click();
@@ -105,9 +105,7 @@ test.describe('Containers', () => {
 
     await page.getByRole('button', { name: 'Cards view' }).click();
     await expect(page.getByRole('button', { name: /Select / }).first()).toBeVisible();
-
-    await page.getByRole('button', { name: 'List view' }).click();
-    await expect(page.getByRole('button', { name: /Select / }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'List view' })).toHaveCount(0);
   });
 
   test('stack grouping and search filtering narrow the container list', async ({ page }) => {

--- a/e2e/playwright/v16-mobile.spec.ts
+++ b/e2e/playwright/v16-mobile.spec.ts
@@ -114,7 +114,8 @@ async function expectNoHorizontalOverflow(page: Page): Promise<void> {
   await expect
     .poll(() =>
       page.evaluate(() => {
-        const rootOverflow = document.documentElement.scrollWidth - document.documentElement.clientWidth;
+        const rootOverflow =
+          document.documentElement.scrollWidth - document.documentElement.clientWidth;
         const bodyOverflow = document.body.scrollWidth - window.innerWidth;
         return Math.max(rootOverflow, bodyOverflow);
       }),
@@ -166,22 +167,26 @@ test.describe('v1.6 mobile release promises', () => {
     await expectNoHorizontalOverflow(page);
   });
 
-  test('#295 keeps resource actions ordered and the release dialog touch-safe', async ({ page }) => {
+  test('#295 keeps resource actions ordered and the release dialog touch-safe', async ({
+    page,
+  }) => {
     await openMobileContainers(page);
 
     const cards = FIXTURE_NAMES.map((name) => cardFor(page, name));
     const resourceGroups = cards.map((card) =>
-      card.locator('[data-test="container-card-resource-actions"] [data-test="container-quick-links"]'),
+      card.locator(
+        '[data-test="container-card-resource-actions"] [data-test="container-quick-links"]',
+      ),
     );
     const firstActions = resourceGroups[0].locator(
       '[data-test="project-link"], [data-test="current-release-notes-link"], [data-test="registry-link"]',
     );
     await expect(firstActions).toHaveCount(3);
-    expect(await firstActions.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-test')))).toEqual([
-      'project-link',
-      'current-release-notes-link',
-      'registry-link',
-    ]);
+    expect(
+      await firstActions.evaluateAll((nodes) =>
+        nodes.map((node) => node.getAttribute('data-test')),
+      ),
+    ).toEqual(['project-link', 'current-release-notes-link', 'registry-link']);
     for (let index = 0; index < 3; index += 1) {
       await expectTouchTarget(firstActions.nth(index));
     }

--- a/e2e/playwright/v16-mobile.spec.ts
+++ b/e2e/playwright/v16-mobile.spec.ts
@@ -1,0 +1,215 @@
+import { expect, type Locator, type Page, type Route, test } from '@playwright/test';
+import {
+  dismissAnnouncementBanners,
+  registerServerAvailabilityCheck,
+} from './helpers/test-helpers';
+
+registerServerAvailabilityCheck(test);
+
+const FIXTURE_NAMES = ['V16 Mobile Fixture One', 'V16 Mobile Fixture Two'] as const;
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function collectionFrom(payload: unknown): JsonRecord[] {
+  if (Array.isArray(payload)) {
+    return payload.filter(isRecord);
+  }
+  if (!isRecord(payload)) {
+    return [];
+  }
+  for (const key of ['data', 'items', 'entries'] as const) {
+    const value = payload[key];
+    if (Array.isArray(value)) {
+      return value.filter(isRecord);
+    }
+  }
+  return [];
+}
+
+function replaceCollection(payload: unknown, collection: JsonRecord[]): unknown {
+  if (Array.isArray(payload)) {
+    return collection;
+  }
+  if (!isRecord(payload)) {
+    return collection;
+  }
+  for (const key of ['data', 'items', 'entries'] as const) {
+    if (Array.isArray(payload[key])) {
+      return { ...payload, [key]: collection };
+    }
+  }
+  return collection;
+}
+
+function fixtureContainer(source: JsonRecord, index: number): JsonRecord {
+  const image = isRecord(source.image) ? source.image : {};
+  const tag = isRecord(image.tag) ? image.tag : {};
+  return {
+    ...source,
+    displayName: FIXTURE_NAMES[index],
+    status: 'running',
+    sourceRepo: 'github.com/CodesWhat/drydock',
+    image: {
+      ...image,
+      name: 'nginx',
+      registry: { name: 'hub', url: 'https://registry-1.docker.io' },
+      tag: { ...tag, value: `1.25.${index + 1}` },
+    },
+    result: null,
+    updateAvailable: false,
+    updateKind: null,
+    error: null,
+    currentReleaseNotes: {
+      title: `${FIXTURE_NAMES[index]} release`,
+      body: `Deterministic release notes for ${FIXTURE_NAMES[index]}.`,
+      url: `https://github.com/CodesWhat/drydock/releases/tag/v1.5.${index + 1}`,
+      publishedAt: `2026-07-0${index + 1}T12:00:00.000Z`,
+      provider: 'github',
+    },
+  };
+}
+
+async function interceptContainerCollection(route: Route): Promise<void> {
+  const response = await route.fetch();
+  const payload: unknown = await response.json();
+  const collection = collectionFrom(payload);
+  if (collection.length < FIXTURE_NAMES.length) {
+    throw new Error('The v1.6 mobile fixture requires at least two QA containers');
+  }
+  const withFixtures = collection.map((container, index) =>
+    index < FIXTURE_NAMES.length ? fixtureContainer(container, index) : container,
+  );
+  await route.fulfill({ response, json: replaceCollection(payload, withFixtures) });
+}
+
+async function openMobileContainers(page: Page): Promise<void> {
+  await page.route(/\/api\/v1\/containers(?:\?.*)?$/, interceptContainerCollection);
+  await page.goto('/containers');
+  await dismissAnnouncementBanners(page);
+
+  await expect(cardFor(page, FIXTURE_NAMES[0])).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole('button', { name: 'Table view' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Cards view' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'List view' })).toHaveCount(0);
+  await expect(page.locator('[data-test="containers-grouped-views"] table')).toHaveCount(0);
+}
+
+function cardFor(page: Page, name: string): Locator {
+  return page.locator('[data-test="dd-card"]').filter({ hasText: name }).first();
+}
+
+async function expectTouchTarget(locator: Locator): Promise<void> {
+  await expect(locator).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, 'expected a rendered touch target').not.toBeNull();
+  expect(box!.width, 'touch target width').toBeGreaterThanOrEqual(44);
+  expect(box!.height, 'touch target height').toBeGreaterThanOrEqual(44);
+}
+
+async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const rootOverflow = document.documentElement.scrollWidth - document.documentElement.clientWidth;
+        const bodyOverflow = document.body.scrollWidth - window.innerWidth;
+        return Math.max(rootOverflow, bodyOverflow);
+      }),
+    )
+    .toBeLessThanOrEqual(1);
+}
+
+test.describe('v1.6 mobile release promises', () => {
+  test('#242 forces card reflow and keeps mobile controls and detail panel touch-safe', async ({
+    page,
+  }) => {
+    await openMobileContainers(page);
+    await expectNoHorizontalOverflow(page);
+
+    await expectTouchTarget(page.getByRole('button', { name: 'Toggle filters' }));
+    await expectTouchTarget(page.getByRole('button', { name: 'Group by stack' }));
+    await expectTouchTarget(page.getByRole('button', { name: 'Recheck for updates' }).first());
+    await expectTouchTarget(page.locator('[data-test="dd-toolbar-sort-select"]'));
+    await expectTouchTarget(page.locator('[data-test="dd-toolbar-sort-direction"]'));
+
+    const firstCard = cardFor(page, FIXTURE_NAMES[0]);
+    await firstCard.click({ position: { x: 8, y: 8 } });
+
+    const dialog = page.locator('[data-test="container-side-detail"] [role="dialog"]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+    await dialog.evaluate(async (element) => {
+      await Promise.all(element.getAnimations().map((animation) => animation.finished));
+    });
+    const dialogBox = await dialog.boundingBox();
+    expect(dialogBox).not.toBeNull();
+    expect(dialogBox!.x).toBeLessThanOrEqual(1);
+    expect(dialogBox!.y).toBeLessThanOrEqual(1);
+    expect(dialogBox!.width).toBeGreaterThanOrEqual(389);
+    expect(dialogBox!.height).toBeGreaterThanOrEqual(843);
+
+    for (const name of [
+      'Open full page view',
+      'Close details panel',
+      'Stop',
+      'Restart',
+      'Scan',
+      'Recheck for updates',
+      'Delete',
+      'Overview',
+    ]) {
+      await expectTouchTarget(dialog.getByRole('button', { name, exact: true }));
+    }
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('#295 keeps resource actions ordered and the release dialog touch-safe', async ({ page }) => {
+    await openMobileContainers(page);
+
+    const cards = FIXTURE_NAMES.map((name) => cardFor(page, name));
+    const resourceGroups = cards.map((card) =>
+      card.locator('[data-test="container-card-resource-actions"] [data-test="container-quick-links"]'),
+    );
+    const firstActions = resourceGroups[0].locator(
+      '[data-test="project-link"], [data-test="current-release-notes-link"], [data-test="registry-link"]',
+    );
+    await expect(firstActions).toHaveCount(3);
+    expect(await firstActions.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-test')))).toEqual([
+      'project-link',
+      'current-release-notes-link',
+      'registry-link',
+    ]);
+    for (let index = 0; index < 3; index += 1) {
+      await expectTouchTarget(firstActions.nth(index));
+    }
+
+    const releaseButtons = resourceGroups.map((group) =>
+      group.locator('[data-test="current-release-notes-link"]'),
+    );
+    await releaseButtons[0].tap();
+    const popover = page.locator('[data-test="release-notes-popover"]');
+    await expect(popover).toHaveCount(1);
+    await expect(popover).toContainText(`${FIXTURE_NAMES[0]} release`);
+    const popoverBox = await popover.boundingBox();
+    expect(popoverBox).not.toBeNull();
+    expect(popoverBox!.x).toBeGreaterThanOrEqual(7);
+    expect(popoverBox!.y).toBeGreaterThanOrEqual(0);
+    expect(popoverBox!.x + popoverBox!.width).toBeLessThanOrEqual(383);
+    expect(popoverBox!.y + popoverBox!.height).toBeLessThanOrEqual(844);
+    await expect(popover.getByRole('button').first()).toBeFocused();
+
+    await popover.getByRole('button', { name: 'Close' }).tap();
+    await expect(popover).toHaveCount(0);
+    await expect(releaseButtons[0]).toBeFocused();
+
+    await releaseButtons[0].tap();
+    await releaseButtons[1].tap({ force: true });
+    await expect(popover).toHaveCount(1);
+    await expect(popover).toContainText(`${FIXTURE_NAMES[1]} release`);
+    await expect(page.locator('[data-test="container-side-detail"]')).toHaveCount(0);
+    await expectNoHorizontalOverflow(page);
+  });
+});

--- a/e2e/playwright/v16-mobile.spec.ts
+++ b/e2e/playwright/v16-mobile.spec.ts
@@ -78,7 +78,12 @@ async function interceptContainerCollection(route: Route): Promise<void> {
   const payload: unknown = await response.json();
   const collection = collectionFrom(payload);
   if (collection.length < FIXTURE_NAMES.length) {
-    throw new Error('The v1.6 mobile fixture requires at least two QA containers');
+    await route.fulfill({
+      response,
+      status: 503,
+      json: { error: 'The v1.6 mobile fixture requires at least two QA containers' },
+    });
+    return;
   }
   const withFixtures = collection.map((container, index) =>
     index < FIXTURE_NAMES.length ? fixtureContainer(container, index) : container,
@@ -211,7 +216,7 @@ test.describe('v1.6 mobile release promises', () => {
     await expect(releaseButtons[0]).toBeFocused();
 
     await releaseButtons[0].tap();
-    await releaseButtons[1].tap({ force: true });
+    await releaseButtons[1].tap();
     await expect(popover).toHaveCount(1);
     await expect(popover).toContainText(`${FIXTURE_NAMES[1]} release`);
     await expect(page.locator('[data-test="container-side-detail"]')).toHaveCount(0);

--- a/ui/src/components/AppTabBar.vue
+++ b/ui/src/components/AppTabBar.vue
@@ -29,7 +29,7 @@ defineEmits<{
 
 const sizeClasses = computed(() =>
   props.iconOnly
-    ? `inline-flex items-center justify-center ${iconButtonSizeClasses.sm} dd-text-tab-sm`
+    ? `inline-flex shrink-0 items-center justify-center ${iconButtonSizeClasses.sm} dd-text-tab-sm`
     : props.size === 'compact'
       ? 'px-2 py-1.5 dd-text-tab-sm'
       : 'px-3 py-2 dd-text-tab',

--- a/ui/src/components/AppTabBar.vue
+++ b/ui/src/components/AppTabBar.vue
@@ -29,14 +29,14 @@ defineEmits<{
 
 const sizeClasses = computed(() =>
   props.iconOnly
-    ? `inline-flex items-center justify-center ${iconButtonSizeClasses.toolbar} dd-text-tab-sm`
+    ? `inline-flex items-center justify-center ${iconButtonSizeClasses.sm} dd-text-tab-sm`
     : props.size === 'compact'
       ? 'px-2 py-1.5 dd-text-tab-sm'
       : 'px-3 py-2 dd-text-tab',
 );
 
 const iconSize = computed(() =>
-  props.iconOnly ? iconButtonIconSizes.toolbar : props.size === 'compact' ? 10 : 12,
+  props.iconOnly ? iconButtonIconSizes.sm : props.size === 'compact' ? 10 : 12,
 );
 
 const countStyle = {

--- a/ui/src/components/DataFilterBar.vue
+++ b/ui/src/components/DataFilterBar.vue
@@ -58,7 +58,7 @@ function viewModeLabel(id: string): string {
       <div class="flex items-center gap-2.5 relative">
         <!-- Filter toggle button -->
         <div v-if="!hideFilter" class="relative" v-tooltip.top="t('sharedComponents.dataFilterBar.filters')">
-          <AppIconButton icon="filter" size="toolbar" variant="plain" class="text-2xs-plus"
+          <AppIconButton icon="filter" size="sm" variant="plain" class="text-2xs-plus"
                   :class="showFilters || (activeFilterCount ?? 0) > 0 ? 'dd-text dd-bg-elevated' : 'dd-text-secondary hover:dd-text hover:dd-bg-elevated'"
                   :aria-label="t('sharedComponents.dataFilterBar.toggleFilters')"
                   :aria-expanded="String(showFilters)"
@@ -92,7 +92,7 @@ function viewModeLabel(id: string): string {
                role="group"
                :aria-label="t('sharedComponents.dataFilterBar.viewMode')">
             <AppIconButton v-for="vm in (viewModes ?? defaultViewModes)" :key="vm.id"
-                    :icon="vm.icon" size="toolbar" variant="plain"
+                    :icon="vm.icon" size="sm" variant="plain"
                     :class="modelValue === vm.id ? 'dd-text dd-bg-elevated' : 'dd-text-secondary hover:dd-text hover:dd-bg-elevated'"
                     :tooltip="viewModeLabel(vm.id)"
                     :aria-label="viewModeLabel(vm.id)"

--- a/ui/src/components/DataFilterBar.vue
+++ b/ui/src/components/DataFilterBar.vue
@@ -55,10 +55,10 @@ function viewModeLabel(id: string): string {
          :style="{
            backgroundColor: 'var(--dd-bg-card)',
          }">
-      <div class="flex items-center gap-2.5 relative">
+      <div data-test="data-filter-bar-controls" class="flex flex-wrap items-center gap-2.5 relative">
         <!-- Filter toggle button -->
-        <div v-if="!hideFilter" class="relative" v-tooltip.top="t('sharedComponents.dataFilterBar.filters')">
-          <AppIconButton icon="filter" size="sm" variant="plain" class="text-2xs-plus"
+        <div v-if="!hideFilter" class="relative shrink-0" v-tooltip.top="t('sharedComponents.dataFilterBar.filters')">
+          <AppIconButton icon="filter" size="sm" variant="plain" class="text-2xs-plus shrink-0"
                   :class="showFilters || (activeFilterCount ?? 0) > 0 ? 'dd-text dd-bg-elevated' : 'dd-text-secondary hover:dd-text hover:dd-bg-elevated'"
                   :aria-label="t('sharedComponents.dataFilterBar.toggleFilters')"
                   :aria-expanded="String(showFilters)"
@@ -81,14 +81,15 @@ function viewModeLabel(id: string): string {
         <slot name="center" />
 
         <!-- Right side: count + view mode switcher -->
-        <div class="flex items-center gap-2 ml-auto">
+        <div data-test="data-filter-bar-trailing" class="flex flex-wrap items-center gap-2 ml-auto min-w-0">
           <span class="text-2xs font-semibold tabular-nums shrink-0 px-2 py-1 dd-rounded dd-text-muted dd-bg-card">
             {{ filteredCount }}/{{ totalCount }}<template v-if="countLabel"> {{ countLabel }}</template>
           </span>
           <!-- Sort control (card mode only — table mode sorts via column headers) -->
           <slot name="sort" />
           <div v-if="modelValue !== undefined && !hideViewToggle"
-               class="flex items-center dd-rounded overflow-hidden"
+               data-test="data-filter-bar-view-modes"
+               class="flex items-center dd-rounded overflow-hidden shrink-0"
                role="group"
                :aria-label="t('sharedComponents.dataFilterBar.viewMode')">
             <AppIconButton v-for="vm in (viewModes ?? defaultViewModes)" :key="vm.id"

--- a/ui/src/components/DataSortControl.vue
+++ b/ui/src/components/DataSortControl.vue
@@ -38,7 +38,7 @@ function toggleDirection(): void {
   <div class="flex items-center gap-1" role="group" :aria-label="t('sharedComponents.dataTable.sortBy')">
     <select
       data-test="dd-toolbar-sort-select"
-      class="h-8 min-w-0 max-w-[9rem] px-2 dd-rounded dd-bg-elevated dd-text text-2xs font-medium outline-none cursor-pointer"
+      class="min-h-[44px] min-w-0 max-w-[9rem] px-2 dd-rounded dd-bg-elevated dd-text text-2xs font-medium outline-none cursor-pointer"
       :aria-label="t('sharedComponents.dataTable.sortBy')"
       :value="sortKey ?? ''"
       @change="onFieldChange">
@@ -48,7 +48,7 @@ function toggleDirection(): void {
     <AppIconButton
       data-test="dd-toolbar-sort-direction"
       :icon="sortAsc === false ? 'sort-desc' : 'sort-asc'"
-      size="toolbar"
+      size="sm"
       variant="plain"
       :disabled="!sortKey"
       class="dd-text-secondary hover:dd-text hover:dd-bg-elevated"

--- a/ui/src/components/DataSortControl.vue
+++ b/ui/src/components/DataSortControl.vue
@@ -35,7 +35,7 @@ function toggleDirection(): void {
 </script>
 
 <template>
-  <div class="flex items-center gap-1" role="group" :aria-label="t('sharedComponents.dataTable.sortBy')">
+  <div class="flex shrink-0 items-center gap-1" role="group" :aria-label="t('sharedComponents.dataTable.sortBy')">
     <select
       data-test="dd-toolbar-sort-select"
       class="min-h-[44px] min-w-0 max-w-[9rem] px-2 dd-rounded dd-bg-elevated dd-text text-2xs font-medium outline-none cursor-pointer"
@@ -51,7 +51,7 @@ function toggleDirection(): void {
       size="sm"
       variant="plain"
       :disabled="!sortKey"
-      class="dd-text-secondary hover:dd-text hover:dd-bg-elevated"
+      class="shrink-0 dd-text-secondary hover:dd-text hover:dd-bg-elevated"
       :aria-pressed="String(!!sortKey && sortAsc !== false)"
       :tooltip="sortAsc === false
         ? t('sharedComponents.dataTable.sortDirectionDescending')

--- a/ui/src/components/DataTableColumnPicker.vue
+++ b/ui/src/components/DataTableColumnPicker.vue
@@ -106,7 +106,7 @@ onUnmounted(() => {
   <div class="hidden sm:flex relative items-center" data-test="data-table-column-picker">
     <AppIconButton
       icon="config"
-      size="toolbar"
+      size="sm"
       variant="secondary"
       :class="showPicker ? 'dd-text dd-bg-elevated' : ''"
       :tooltip="t('sharedComponents.columnPicker.toggleTooltip')"

--- a/ui/src/components/DataTableColumnPicker.vue
+++ b/ui/src/components/DataTableColumnPicker.vue
@@ -103,7 +103,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="hidden sm:flex relative items-center" data-test="data-table-column-picker">
+  <div class="hidden sm:flex relative items-center shrink-0" data-test="data-table-column-picker">
     <AppIconButton
       icon="config"
       size="sm"

--- a/ui/src/components/DetailPanel.vue
+++ b/ui/src/components/DetailPanel.vue
@@ -93,9 +93,11 @@ useFocusTrap(panelRef, trapActive);
          }">
 
     <!-- Panel toolbar: size + full page + close -->
-    <div class="shrink-0 px-4 py-2.5 flex items-center justify-between"
+    <div
+         data-test="detail-panel-toolbar"
+         class="shrink-0 px-4 py-2.5 flex flex-wrap items-center justify-between gap-2"
          :style="{ borderBottom: '1px solid var(--dd-border)' }">
-      <div class="flex items-center gap-2">
+      <div data-test="detail-panel-toolbar-leading" class="flex flex-1 flex-wrap items-center gap-2 min-w-0">
         <div v-if="(showSizeControls && !isMobile) || showFullPage" class="flex items-center dd-rounded overflow-hidden">
           <AppIconButton v-if="showFullPage"
                   icon="frame-corners" size="sm" variant="muted"

--- a/ui/src/components/DetailPanel.vue
+++ b/ui/src/components/DetailPanel.vue
@@ -98,7 +98,7 @@ useFocusTrap(panelRef, trapActive);
       <div class="flex items-center gap-2">
         <div v-if="(showSizeControls && !isMobile) || showFullPage" class="flex items-center dd-rounded overflow-hidden">
           <AppIconButton v-if="showFullPage"
-                  icon="frame-corners" size="toolbar" variant="muted"
+                  icon="frame-corners" size="sm" variant="muted"
                   :tooltip="t('sharedComponents.detailPanel.openFullPage')"
                   @click="$emit('full-page')" />
           <AppButton size="none" variant="plain" weight="none" v-if="showSizeControls && !isMobile"
@@ -113,7 +113,7 @@ useFocusTrap(panelRef, trapActive);
         </div>
         <slot name="toolbar" />
       </div>
-      <AppIconButton icon="xmark" size="toolbar" variant="muted"
+      <AppIconButton icon="xmark" size="sm" variant="muted"
               :aria-label="t('sharedComponents.detailPanel.closePanel')"
               @click="closePanel" />
     </div>

--- a/ui/src/components/containers/ContainerSideDetail.vue
+++ b/ui/src/components/containers/ContainerSideDetail.vue
@@ -115,11 +115,11 @@ function getStatusTone(container: { id?: unknown; name?: unknown; status?: strin
       @update:size="panelSize = $event"
       @full-page="openFullPage">
       <template #toolbar>
-        <div class="flex items-center gap-0.5">
+        <div class="flex flex-wrap items-center gap-0.5" data-test="container-side-detail-actions">
           <AppIconButton
             v-if="selectedContainer.status === 'running'"
             icon="stop"
-            size="xs"
+            size="sm"
             variant="danger"
             :disabled="isActionBlocked(selectedContainer)"
             :tooltip="t('containerComponents.sideDetail.stopTooltip')"
@@ -127,28 +127,28 @@ function getStatusTone(container: { id?: unknown; name?: unknown; status?: strin
           <AppIconButton
             v-else
             icon="play"
-            size="xs"
+            size="sm"
             variant="success"
             :disabled="isActionBlocked(selectedContainer)"
             :tooltip="t('containerComponents.sideDetail.startTooltip')"
             @click="startContainer(selectedContainer)" />
           <AppIconButton
             icon="restart"
-            size="xs"
+            size="sm"
             variant="muted"
             :disabled="isActionBlocked(selectedContainer)"
             :tooltip="t('containerComponents.sideDetail.restartTooltip')"
             @click="confirmRestart(selectedContainer)" />
           <AppIconButton
             icon="security"
-            size="xs"
+            size="sm"
             variant="secondary"
             :disabled="isActionBlocked(selectedContainer)"
             :tooltip="t('containerComponents.sideDetail.scanTooltip')"
             @click="scanContainer(selectedContainer)" />
           <AppIconButton
             icon="restart"
-            size="xs"
+            size="sm"
             variant="secondary"
             :loading="recheckingContainerId === selectedContainer.id"
             :disabled="recheckingContainerId === selectedContainer.id || isActionBlocked(selectedContainer)"
@@ -157,14 +157,14 @@ function getStatusTone(container: { id?: unknown; name?: unknown; status?: strin
 	          <AppIconButton
 	            v-if="updateMode !== 'notify' && hasRawUpdateCandidate(selectedContainer) && isUpdateHardBlocked(selectedContainer)"
 	            icon="lock"
-	            size="xs"
+	            size="sm"
 	            variant="danger"
 	            :disabled="true"
 	            :tooltip="getUpdateBlockedTooltip(selectedContainer)" />
 	          <AppIconButton
 	            v-else-if="updateMode !== 'notify' && hasRawUpdateCandidate(selectedContainer) && selectedContainer.bouncer === 'blocked'"
 	            icon="lock"
-	            size="xs"
+	            size="sm"
 	            variant="danger"
 	            :disabled="isActionBlocked(selectedContainer)"
             :tooltip="t('containerComponents.sideDetail.blockedForceUpdateTooltip')"
@@ -172,14 +172,14 @@ function getStatusTone(container: { id?: unknown; name?: unknown; status?: strin
           <AppIconButton
             v-else-if="updateMode !== 'notify' && hasRawUpdateCandidate(selectedContainer)"
             icon="cloud-download"
-            size="xs"
+            size="sm"
             variant="success"
             :disabled="isActionBlocked(selectedContainer)"
             :tooltip="t('containerComponents.sideDetail.updateTooltip')"
             @click="confirmUpdate(selectedContainer)" />
           <AppIconButton
             icon="trash"
-            size="xs"
+            size="sm"
             variant="danger"
             :disabled="isActionBlocked(selectedContainer)"
             :tooltip="t('containerComponents.sideDetail.deleteTooltip')"

--- a/ui/src/components/containers/ContainersListContent.vue
+++ b/ui/src/components/containers/ContainersListContent.vue
@@ -237,7 +237,7 @@ const activeFilterChips = computed(() => {
           @reset="resetColumns" />
       </template>
       <template #left>
-        <AppIconButton icon="stack" size="sm" variant="secondary"
+        <AppIconButton icon="stack" size="sm" variant="secondary" class="shrink-0"
           :class="groupByStack ? 'dd-text dd-bg-elevated' : ''"
           :tooltip="tt(t('containerComponents.listContent.groupByStackTooltip'))"
           :aria-label="t('containerComponents.listContent.groupByStackTooltip')"
@@ -252,7 +252,7 @@ const activeFilterChips = computed(() => {
           @click="allGroupsCollapsed ? expandAllGroups() : collapseAllGroups()">
           {{ allGroupsCollapsed ? t('containerComponents.listContent.expandAll') : t('containerComponents.listContent.collapseAll') }}
         </AppButton>
-        <AppIconButton icon="restart" size="sm" variant="secondary"
+        <AppIconButton icon="restart" size="sm" variant="secondary" class="shrink-0"
           :class="rechecking ? 'dd-text-muted cursor-wait' : ''"
           :disabled="rechecking"
           :loading="rechecking"

--- a/ui/src/components/containers/ContainersListContent.vue
+++ b/ui/src/components/containers/ContainersListContent.vue
@@ -237,7 +237,7 @@ const activeFilterChips = computed(() => {
           @reset="resetColumns" />
       </template>
       <template #left>
-        <AppIconButton icon="stack" size="toolbar" variant="secondary"
+        <AppIconButton icon="stack" size="sm" variant="secondary"
           :class="groupByStack ? 'dd-text dd-bg-elevated' : ''"
           :tooltip="tt(t('containerComponents.listContent.groupByStackTooltip'))"
           @click="groupByStack = !groupByStack" />
@@ -251,7 +251,7 @@ const activeFilterChips = computed(() => {
           @click="allGroupsCollapsed ? expandAllGroups() : collapseAllGroups()">
           {{ allGroupsCollapsed ? t('containerComponents.listContent.expandAll') : t('containerComponents.listContent.collapseAll') }}
         </AppButton>
-        <AppIconButton icon="restart" size="toolbar" variant="secondary"
+        <AppIconButton icon="restart" size="sm" variant="secondary"
           :class="rechecking ? 'dd-text-muted cursor-wait' : ''"
           :disabled="rechecking"
           :loading="rechecking"

--- a/ui/src/components/containers/ContainersListContent.vue
+++ b/ui/src/components/containers/ContainersListContent.vue
@@ -240,6 +240,7 @@ const activeFilterChips = computed(() => {
         <AppIconButton icon="stack" size="sm" variant="secondary"
           :class="groupByStack ? 'dd-text dd-bg-elevated' : ''"
           :tooltip="tt(t('containerComponents.listContent.groupByStackTooltip'))"
+          :aria-label="t('containerComponents.listContent.groupByStackTooltip')"
           @click="groupByStack = !groupByStack" />
         <AppButton
           v-if="groupByStack"
@@ -256,6 +257,7 @@ const activeFilterChips = computed(() => {
           :disabled="rechecking"
           :loading="rechecking"
           :tooltip="tt(t('containerComponents.listContent.recheckTooltip'))"
+          :aria-label="t('containerComponents.listContent.recheckTooltip')"
           @click="recheckAll" />
       </template>
       <template #center>

--- a/ui/tests/components/AppTabBar.spec.ts
+++ b/ui/tests/components/AppTabBar.spec.ts
@@ -166,18 +166,18 @@ describe('AppTabBar', () => {
     expect(buttons[2].attributes('aria-label')).toBe('Logs');
   });
 
-  it('iconOnly compact mode uses toolbar-sized hit targets and icons', () => {
+  it('iconOnly compact mode uses 44px touch targets and icons', () => {
     const wrapper = factory({ iconOnly: true, size: 'compact' });
     const overviewButton = wrapper.findAll('button')[0];
     const iconEl = overviewButton.find('iconify-icon');
 
-    expect(overviewButton.classes()).toContain('w-8');
-    expect(overviewButton.classes()).toContain('h-8');
+    expect(overviewButton.classes()).toContain('w-11');
+    expect(overviewButton.classes()).toContain('h-11');
     expect(overviewButton.classes()).toContain('inline-flex');
     expect(overviewButton.classes()).toContain('items-center');
     expect(overviewButton.classes()).toContain('justify-center');
-    expect(iconEl.attributes('width')).toBe('15');
-    expect(iconEl.attributes('height')).toBe('15');
+    expect(iconEl.attributes('width')).toBe('18');
+    expect(iconEl.attributes('height')).toBe('18');
   });
 
   it('non-iconOnly mode does not set aria-label on tabs', () => {

--- a/ui/tests/components/AppTabBar.spec.ts
+++ b/ui/tests/components/AppTabBar.spec.ts
@@ -173,6 +173,7 @@ describe('AppTabBar', () => {
 
     expect(overviewButton.classes()).toContain('w-11');
     expect(overviewButton.classes()).toContain('h-11');
+    expect(overviewButton.classes()).toContain('shrink-0');
     expect(overviewButton.classes()).toContain('inline-flex');
     expect(overviewButton.classes()).toContain('items-center');
     expect(overviewButton.classes()).toContain('justify-center');

--- a/ui/tests/components/ContainerSideDetail.spec.ts
+++ b/ui/tests/components/ContainerSideDetail.spec.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { nextTick, ref } from 'vue';
+import AppIconButton from '@/components/AppIconButton.vue';
 import ContainerSideDetail from '@/components/containers/ContainerSideDetail.vue';
 import DetailPanel from '@/components/DetailPanel.vue';
 
@@ -64,6 +65,7 @@ vi.mock('@/components/containers/containersViewTemplateContext', () => ({
 describe('ContainerSideDetail', () => {
   afterEach(() => {
     detailPanelOpen.value = true;
+    isMobile.value = false;
     panelSize.value = 'sm';
     activeDetailTab.value = 'overview';
     updateMode.value = 'manual';
@@ -92,6 +94,33 @@ describe('ContainerSideDetail', () => {
     isContainerUpdateQueued.mockReturnValue(false);
     getContainerUpdateSequenceLabel.mockReset();
     getContainerUpdateSequenceLabel.mockReturnValue(null);
+  });
+
+  it('uses wrapping 44px controls for mobile container actions', () => {
+    isMobile.value = true;
+    const wrapper = mount(ContainerSideDetail, {
+      global: {
+        components: { DetailPanel },
+        stubs: {
+          AppIcon: { template: '<span class="app-icon-stub" />' },
+          ContainerSideTabContent: { template: '<div />' },
+        },
+        directives: { tooltip: {} },
+      },
+    });
+
+    expect(wrapper.get('[data-test="container-side-detail-actions"]').classes()).toContain(
+      'flex-wrap',
+    );
+    const actionLabels = new Set(['Stop', 'Restart', 'Scan', 'Recheck for updates', 'Delete']);
+    const actionButtons = wrapper
+      .findAllComponents(AppIconButton)
+      .filter((button) => actionLabels.has(button.attributes('aria-label') ?? ''));
+
+    expect(actionButtons).toHaveLength(actionLabels.size);
+    expect(actionButtons.map((button) => button.props('size'))).toEqual(
+      Array(actionLabels.size).fill('sm'),
+    );
   });
 
   it('updates panel width when size controls are clicked', async () => {

--- a/ui/tests/components/DataFilterBar.spec.ts
+++ b/ui/tests/components/DataFilterBar.spec.ts
@@ -49,6 +49,14 @@ function factoryWithTooltip(props: Record<string, any> = {}, slots: Record<strin
 }
 
 describe('DataFilterBar', () => {
+  it('wraps toolbar control groups instead of compressing their touch targets', () => {
+    const w = factory({ modelValue: 'table' });
+
+    expect(w.get('[data-test="data-filter-bar-controls"]').classes()).toContain('flex-wrap');
+    expect(w.get('[data-test="data-filter-bar-trailing"]').classes()).toContain('flex-wrap');
+    expect(w.get('[data-test="data-filter-bar-view-modes"]').classes()).toContain('shrink-0');
+  });
+
   describe('count display', () => {
     it('renders filtered/total count', () => {
       const w = factory({ filteredCount: 3, totalCount: 12 });

--- a/ui/tests/components/DataFilterBar.spec.ts
+++ b/ui/tests/components/DataFilterBar.spec.ts
@@ -15,9 +15,9 @@ function factory(props: Record<string, any> = {}, slots: Record<string, any> = {
       stubs: {
         AppIcon: { template: '<span class="app-icon-stub" />' },
         AppIconButton: {
-          props: ['icon', 'variant', 'tooltip', 'ariaLabel'],
+          props: ['icon', 'variant', 'tooltip', 'ariaLabel', 'size'],
           template:
-            '<button class="app-icon-button-stub" :data-icon="icon" :data-variant="variant" :aria-label="ariaLabel"><slot /></button>',
+            '<button class="app-icon-button-stub" :data-icon="icon" :data-variant="variant" :data-size="size" :aria-label="ariaLabel"><slot /></button>',
         },
       },
       directives: { tooltip: {} },
@@ -75,6 +75,11 @@ describe('DataFilterBar', () => {
       expect(filterBtn.exists()).toBe(true);
       expect(filterBtn.attributes('data-icon')).toBe('filter');
       expect(filterBtn.attributes('data-variant')).toBe('plain');
+    });
+
+    it('uses the 44px icon-button size for the filter toggle', () => {
+      const w = factory();
+      expect(w.get('button[aria-label="Toggle filters"]').attributes('data-size')).toBe('sm');
     });
 
     it('renders filter button when hideFilter is not set', () => {
@@ -151,6 +156,15 @@ describe('DataFilterBar', () => {
       expect(buttons[1].attributes('aria-label')).toBe('Cards view');
       expect(buttons[1].attributes('aria-pressed')).toBe('false');
       expect(buttons[1].attributes('data-icon')).toBe('grid');
+    });
+
+    it('uses the 44px icon-button size for each view mode', () => {
+      const w = factory({ modelValue: 'table' });
+
+      expect(viewModeButtons(w).map((button) => button.attributes('data-size'))).toEqual([
+        'sm',
+        'sm',
+      ]);
     });
 
     it('renders custom view modes when provided', () => {

--- a/ui/tests/components/DataSortControl.spec.ts
+++ b/ui/tests/components/DataSortControl.spec.ts
@@ -46,6 +46,8 @@ describe('DataSortControl', () => {
 
     expect(select.classes()).toContain('min-h-[44px]');
     expect(button.attributes('data-size')).toBe('sm');
+    expect(wrapper.get('[role="group"]').classes()).toContain('shrink-0');
+    expect(button.classes()).toContain('shrink-0');
   });
 
   it('renders the unset disabled state with the ascending icon and inactive press state', () => {

--- a/ui/tests/components/DataSortControl.spec.ts
+++ b/ui/tests/components/DataSortControl.spec.ts
@@ -9,7 +9,7 @@ const columns = [
 
 const AppIconButtonStub = defineComponent({
   inheritAttrs: false,
-  props: ['icon', 'disabled', 'tooltip', 'ariaLabel'],
+  props: ['icon', 'disabled', 'tooltip', 'ariaLabel', 'size'],
   emits: ['click'],
   template: `
     <button
@@ -17,6 +17,7 @@ const AppIconButtonStub = defineComponent({
       type="button"
       :disabled="disabled"
       :data-icon="icon"
+      :data-size="size"
       :data-tooltip="tooltip"
       :aria-label="ariaLabel"
       @click="$emit('click', $event)" />
@@ -38,6 +39,15 @@ function factory(props: Record<string, unknown> = {}) {
 }
 
 describe('DataSortControl', () => {
+  it('uses 44px targets for both sort controls', () => {
+    const wrapper = factory({ sortKey: 'name', sortAsc: true });
+    const select = wrapper.get('[data-test="dd-toolbar-sort-select"]');
+    const button = wrapper.get('[data-test="dd-toolbar-sort-direction"]');
+
+    expect(select.classes()).toContain('min-h-[44px]');
+    expect(button.attributes('data-size')).toBe('sm');
+  });
+
   it('renders the unset disabled state with the ascending icon and inactive press state', () => {
     const wrapper = factory({ sortAsc: true });
     const select = wrapper.get('[data-test="dd-toolbar-sort-select"]');

--- a/ui/tests/components/DataTableColumnPicker.spec.ts
+++ b/ui/tests/components/DataTableColumnPicker.spec.ts
@@ -47,6 +47,7 @@ describe('DataTableColumnPicker', () => {
       const root = w.find('[data-test="data-table-column-picker"]');
       expect(root.classes()).toContain('hidden');
       expect(root.classes()).toContain('sm:flex');
+      expect(root.classes()).toContain('shrink-0');
     });
 
     it('renders exactly one trigger button', () => {

--- a/ui/tests/components/DataTableColumnPicker.spec.ts
+++ b/ui/tests/components/DataTableColumnPicker.spec.ts
@@ -1,5 +1,6 @@
 import type { VueWrapper } from '@vue/test-utils';
 import { nextTick } from 'vue';
+import AppIconButton from '@/components/AppIconButton.vue';
 import DataTableColumnPicker from '@/components/DataTableColumnPicker.vue';
 import type { PickerColumn } from '@/composables/useViewColumnVisibility';
 import { mountWithPlugins } from '../helpers/mount';
@@ -51,6 +52,11 @@ describe('DataTableColumnPicker', () => {
     it('renders exactly one trigger button', () => {
       const w = factory();
       expect(w.findAll('button')).toHaveLength(1);
+    });
+
+    it('uses the 44px icon-button size for the picker trigger', () => {
+      const w = factory();
+      expect(w.getComponent(AppIconButton).props('size')).toBe('sm');
     });
   });
 

--- a/ui/tests/components/DetailPanel.spec.ts
+++ b/ui/tests/components/DetailPanel.spec.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
+import AppIconButton from '@/components/AppIconButton.vue';
 import DetailPanel from '@/components/DetailPanel.vue';
 
 const mountedWrappers: Array<ReturnType<typeof mount>> = [];
@@ -76,9 +77,18 @@ describe('DetailPanel', () => {
   });
 
   describe('close button', () => {
+    it('uses the 44px icon-button size for the close control', () => {
+      const w = factory({ isMobile: true });
+      const closeButton = w
+        .findAllComponents(AppIconButton)
+        .find((button) => button.attributes('aria-label') === 'Close details panel');
+
+      expect(closeButton?.props('size')).toBe('sm');
+    });
+
     it('emits update:open false when close button is clicked', async () => {
       const w = factory();
-      // Close button is the w-8 h-8 AppIconButton in the toolbar
+      // Close button is the 44px AppIconButton in the panel toolbar.
       const closeBtn = w
         .findAll('button')
         .find((b) => b.attributes('aria-label') === 'Close details panel');
@@ -235,6 +245,15 @@ describe('DetailPanel', () => {
   });
 
   describe('full page button', () => {
+    it('uses the 44px icon-button size for the full-page control', () => {
+      const w = factory({ showFullPage: true });
+      const fullPageButton = w
+        .findAllComponents(AppIconButton)
+        .find((button) => button.attributes('aria-label') === 'Open full page view');
+
+      expect(fullPageButton?.props('size')).toBe('sm');
+    });
+
     it('renders full page button when showFullPage is true', () => {
       const w = factory({ showFullPage: true });
       const fpBtn = w

--- a/ui/tests/components/DetailPanel.spec.ts
+++ b/ui/tests/components/DetailPanel.spec.ts
@@ -74,6 +74,17 @@ describe('DetailPanel', () => {
       expect(classes).toContain('end-0');
       expect(classes).not.toContain('right-0');
     });
+
+    it('allows the mobile toolbar and its leading controls to wrap without widening the panel', () => {
+      const w = factory({ open: true, isMobile: true });
+      const toolbar = w.get('[data-test="detail-panel-toolbar"]');
+      const leading = w.get('[data-test="detail-panel-toolbar-leading"]');
+
+      expect(toolbar.classes()).toContain('flex-wrap');
+      expect(leading.classes()).toContain('flex-wrap');
+      expect(leading.classes()).toContain('min-w-0');
+      expect(leading.classes()).toContain('flex-1');
+    });
   });
 
   describe('close button', () => {

--- a/ui/tests/components/containers/ContainersListContent.spec.ts
+++ b/ui/tests/components/containers/ContainersListContent.spec.ts
@@ -187,6 +187,16 @@ describe('ContainersListContent', () => {
     expect(wrapper.get('[data-icon="restart"]').attributes('data-size')).toBe('sm');
   });
 
+  it('gives group and recheck toolbar actions stable accessible names', () => {
+    const context = makeTemplateContext();
+    wrapper = mountWithContext(context);
+
+    expect(wrapper.get('[data-icon="stack"]').attributes('aria-label')).toBe('Group by stack');
+    expect(wrapper.get('[data-icon="restart"]').attributes('aria-label')).toBe(
+      'Recheck for updates',
+    );
+  });
+
   it('hides the column picker in cards mode and shows it in table mode', async () => {
     const context = makeTemplateContext({
       containerViewMode: writableRef<ViewMode>('cards'),

--- a/ui/tests/components/containers/ContainersListContent.spec.ts
+++ b/ui/tests/components/containers/ContainersListContent.spec.ts
@@ -185,6 +185,8 @@ describe('ContainersListContent', () => {
 
     expect(wrapper.get('[data-icon="stack"]').attributes('data-size')).toBe('sm');
     expect(wrapper.get('[data-icon="restart"]').attributes('data-size')).toBe('sm');
+    expect(wrapper.get('[data-icon="stack"]').classes()).toContain('shrink-0');
+    expect(wrapper.get('[data-icon="restart"]').classes()).toContain('shrink-0');
   });
 
   it('gives group and recheck toolbar actions stable accessible names', () => {

--- a/ui/tests/components/containers/ContainersListContent.spec.ts
+++ b/ui/tests/components/containers/ContainersListContent.spec.ts
@@ -157,10 +157,10 @@ describe('ContainersListContent', () => {
       global: {
         stubs: {
           AppIconButton: {
-            props: ['icon', 'tooltip', 'disabled', 'ariaLabel'],
+            props: ['icon', 'tooltip', 'disabled', 'ariaLabel', 'size'],
             emits: ['click'],
             template:
-              '<button v-bind="$attrs" type="button" class="app-icon-button-stub" :disabled="disabled" :data-icon="icon" :aria-label="ariaLabel" @click="$emit(\'click\', $event)">{{ tooltip?.value ?? tooltip }}</button>',
+              '<button v-bind="$attrs" type="button" class="app-icon-button-stub" :disabled="disabled" :data-icon="icon" :data-size="size" :aria-label="ariaLabel" @click="$emit(\'click\', $event)">{{ tooltip?.value ?? tooltip }}</button>',
           },
           ContainersGroupedViews: {
             template: '<div data-test="grouped-views-stub" />',
@@ -177,6 +177,14 @@ describe('ContainersListContent', () => {
     wrapper = mountWithContext(context);
 
     expect(wrapper.find('[data-test="data-table-column-picker"]').exists()).toBe(true);
+  });
+
+  it('uses 44px icon-button sizes for group and recheck toolbar actions', () => {
+    const context = makeTemplateContext();
+    wrapper = mountWithContext(context);
+
+    expect(wrapper.get('[data-icon="stack"]').attributes('data-size')).toBe('sm');
+    expect(wrapper.get('[data-icon="restart"]').attributes('data-size')).toBe('sm');
   });
 
   it('hides the column picker in cards mode and shows it in table mode', async () => {


### PR DESCRIPTION
## Summary
- remove the retired three-way container List-mode assertion and target rendered cards reliably
- preserve rendered 44×44 touch targets across the responsive filter, sort, group, recheck, detail-toolbar, detail-action, and tab controls
- wrap mobile toolbars without changing dense row-action sizing
- add a scoped 390×844 mobile Chromium project and release UAT for Discussions #242 and #295

## Browser evidence
- #242: automatic card reflow, hidden desktop mode switches, no horizontal overflow, full-screen detail dialog, and rendered 44px controls
- #295: Source → Release → Registry order, 44px resource actions, touch-open release notes, viewport bounds, focus restoration, one popover at a time, and no accidental card activation
- mobile auth + #242 + #295: 3/3 passed
- existing desktop Containers suite: auth + 4/4 passed
- final branch Docker image built successfully

## Verification
- focused UI suite: 152/152
- UI typecheck and UI/E2E Biome checks
- complete pre-push gate: repository Biome, accepted Qlty baseline, 83 maintenance tests, 31 workflow tests, 37 website script tests, UI typecheck, fresh backend/UI 100% coverage, app/UI builds, zizmor

The real browser run caught the key product bug: flexbox compressed the nominal 44px Group control to 36px. Local `shrink-0` constraints now preserve its actual rendered size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added a scoped `mobile-chromium` Playwright project (390×844) and dedicated v1.6 mobile release UAT coverage (`#242`, `#295`).
- ✨ Added v1.6 mobile E2E flow that intercepts `GET /api/v1/containers`, deterministically stamps the first two QA containers, and asserts card reflow, dialogs, touch target sizing, overflow prevention, resource action ordering, and release-notes popover behavior.
- 🔧 Updated Playwright `chromium` project ignores to exclude `v16-mobile.spec.ts`, while reusing shared authenticated `storageState` and `setup` dependency wiring.
- 🔧 Updated container E2E readiness logic to wait for rendered cards (`[data-test="dd-card"]`) instead of relying on the retired list-mode readiness assertion.
- 🔧 Refined Containers suite toggles/counting to validate cards rendering (including grouped views and filtered counts) using `[data-test="dd-card"]` locators.
- 🔧 Hardened mobile UI to preserve 44×44 touch targets via `sm` icon-button sizing, `shrink-0` behavior, and responsive wrapping for toolbars/detail panel controls.
- 🔧 Updated toolbar/filter/sort/detail and side-detail action markup with test hooks and mobile-safe flex wrapping without changing dense row-action sizing.
- 🐛 Fixed mobile action and release-notes popover contracts (focus restoration, bounding-box constraints, and touch-safe interaction flows), including behavior for blocked/force-update scenarios.
- 🐛 Fixed Playwright fixture insufficiency handling to return an explicit HTTP 503 via `route.fulfill` (instead of throwing) when fewer than two QA containers are present.
- 🗑️ Removed the retired three-way container List-mode assertion.

## Concerns

- Verify `mobile-chromium` is included in CI/release verification gating and that viewport/device parameters match the supported mobile breakpoints.
- Ensure the new fixture interception/HTTP 503 path is compatible with all environments where `/api/v1/containers` may not return the expected QA container shape/count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->