### PR TITLE
🧪 test(e2e): verify v1.6 release promises

### DIFF
--- a/e2e/playwright/v16-health-preferences.spec.ts
+++ b/e2e/playwright/v16-health-preferences.spec.ts
@@ -168,18 +168,25 @@ test.describe('v1.6 discussion promises', () => {
                 (event) => event.containerName === containerName && event.health === 'unhealthy',
               );
             }, HEALTH_FIXTURE_NAME),
-          { message: 'Expected the browser SSE stream to receive dd:container-unhealthy' },
+          {
+            message: 'Expected the browser SSE stream to receive dd:container-unhealthy',
+            timeout: 15_000,
+          },
         )
         .toBe(true);
       await expect
         .poll(() => auditResponseCount, {
           message: 'Expected the mounted notification bell to refetch audit entries',
+          timeout: 15_000,
         })
         .toBeGreaterThan(auditResponsesBeforeTransition);
 
       await page.getByRole('button', { name: 'Notifications', exact: true }).click();
       await expect(
-        page.locator('[data-test="notification-row"]').filter({ hasText: HEALTH_FIXTURE_NAME }),
+        page
+          .locator('[data-test="notification-row"]')
+          .filter({ hasText: HEALTH_FIXTURE_NAME })
+          .first(),
       ).toBeVisible();
     } finally {
       await stopHealthEventProbe(page).catch(() => {});

--- a/e2e/playwright/v16-health-preferences.spec.ts
+++ b/e2e/playwright/v16-health-preferences.spec.ts
@@ -1,0 +1,279 @@
+import { expect, type Page, test } from '@playwright/test';
+import {
+  dismissAnnouncementBanners,
+  registerServerAvailabilityCheck,
+} from './helpers/test-helpers';
+
+registerServerAvailabilityCheck(test);
+
+const HEALTH_FIXTURE_NAME = 'drydock-playwright-health-transition';
+const HEALTH_FIXTURE_URL = process.env.DD_PLAYWRIGHT_HEALTH_FIXTURE_URL || 'http://127.0.0.1:3334';
+const APP_ORIGIN = new URL(process.env.DD_PLAYWRIGHT_BASE_URL || 'http://localhost:3333').origin;
+
+interface ApiContainer {
+  health?: string;
+  id: string;
+  name: string;
+}
+
+interface CollectionEnvelope<T> {
+  data: T[];
+}
+
+interface NotificationRule {
+  bellEnabled: boolean;
+  id: string;
+}
+
+interface PreferencesEnvelope {
+  apiVersion: number;
+  preferences: Record<string, unknown> | null;
+  schemaVersion: number | null;
+}
+
+async function findHealthFixture(page: Page): Promise<ApiContainer | undefined> {
+  const response = await page.context().request.get('/api/v1/containers?limit=100');
+  expect(response.ok()).toBeTruthy();
+  const envelope = (await response.json()) as CollectionEnvelope<ApiContainer>;
+  return envelope.data.find((container) => container.name === HEALTH_FIXTURE_NAME);
+}
+
+async function waitForHealthFixture(page: Page, expectedHealth: string): Promise<ApiContainer> {
+  await expect
+    .poll(async () => (await findHealthFixture(page))?.health, {
+      message: `Expected ${HEALTH_FIXTURE_NAME} to become ${expectedHealth}`,
+      timeout: 30_000,
+    })
+    .toBe(expectedHealth);
+
+  const fixture = await findHealthFixture(page);
+  expect(fixture).toBeDefined();
+  return fixture as ApiContainer;
+}
+
+async function startHealthEventProbe(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const probeWindow = window as typeof window & {
+      __ddHealthProbe?: {
+        events: Array<Record<string, unknown>>;
+        source: EventSource;
+      };
+    };
+    const events: Array<Record<string, unknown>> = [];
+    const source = new EventSource('/api/v1/events/ui');
+    probeWindow.__ddHealthProbe = { events, source };
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = window.setTimeout(() => {
+        reject(new Error('Timed out connecting the health-event SSE probe'));
+      }, 10_000);
+
+      source.addEventListener(
+        'dd:connected',
+        () => {
+          window.clearTimeout(timeout);
+          resolve();
+        },
+        { once: true },
+      );
+      source.addEventListener('dd:container-unhealthy', (event) => {
+        try {
+          events.push(JSON.parse((event as MessageEvent).data) as Record<string, unknown>);
+        } catch {
+          events.push({ invalidPayload: true });
+        }
+      });
+    });
+  });
+}
+
+async function stopHealthEventProbe(page: Page): Promise<void> {
+  if (page.isClosed()) return;
+  await page.evaluate(() => {
+    const probeWindow = window as typeof window & {
+      __ddHealthProbe?: { source: EventSource };
+    };
+    probeWindow.__ddHealthProbe?.source.close();
+  });
+}
+
+async function disableServerPreferenceSync(page: Page): Promise<void> {
+  if (page.isClosed()) return;
+  const response = await page.context().request.get('/api/v1/preferences');
+  if (!response.ok()) return;
+  const envelope = (await response.json()) as PreferencesEnvelope;
+  if (!envelope.preferences || envelope.schemaVersion === null) return;
+
+  await page.context().request.patch('/api/v1/preferences', {
+    headers: { Origin: APP_ORIGIN },
+    data: {
+      apiVersion: envelope.apiVersion,
+      schemaVersion: envelope.schemaVersion,
+      preferences: {
+        ...envelope.preferences,
+        sync: { enabled: false },
+      },
+    },
+  });
+}
+
+test.describe('v1.6 discussion promises', () => {
+  test('#198 health-only transitions refresh the notification bell', async ({ page, request }) => {
+    const notificationsResponse = await page.context().request.get('/api/v1/notifications');
+    expect(notificationsResponse.ok()).toBeTruthy();
+    const rules = (await notificationsResponse.json()) as CollectionEnvelope<NotificationRule>;
+    const originalRule = rules.data.find((rule) => rule.id === 'container-unhealthy');
+    expect(originalRule).toBeDefined();
+
+    let auditResponseCount = 0;
+    page.on('response', (response) => {
+      const url = new URL(response.url());
+      if (url.pathname === '/api/v1/audit') {
+        auditResponseCount += 1;
+      }
+    });
+
+    try {
+      const enableBellResponse = await page
+        .context()
+        .request.patch('/api/v1/notifications/container-unhealthy', {
+          headers: { Origin: APP_ORIGIN },
+          data: { bellEnabled: true },
+        });
+      expect(enableBellResponse.ok()).toBeTruthy();
+
+      const resetResponse = await request.get(`${HEALTH_FIXTURE_URL}/cgi-bin/healthy`);
+      expect(resetResponse.ok()).toBeTruthy();
+      await waitForHealthFixture(page, 'healthy');
+
+      await page.goto('/');
+      await dismissAnnouncementBanners(page);
+      await expect(page.getByRole('button', { name: 'Notifications', exact: true })).toBeVisible();
+      await expect.poll(() => auditResponseCount, { timeout: 15_000 }).toBeGreaterThan(0);
+      await startHealthEventProbe(page);
+      const auditResponsesBeforeTransition = auditResponseCount;
+
+      const unhealthyResponse = await request.get(`${HEALTH_FIXTURE_URL}/cgi-bin/unhealthy`);
+      expect(unhealthyResponse.ok()).toBeTruthy();
+      await waitForHealthFixture(page, 'unhealthy');
+
+      await expect
+        .poll(
+          () =>
+            page.evaluate((containerName) => {
+              const probeWindow = window as typeof window & {
+                __ddHealthProbe?: { events: Array<Record<string, unknown>> };
+              };
+              return probeWindow.__ddHealthProbe?.events.some(
+                (event) => event.containerName === containerName && event.health === 'unhealthy',
+              );
+            }, HEALTH_FIXTURE_NAME),
+          { message: 'Expected the browser SSE stream to receive dd:container-unhealthy' },
+        )
+        .toBe(true);
+      await expect
+        .poll(() => auditResponseCount, {
+          message: 'Expected the mounted notification bell to refetch audit entries',
+        })
+        .toBeGreaterThan(auditResponsesBeforeTransition);
+
+      await page.getByRole('button', { name: 'Notifications', exact: true }).click();
+      await expect(
+        page.locator('[data-test="notification-row"]').filter({ hasText: HEALTH_FIXTURE_NAME }),
+      ).toBeVisible();
+    } finally {
+      await stopHealthEventProbe(page).catch(() => {});
+      await request.get(`${HEALTH_FIXTURE_URL}/cgi-bin/healthy`).catch(() => {});
+      if (originalRule) {
+        await page
+          .context()
+          .request.patch('/api/v1/notifications/container-unhealthy', {
+            headers: { Origin: APP_ORIGIN },
+            data: { bellEnabled: originalRule.bellEnabled },
+          })
+          .catch(() => {});
+      }
+    }
+  });
+
+  test('#220 preference changes synchronize across two browser contexts', async ({
+    baseURL,
+    browser,
+    page,
+  }) => {
+    expect(baseURL).toBeTruthy();
+    let secondContext: Awaited<ReturnType<typeof browser.newContext>> | undefined;
+
+    try {
+      await page.goto('/config?tab=appearance');
+      await dismissAnnouncementBanners(page);
+
+      const syncToggle = page.locator('[data-test="sync-toggle"]');
+      await expect(syncToggle).toBeVisible();
+
+      if ((await syncToggle.getAttribute('aria-checked')) === 'true') {
+        const disabledWrite = page.waitForResponse(
+          (response) =>
+            response.url().endsWith('/api/v1/preferences') &&
+            response.request().method() === 'PATCH' &&
+            response.ok(),
+        );
+        await syncToggle.click();
+        await disabledWrite;
+        await expect(syncToggle).toHaveAttribute('aria-checked', 'false');
+      }
+
+      const expandSidebarButton = page.getByRole('button', { name: 'Expand sidebar' });
+      if (await expandSidebarButton.isVisible().catch(() => false)) {
+        await expandSidebarButton.click();
+      }
+      await expect(page.getByRole('button', { name: 'Collapse sidebar' })).toBeVisible();
+
+      const enabledWrite = page.waitForResponse(
+        (response) =>
+          response.url().endsWith('/api/v1/preferences') &&
+          response.request().method() === 'PATCH' &&
+          response.ok(),
+      );
+      await syncToggle.click();
+      await enabledWrite;
+      await expect(syncToggle).toHaveAttribute('aria-checked', 'true');
+
+      const cookies = await page.context().cookies();
+      secondContext = await browser.newContext({ baseURL });
+      await secondContext.addCookies(cookies);
+      const secondPage = await secondContext.newPage();
+      await secondPage.goto('/');
+      await dismissAnnouncementBanners(secondPage);
+      await expect(secondPage.getByRole('button', { name: 'Collapse sidebar' })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      const synchronizedWrite = page.waitForResponse(
+        (response) =>
+          response.url().endsWith('/api/v1/preferences') &&
+          response.request().method() === 'PATCH' &&
+          response.ok(),
+      );
+      await page.getByRole('button', { name: 'Collapse sidebar' }).click();
+      await synchronizedWrite;
+
+      await expect(secondPage.getByRole('button', { name: 'Expand sidebar' })).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect
+        .poll(() =>
+          secondPage.evaluate(() => {
+            const raw = localStorage.getItem('dd-preferences');
+            if (!raw) return undefined;
+            return (JSON.parse(raw) as { layout?: { sidebarCollapsed?: boolean } }).layout
+              ?.sidebarCollapsed;
+          }),
+        )
+        .toBe(true);
+    } finally {
+      await secondContext?.close();
+      await disableServerPreferenceSync(page).catch(() => {});
+    }
+  });
+});

--- a/e2e/playwright/v16-modes-pins.spec.ts
+++ b/e2e/playwright/v16-modes-pins.spec.ts
@@ -1,0 +1,228 @@
+import { expect, type Page, type Route, test } from '@playwright/test';
+import {
+  dismissAnnouncementBanners,
+  escapeRegExp,
+  registerServerAvailabilityCheck,
+} from './helpers/test-helpers';
+
+registerServerAvailabilityCheck(test);
+
+type UpdateMode = 'notify' | 'manual' | 'auto';
+
+interface ContainersPayload {
+  data: ContainerFixture[];
+}
+
+interface ContainerFixture {
+  displayName?: string;
+  image: {
+    tag: Record<string, unknown>;
+  };
+  result?: Record<string, unknown>;
+  tagFamily?: string;
+  tagPinned?: boolean;
+  tagPinInfo?: boolean;
+  updateAvailable?: boolean;
+  updateKind?: Record<string, unknown>;
+  updateEligibility?: Record<string, unknown>;
+}
+
+const TARGET_CONTAINER = 'Nginx (Hooked)';
+
+async function interceptSettings(page: Page, initialMode: UpdateMode): Promise<() => UpdateMode> {
+  let updateMode = initialMode;
+  await page.route('**/api/v1/settings', async (route) => {
+    if (route.request().method() === 'PATCH') {
+      const body = route.request().postDataJSON() as { updateMode?: UpdateMode };
+      if (body.updateMode) updateMode = body.updateMode;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      json: { internetlessMode: false, updateMode },
+    });
+  });
+  return () => updateMode;
+}
+
+async function openContainerOverview(page: Page, name = TARGET_CONTAINER): Promise<void> {
+  await page.goto('/containers');
+  await dismissAnnouncementBanners(page);
+  const row = page.getByRole('row', { name: new RegExp(escapeRegExp(name), 'i') });
+  await expect(row).toBeVisible({ timeout: 30_000 });
+  await row.click();
+  await expect(page.locator('[data-test="container-side-detail"]')).toContainText(name);
+}
+
+async function selectUpdateMode(page: Page, mode: UpdateMode): Promise<void> {
+  await page.goto('/config?tab=general');
+  await dismissAnnouncementBanners(page);
+  const option = page.locator(`[data-test="update-mode-${mode}"]`);
+  await expect(option).toBeEnabled();
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.url().endsWith('/api/v1/settings') && response.request().method() === 'PATCH',
+  );
+  await option.click();
+  const response = await responsePromise;
+  expect(response.ok()).toBeTruthy();
+  expect(response.request().postDataJSON()).toEqual({ updateMode: mode });
+  await expect(option).toHaveAttribute('aria-pressed', 'true');
+}
+
+async function interceptContainer(
+  page: Page,
+  displayName: string,
+  mutate: (container: ContainerFixture) => void,
+): Promise<void> {
+  await page.route('**/api/v1/containers', async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    const payload = (await response.json()) as ContainersPayload;
+    const container = payload.data.find((candidate) => candidate.displayName === displayName);
+    expect(container, `QA fixture ${displayName} must exist`).toBeTruthy();
+    mutate(container!);
+    await route.fulfill({ response, json: payload });
+  });
+}
+
+test.describe('v1.6 update modes, scheduling, and pinned tags', () => {
+  test('#325 persists notify/manual/auto and updates the Update Status panel', async ({ page }) => {
+    const currentMode = await interceptSettings(page, 'manual');
+
+    await selectUpdateMode(page, 'notify');
+    expect(currentMode()).toBe('notify');
+    await page.reload();
+    await expect(page.locator('[data-test="update-mode-notify"]')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    await openContainerOverview(page);
+
+    const notifyPanel = page.locator('[data-test="update-status-panel"]');
+    await expect(notifyPanel).toHaveAttribute('data-state', 'notify');
+    await expect(notifyPanel.locator('[data-test="update-status-summary"]')).toHaveText(
+      "Notifications only — Drydock won't apply updates.",
+    );
+    await expect(notifyPanel.locator('[data-test="update-status-manual-cta"]')).toBeDisabled();
+
+    await selectUpdateMode(page, 'auto');
+    expect(currentMode()).toBe('auto');
+    await openContainerOverview(page);
+    const autoPanel = page.locator('[data-test="update-status-panel"]');
+    await expect(autoPanel).toHaveAttribute('data-state', 'ready');
+    await expect(autoPanel.locator('[data-test="update-status-summary"]')).toHaveText(
+      'Update available — eligible for automatic dispatch.',
+    );
+    await expect(autoPanel.locator('[data-test="update-status-manual-cta"]')).toBeEnabled();
+
+    await selectUpdateMode(page, 'manual');
+    expect(currentMode()).toBe('manual');
+    await page.reload();
+    await expect(page.locator('[data-test="update-mode-manual"]')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  test('#406 shows a live stabilization countdown, ETA, and manual override', async ({ page }) => {
+    const now = new Date('2026-07-13T16:00:00.000Z');
+    const liftableAt = new Date(now.getTime() + 6 * 60_000).toISOString();
+    await interceptSettings(page, 'manual');
+    await page.clock.install({ time: now });
+    await interceptContainer(page, TARGET_CONTAINER, (container) => {
+      container.updateEligibility = {
+        eligible: false,
+        evaluatedAt: now.toISOString(),
+        blockers: [
+          {
+            reason: 'maturity-not-reached',
+            severity: 'soft',
+            actionable: true,
+            message: 'The candidate must remain unchanged until the stabilization period ends.',
+            liftableAt,
+          },
+        ],
+      };
+    });
+
+    await openContainerOverview(page);
+    const panel = page.locator('[data-test="update-status-panel"]');
+    await expect(panel).toHaveAttribute('data-state', 'soft-blocked');
+    const condition = panel.locator('[data-reason="maturity-not-reached"]');
+    await expect(condition).toContainText('Maturity policy waiting');
+    await expect(condition).toContainText(
+      'The candidate must remain unchanged until the stabilization period ends.',
+    );
+    await expect(condition).toContainText(/6m\s*·\s*Lifts at /);
+    await expect(panel.locator('[data-test="update-status-manual-cta"]')).toBeEnabled();
+
+    await page.clock.fastForward(60_000);
+    await expect(condition).toContainText(/5m\s*·\s*Lifts at /);
+  });
+
+  test('#498 renders pinned current-to-newer tags as information in table and cards', async ({
+    page,
+  }) => {
+    await interceptSettings(page, 'manual');
+    await interceptContainer(page, 'Traefik Proxy', (container) => {
+      container.displayName = 'Immich ML (Pinned)';
+      container.tagFamily = 'strict';
+      container.tagPinned = true;
+      container.tagPinInfo = true;
+      container.updateAvailable = false;
+      container.updateKind = {
+        kind: 'unknown',
+        localValue: null,
+        remoteValue: null,
+        semverDiff: 'unknown',
+      };
+      container.image.tag = {
+        ...container.image.tag,
+        value: 'v2.7.5-openvino',
+        semver: true,
+        tagPrecision: 'specific',
+      };
+      container.result = {
+        ...container.result,
+        tag: 'v2.7.5-openvino',
+        updateInsight: { tag: 'v3.0.2-openvino', kind: 'major' },
+      };
+      container.updateEligibility = {
+        eligible: false,
+        evaluatedAt: '2026-07-13T16:00:00.000Z',
+        blockers: [
+          {
+            reason: 'no-update-available',
+            severity: 'hard',
+            actionable: false,
+            message: 'Pinned version insight is informational only.',
+          },
+        ],
+      };
+    });
+
+    await page.goto('/containers');
+    await dismissAnnouncementBanners(page);
+    const row = page.getByRole('row', { name: /Immich ML \(Pinned\)/i });
+    await expect(row).toBeVisible({ timeout: 30_000 });
+    const tableFlow = row.locator('.container-version-flow');
+    await expect(tableFlow).toContainText('v2.7.5-openvino');
+    await expect(tableFlow).toContainText('v3.0.2-openvino');
+    const tableText = (await tableFlow.innerText()).replace(/\s+/g, ' ');
+    expect(tableText.indexOf('v2.7.5-openvino')).toBeLessThan(tableText.indexOf('v3.0.2-openvino'));
+    await expect(row.getByRole('button', { name: /^Update$/ })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Cards view' }).click();
+    const card = page.locator('[data-test="dd-card"]').filter({ hasText: 'Immich ML (Pinned)' });
+    await expect(card).toBeVisible();
+    await expect(card).toContainText(/v2\.7\.5-openvino\s*→\s*v3\.0\.2-openvino/);
+    await expect(card.locator('[data-test="container-card-update-state"]')).toHaveText('Pinned');
+    await expect(card.locator('[data-test="update-insight-kind-badge"]')).toHaveText('Major');
+    await expect(card.getByRole('button', { name: /^Update$/ })).toHaveCount(0);
+  });
+});

--- a/test/qa-compose.yml
+++ b/test/qa-compose.yml
@@ -94,8 +94,37 @@ services:
     depends_on:
       docker-remote:
         condition: service_healthy
+      health-transition:
+        condition: service_healthy
       mosquitto:
         condition: service_healthy
+
+  # Deterministic health-only transition fixture for Discussion #198 browser UAT.
+  # The CGI endpoints toggle only the healthcheck marker; the container process,
+  # identity, labels, and image stay unchanged so the observed event is health-only.
+  health-transition:
+    image: mirror.gcr.io/library/busybox:1.36
+    pull_policy: missing
+    container_name: drydock-playwright-health-transition
+    ports:
+      - "127.0.0.1:${DD_PLAYWRIGHT_HEALTH_FIXTURE_PORT:-3334}:8080"
+    labels:
+      - dd.watch=true
+      - dd.display.name=Health Transition Fixture
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        mkdir -p /state /www/cgi-bin
+        printf '%s\n' '#!/bin/sh' 'rm -f /state/unhealthy' 'printf "Content-Type: text/plain\r\n\r\nhealthy\n"' > /www/cgi-bin/healthy
+        printf '%s\n' '#!/bin/sh' 'touch /state/unhealthy' 'printf "Content-Type: text/plain\r\n\r\nunhealthy\n"' > /www/cgi-bin/unhealthy
+        chmod +x /www/cgi-bin/healthy /www/cgi-bin/unhealthy
+        exec httpd -f -p 8080 -h /www
+    healthcheck:
+      test: ["CMD-SHELL", "test ! -f /state/unhealthy"]
+      interval: 1s
+      timeout: 1s
+      retries: 1
+      start_period: 1s
 
   # ── OIDC Identity Provider (Dex) ─────────────────────
   dex:


### PR DESCRIPTION
## Summary

Adds focused real-browser release UAT for the remaining v1.6 promises without changing production runtime code.

- #198: drives a real Docker health-only transition from healthy to unhealthy, verifies the SSE event, the notification-bell audit refetch, and the visible audit row
- #220: verifies live preference convergence between two independent authenticated browser contexts
- #325: verifies persisted global `notify | manual | auto` mode and the Update Status panel states
- #406: uses a deterministic browser clock to verify maturity countdown, exact ETA, and manual override
- #498: verifies `v2.7.5-openvino → v3.0.2-openvino` renders as informational Pinned/Major in table and cards with no Update action

The QA Compose fixture adds one deterministic BusyBox health-transition container used only by the scoped UAT.

## Verification

- health/preferences Playwright: 3/3 passed
- modes/status/pinned-tag Playwright: 4/4 passed
- focused UI/backend suites passed
- Docker Compose configuration validation passed
- complete pre-push gate passed on `76af0b1b`:
  - clean-tree and `@ts-nocheck` guards
  - Biome and accepted Qlty baseline
  - 83 maintenance-script tests
  - 31 workflow tests
  - UI typecheck and 37 website script tests
  - backend/UI 100% coverage
  - backend/UI builds
  - zizmor

No production-code fix was required by these browser checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added Playwright v16 health UAT covering container `healthy→unhealthy` transitions, SSE `dd:container-unhealthy` delivery, notification-audit refetch, and visible audit row rendering.
- ✨ Added Playwright v16 UAT for v1.6 update modes: request interception, persistent mode behavior (including reload), stabilization countdown/ETAs, manual override enablement via deterministic clock, and pinned “current-to-newer” rendering (table + card).
- ✨ Added informational rendering for `v2.7.5-openvino → v3.0.2-openvino` (major badge) while ensuring pinned items do not show an Update action.
- ✨ Added deterministic BusyBox `health-transition` container/fixture to QA Compose, with health transitions driven by marker-file state.
- 🔧 Added browser preference convergence coverage across independent authenticated contexts (via cookies + `dd-preferences` polling/localStorage) and hardened waits/controls for the above scenarios.

## Concerns

- Tests depend on Docker Compose + QA Compose environment configuration (including health-fixture URL/port env inputs).
- Ensure SSE probe teardown, fixture reset, and preference/bell restoration are reliable even on failed assertions to avoid cross-test contamination.
- Verify Compose `depends_on`/health gating timing doesn’t introduce flakiness in CI under slower startup conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->