### PR TITLE
🐛 fix(docker): update Alpine tzdata pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache \
     openssl=3.5.7-r0 \
     su-exec=0.3-r0 \
     tini=0.19.0-r3 \
-    tzdata=2026b-r0 \
+    tzdata=2026c-r0 \
     && apk add --no-cache cosign=3.0.6-r1 \
     && apk upgrade --no-cache zlib libcrypto3 libssl3 libexpat \
     && mkdir /store && chown node:node /store

--- a/app/configuration/dockerfile-defaults.test.ts
+++ b/app/configuration/dockerfile-defaults.test.ts
@@ -17,4 +17,11 @@ describe('Dockerfile release defaults', () => {
     expect(dockerfile).not.toContain('alpine/edge/testing');
     expect(dockerfile).not.toMatch(/apk add[^\n]*trivy/u);
   });
+
+  test('release image pins the available Alpine tzdata revision', () => {
+    const dockerfile = fs.readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
+
+    expect(dockerfile).toContain('tzdata=2026c-r0');
+    expect(dockerfile).not.toContain('tzdata=2026b-r0');
+  });
 });


### PR DESCRIPTION
## Summary

- updates the Alpine tzdata pin from 2026b-r0 to the currently available 2026c-r0
- adds a regression that rejects the retired revision
- restores the release-container build that blocked PR #522 Playwright before tests could start

## Verification

- regression failed against the old pin and passes with the fix
- complete release image builds locally with fresh pulls
- full pre-push gate passes: 100 maintenance tests, 31 workflow tests, 37 website-script tests, 100 percent backend/UI coverage, app/UI builds, Biome, accepted Qlty baseline, and Zizmor

After this merges, PR #522 will be rebuilt from the new accepted dev/v1.6 tree and its complete matrix restarted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changelog

- 🔧 Changed Alpine `tzdata` pin from `2026b-r0` to `2026c-r0`.
- ✨ Added regression coverage rejecting the retired `2026b-r0` revision.
- 🐛 Fixed release-container build configuration.

### Verification

- Regression tests passed.
- Release-image build passed.
- Full pre-push checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->