### PR TITLE
🔒 security(grype): track bundled Trivy path

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,19 +10,19 @@
 # Why: those CVEs (golang.org/x/crypto, x/net, Go stdlib, …) live inside upstream
 # tool binaries, not drydock's own code, and reach the binary only as cosign's /
 # trivy's vendored modules. We cannot patch them independently — they clear only
-# when Alpine rebuilds the cosign/trivy packages with a patched toolchain, which
-# we pick up by bumping the base image / package pins (the cosign 2.6.3-r1 ->
-# 3.0.6-r1 bump in this change already cleared the bulk of them). Gating the build
+# when upstream releases a rebuilt Trivy image or Alpine rebuilds Cosign, which we
+# pick up by bumping the pinned Trivy image index or Alpine package (the cosign
+# 2.6.3-r1 -> 3.0.6-r1 bump already cleared the bulk of them). Gating the build
 # on a module graph we don't control is the same manifest-vs-shipped mismatch we
 # dropped Snyk over. The Node runtime, musl, curl, git, every other OS package,
 # and the entire app dependency graph stay fully gated — confirmed by the scan,
 # which after the base bump leaves residual HIGH/CRITICAL findings only at these
 # two binary locations.
 #
-# Revisit on each base-image bump: if Alpine ships rebuilt cosign/trivy packages,
-# the residuals clear on their own and these scopes simply stop matching anything.
+# Revisit on each pinned-tool or base-image bump: fixed upstream binaries make
+# these scopes stop matching anything.
 ignore:
   - package:
       location: "/usr/bin/cosign"
   - package:
-      location: "/usr/bin/trivy"
+      location: "/usr/local/bin/trivy"

--- a/scripts/grype-policy.test.mjs
+++ b/scripts/grype-policy.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const dockerfile = readFileSync(path.join(repositoryRoot, 'Dockerfile'), 'utf8');
+const grypeConfig = readFileSync(path.join(repositoryRoot, '.grype.yaml'), 'utf8');
+
+test('Grype policy follows the bundled Trivy binary destination', () => {
+  const copyMatch = dockerfile.match(
+    /^COPY --from=trivy-bin \/usr\/local\/bin\/trivy (?<destination>\S+)$/mu,
+  );
+
+  assert.ok(copyMatch?.groups?.destination, 'Dockerfile must copy the pinned Trivy binary');
+  assert.match(
+    grypeConfig,
+    new RegExp(`^\\s+location: "${copyMatch.groups.destination.replaceAll('/', '\\/')}"$`, 'mu'),
+  );
+});


### PR DESCRIPTION
## Summary

- align the Grype policy with the bundled Trivy destination in the Dockerfile
- retain high/critical gating for Drydock, Node, and OS packages while excluding the intentionally separately-pinned upstream scanner module graph
- add a regression test that fails whenever the Dockerfile destination and policy path drift apart

## Why

The final v1.6 matrix exposed two high findings inside the latest pinned Trivy 0.72.0 binary. The policy already excludes vendored Go module graphs for independently pinned Cosign and Trivy, but the Trivy path still referenced its old Alpine package location. v1.6 copies the upstream binary to /usr/local/bin/trivy, so the intended exclusion no longer matched.

One upstream ORAS advisory currently has no patched release, and the latest Trivy still bundles the affected dependency. After this path correction, an exact local Grype scan of the RC candidate reports zero high/critical findings outside the intended third-party tool exclusion.

## Verification

- node --test scripts/grype-policy.test.mjs
- node --test scripts/*.test.mjs (101/101)
- complete pre-push gate (338.9s)
- app/UI coverage: 100%
- workflow tests: 31/31
- website script tests: 37/37
- app/UI builds: pass
- Biome and accepted Qlty baseline: pass
- Zizmor: zero findings
- exact candidate Grype scan after policy correction: 0 high/critical matches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
✨ **Added**
- Added `scripts/grype-policy.test.mjs` regression test that extracts the `COPY --from=trivy-bin /usr/local/bin/trivy <destination>` path from the `Dockerfile` and asserts `.grype.yaml` contains an exact matching `location: "<destination>"` entry.

🔧 **Changed**
- Updated `.grype.yaml` Grype ignore location for the bundled Trivy binary from `/usr/bin/trivy` to `/usr/local/bin/trivy`.
- Updated `.grype.yaml` gating/triage documentation and “revisit” guidance to reflect that scan-matching scopes can change when the pinned Trivy image (or related upstream/base components like Cosign/Alpine packages) are bumped, while continuing to ignore only the independently pinned `cosign` binary at `/usr/bin/cosign`.

🔒 **Security**
- Ensures the policy continues gating HIGH/CRITICAL vulnerabilities for Drydock, Node, and OS packages while preventing vulnerabilities associated with the independently bundled Trivy module graph from bypassing intended exclusions—covering cases like unpatched upstream advisories.

- Test may fail if the `Dockerfile`’s Trivy copy line format changes (e.g., extra whitespace, different destination formatting, or additional `COPY` lines).
- Policy enforcement depends on `.grype.yaml` using an exact `location` match for the extracted destination string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->