### PR TITLE
🐛 fix(auth): preserve public rate-limit budget

### DIFF
--- a/app/api/auth.test.ts
+++ b/app/api/auth.test.ts
@@ -3457,6 +3457,27 @@ describe('Auth Router', () => {
       );
     });
 
+    test('authLimiter preserves the public auth budget for authenticated sessions', () => {
+      const app = createApp();
+      auth.init(app);
+
+      const limiterOptions = mockRateLimit.mock.calls[0][0];
+      expect(limiterOptions.skip).toEqual(expect.any(Function));
+      const authenticated = vi.fn(() => true);
+      expect(
+        limiterOptions.skip({ method: 'GET', path: '/user', isAuthenticated: authenticated }),
+      ).toBe(true);
+
+      for (const request of [
+        { method: 'GET', path: '/api/v1/auth/status', isAuthenticated: authenticated },
+        { method: 'POST', path: '/login', isAuthenticated: authenticated },
+        { method: 'GET', path: '/user', isAuthenticated: vi.fn(() => false) },
+        {},
+      ]) {
+        expect(limiterOptions.skip(request)).toBe(false);
+      }
+    });
+
     test('authLimiter standardHeaders is true', () => {
       // Line 379: BooleanLiteral false mutant
       const app = createApp();

--- a/app/api/auth.ts
+++ b/app/api/auth.ts
@@ -412,6 +412,14 @@ export function init(app: Application): void {
   const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 100,
+    // Authenticated UI navigations re-read the current user. Keep that safe
+    // probe from exhausting the public discovery and login budget for clients
+    // behind the same address; every other auth route remains capped.
+    skip: (req: Request) =>
+      req.method === 'GET' &&
+      req.path === '/user' &&
+      typeof req.isAuthenticated === 'function' &&
+      req.isAuthenticated(),
     standardHeaders: true,
     legacyHeaders: false,
     validate: { xForwardedForHeader: false },


### PR DESCRIPTION
## Summary
- exempt only authenticated GET /auth/user session checks from the shared public auth limiter
- keep unauthenticated user checks, status discovery, login, remember, logout, and mutations rate-limited
- add predicate-level regression coverage for every preserved boundary

## Why
The v1.6 Playwright run exhausted the shared 100-request auth budget through repeated authenticated navigation checks. The next auth/user and auth/status reads returned 429 even though the backend remained healthy, causing five late-suite failures.

## Validation
- full local pre-push gate passed at exact head
- 163 focused auth tests passed
- 101 maintenance tests and 31 workflow tests passed
- 100% backend and UI coverage passed
- app/UI builds, UI typecheck, Biome, Qlty baseline, and Zizmor passed

The unchanged full Playwright suite will provide the integration proof after this lands in the rebuilt one-commit release PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed rate limiting to exempt only authenticated `GET /auth/user` session checks.
- 🔒 Preserved rate limits for unauthenticated checks, status discovery, login, remember, logout, and mutations.
- ✨ Added predicate-level regression coverage for all rate-limit boundaries.
- 🐛 Fixed authenticated navigation checks exhausting the shared 100-request budget and triggering `429` responses.

## Concerns

- Verify focused auth, maintenance, workflow, backend, UI, build, type-check, formatting, Qlty, and Zizmor validations pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->