### PR TITLE
🐛 fix(ci): version first-party API clients

### DIFF
--- a/scripts/e2e-readiness-endpoints.test.mjs
+++ b/scripts/e2e-readiness-endpoints.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const readScript = (name) => readFile(new URL(name, import.meta.url), 'utf8');
+const readRepositoryFile = (name) => readFile(new URL(`../${name}`, import.meta.url), 'utf8');
+
+const operationalClients = [
+  ['scripts/start-drydock.sh', () => readScript('start-drydock.sh')],
+  ['scripts/run-load-test.sh', () => readScript('run-load-test.sh')],
+  ['test/test.yml', () => readRepositoryFile('test/test.yml')],
+  ['test/test-behavior.yml', () => readRepositoryFile('test/test-behavior.yml')],
+  ['test/load-test.processor.cjs', () => readRepositoryFile('test/load-test.processor.cjs')],
+];
+
+test('first-party test clients use only the versioned operational API', async () => {
+  const staleEndpoints = [];
+
+  for (const [name, read] of operationalClients) {
+    const source = await read();
+    for (const [index, line] of source.split('\n').entries()) {
+      if (/\/api\/(?!v1(?:\/|[?"'`\s]|$))/u.test(line)) {
+        staleEndpoints.push(`${name}:${index + 1}: ${line.trim()}`);
+      }
+    }
+  }
+
+  assert.deepEqual(staleEndpoints, []);
+});
+
+test('readiness probes poll the canonical container collection', async () => {
+  for (const scriptName of ['start-drydock.sh', 'run-load-test.sh']) {
+    const source = await readScript(scriptName);
+
+    assert.match(source, /curl[^\n]*\/api\/v1\/containers/u);
+  }
+});
+
+test('behavior profile captures collection envelopes and patches notifications', async () => {
+  const source = await readRepositoryFile('test/test-behavior.yml');
+
+  assert.equal(source.match(/json: "\$\.data\[0\]\.id"/gu)?.length, 3);
+  assert.doesNotMatch(source, /json: "\$\[0\]\.id"/u);
+  assert.match(
+    source,
+    /- patch:\n\s+url: "\/api\/v1\/notifications\/\{\{ notificationRuleId \}\}"/u,
+  );
+});
+
+test('agent log probe unwraps the canonical collection envelope', async () => {
+  const source = await readRepositoryFile('test/load-test.processor.cjs');
+
+  assert.match(source, /Array\.isArray\(agentsResponse\.body\?\.data\)/u);
+});

--- a/scripts/run-load-test.sh
+++ b/scripts/run-load-test.sh
@@ -143,7 +143,7 @@ AUTH_HEADER="Basic $(echo -n 'admin:password' | base64)"
 echo "Waiting for drydock to discover watched containers..."
 for _ in $(seq 1 15); do
 	CONTAINERS_JSON=""
-	if CONTAINERS_JSON=$(curl -sf -H "Authorization: ${AUTH_HEADER}" "${DD_LOAD_TEST_TARGET}/api/containers" 2>/dev/null); then
+	if CONTAINERS_JSON=$(curl -sf -H "Authorization: ${AUTH_HEADER}" "${DD_LOAD_TEST_TARGET}/api/v1/containers" 2>/dev/null); then
 		:
 	fi
 	COUNT=0

--- a/scripts/setup-test-containers.sh
+++ b/scripts/setup-test-containers.sh
@@ -75,7 +75,7 @@ run_test_container hub_homeassistant_202161 \
 	-f /dev/null
 # Keep-alive entrypoint: drydock only reads the image reference for metadata; the
 # real home-assistant app crashes in CI (needs a valid /config) and drydock lists
-# only running containers, so an exited fixture vanishes from /api/containers.
+# only running containers, so an exited fixture vanishes from /api/v1/containers.
 run_test_container hub_homeassistant_latest --label "$LABEL_WATCH" --label 'dd.watch.digest=true' --label 'dd.tag.include=^latest$' --entrypoint tail homeassistant/home-assistant -f /dev/null
 run_test_container hub_nginx_120 --label "$LABEL_WATCH" --label 'dd.tag.include=^\d+\.\d+-alpine$' nginx:1.20-alpine
 run_test_container hub_nginx_latest --label "$LABEL_WATCH" --label 'dd.watch.digest=true' --label 'dd.tag.include=^latest$' nginx

--- a/scripts/start-drydock.sh
+++ b/scripts/start-drydock.sh
@@ -164,7 +164,7 @@ echo "Waiting for drydock to discover ${EXPECTED_CONTAINERS}+ containers with im
 for i in $(seq 1 75); do
 	# Count containers that have a populated image.name (not just discovered)
 	CONTAINERS_JSON=""
-	if CONTAINERS_JSON=$(curl -sf -H "Authorization: ${AUTH_HEADER}" "http://localhost:${E2E_PORT}/api/containers" 2>/dev/null); then
+	if CONTAINERS_JSON=$(curl -sf -H "Authorization: ${AUTH_HEADER}" "http://localhost:${E2E_PORT}/api/v1/containers" 2>/dev/null); then
 		:
 	fi
 	READY=0

--- a/test/load-test.processor.cjs
+++ b/test/load-test.processor.cjs
@@ -60,7 +60,7 @@ async function requestJson(pathname, options = {}) {
 
 function openSseConnection(timeoutMs = 5000) {
   return new Promise((resolve, reject) => {
-    const targetUrl = new URL('/api/events/ui', getLoadTestTarget());
+    const targetUrl = new URL('/api/v1/events/ui', getLoadTestTarget());
     const transport = targetUrl.protocol === 'https:' ? https : http;
     let settled = false;
 
@@ -144,12 +144,12 @@ async function probeSseReconnect() {
 }
 
 async function probeConnectedAgentLogs() {
-  const agentsResponse = await requestJson('/api/agents');
+  const agentsResponse = await requestJson('/api/v1/agents');
   if (agentsResponse.status !== 200) {
     throw new Error(`Failed to list agents (status ${agentsResponse.status})`);
   }
 
-  const agents = Array.isArray(agentsResponse.body) ? agentsResponse.body : [];
+  const agents = Array.isArray(agentsResponse.body?.data) ? agentsResponse.body.data : [];
   const connectedAgent = agents.find(
     (agent) => agent && agent.connected === true && typeof agent.name === 'string',
   );
@@ -160,7 +160,7 @@ async function probeConnectedAgentLogs() {
   }
 
   const logsResponse = await requestJson(
-    `/api/agents/${encodeURIComponent(connectedAgent.name)}/log/entries?tail=100`,
+    `/api/v1/agents/${encodeURIComponent(connectedAgent.name)}/log/entries?tail=100`,
   );
   if (logsResponse.status !== 200) {
     throw new Error(`Expected 200 from connected agent log endpoint, got ${logsResponse.status}`);

--- a/test/test-behavior.yml
+++ b/test/test-behavior.yml
@@ -65,12 +65,12 @@ scenarios:
     weight: 15
     flow:
       - get:
-          url: "/api/containers"
+          url: "/api/v1/containers"
           expect:
             - statusCode: 200
       - think: 1
       - get:
-          url: "/api/containers/__missing__/logs?tail=100"
+          url: "/api/v1/containers/__missing__/logs?tail=100"
           expect:
             - statusCode: 404
 
@@ -78,14 +78,14 @@ scenarios:
     weight: 20
     flow:
       - post:
-          url: "/api/containers/watch"
+          url: "/api/v1/containers/watch"
           expect:
             - statusCode: 200
           capture:
-            - json: "$[0].id"
+            - json: "$.data[0].id"
               as: "containerId"
       - get:
-          url: "/api/containers/{{ containerId }}/logs?tail=100&since=0&timestamps=false"
+          url: "/api/v1/containers/{{ containerId }}/logs?tail=100&since=0&timestamps=false"
           expect:
             - statusCode: 200
 
@@ -93,12 +93,12 @@ scenarios:
     weight: 15
     flow:
       - get:
-          url: "/api/agents"
+          url: "/api/v1/agents"
           expect:
             - statusCode: 200
       - think: 1
       - get:
-          url: "/api/agents/__missing__/log/entries?tail=100"
+          url: "/api/v1/agents/__missing__/log/entries?tail=100"
           expect:
             - statusCode: 404
 
@@ -111,27 +111,27 @@ scenarios:
     weight: 10
     flow:
       - post:
-          url: "/api/containers/watch"
+          url: "/api/v1/containers/watch"
           expect:
             - statusCode: 200
           capture:
-            - json: "$[0].id"
+            - json: "$.data[0].id"
               as: "containerId"
       - patch:
-          url: "/api/containers/{{ containerId }}/update-policy"
+          url: "/api/v1/containers/{{ containerId }}/update-policy"
           json:
             action: "clear"
           expect:
             - statusCode: 200
       - get:
-          url: "/api/notifications"
+          url: "/api/v1/notifications"
           expect:
             - statusCode: 200
           capture:
-            - json: "$[0].id"
+            - json: "$.data[0].id"
               as: "notificationRuleId"
-      - put:
-          url: "/api/notifications/{{ notificationRuleId }}"
+      - patch:
+          url: "/api/v1/notifications/{{ notificationRuleId }}"
           json:
             enabled: true
           expect:

--- a/test/test.yml
+++ b/test/test.yml
@@ -57,7 +57,7 @@ scenarios:
     weight: 10
     flow:
       - get:
-          url: "/api/app"
+          url: "/api/v1/app"
           expect:
             - statusCode: 200
 
@@ -65,12 +65,12 @@ scenarios:
     weight: 10
     flow:
       - get:
-          url: "/api/containers"
+          url: "/api/v1/containers"
           expect:
             - statusCode: 200
       - think: 1
       - get:
-          url: "/api/settings"
+          url: "/api/v1/settings"
           expect:
             - statusCode: 200
 
@@ -78,12 +78,12 @@ scenarios:
     weight: 8
     flow:
       - get:
-          url: "/api/watchers"
+          url: "/api/v1/watchers"
           expect:
             - statusCode: 200
       - think: 1
       - get:
-          url: "/api/triggers"
+          url: "/api/v1/triggers"
           expect:
             - statusCode: 200
 
@@ -91,12 +91,12 @@ scenarios:
     weight: 10
     flow:
       - get:
-          url: "/api/registries"
+          url: "/api/v1/registries"
           expect:
             - statusCode: 200
       - think: 1
       - get:
-          url: "/api/server"
+          url: "/api/v1/server"
           expect:
             - statusCode: 200
 
@@ -104,12 +104,12 @@ scenarios:
     weight: 8
     flow:
       - get:
-          url: "/api/app"
+          url: "/api/v1/app"
           expect:
             - statusCode: 200
       - think: 1
       - get:
-          url: "/api/containers"
+          url: "/api/v1/containers"
           expect:
             - statusCode: 200
 
@@ -117,11 +117,11 @@ scenarios:
     weight: 10
     flow:
       - get:
-          url: "/api/log/entries?tail=200"
+          url: "/api/v1/log/entries?tail=200"
           expect:
             - statusCode: 200
       - think: 1
       - get:
-          url: "/api/log/entries?level=info&tail=100&since=0"
+          url: "/api/v1/log/entries?level=info&tail=100&since=0"
           expect:
             - statusCode: 200


### PR DESCRIPTION
## Summary
- poll the canonical /api/v1 container collection during Cucumber and load-test startup
- migrate both Artillery profiles and their processor to the versioned API
- unwrap canonical collection envelopes and use PATCH for notification updates
- add a repository guard that rejects future unversioned operational test clients

## Why
The release PR Cucumber job reported 0/8 ready containers even though backend logs showed all eight were processed. The readiness script was polling the intentionally tombstoned /api/containers alias, receiving 410, and discarding the response through curl -f. The push-only load profiles contained the same migration gap.

## Validation
- full local pre-push gate passed at exact head
- 105 maintenance tests and 31 workflow tests passed
- new API-client guard covers five operational files
- both Artillery YAML profiles parse successfully
- 100% backend and UI coverage passed
- app/UI builds, UI typecheck, Biome, Qlty baseline, and Zizmor passed

The rebuilt one-commit v1.6 release PR will rerun the unchanged Cucumber and load-test jobs for integration proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added guard tests preventing unversioned operational API clients.
- 🔧 Changed Cucumber and Artillery/load-test clients to use `/api/v1` endpoints.
- 🔧 Changed collection parsing to unwrap canonical `data` envelopes.
- 🔧 Changed notification rule updates from `PUT` to `PATCH`.
- 🐛 Fixed readiness polling receiving `410` responses from the tombstoned `/api/containers` alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->