### PR TITLE
🐛 fix(api): avoid double-limiting icon reads

### DIFF
--- a/app/api/api.test.ts
+++ b/app/api/api.test.ts
@@ -475,6 +475,50 @@ describe('API Router', () => {
     );
   });
 
+  test('should exempt only valid icon reads from the outer API rate limiter', async () => {
+    const limiterOptions = mockRateLimit.mock.calls[0]?.[0];
+    expect(limiterOptions).toBeDefined();
+    expect(typeof limiterOptions.skip).toBe('function');
+
+    const authenticated = { isAuthenticated: () => true };
+    const unauthenticated = { isAuthenticated: () => false };
+
+    expect(
+      await limiterOptions.skip({ ...authenticated, method: 'GET', path: '/icons/selfhst/docker' }),
+    ).toBe(true);
+    expect(
+      await limiterOptions.skip({
+        ...authenticated,
+        method: 'HEAD',
+        path: '/icons/selfhst/docker/',
+      }),
+    ).toBe(true);
+    expect(
+      await limiterOptions.skip({
+        ...unauthenticated,
+        method: 'GET',
+        path: '/icons/selfhst/docker',
+      }),
+    ).toBe(false);
+    expect(await limiterOptions.skip({ method: 'GET', path: '/icons/selfhst/docker' })).toBe(false);
+    expect(
+      await limiterOptions.skip({ ...authenticated, method: 'DELETE', path: '/icons/cache' }),
+    ).toBe(false);
+    expect(
+      await limiterOptions.skip({ ...authenticated, method: 'GET', path: '/containers' }),
+    ).toBe(false);
+    expect(
+      await limiterOptions.skip({
+        ...authenticated,
+        method: 'GET',
+        path: '/icons/selfhst/docker/extra',
+      }),
+    ).toBe(false);
+    expect(await limiterOptions.skip({ ...authenticated, method: 'GET', path: '/icons' })).toBe(
+      false,
+    );
+  });
+
   test('should mount only /portwing router when DD_EXPERIMENTAL_PORTWING is enabled', async () => {
     mockGetExperimentalPortwingEnabled.mockReturnValue(true);
 

--- a/app/api/api.ts
+++ b/app/api/api.ts
@@ -14,6 +14,7 @@ import { requireSameOriginForMutations } from './csrf.js';
 import * as debugRouter from './debug.js';
 import { sendErrorResponse } from './error-response.js';
 import * as groupRouter from './group.js';
+import { isIconProxyApiPath } from './icons/route.js';
 import * as iconsRouter from './icons.js';
 import * as internalSelfUpdateRouter from './internal-self-update.js';
 import { requireJsonContentTypeForMutations, shouldParseJsonBody } from './json-content-type.js';
@@ -41,6 +42,13 @@ import * as watcherRouter from './watcher.js';
 import * as webhookRouter from './webhook.js';
 import * as webhooksRouter from './webhooks.js';
 
+function shouldSkipOuterApiRateLimit(req: Request): boolean {
+  const isSafeRead = req.method === 'GET' || req.method === 'HEAD';
+  const isAuthenticated =
+    typeof req.isAuthenticated === 'function' && req.isAuthenticated() === true;
+  return isAuthenticated && isSafeRead && isIconProxyApiPath(req.path);
+}
+
 /**
  * Init the API router.
  * @returns {*|Router}
@@ -55,6 +63,11 @@ export function init(): express.Router {
   const apiLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 1000,
+    // Icon reads have their own stricter limiter in icons.ts. Do not charge
+    // those immutable assets against this outer API budget as well; Playwright
+    // routing and cache-disabled clients otherwise exhaust it while the
+    // dedicated icon limiter is still providing endpoint-specific protection.
+    skip: shouldSkipOuterApiRateLimit,
     standardHeaders: true,
     legacyHeaders: false,
     validate: { xForwardedForHeader: false },

--- a/app/api/icons.ts
+++ b/app/api/icons.ts
@@ -14,6 +14,7 @@ import {
   sendMissingIconResponse,
   shouldServeImageFallback,
 } from './icons/response.js';
+import { ICON_PROXY_ROUTE_PATH } from './icons/route.js';
 import {
   ICON_PROXY_RATE_LIMIT_MAX,
   ICON_PROXY_RATE_LIMIT_WINDOW_MS,
@@ -138,7 +139,7 @@ export function init() {
       ? { keyGenerator: identityAwareRateLimitKeyGenerator }
       : {}),
   });
-  router.get('/:provider/:slug', iconProxyRateLimiter, getIcon);
+  router.get(ICON_PROXY_ROUTE_PATH, iconProxyRateLimiter, getIcon);
   router.delete('/cache', clearCache);
   return router;
 }

--- a/app/api/icons/route.test.ts
+++ b/app/api/icons/route.test.ts
@@ -1,0 +1,20 @@
+import { ICON_PROXY_ROUTE_PATH, isIconProxyApiPath } from './route.js';
+
+describe('icon proxy route contract', () => {
+  test('defines the router path from the provider and slug segments', () => {
+    expect(ICON_PROXY_ROUTE_PATH).toBe('/:provider/:slug');
+  });
+
+  test.each([
+    ['/icons/selfhst/docker', true],
+    ['/icons/selfhst/docker/', true],
+    ['/icons', false],
+    ['/icons/selfhst', false],
+    ['/icons/selfhst/docker/extra', false],
+    ['x/icons/selfhst/docker', false],
+    ['/other/selfhst/docker', false],
+    ['/icons//docker', false],
+  ])('matches %s consistently with the mounted API route', (path, expected) => {
+    expect(isIconProxyApiPath(path)).toBe(expected);
+  });
+});

--- a/app/api/icons/route.ts
+++ b/app/api/icons/route.ts
@@ -1,0 +1,16 @@
+const ICON_PROXY_API_PREFIX = 'icons';
+const ICON_PROXY_ROUTE_SEGMENTS = ['provider', 'slug'] as const;
+
+export const ICON_PROXY_ROUTE_PATH = `/${ICON_PROXY_ROUTE_SEGMENTS.map((segment) => `:${segment}`).join('/')}`;
+
+export function isIconProxyApiPath(path: string): boolean {
+  const normalizedPath = path.endsWith('/') ? path.slice(0, -1) : path;
+  const segments = normalizedPath.split('/');
+
+  return (
+    segments.length === ICON_PROXY_ROUTE_SEGMENTS.length + 2 &&
+    segments[0] === '' &&
+    segments[1] === ICON_PROXY_API_PREFIX &&
+    segments.slice(2).every((segment) => segment.length > 0)
+  );
+}


### PR DESCRIPTION
## Summary

- exclude only authenticated `GET`/`HEAD /icons/:provider/:slug` reads from the outer `/api/v1` limiter
- keep unauthenticated/auth-failed traffic, data APIs, mutations, cache deletion, and malformed/deeper icon paths on the outer `1000/15 minutes` budget
- keep the dedicated icon-proxy limiter (`100/minute`) authoritative for authenticated immutable asset reads
- share and test the icon route contract used by both the outer skip predicate and the mounted icon router

## Root cause

The release PR's serial Playwright run exhausted the outer API budget after about 118 seconds. Playwright request routing disables the browser HTTP cache, so immutable icon requests were repeatedly fetched and charged by both the outer API limiter and the icon endpoint's own stricter limiter. Once the outer bucket reached zero, the final container collection reads returned 429 and the mobile fixture interceptor failed while parsing the plain-text rate-limit response.

## Verification

- focused TDD: 29 tests across `app/api/api.test.ts` and `app/api/icons/route.test.ts`
- unauthenticated and auth-failed icon reads remain globally rate-limited
- production TypeScript build
- Biome and Qlty focused checks
- unchanged local Playwright QA suite: 28 passed, 2 intentional skips (including both late mobile tests)
- full exact-head pre-push gate: 105 maintenance tests, 31 workflow tests, UI typecheck, 100% app/UI coverage, app/UI builds, Biome, Qlty, and Zizmor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added predicate-level regression tests covering the outer rate-limit `skip` boundary for authenticated icon proxy reads (GET/HEAD, including trailing-slash variants).
- 🔧 Updated outer `/api/v1` rate limiting to skip only authenticated `GET`/`HEAD` requests whose `req.path` matches the immutable `GET|HEAD /icons/:provider/:slug` icon-proxy pattern.
- 🔒 Ensured icon-proxy asset requests remain governed by the dedicated 100 requests/min limiter, while other request types still count against the outer budget.
- 🐛 Preserved outer limiting for non-icon APIs (e.g., data/mutations/cache deletion), unauthenticated icon requests, malformed paths, and deeper icon routes.

## Concerns / issues to address

- Verify the authentication check used by `shouldSkipOuterApiRateLimit(req)` matches the actual auth/user property available to the rate-limit middleware in all runtime modes.
- Confirm `isIconProxyApiPath()` path normalization (trailing slashes + segment parsing) matches what Express populates in `req.path` for all icon-proxy URL variants.
- Check whether route mounting changes (`ICON_PROXY_ROUTE_PATH`) impact any non-tested routing edge cases (e.g., unusual provider/slug characters or URL encoding).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->