### PR TITLE
🐛 fix(ci): pin Cucumber browser runtime

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -6,6 +6,7 @@ import yaml from 'yaml';
 import { expectedActionUse } from './github-action-pins';
 
 interface WorkflowJob {
+  env?: Record<string, string>;
   name?: string;
   steps?: WorkflowJobStep[];
   'timeout-minutes'?: number;
@@ -19,6 +20,7 @@ interface WorkflowJobStep {
   run?: string;
   if?: string;
   uses?: string;
+  'working-directory'?: string;
   env?: Record<string, string>;
   with?: Record<string, string>;
   'continue-on-error'?: boolean;
@@ -104,11 +106,13 @@ test('workflow tests are wired outside the app coverage suite', () => {
   });
 });
 
-test('ci-verify skips Playwright browser downloads on load-test jobs but not cucumber', () => {
+test('ci-verify runs Cucumber in the pinned Playwright browser image', () => {
   const workflow = loadWorkflow();
+  const playwrightImage =
+    'mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48';
 
-  // Workflow-level skip would break the cucumber job, which actually launches
-  // a browser via @playwright/test. Scope the skip to load-test jobs only.
+  // Keep host-side installs from downloading a browser. The Cucumber browser
+  // comes from the same immutable image used by the dedicated Playwright gate.
   expect(workflow.env?.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD).toBeUndefined();
 
   for (const jobId of ['load-test-ci', 'load-test-behavior']) {
@@ -116,11 +120,41 @@ test('ci-verify skips Playwright browser downloads on load-test jobs but not cuc
     expect(getWorkflowStep(jobId, 'Install e2e dependencies')).toBeDefined();
   }
 
-  // Cucumber needs the browser, so it must not inherit the skip, and it gets
-  // a cache step so the postinstall fetch survives CDN throttling.
-  expect(workflow.jobs?.e2e?.env?.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD).toBeUndefined();
-  expect(getWorkflowStep('e2e', 'Cache Playwright browsers')).toBeDefined();
-  expect(getWorkflowStep('e2e', 'Install e2e dependencies')).toBeDefined();
+  expect(workflow.jobs?.e2e?.env).toMatchObject({
+    PLAYWRIGHT_IMAGE: playwrightImage,
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1',
+  });
+  expect(getWorkflowStep('e2e', 'Cache Playwright browsers')).toBeUndefined();
+  expect(getWorkflowStep('e2e', 'Install e2e dependencies')).toBeUndefined();
+
+  const verifyImage = getWorkflowStep('e2e', 'Verify Playwright image matches package')?.run;
+  expect(verifyImage).toContain(
+    "require('./e2e/package.json').devDependencies['@playwright/test']",
+  );
+  expect(verifyImage).toContain('PLAYWRIGHT_IMAGE uses $image_version');
+
+  expect(getWorkflowStep('e2e', 'Pull Playwright container')).toMatchObject({
+    with: {
+      command: 'docker pull "$PLAYWRIGHT_IMAGE"',
+    },
+  });
+
+  const cucumber = getWorkflowStep('e2e', 'Run Cucumber e2e tests');
+  expect(cucumber?.['working-directory']).toBeUndefined();
+  expect(cucumber?.run).toContain('docker run --rm');
+  expect(cucumber?.run).toContain('--network host');
+  expect(cucumber?.run).toContain('--user 1001:1001');
+  expect(cucumber?.run).toContain('-e PLAYWRIGHT_BROWSERS_PATH=/ms-playwright');
+  expect(cucumber?.run).toContain('-e PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD');
+  expect(cucumber?.run).not.toContain('PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1');
+  expect(cucumber?.env?.DD_PORT).toBe('${{ steps.drydock.outputs.dd_port }}');
+  expect(cucumber?.run).toContain('-e DD_PORT');
+  expect(cucumber?.run).toContain('-v "${{ github.workspace }}:/work"');
+  expect(cucumber?.run).toContain('-w /work/e2e');
+  expect(cucumber?.run).toContain('"$PLAYWRIGHT_IMAGE"');
+  expect(cucumber?.run).toContain(
+    'npm ci --no-audit --no-fund && npm run cucumber -- --tags "not @requires_gitlab" --retry 1',
+  );
 });
 
 test('DAST auth steps mask derived basic auth credentials', () => {

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -994,6 +994,11 @@ jobs:
     needs: [build, changes]
     permissions:
       contents: read
+    env:
+      # Use the same immutable browser runtime as the dedicated Playwright
+      # workflow. This avoids stale cache restores and runtime CDN downloads.
+      PLAYWRIGHT_IMAGE: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 
     steps:
       - name: Harden Runner
@@ -1012,29 +1017,30 @@ jobs:
           node-version: 24
           package-manager-cache: false
 
-      # Cache Playwright's browser binary directory across runs.
-      # `npm ci` in e2e/ triggers a 167 MiB @playwright/browser-chromium
-      # postinstall fetch from cdn.playwright.dev; the CDN has repeatedly
-      # throttled the download to ~30 min, which used to time the job out.
-      # Per-ref key mirrors the cache scoping in quality-mutation-monthly.yml
-      # so an untrusted PR can't poison main's chromium binary.
-      - name: Cache Playwright browsers
-        # zizmor: ignore[cache-poisoning]
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ github.ref_name }}-${{ hashFiles('e2e/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-${{ github.ref_name }}-
-            ${{ runner.os }}-playwright-
+      - name: Verify Playwright image matches package
+        shell: bash
+        run: |
+          set -euo pipefail
 
-      - name: Install e2e dependencies
+          package_version="$(node -p "require('./e2e/package.json').devDependencies['@playwright/test']")"
+          if [[ ! "$PLAYWRIGHT_IMAGE" =~ :v([0-9]+\.[0-9]+\.[0-9]+)-noble(@sha256:[0-9a-f]{64})?$ ]]; then
+            echo "::error title=Invalid Playwright image tag::Expected $PLAYWRIGHT_IMAGE to use :v<major>.<minor>.<patch>-noble optionally pinned with @sha256:<digest>."
+            exit 1
+          fi
+
+          image_version="${BASH_REMATCH[1]}"
+          if [[ "$package_version" != "$image_version" ]]; then
+            echo "::error title=Playwright version mismatch::PLAYWRIGHT_IMAGE uses $image_version, but e2e/package.json pins @playwright/test to $package_version."
+            exit 1
+          fi
+
+      - name: Pull Playwright container
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 15
+          timeout_minutes: 5
           max_attempts: 3
           retry_wait_seconds: 30
-          command: cd e2e && npm ci
+          command: docker pull "$PLAYWRIGHT_IMAGE"
 
       - name: Setup test containers
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
@@ -1054,10 +1060,26 @@ jobs:
         # @requires_gitlab scenarios here to match, otherwise they fail looking
         # for a missing container. The token-gated local path that runs them
         # lives in scripts/run-e2e-tests.sh.
-        run: npm run cucumber -- --tags "not @requires_gitlab" --retry 1
-        working-directory: e2e
+        # The pinned image supplies the browser revision expected by
+        # @playwright/test. Host networking keeps localhost API/browser access
+        # identical to the former host-side invocation.
         env:
           DD_PORT: ${{ steps.drydock.outputs.dd_port }}
+        run: |
+          docker run --rm \
+            --init \
+            --network host \
+            --ipc=host \
+            --user 1001:1001 \
+            -e CI=true \
+            -e HOME=/tmp \
+            -e PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+            -e PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD \
+            -e DD_PORT \
+            -v "${{ github.workspace }}:/work" \
+            -w /work/e2e \
+            "$PLAYWRIGHT_IMAGE" \
+            sh -c 'npm ci --no-audit --no-fund && npm run cucumber -- --tags "not @requires_gitlab" --retry 1'
 
       - name: Show drydock logs on failure
         if: failure()


### PR DESCRIPTION
## Summary
- run Cucumber inside the same digest-pinned Playwright 1.61.1 image as the dedicated browser gate
- remove the stale cross-version browser cache and runtime CDN dependency
- verify the image tag matches the lockfile-pinned `@playwright/test` version before execution
- keep the existing host network, dynamic Drydock port, GitLab exclusion, and retry behavior

## Root cause
The v1.6 release matrix restored a Playwright 1.60 browser cache while `e2e/package.json` pins Playwright 1.61.1. npm lifecycle allow-listing did not install the required Chromium shell revision 1228, so all 16 UI scenarios failed before launch; all 50 non-UI Cucumber scenarios passed.

## Verification
- TDD regression: old workflow fails the new pinned-runtime invariant
- 31/31 workflow tests
- Zizmor: zero findings
- Biome clean
- full exact-commit pre-push gate: 105 maintenance tests, 31 workflow tests, 37 website-script tests, UI typecheck, 100% backend/UI coverage, app/UI builds, Qlty, and Zizmor
- pinned image manifest resolves for both amd64 and arm64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Changelog

- 🔧 Changed Cucumber CI to run inside the dedicated digest-pinned Playwright Docker image (`mcr.microsoft.com/playwright:v1.61.1-noble@sha256:...`) instead of host/browser-cache-based execution.
- 🔧 Added an `e2e` pre-test validation step that parses `PLAYWRIGHT_IMAGE` (`:v<major>.<minor>.<patch>-noble` optionally with `@sha256:<64hex>`) and fails if the embedded Playwright version doesn’t match `e2e/package.json`’s pinned `@playwright/test` version.
- 🔧 Changed `e2e` execution to use `docker run` with host networking and preserved runtime wiring:
  - `--network host`, `--ipc=host`, `--user 1001:1001`
  - mounts workspace `-v "${{ github.workspace }}:/work"` and runs at `-w /work/e2e`
  - propagates `DD_PORT` plus Playwright env (`PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`, `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`)
  - runs inside the container: `npm ci --no-audit --no-fund && npm run cucumber -- --tags "not `@requires_gitlab`" --retry 1`
- 🗑️ Removed the `e2e` host-side “Cache Playwright browsers” and “Install e2e dependencies” steps; browser runtime comes from the immutable image and deps are installed inside the container.
- 🔧 Updated `ci-verify-workflow` tests/fixtures to reflect the new container-based `e2e` flow:
  - extended workflow model support (`WorkflowJob.env`, `WorkflowJobStep.working-directory`)
  - replaced/rewired assertions to validate the new `PLAYWRIGHT_IMAGE` + docker-based Cucumber run behavior and step placement.
- 🐛 Fixed the UI scenario failures caused by cross-version browser-cache mismatch (Playwright 1.60 cached browsers vs project dependency on Playwright 1.61.1).
- 🔒 Removed runtime browser download dependency for `e2e` by enforcing `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and relying on the image’s browser revision.

### Concerns / issues to address

- Confirm the `PLAYWRIGHT_IMAGE` tag regex is intentionally strict (`-noble` only) and won’t break if image tags change naming conventions.
- Confirm `docker run` user/workdir/mounts (`--user 1001:1001`, `-v ...:/work`, `-w /work/e2e`) match what `npm ci` and the `e2e` runner expect (permissions, paths).
- Confirm the `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` and `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` values are consistent with the Playwright image layout and the test harness across amd64/arm64.
- Confirm `load-test-ci` / `load-test-behavior` continue to set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` while retaining the required “Install e2e dependencies” step (so those jobs don’t accidentally regress back to host browser downloads).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->