### PR TITLE
🐛 fix(auth): authenticate before rate-limit exemption

### DIFF
--- a/app/api/auth.test.ts
+++ b/app/api/auth.test.ts
@@ -6,6 +6,7 @@ const {
   mockFs,
   mockRateLimit,
   mockCreateAuthenticatedRouteRateLimitKeyGenerator,
+  mockIsRequestAuthenticated,
   mockIsIdentityAwareRateLimitKeyingEnabled,
   mockDdEnvVars,
 } = vi.hoisted(() => {
@@ -24,6 +25,10 @@ const {
     },
     mockRateLimit: vi.fn(() => rateLimitMiddleware),
     mockCreateAuthenticatedRouteRateLimitKeyGenerator: vi.fn(() => undefined),
+    mockIsRequestAuthenticated: vi.fn(
+      (request: { isAuthenticated?: () => boolean }) =>
+        typeof request.isAuthenticated === 'function' && request.isAuthenticated(),
+    ),
     mockIsIdentityAwareRateLimitKeyingEnabled: vi.fn(() => false),
     mockDdEnvVars: {} as Record<string, string | undefined>,
   };
@@ -109,6 +114,7 @@ vi.mock('./openapi-contract.js', () => ({
 }));
 vi.mock('./rate-limit-key.js', () => ({
   createAuthenticatedRouteRateLimitKeyGenerator: mockCreateAuthenticatedRouteRateLimitKeyGenerator,
+  isRequestAuthenticated: mockIsRequestAuthenticated,
   isIdentityAwareRateLimitKeyingEnabled: mockIsIdentityAwareRateLimitKeyingEnabled,
 }));
 
@@ -3457,25 +3463,64 @@ describe('Auth Router', () => {
       );
     });
 
-    test('authLimiter preserves the public auth budget for authenticated sessions', () => {
+    test('authLimiter authenticates before evaluating the requested method and path', () => {
       const app = createApp();
       auth.init(app);
 
       const limiterOptions = mockRateLimit.mock.calls[0][0];
       expect(limiterOptions.skip).toEqual(expect.any(Function));
-      const authenticated = vi.fn(() => true);
-      expect(
-        limiterOptions.skip({ method: 'GET', path: '/user', isAuthenticated: authenticated }),
-      ).toBe(true);
 
-      for (const request of [
-        { method: 'GET', path: '/api/v1/auth/status', isAuthenticated: authenticated },
-        { method: 'POST', path: '/login', isAuthenticated: authenticated },
-        { method: 'GET', path: '/user', isAuthenticated: vi.fn(() => false) },
-        {},
-      ]) {
-        expect(limiterOptions.skip(request)).toBe(false);
-      }
+      const evaluations: string[] = [];
+      const request = {
+        get method() {
+          evaluations.push('method');
+          return 'GET';
+        },
+        get path() {
+          evaluations.push('path');
+          return '/user';
+        },
+        isAuthenticated: vi.fn(() => {
+          evaluations.push('authenticated');
+          return true;
+        }),
+      };
+
+      expect(limiterOptions.skip(request)).toBe(true);
+      expect(evaluations).toEqual(['authenticated', 'method', 'path']);
+      expect(mockIsRequestAuthenticated).toHaveBeenCalledWith(request);
+    });
+
+    test('authLimiter preserves the public auth budget only for authenticated GET /user', () => {
+      const app = createApp();
+      auth.init(app);
+
+      const limiterOptions = mockRateLimit.mock.calls[0][0];
+      const userSession = vi.fn(() => true);
+      expect(
+        limiterOptions.skip({ method: 'GET', path: '/user', isAuthenticated: userSession }),
+      ).toBe(true);
+      expect(userSession).toHaveBeenCalledOnce();
+
+      const statusSession = vi.fn(() => true);
+      expect(
+        limiterOptions.skip({ method: 'GET', path: '/status', isAuthenticated: statusSession }),
+      ).toBe(false);
+      expect(statusSession).toHaveBeenCalledOnce();
+
+      const mutationSession = vi.fn(() => true);
+      expect(
+        limiterOptions.skip({ method: 'POST', path: '/user', isAuthenticated: mutationSession }),
+      ).toBe(false);
+      expect(mutationSession).toHaveBeenCalledOnce();
+
+      const anonymousSession = vi.fn(() => false);
+      expect(
+        limiterOptions.skip({ method: 'GET', path: '/user', isAuthenticated: anonymousSession }),
+      ).toBe(false);
+      expect(anonymousSession).toHaveBeenCalledOnce();
+
+      expect(limiterOptions.skip({ method: 'GET', path: '/user' })).toBe(false);
     });
 
     test('authLimiter standardHeaders is true', () => {

--- a/app/api/auth.ts
+++ b/app/api/auth.ts
@@ -38,6 +38,7 @@ import { requireJsonContentTypeForMutations, shouldParseJsonBody } from './json-
 import {
   createAuthenticatedRouteRateLimitKeyGenerator,
   isIdentityAwareRateLimitKeyingEnabled,
+  isRequestAuthenticated,
 } from './rate-limit-key.js';
 
 const LokiStore = ConnectLoki(session);
@@ -414,12 +415,11 @@ export function init(app: Application): void {
     max: 100,
     // Authenticated UI navigations re-read the current user. Keep that safe
     // probe from exhausting the public discovery and login budget for clients
-    // behind the same address; every other auth route remains capped.
+    // behind the same address; every other auth route remains capped. Check
+    // authentication before request-controlled route data so the request
+    // cannot decide whether the security check runs.
     skip: (req: Request) =>
-      req.method === 'GET' &&
-      req.path === '/user' &&
-      typeof req.isAuthenticated === 'function' &&
-      req.isAuthenticated(),
+      isRequestAuthenticated(req) && req.method === 'GET' && req.path === '/user',
     standardHeaders: true,
     legacyHeaders: false,
     validate: { xForwardedForHeader: false },

--- a/app/api/rate-limit-key.test.ts
+++ b/app/api/rate-limit-key.test.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express';
 import {
   createAuthenticatedRouteRateLimitKeyGenerator,
   isIdentityAwareRateLimitKeyingEnabled,
+  isRequestAuthenticated,
 } from './rate-limit-key.js';
 
 function createRequest(
@@ -20,6 +21,22 @@ function createRequest(
 }
 
 const response = {} as Response;
+
+describe('isRequestAuthenticated', () => {
+  test('returns the Passport authentication state', () => {
+    const authenticated = vi.fn(() => true);
+    const anonymous = vi.fn(() => false);
+
+    expect(isRequestAuthenticated({ isAuthenticated: authenticated })).toBe(true);
+    expect(authenticated).toHaveBeenCalledOnce();
+    expect(isRequestAuthenticated({ isAuthenticated: anonymous })).toBe(false);
+    expect(anonymous).toHaveBeenCalledOnce();
+  });
+
+  test('returns false when the Passport helper is missing', () => {
+    expect(isRequestAuthenticated({})).toBe(false);
+  });
+});
 
 describe('createAuthenticatedRouteRateLimitKeyGenerator', () => {
   test('should return undefined when identity-aware keying is disabled', () => {

--- a/app/api/rate-limit-key.ts
+++ b/app/api/rate-limit-key.ts
@@ -13,6 +13,12 @@ export type IdentityAwareRateLimitRequestLike = {
   };
 };
 
+export function isRequestAuthenticated(
+  request: Pick<IdentityAwareRateLimitRequestLike, 'isAuthenticated'>,
+): boolean {
+  return typeof request.isAuthenticated === 'function' && request.isAuthenticated();
+}
+
 function getTrimmedString(value: unknown): string | undefined {
   if (typeof value !== 'string') {
     return undefined;
@@ -34,7 +40,7 @@ function getIpRateLimitKey(
 function getAuthenticatedIdentityRateLimitKey(
   request: IdentityAwareRateLimitRequestLike,
 ): string | undefined {
-  if (typeof request.isAuthenticated !== 'function' || !request.isAuthenticated()) {
+  if (!isRequestAuthenticated(request)) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- evaluate trusted Passport authentication state before request-controlled method/path data in the auth rate-limit exemption
- share that security-sensitive authentication predicate with identity-aware rate-limit keying
- preserve the existing contract: only authenticated `GET /auth/user` skips the shared public auth budget
- add ordering, helper-delegation, and truth-table regression coverage for authenticated, anonymous, nonmatching, and missing-auth-function requests

## Why

GitHub Code Scanning alert #551 (`js/user-controlled-bypass`) traced `req.path` to a later short-circuited `req.isAuthenticated()` call. Reordering the conjunction removes request control over whether the security check runs without moving any routes or weakening the 100-per-15-minute limiter for unauthenticated traffic.

CodeRabbit review-body feedback was incorporated: the Passport guard is centralized in one tested helper, both limiter paths use it, and the auth limiter test explicitly asserts delegation while independently proving evaluation order.

## Verification

- TDD red: ordering regression received `method`, `path`, `authenticated`
- TDD red: shared helper tests failed before the helper export existed
- focused auth/rate-limit suites: 183/183 passed
- app production build passed
- final exact-head pre-push gate passed in 338.07s
  - 105 maintenance tests
  - 31 workflow tests
  - UI typecheck
  - 100% backend and UI coverage
  - backend and UI builds
  - Biome and accepted Qlty baseline

## Release integration

Target is `dev/v1.6`. After exact-head review and merge, PR #522 will be rebuilt from the updated frozen remote dev tree and its complete release matrix rerun before the final 24-hour NAS acceptance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed auth rate-limit exemption ordering to evaluate trusted Passport authentication before request-controlled method and path data.
- 🔧 Changed auth limiter and identity-aware rate-limit keying to use shared `isRequestAuthenticated`.
- ✨ Added regression coverage for authentication ordering, helper delegation, authenticated/anonymous requests, nonmatching routes, and missing auth functions.
- 🔒 Preserved bypass behavior exclusively for authenticated `GET /auth/user` requests.

## Verification

- Focused auth/rate-limit tests passed.
- Production build passed.
- Full pre-push verification passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->