### PR TITLE
🔧 chore(ci): allow full release matrix dispatch

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -29,6 +29,7 @@ interface WorkflowJobStep {
 interface WorkflowDefinition {
   env?: Record<string, string>;
   jobs?: Record<string, WorkflowJob>;
+  on?: Record<string, unknown>;
 }
 
 interface LefthookCommand {
@@ -106,6 +107,39 @@ test('workflow tests are wired outside the app coverage suite', () => {
   });
 });
 
+test('ci-verify can dispatch the complete release-candidate matrix manually', () => {
+  const workflow = loadWorkflow();
+
+  expect(workflow.on).toHaveProperty('workflow_dispatch');
+  expect(getWorkflowStep('changes', 'Filter paths')?.with?.base).toContain(
+    "github.event_name == 'workflow_dispatch'",
+  );
+
+  for (const jobId of [
+    'codeql',
+    'fuzz',
+    'web',
+    'dast-zap-baseline',
+    'e2e',
+    'load-test-ci',
+    'load-test-behavior',
+  ]) {
+    expect(workflow.jobs?.[jobId]?.if).toContain("github.event_name == 'workflow_dispatch'");
+  }
+
+  for (const jobId of ['zizmor', 'changes', 'lint', 'test', 'build']) {
+    expect(workflow.jobs?.[jobId]?.if).toBeUndefined();
+  }
+
+  expect(workflow.jobs?.codeql?.needs).toStrictEqual(['zizmor']);
+  expect(workflow.jobs?.fuzz?.needs).toStrictEqual(['zizmor']);
+  expect(workflow.jobs?.web?.needs).toStrictEqual(['changes']);
+  expect(workflow.jobs?.['dast-zap-baseline']?.needs).toStrictEqual(['build']);
+  expect(workflow.jobs?.e2e?.needs).toStrictEqual(['build', 'changes']);
+  expect(workflow.jobs?.['load-test-ci']?.needs).toStrictEqual(['build']);
+  expect(workflow.jobs?.['load-test-behavior']?.needs).toStrictEqual(['build']);
+});
+
 test('ci-verify runs Cucumber in the pinned Playwright browser image', () => {
   const workflow = loadWorkflow();
   const playwrightImage =
@@ -171,18 +205,18 @@ test('DAST auth steps mask derived basic auth credentials', () => {
 
 test('load-test workflow runs load profiles in parallel jobs', () => {
   const workflow = loadWorkflow();
-  const pushOnlyCondition =
-    "github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))";
+  const releaseMatrixCondition =
+    "github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))";
 
   expect(workflow.jobs?.['load-test-ci']).toMatchObject({
     name: '⚡ Load Test: CI',
-    if: pushOnlyCondition,
+    if: releaseMatrixCondition,
     needs: ['build'],
     'timeout-minutes': expect.any(Number),
   });
   expect(workflow.jobs?.['load-test-behavior']).toMatchObject({
     name: '⚡ Load Test: Behavior + Stress (Advisory)',
-    if: pushOnlyCondition,
+    if: releaseMatrixCondition,
     needs: ['build'],
     'timeout-minutes': expect.any(Number),
   });

--- a/.github/tests/e2e-playwright-workflow.test.ts
+++ b/.github/tests/e2e-playwright-workflow.test.ts
@@ -11,12 +11,15 @@ interface WorkflowStep {
 
 interface WorkflowJob {
   env?: Record<string, string>;
+  if?: string;
+  needs?: string[];
   steps?: WorkflowStep[];
 }
 
 interface WorkflowDefinition {
   env?: Record<string, string>;
   jobs?: Record<string, WorkflowJob>;
+  on?: Record<string, unknown>;
 }
 
 const workflowPath = fileURLToPath(new URL('../workflows/e2e-playwright.yml', import.meta.url));
@@ -41,4 +44,16 @@ test('Playwright workflow disables browser downloads for host-side npm installs'
       command: 'cd ui && npm ci',
     },
   });
+});
+
+test('Playwright can be dispatched against a frozen release candidate', () => {
+  const workflow = loadWorkflow();
+
+  expect(workflow.on).toHaveProperty('workflow_dispatch');
+  expect(getWorkflowStep('changes', 'Filter paths')?.with?.base).toContain(
+    "github.event_name == 'workflow_dispatch'",
+  );
+  expect(workflow.jobs?.playwright?.if).toContain("github.event_name == 'workflow_dispatch'");
+  expect(workflow.jobs?.changes?.if).toBeUndefined();
+  expect(workflow.jobs?.playwright?.needs).toStrictEqual(['changes']);
 });

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -9,6 +9,9 @@ run-name: >-
   }}
 
 on:
+  # Release candidates use this trigger to run the complete matrix against the
+  # frozen branch before the final NAS acceptance starts.
+  workflow_dispatch:
   push:
     # Only `main` — release/** branches reach main via a PR (covered by
     # `pull_request` below) and post-merge `push: main` drives release-cut
@@ -104,7 +107,7 @@ jobs:
           # the entire branch diff and runtime is always true. Pull
           # request events leave base unset so the action falls back to
           # the PR target diff (the correct behavior there).
-          base: ${{ github.event_name == 'push' && github.event.before || '' }}
+          base: ${{ github.event_name == 'push' && github.event.before || github.event_name == 'workflow_dispatch' && 'main' || '' }}
           # runtime=true when the changeset touches anything that can affect
           # runtime behavior. Keep this shared with e2e-playwright.yml so both
           # heavy E2E gates short-circuit symmetrically on pure docs/changelog
@@ -113,7 +116,7 @@ jobs:
 
   codeql:
     name: "🛡️ SAST: CodeQL"
-    if: github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [zizmor]
     runs-on: ubuntu-latest
     timeout-minutes: 60  # CodeQL init/autobuild/analyze can be long on cache misses
@@ -153,7 +156,7 @@ jobs:
 
   fuzz:
     name: "🎯 Fuzz Testing"
-    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [zizmor]
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -459,7 +462,7 @@ jobs:
     # Path-filtered: skips (→ counts as pass) on changesets that don't touch the
     # site, so it never blocks backend-only PRs.
     needs: [changes]
-    if: needs.changes.outputs.web == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.web == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -594,7 +597,8 @@ jobs:
     # release branches (back-compat), and on the existing weekly schedules
     # so external-template/signature drift is caught between merges.
     if: |
-      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
+      github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
       || github.event_name == 'schedule'
     needs: [build]
     permissions:
@@ -988,7 +992,7 @@ jobs:
 
   e2e:
     name: "🥒 E2E: Cucumber"
-    if: github.event_name != 'schedule' && needs.changes.outputs.runtime == 'true'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name != 'schedule' && needs.changes.outputs.runtime == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [build, changes]
@@ -1099,7 +1103,7 @@ jobs:
     name: "⚡ Load Test: CI"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
     needs: [build]
     # Load tests hit the API with Artillery; no browser needed. Skip the
     # @playwright/test postinstall chromium download (167 MiB from
@@ -1224,7 +1228,7 @@ jobs:
     name: "⚡ Load Test: Behavior + Stress (Advisory)"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
     needs: [build]
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -17,6 +17,9 @@ run-name: >-
 # Playwright job remains a required status check via branch ruleset.
 
 on:
+  # Release candidates use this trigger to run Playwright against the frozen
+  # branch before the final NAS acceptance starts.
+  workflow_dispatch:
   push:
     # Only `main` — release/** branches reach main via a PR (covered by
     # `pull_request` below). Triggering on `push: release/**` produced a
@@ -67,14 +70,14 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         with:
-          base: ${{ github.event_name == 'push' && github.event.before || '' }}
+          base: ${{ github.event_name == 'push' && github.event.before || github.event_name == 'workflow_dispatch' && 'main' || '' }}
           # Shared with ci-verify.yml so Cucumber and Playwright short-circuit
           # symmetrically on pure docs/changelog edits.
           filters: .github/filters/runtime.yml
 
   playwright:
     name: "🎭 E2E: Playwright"
-    if: needs.changes.outputs.runtime == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.runtime == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 35  # UI build + Docker build + QA stack startup + Playwright pull + UI flow tests
     needs: [changes]


### PR DESCRIPTION
## Summary

- add manual dispatch to CI Verify and Playwright
- run CodeQL, fuzz, web, DAST, Cucumber, load, and browser gates against the selected frozen ref
- preserve path-filter diagnostics while explicitly overriding their skip decisions for a manual release-candidate run
- keep dependency review on the exact-head PR check

## Why

The v1.6 release runbook requires the complete hosted matrix before the final 24-hour NAS acceptance. The existing triggers skip fuzz, DAST, and load jobs on release PRs and cannot be manually dispatched.

## Verification

- TDD red confirmed both workflows lacked manual dispatch
- 33 workflow tests pass
- Biome passes
- Zizmor reports zero findings
- full pre-push gate passes: 105 script tests, workflow tests, 37 website-script tests, UI typecheck, 100% app/UI coverage, builds, Qlty baseline, and Zizmor

The default branch needs the companion bootstrap before GitHub permits dispatching these workflows against a selected release ref.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added
- Added manual `workflow_dispatch` support for CI verification and Playwright workflows.
- Enabled release-candidate validation across CodeQL, fuzz, web, DAST, Cucumber, load, and browser gates.
- Added workflow tests covering dispatch triggers, job conditions, path filtering, and dependencies.

🔧 Changed
- Manual runs use `main` as the path-filter comparison base and override skip decisions.
- Load-test, Playwright, and other validation gates now include manual dispatch conditions.
- Preserved dependency review against the exact PR head.

⚠️ Concerns
- Bootstrap the workflow changes on the default branch before dispatching against a selected release ref.
- Confirm manual dispatch ref selection and dependency-review behavior match the release runbook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->