### PR TITLE
🔧 chore(ci): allow manual final-matrix dispatch

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -27,6 +27,7 @@ interface WorkflowJobStep {
 interface WorkflowDefinition {
   env?: Record<string, string>;
   jobs?: Record<string, WorkflowJob>;
+  on?: Record<string, unknown>;
 }
 
 interface LefthookCommand {
@@ -75,6 +76,34 @@ test('ci-verify job names are emoji-prefixed for GitHub checks readability', () 
     .filter(({ name }) => !emojiPrefix.test(name));
 
   expect(jobsWithoutEmoji).toStrictEqual([]);
+});
+
+test('manual dispatch runs the complete release-candidate matrix regardless of path filters', () => {
+  const workflow = loadWorkflow();
+  const manualDispatch = "github.event_name == 'workflow_dispatch'";
+
+  expect(Object.hasOwn(workflow.on ?? {}, 'workflow_dispatch')).toBe(true);
+  expect(getWorkflowStep('changes', 'Filter paths')?.with?.base).toContain(
+    "github.event_name == 'workflow_dispatch'",
+  );
+
+  for (const jobId of [
+    'codeql',
+    'fuzz',
+    'web',
+    'dast-zap-baseline',
+    'e2e',
+    'load-test-ci',
+    'load-test-behavior',
+  ]) {
+    expect(workflow.jobs?.[jobId]?.if, `${jobId} must run on manual dispatch`).toContain(
+      manualDispatch,
+    );
+  }
+
+  expect(workflow.jobs?.['dependency-review']?.if).toBe(
+    "github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')",
+  );
 });
 
 test('script node tests are wired into local and CI gates', () => {
@@ -137,18 +166,18 @@ test('DAST auth steps mask derived basic auth credentials', () => {
 
 test('load-test workflow runs load profiles in parallel jobs', () => {
   const workflow = loadWorkflow();
-  const pushOnlyCondition =
-    "github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))";
+  const releaseCandidateCondition =
+    "github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))";
 
   expect(workflow.jobs?.['load-test-ci']).toMatchObject({
     name: '⚡ Load Test: CI',
-    if: pushOnlyCondition,
+    if: releaseCandidateCondition,
     needs: ['build'],
     'timeout-minutes': expect.any(Number),
   });
   expect(workflow.jobs?.['load-test-behavior']).toMatchObject({
     name: '⚡ Load Test: Behavior + Stress (Advisory)',
-    if: pushOnlyCondition,
+    if: releaseCandidateCondition,
     needs: ['build'],
     'timeout-minutes': expect.any(Number),
   });

--- a/.github/tests/e2e-playwright-workflow.test.ts
+++ b/.github/tests/e2e-playwright-workflow.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import yaml from 'yaml';
 
 interface WorkflowStep {
+  if?: string;
   name?: string;
   uses?: string;
   with?: Record<string, string>;
@@ -11,12 +12,14 @@ interface WorkflowStep {
 
 interface WorkflowJob {
   env?: Record<string, string>;
+  if?: string;
   steps?: WorkflowStep[];
 }
 
 interface WorkflowDefinition {
   env?: Record<string, string>;
   jobs?: Record<string, WorkflowJob>;
+  on?: Record<string, unknown>;
 }
 
 const workflowPath = fileURLToPath(new URL('../workflows/e2e-playwright.yml', import.meta.url));
@@ -41,4 +44,16 @@ test('Playwright workflow disables browser downloads for host-side npm installs'
       command: 'cd ui && npm ci',
     },
   });
+});
+
+test('manual dispatch runs Playwright against the selected ref regardless of path filters', () => {
+  const workflow = loadWorkflow();
+
+  expect(Object.hasOwn(workflow.on ?? {}, 'workflow_dispatch')).toBe(true);
+  expect(getWorkflowStep('changes', 'Filter paths')?.with?.base).toContain(
+    "github.event_name == 'workflow_dispatch'",
+  );
+  expect(workflow.jobs?.playwright?.if).toBe(
+    "github.event_name == 'workflow_dispatch' || needs.changes.outputs.runtime == 'true'",
+  );
 });

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -9,6 +9,9 @@ run-name: >-
   }}
 
 on:
+  # Allows maintainers to run the complete pre-release matrix against an
+  # explicitly selected ref (for example, via `gh workflow run --ref ...`).
+  workflow_dispatch:
   push:
     # Only `main` — release/** branches reach main via a PR (covered by
     # `pull_request` below) and post-merge `push: main` drives release-cut
@@ -104,7 +107,7 @@ jobs:
           # the entire branch diff and runtime is always true. Pull
           # request events leave base unset so the action falls back to
           # the PR target diff (the correct behavior there).
-          base: ${{ github.event_name == 'push' && github.event.before || '' }}
+          base: ${{ github.event_name == 'push' && github.event.before || github.event_name == 'workflow_dispatch' && 'main' || '' }}
           # runtime=true when the changeset touches anything that can affect
           # runtime behavior. Keep this shared with e2e-playwright.yml so both
           # heavy E2E gates short-circuit symmetrically on pure docs/changelog
@@ -113,7 +116,7 @@ jobs:
 
   codeql:
     name: "🛡️ SAST: CodeQL"
-    if: github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [zizmor]
     runs-on: ubuntu-latest
     timeout-minutes: 60  # CodeQL init/autobuild/analyze can be long on cache misses
@@ -153,7 +156,7 @@ jobs:
 
   fuzz:
     name: "🎯 Fuzz Testing"
-    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [zizmor]
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -459,7 +462,7 @@ jobs:
     # Path-filtered: skips (→ counts as pass) on changesets that don't touch the
     # site, so it never blocks backend-only PRs.
     needs: [changes]
-    if: needs.changes.outputs.web == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.web == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -594,7 +597,8 @@ jobs:
     # release branches (back-compat), and on the existing weekly schedules
     # so external-template/signature drift is caught between merges.
     if: |
-      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
+      github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
       || github.event_name == 'schedule'
     needs: [build]
     permissions:
@@ -988,7 +992,7 @@ jobs:
 
   e2e:
     name: "🥒 E2E: Cucumber"
-    if: github.event_name != 'schedule' && needs.changes.outputs.runtime == 'true'
+    if: github.event_name != 'schedule' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.runtime == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [build, changes]
@@ -1077,7 +1081,7 @@ jobs:
     name: "⚡ Load Test: CI"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
     needs: [build]
     # Load tests hit the API with Artillery; no browser needed. Skip the
     # @playwright/test postinstall chromium download (167 MiB from
@@ -1202,7 +1206,7 @@ jobs:
     name: "⚡ Load Test: Behavior + Stress (Advisory)"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
     needs: [build]
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -17,6 +17,9 @@ run-name: >-
 # Playwright job remains a required status check via branch ruleset.
 
 on:
+  # Allows maintainers to run the pre-release browser gate against an
+  # explicitly selected ref (for example, via `gh workflow run --ref ...`).
+  workflow_dispatch:
   push:
     # Only `main` — release/** branches reach main via a PR (covered by
     # `pull_request` below). Triggering on `push: release/**` produced a
@@ -67,14 +70,14 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         with:
-          base: ${{ github.event_name == 'push' && github.event.before || '' }}
+          base: ${{ github.event_name == 'push' && github.event.before || github.event_name == 'workflow_dispatch' && 'main' || '' }}
           # Shared with ci-verify.yml so Cucumber and Playwright short-circuit
           # symmetrically on pure docs/changelog edits.
           filters: .github/filters/runtime.yml
 
   playwright:
     name: "🎭 E2E: Playwright"
-    if: needs.changes.outputs.runtime == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.runtime == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 35  # UI build + Docker build + QA stack startup + Playwright pull + UI flow tests
     needs: [changes]


### PR DESCRIPTION
## Summary

- add manual dispatch to CI Verify and Playwright on the default branch
- enable CodeQL, fuzz, web, DAST, Cucumber, load, and browser gates for an explicitly selected frozen ref
- preserve path-filter diagnostics while overriding their skip decisions for manual release-candidate validation
- keep dependency review on the exact-head PR check

## Why

GitHub only permits manual workflow dispatch when the workflow advertises that trigger on the default branch. This focused bootstrap is therefore required before the complete v1.6 matrix can run against the frozen release ref.

After this lands, the sanitized v1.6 release PR will be rebuilt from the new immutable main SHA plus the accepted dev/v1.6 tree.

## Verification

- TDD red confirmed both workflows lacked manual dispatch
- 33 workflow tests pass
- Biome passes with the exact main lockfile
- Actionlint passes
- Zizmor reports zero findings
- no runtime, dependency, release, or planning files changed

Companion v1.6 behavior PR: #531.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Changelog

- ✨ Added `workflow_dispatch` support to CI Verify and Playwright workflows.
- 🔧 Updated `dorny/paths-filter` “Filter paths” base handling for manual runs (defaulting to `main`) and broadened key job `if` conditions to include `workflow_dispatch` (including release-candidate validation paths).
- 🔧 Updated CI Verify + Playwright e2e workflow tests and workflow-YAML typings to assert manual dispatch bypasses path gating where intended (including `dependency-review` `if` conditions) and to validate combined load-test dispatch logic.
- 🔒 Kept dependency review limited to exact-head PR checks.
- 🔧 Verified the workflow/test matrix with 33 passing workflow tests plus Biome, Actionlint, and Zizmor.

### Concerns

- Confirm the `workflow_dispatch` path-filter comparison base (`main`) matches the intended frozen/ref selection behavior for manual release-candidate validation.
- Confirm every manually dispatched gated job (and their internal steps like Playwright browser cache/download) follows the expected dispatch vs. path-change semantics.
- Confirm `dependency-review` continues to use exact-head logic for the relevant event types when run via manual dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->