### PR TITLE
✨ feat(ui): add "version update" container filter (#538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **"Version update" container filter** ([#538](https://github.com/CodesWhat/drydock/issues/538)). The Containers filter bar gains a **Version Update** kind option that shows only real semver upgrades (major, minor, patch) and hides digest-only churn — the noise that dominates the dashboard on fleets that rebuild images daily in CI. Like every other container filter, it round-trips through the URL (`?filterKind=version`), so the filtered view can be saved as a bookmark for one-click access.
+
 ## [1.6.0-rc.1] — 2026-07-15
 
 ### Added

--- a/ui/src/components/containers/ContainersListContent.vue
+++ b/ui/src/components/containers/ContainersListContent.vue
@@ -115,6 +115,7 @@ const activeFilterChips = computed(() => {
   if (filterKind.value !== 'all') {
     const kindKeyMap: Record<string, string> = {
       any: 'hasUpdate',
+      version: 'versionUpdate',
       major: 'major',
       minor: 'minor',
       patch: 'patch',
@@ -202,6 +203,7 @@ const activeFilterChips = computed(() => {
           class="px-2 py-1.5 dd-rounded text-2xs-plus font-semibold uppercase tracking-wide outline-none cursor-pointer dd-bg dd-text">
           <option value="all">{{ t('containerComponents.listContent.allContainers') }}</option>
           <option value="any">{{ t('containerComponents.listContent.hasUpdate') }}</option>
+          <option value="version">{{ t('containerComponents.listContent.versionUpdate') }}</option>
           <option value="major">{{ t('containerComponents.listContent.major') }}</option>
           <option value="minor">{{ t('containerComponents.listContent.minor') }}</option>
           <option value="patch">{{ t('containerComponents.listContent.patch') }}</option>

--- a/ui/src/composables/useContainerFilters.ts
+++ b/ui/src/composables/useContainerFilters.ts
@@ -80,6 +80,15 @@ function matchesKindFilter(container: Container, selectedKind: string): boolean 
   if (selectedKind === 'any') {
     return Boolean(container.newTag);
   }
+  if (selectedKind === 'version') {
+    // Real version upgrades only — major/minor/patch. Excludes digest-only
+    // churn, which floods the view on fleets that rebuild images daily (#538).
+    return (
+      container.updateKind === 'major' ||
+      container.updateKind === 'minor' ||
+      container.updateKind === 'patch'
+    );
+  }
   if (selectedKind === 'blocked') {
     return Boolean(container.newTag) && container.bouncer === 'blocked';
   }

--- a/ui/src/locales/en/containerComponents.json
+++ b/ui/src/locales/en/containerComponents.json
@@ -276,6 +276,7 @@
       "allHosts": "All Hosts",
       "allContainers": "All Containers",
       "hasUpdate": "Has Update",
+      "versionUpdate": "Version Update",
       "major": "Major",
       "minor": "Minor",
       "patch": "Patch",

--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -580,7 +580,15 @@ function clearContainerIdsFilter() {
   void router.replace({ query: rest as Record<string, string> });
 }
 
-const VALID_FILTER_KIND_VALUES = ['all', 'a\u006Ey', 'major', 'minor', 'patch', 'digest'] as const;
+const VALID_FILTER_KIND_VALUES = [
+  'all',
+  'a\u006Ey',
+  'version',
+  'major',
+  'minor',
+  'patch',
+  'digest',
+] as const;
 type FilterKindQueryValue = (typeof VALID_FILTER_KIND_VALUES)[number];
 const DEFAULT_FILTER_KIND: FilterKindQueryValue = 'all';
 const VALID_FILTER_KINDS: ReadonlySet<FilterKindQueryValue> = new Set(VALID_FILTER_KIND_VALUES);

--- a/ui/tests/components/containers/ContainersListContent.spec.ts
+++ b/ui/tests/components/containers/ContainersListContent.spec.ts
@@ -283,6 +283,23 @@ describe('ContainersListContent', () => {
     expect(wrapper.find('[data-test="dd-toolbar-sort-select"]').exists()).toBe(false);
   });
 
+  it('renders the version update kind option with its translated label', () => {
+    const context = makeTemplateContext();
+    wrapper = mountWithContext(context);
+
+    expect(wrapper.get('option[value="version"]').text()).toBe('Version Update');
+  });
+
+  it('shows the translated version update active-filter chip', () => {
+    const context = makeTemplateContext({
+      filterKind: ref('version'),
+      activeFilterCount: computed(() => 1),
+    });
+    wrapper = mountWithContext(context);
+
+    expect(wrapper.text()).toContain('Kind: Version Update');
+  });
+
   it('passes only labelled catalog columns (translated) to the picker', () => {
     const context = makeTemplateContext();
     wrapper = mountWithContext(context);

--- a/ui/tests/composables/useContainerFilters.spec.ts
+++ b/ui/tests/composables/useContainerFilters.spec.ts
@@ -186,6 +186,25 @@ describe('useContainerFilters', () => {
       expect(filters.filteredContainers.value[0].name).toBe('postgres');
     });
 
+    it('should filter version updates to major, minor, and patch kinds', async () => {
+      const versionKinds = ref<Container[]>([
+        makeContainer({ id: 'c1', name: 'major-update', updateKind: 'major' }),
+        makeContainer({ id: 'c2', name: 'minor-update', updateKind: 'minor' }),
+        makeContainer({ id: 'c3', name: 'patch-update', updateKind: 'patch' }),
+        makeContainer({ id: 'c4', name: 'digest-update', updateKind: 'digest' }),
+        makeContainer({ id: 'c5', name: 'no-update', updateKind: null }),
+      ]);
+      const mod = await import('@/composables/useContainerFilters');
+      const filters = mod.useContainerFilters(versionKinds);
+      filters.filterKind.value = 'version';
+
+      expect(filters.filteredContainers.value.map((c) => c.name)).toEqual([
+        'major-update',
+        'minor-update',
+        'patch-update',
+      ]);
+    });
+
     it('should filter "any" to containers with a newTag', async () => {
       const filters = await loadFilters();
       filters.filterKind.value = 'any';

--- a/ui/tests/views/ContainersView.spec.ts
+++ b/ui/tests/views/ContainersView.spec.ts
@@ -827,6 +827,12 @@ describe('ContainersView', () => {
       expect(mockFilterKind.value).toBe('any');
     });
 
+    it('applies version filterKind from route query', async () => {
+      mockRoute.query = { filterKind: 'version' };
+      await mountContainersView([makeContainer({ newTag: '2.0.0', updateKind: 'major' })]);
+      expect(mockFilterKind.value).toBe('version');
+    });
+
     it('applies filterKind from array route query', async () => {
       mockRoute.query = { filterKind: ['major'] };
       await mountContainersView([makeContainer({ newTag: '2.0.0', updateKind: 'major' })]);
@@ -904,6 +910,18 @@ describe('ContainersView', () => {
           groupByStack: 'true',
           sort: 'status-desc',
         }),
+      });
+    });
+
+    it('syncs version filterKind to the URL query', async () => {
+      await mountContainersView([makeContainer()]);
+
+      mockFilterKind.value = 'version';
+      await flushPromises();
+
+      const lastCall = mockRouterReplace.mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual({
+        query: expect.objectContaining({ filterKind: 'version' }),
       });
     });
   });


### PR DESCRIPTION
## What

Adds a **Version Update** option to the Containers kind filter. It matches containers whose update is a real semver bump (`major`, `minor`, or `patch`) and excludes `digest`-only updates.

## Why

Since 1.5.2 restored mandatory digest comparison, fleets that rebuild images daily in CI see the dashboard fill with digest-only "updates" that aren't version upgrades ([#538](https://github.com/CodesWhat/drydock/issues/538)). The kind filter could already show "Has update" (which includes digest) or one specific kind at a time, but there was no single option for "any real version bump, minus digest" — exactly the view people want for spotting upgrades.

The other half of #538 (a bookmarkable filtered view) already works: every container filter round-trips through the URL query, so `?filterKind=version` (optionally stacked with `filterStatus`, `filterRegistry`, etc.) can be saved to favorites for one-click access. This PR just adds the missing filter value.

## Changes

- `useContainerFilters.ts` — `matchesKindFilter` gains a `version` branch (`updateKind ∈ {major, minor, patch}`).
- `ContainersView.vue` — `version` added to `VALID_FILTER_KIND_VALUES` so it's a valid, round-trippable URL query value.
- `ContainersListContent.vue` — new `<option value="version">` in the kind select (after "Has Update") plus the chip label mapping.
- `locales/en/containerComponents.json` — new `versionUpdate` = "Version Update" source string (other locales fall back to English until Crowdin translates).
- Tests for the matcher (both branches), the option/chip rendering, and URL round-trip in both directions. UI coverage stays at 100%.

## Scope

Lands on `dev/v1.6` for a later build. Not part of the frozen `v1.6.0-rc.1` release head, so no acceptance re-run is triggered.

Refs #538


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added
- Added a `Version Update` container kind filter.
- Matches `major`, `minor`, and `patch` updates while excluding digest-only updates.
- Added English localization, filter option, active-filter chip, matcher tests, rendering tests, and URL round-trip tests.

🔧 Changed
- Added `version` filter support for bookmarkable URL queries and combinations with other filters.

- Verify `VALID_FILTER_KIND_VALUES` includes `version`; the supplied summary indicates it may still be excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->