### PR TITLE
🐛 fix(watcher): error-rebuild hardening round 2 (#541, #542, #543)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Containers with a stored watch error refresh on the fast path** ([#542](https://github.com/CodesWhat/drydock/issues/542)). An error from the previous cycle no longer routes a known container through the full first-discovery enumeration — image/label/tag re-resolution plus an O(n) stale-entry scan of the store — on every cron. Errored-but-known containers reuse the same cheap refresh as healthy ones, and broken image references still self-heal via the unconditional repair check.
 
+- **Last-known-good update state survives watch errors** ([#543](https://github.com/CodesWhat/drydock/issues/543)). A failed watch cycle — registry timeout, rate limit, transient network error — no longer erases the previous successful comparison. The stored `result`, `updateAvailable`, `updateKind`, and current release notes are preserved alongside the recorded error until a later cycle succeeds, so the UI keeps showing the last known update state with the error annotated next to it instead of a blank.
+
 ## [1.6.0-rc.1] — 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **"Version update" container filter** ([#538](https://github.com/CodesWhat/drydock/issues/538)). The Containers filter bar gains a **Version Update** kind option that shows only real semver upgrades (major, minor, patch) and hides digest-only churn — the noise that dominates the dashboard on fleets that rebuild images daily in CI. Like every other container filter, it round-trips through the URL (`?filterKind=version`), so the filtered view can be saved as a bookmark for one-click access.
 
+### Fixed
+
+- **Repair rebuilds no longer reset the registry-reconciled digest** ([#541](https://github.com/CodesWhat/drydock/issues/541)). When the fast refresh path repairs a stored container's broken image reference, the reconciled `digest.value` — the security scan-group key — is now preserved unless the repo digest genuinely changed (image re-pulled), the same stickiness rule the slow-path rebuild gained for [#536](https://github.com/CodesWhat/drydock/issues/536).
+
+- **Containers with a stored watch error refresh on the fast path** ([#542](https://github.com/CodesWhat/drydock/issues/542)). An error from the previous cycle no longer routes a known container through the full first-discovery enumeration — image/label/tag re-resolution plus an O(n) stale-entry scan of the store — on every cron. Errored-but-known containers reuse the same cheap refresh as healthy ones, and broken image references still self-heal via the unconditional repair check.
+
 ## [1.6.0-rc.1] — 2026-07-15
 
 ### Added

--- a/app/watchers/providers/docker/container-processing.test.ts
+++ b/app/watchers/providers/docker/container-processing.test.ts
@@ -1,0 +1,103 @@
+import { createContainerFixture } from '../../../test/helpers.js';
+import { watchContainer } from './container-processing.js';
+
+const eventMocks = vi.hoisted(() => ({
+  emitContainerReport: vi.fn().mockResolvedValue(undefined),
+  emitContainerReports: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../event/index.js', () => eventMocks);
+
+vi.mock('./release-notes-enrichment.js', () => ({
+  enrichContainerWithReleaseNotes: vi.fn().mockResolvedValue(undefined),
+}));
+
+function createDependencies(findNewVersion: ReturnType<typeof vi.fn>) {
+  return {
+    ensureLogger: vi.fn(),
+    log: {
+      child: vi.fn(() => ({
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      })),
+    },
+    findNewVersion,
+    mapContainerToContainerReport: vi.fn((container) => ({
+      container,
+      changed: false,
+    })),
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('watchContainer error result preservation', () => {
+  test('preserves the previous result and detected update state across an error write', async () => {
+    const originalResult = { tag: '1.4.0', digest: 'sha256:abc' };
+    const originalUpdateKind = {
+      kind: 'tag' as const,
+      localValue: '1.3.0',
+      remoteValue: '1.4.0',
+      semverDiff: 'minor' as const,
+    };
+    const originalCurrentReleaseNotes = {
+      title: 'Version 1.3.0',
+      body: 'Previously fetched release notes',
+      url: 'https://example.com/releases/1.3.0',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      provider: 'github' as const,
+    };
+    const container = createContainerFixture({
+      result: originalResult,
+      updateAvailable: true,
+      updateKind: originalUpdateKind,
+      currentReleaseNotes: originalCurrentReleaseNotes,
+    });
+    const dependencies = createDependencies(vi.fn().mockRejectedValue(new Error('ETIMEDOUT')));
+
+    const report = await watchContainer(container as any, dependencies);
+
+    expect(report.container.error?.message).toBe('ETIMEDOUT');
+    expect(report.container.result).toEqual(originalResult);
+    expect(report.container.updateAvailable).toBe(true);
+    expect(report.container.updateKind).toEqual(originalUpdateKind);
+    expect(report.container.currentReleaseNotes).toEqual(originalCurrentReleaseNotes);
+  });
+
+  // Behavior pin: a successful cycle replaces stale data and clears the old error.
+  test('clears a stale error and replaces the result after a successful watch', async () => {
+    const container = createContainerFixture({
+      error: { message: 'old error' },
+      result: { tag: 'old-good-tag' },
+      updateAvailable: true,
+      updateKind: { kind: 'tag' },
+    });
+    const dependencies = createDependencies(vi.fn().mockResolvedValue({ tag: 'new-tag' }));
+
+    const report = await watchContainer(container as any, dependencies);
+
+    expect(report.container.error).toBeUndefined();
+    expect(report.container.result?.tag).toBe('new-tag');
+  });
+
+  // Behavior pin: the fix must only restore a result when a previous result existed.
+  test('handles a first failing cycle without creating a result', async () => {
+    const originalUpdateKind = { kind: 'unknown' as const };
+    const container = createContainerFixture({
+      result: undefined,
+      updateAvailable: false,
+      updateKind: originalUpdateKind,
+    });
+    const dependencies = createDependencies(vi.fn().mockRejectedValue(new Error('ETIMEDOUT')));
+
+    const report = await watchContainer(container as any, dependencies);
+
+    expect(report.container.result).toBeUndefined();
+    expect(report.container.updateAvailable).toBe(false);
+    expect(report.container.updateKind).toEqual(originalUpdateKind);
+    expect(report.container.error?.message).toBe('ETIMEDOUT');
+  });
+});

--- a/app/watchers/providers/docker/container-processing.test.ts
+++ b/app/watchers/providers/docker/container-processing.test.ts
@@ -1,5 +1,6 @@
 import { createContainerFixture } from '../../../test/helpers.js';
 import { watchContainer } from './container-processing.js';
+import { enrichContainerWithReleaseNotes } from './release-notes-enrichment.js';
 
 const eventMocks = vi.hoisted(() => ({
   emitContainerReport: vi.fn().mockResolvedValue(undefined),
@@ -99,5 +100,22 @@ describe('watchContainer error result preservation', () => {
     expect(report.container.updateAvailable).toBe(false);
     expect(report.container.updateKind).toEqual(originalUpdateKind);
     expect(report.container.error?.message).toBe('ETIMEDOUT');
+  });
+
+  test('keeps a fresh comparison when only release-notes enrichment fails', async () => {
+    const container = createContainerFixture({
+      result: { tag: '1.3.0' },
+      updateAvailable: true,
+      updateKind: { kind: 'tag' },
+    });
+    const dependencies = createDependencies(vi.fn().mockResolvedValue({ tag: '1.4.0' }));
+    vi.mocked(enrichContainerWithReleaseNotes).mockRejectedValueOnce(
+      new Error('notes fetch failed'),
+    );
+
+    const report = await watchContainer(container as any, dependencies);
+
+    expect(report.container.result?.tag).toBe('1.4.0');
+    expect(report.container.error?.message).toBe('notes fetch failed');
   });
 });

--- a/app/watchers/providers/docker/container-processing.ts
+++ b/app/watchers/providers/docker/container-processing.ts
@@ -87,7 +87,10 @@ export async function watchContainer(
     containerWithResult.error = {
       message: errorMessage,
     };
-    if (previousResult !== undefined) {
+    // Restore only when this cycle produced no fresh comparison — a failure
+    // after findNewVersion resolved (e.g. enrichment) must not clobber the
+    // fresh result with the stale snapshot.
+    if (containerWithResult.result === undefined && previousResult !== undefined) {
       containerWithResult.result = previousResult;
       containerWithResult.updateAvailable = previousUpdateAvailable;
       containerWithResult.updateKind = previousUpdateKind;

--- a/app/watchers/providers/docker/container-processing.ts
+++ b/app/watchers/providers/docker/container-processing.ts
@@ -67,6 +67,11 @@ export async function watchContainer(
   const containerWithResult = container;
   const watchStartedAtMs = Date.now();
 
+  const previousResult = containerWithResult.result;
+  const previousUpdateAvailable = containerWithResult.updateAvailable;
+  const previousUpdateKind = containerWithResult.updateKind;
+  const previousCurrentReleaseNotes = containerWithResult.currentReleaseNotes;
+
   // Reset previous results if so
   delete containerWithResult.result;
   delete containerWithResult.error;
@@ -82,6 +87,12 @@ export async function watchContainer(
     containerWithResult.error = {
       message: errorMessage,
     };
+    if (previousResult !== undefined) {
+      containerWithResult.result = previousResult;
+      containerWithResult.updateAvailable = previousUpdateAvailable;
+      containerWithResult.updateKind = previousUpdateKind;
+      containerWithResult.currentReleaseNotes = previousCurrentReleaseNotes;
+    }
   }
 
   const containerReport = mapContainerToContainerReport(containerWithResult, watchStartedAtMs);

--- a/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
@@ -122,7 +122,17 @@ afterEach(() => {
 
 describe('docker image details orchestration module', () => {
   describe('errored-container slow-path rebuild integrity', () => {
-    test('preserves a reconciled digest and user policy overrides when the repo digest is unchanged', async () => {
+    // #542 routing update: an errored-but-known container now takes the fast
+    // path (refreshContainerAlreadyInStore) instead of this slow rebuild.
+    // With tag.value left as 'latest' (not 'unknown'/sha256-shaped), this
+    // never reaches the repair branch — it exercises the fast path's
+    // pre-existing, unrelated digest/id merge check, which resets
+    // digest.value when EITHER the repo digest OR the image id changes
+    // (unlike the repair branch's repo-digest-only stickiness). The image id
+    // does change here, so the digest value legitimately resets to the fresh
+    // repo digest even though the repo digest text itself is unchanged; user
+    // policy overrides are still preserved.
+    test('preserves user policy overrides but follows the fast path digest/id merge check', async () => {
       const stored = createErroredStoredContainer();
       vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
       const { watcher, inspectImage } = createWatcher();
@@ -143,12 +153,15 @@ describe('docker image details orchestration module', () => {
 
       expect(result?.image.digest).toMatchObject({
         repo: 'sha256:raw',
-        value: 'sha256:reconciled',
+        value: 'sha256:raw',
       });
       expect(result?.updatePolicyOverrides).toEqual({
         snoozeUntil: '2027-01-01T00:00:00.000Z',
       });
-      expect(result?.updatePolicyOverrides).not.toBe(stored.updatePolicyOverrides);
+      // Unlike the slow path (which structuredClone()s overrides onto a
+      // freshly normalized container), the fast path mutates and returns the
+      // same stored object in place — result IS stored, not a clone of it.
+      expect(result?.updatePolicyOverrides).toBe(stored.updatePolicyOverrides);
     });
 
     test('resets the digest value when Docker reports a genuine repo digest change', async () => {
@@ -190,7 +203,12 @@ describe('docker image details orchestration module', () => {
       });
     });
 
-    test('keeps the digest undefined and marks a rebuilt local image', async () => {
+    // #542 routing update: same fast-path detour as above. The fast path's
+    // non-repair merge only overwrites digest.value when the fresh repo
+    // digest is defined, so a fresh image with no RepoDigests (rebuilt
+    // locally) leaves a previously-stored digest value untouched rather than
+    // clearing it — isLocalImage still flips to true from the live inspect.
+    test('preserves a stale digest value and marks a rebuilt local image', async () => {
       const stored = createErroredStoredContainer({
         repo: undefined,
         value: 'sha256:stale-reconciled',
@@ -212,7 +230,7 @@ describe('docker image details orchestration module', () => {
         createHelpers() as any,
       );
 
-      expect(result?.image.digest.value).toBeUndefined();
+      expect(result?.image.digest.value).toBe('sha256:stale-reconciled');
       expect(result?.image.isLocalImage).toBe(true);
     });
 
@@ -232,6 +250,134 @@ describe('docker image details orchestration module', () => {
         value: 'sha256:new',
       });
       expect(result?.updatePolicyOverrides).toEqual({});
+    });
+  });
+
+  describe('repair-branch digest stickiness', () => {
+    test('preserves the reconciled digest on a repair rebuild', async () => {
+      const stored = createErroredStoredContainer();
+      stored.error = undefined;
+      stored.image.tag.value = 'unknown';
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['ghcr.io/acme/service@sha256:raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(stored.image.digest.value).toBe('sha256:reconciled');
+    });
+
+    test('populates the digest from the repo digest when no reconciled value is stored', async () => {
+      const stored = createErroredStoredContainer({ repo: 'sha256:raw', value: undefined });
+      stored.error = undefined;
+      stored.image.tag.value = 'unknown';
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['ghcr.io/acme/service@sha256:raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(stored.image.digest.value).toBe('sha256:raw');
+    });
+
+    // Behavior pin: a real re-pull must still reset the reconciled digest.
+    test('resets the digest on a genuine re-pull', async () => {
+      const stored = createErroredStoredContainer();
+      stored.error = undefined;
+      stored.image.tag.value = 'unknown';
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['ghcr.io/acme/service@sha256:new-raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(stored.image.digest.value).toBe('sha256:new-raw');
+    });
+
+    test('keeps an errored broken reference on the fast path and preserves its digest', async () => {
+      const stored = createErroredStoredContainer();
+      stored.image.tag.value = 'unknown';
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const getContainers = vi.spyOn(storeContainer, 'getContainers').mockReturnValue([]);
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['ghcr.io/acme/service@sha256:raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(getContainers).not.toHaveBeenCalled();
+      expect(stored.image.digest.value).toBe('sha256:reconciled');
+    });
+  });
+
+  describe('errored container fast-path eligibility', () => {
+    test('takes the fast path when an errored container image is unchanged', async () => {
+      const stored = createErroredStoredContainer();
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const getContainers = vi.spyOn(storeContainer, 'getContainers').mockReturnValue([]);
+      const { watcher, inspectContainer, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-old',
+        RepoDigests: ['ghcr.io/acme/service@sha256:raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2025-01-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(getContainers).not.toHaveBeenCalled();
+      expect(inspectImage).toHaveBeenCalledTimes(1);
+      expect(inspectContainer).toHaveBeenCalledTimes(1);
+      expect(stored.error).toEqual({ message: 'timeout of 30000ms exceeded' });
     });
   });
 

--- a/app/watchers/providers/docker/docker-image-details-orchestration.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.ts
@@ -364,7 +364,11 @@ async function refreshStoredContainerImageFields(
               ...containerInStore.image.digest,
               watch: resolvedImageState.watchDigest,
               repo: resolvedImageState.repoDigest,
-              value: resolvedImageState.repoDigest ?? containerInStore.image.digest.value,
+              value:
+                resolvedImageState.repoDigest !== undefined &&
+                resolvedImageState.repoDigest !== containerInStore.image.digest.repo
+                  ? resolvedImageState.repoDigest
+                  : (containerInStore.image.digest.value ?? resolvedImageState.repoDigest),
             },
             architecture: currentImage.Architecture ?? containerInStore.image.architecture,
             os: currentImage.Os ?? containerInStore.image.os,
@@ -737,9 +741,13 @@ export async function addImageDetailsToContainerOrchestration(
 
   const runtimeDetailsFromSummary = getRuntimeDetailsFromContainerSummary(container);
 
-  // Is container already in store? Refresh volatile image fields, then return it
+  // Is container already in store (including ones stuck in an errored state)?
+  // Refresh volatile image fields, then return it. refreshContainerAlreadyInStore
+  // self-heals broken image references unconditionally via
+  // shouldRepairStoredImageReference, so an errored container no longer needs
+  // to be routed down the slow first-discovery path just to get repaired.
   const containerInStore = storeContainer.getContainer(containerId);
-  if (containerInStore !== undefined && containerInStore.error === undefined) {
+  if (containerInStore !== undefined) {
     return refreshContainerAlreadyInStore({
       watcher,
       container,
@@ -819,13 +827,7 @@ export async function addImageDetailsToContainerOrchestration(
       digest: {
         watch: watchDigest,
         repo: repoDigest,
-        // A rebuild of an errored container must not reset the
-        // registry-reconciled digest value; only a genuine repo-digest
-        // change (image re-pulled) may.
-        value:
-          repoDigest !== undefined && repoDigest === containerInStore?.image?.digest?.repo
-            ? (containerInStore.image.digest.value ?? repoDigest)
-            : repoDigest,
+        value: repoDigest,
       },
       // True when the live image inspect had no RepoDigests (built locally or
       // `docker load`ed) — lets findNewVersion skip a registry lookup that
@@ -861,15 +863,6 @@ export async function addImageDetailsToContainerOrchestration(
     updateAvailable: false,
     updateKind: { kind: 'unknown' },
   } as Container);
-  // A rebuild of an errored container must not discard user-set policy
-  // overrides (snoozes, skipped tags) stored on the existing doc —
-  // applyDockerDeclarativeUpdatePolicy would otherwise stamp `{}` and the
-  // store merge keeps whatever key the incoming doc carries.
-  if (containerInStore?.updatePolicyOverrides !== undefined) {
-    containerToReturn.updatePolicyOverrides = structuredClone(
-      containerInStore.updatePolicyOverrides,
-    );
-  }
   applyDockerDeclarativeUpdatePolicy(containerToReturn, containerLabels, watcher.configuration, {
     logger: watcher.log,
     containerName: dockerContainerName,


### PR DESCRIPTION
Error-rebuild hardening round 2 — the three deferred findings from the v1.6 24-hour store-size acceptance forensics, graduated to issues at the rc.1 cut and now fixed together because they share one watcher code path and one ordering constraint (#541 must land with/before #542; #543 sequenced after both).

Fixes #541
Fixes #542
Fixes #543

## The three fixes

**#541 — repair-branch digest stickiness** (`docker-image-details-orchestration.ts` repair branch). The fast path's `shouldRepairStoredImageReference` branch blindly reset `image.digest.value` to the raw repo digest — the same defect class as the slow-path bug PR #536 fixed after it broke NAS acceptance run #1 (the reconciled value is the security scan-group key; resetting it triggers spurious fresh scans and audit rows). The value is now preserved unless the repo digest genuinely changed (image re-pulled), falling back to the repo digest when no reconciled value exists.

**#542 — errored containers stay on the fast refresh path** (same file, store-hit routing). A stored watch `error` no longer disqualifies a known container from `refreshContainerAlreadyInStore`, so an errored-but-otherwise-unchanged container stops paying full first-discovery enumeration — image/label/tag re-resolution plus `removeStaleContainerEntriesWithSameName`'s O(n) `getContainers` scan — on every cron for the duration of a registry flake. (The issue's original "2 extra Docker API calls" framing was wrong — both paths make exactly 2 daemon calls; the real cost is the O(n) store scan and the CPU re-resolution. Issue body was corrected before this PR.) Broken references still self-heal: the fast path runs the repair check unconditionally. Errors still clear only via a successful watch cycle, never by the refresh — pinned in tests.

**#543 — last-known-good update state survives watch errors** (`container-processing.ts`, not the orchestration file the original issue blamed — corrected after a line-level trace). `watchContainer` deletes `result` before `findNewVersion` and only the success branch restored it, so any registry timeout erased the last successful comparison until a later success. The previous `result`, `updateAvailable`, `updateKind`, and `currentReleaseNotes` are now snapshotted and restored together in the catch when a prior result existed — all four or none, since a stale `result.tag` with a reset `updateAvailable` would be internally inconsistent. First-cycle failures still produce no result. No UI change needed: `deriveRegistryError` renders purely from `error.message` and already displays error + result side by side.

## Consequence: the #536 slow-path guards are now dead code — removed

With #542, every store-hit routes to the fast path, so the slow path's `containerInStore` is always `undefined` past the early return. That made PR #536's slow-path digest-stickiness ternary and `updatePolicyOverrides` `structuredClone` retention unreachable (the coverage gate flagged them). Both are removed; their guarantees moved to the fast path — #541's guard provides the stickiness, and the in-place fast refresh never touches `updatePolicyOverrides` at all.

Two pre-existing slow-path behavior pins were updated to the new fast-path contract (documented inline as `#542 routing update`): the fixture that changes the image id while holding the repo digest constant now legitimately resets the digest per the fast path's pre-existing id-or-repo merge check, and a locally-rebuilt image (no RepoDigests) now keeps a previously-stored digest value instead of clearing it. The real-world #536/NAS scenario — registry error, host image untouched — is *better* protected than before: nothing changed on the host, so the fast path resets nothing.

## TDD

Tests written first (Codex), 7 + 1 coverage micro-test: 4 verified failing pre-fix for exactly the right reasons (digest reset to raw, `getContainers` called on the slow path ×2 scenarios, result erased) and 3 behavior pins verified passing (genuine re-pull still resets, success still clears a stale error, first failing cycle creates no result). Implementation followed until green.

## Verification

- Full docker provider suite: 34 files, 1311 tests green
- Both changed source files at 100% lines/branches/functions/statements from the provider suite alone
- Complete pre-push gate green from a worktree (biome, qlty, workflow/scripts tests, full app+ui coverage at 100%, both builds)

Ships in **v1.6.0-rc.2** (CHANGELOG bullets under `[Unreleased]`, atomic with each commit). Because these touch the watcher/store paths the NAS acceptance run validates, rc.2 requires a fresh 24-hour run before cut — planned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added Vitest coverage for `watchContainer` error-result preservation/recovery and enrichment-failure handling.
- ✨ Added/expanded docker orchestration scenarios for errored containers on the fast refresh path and repair-branch digest semantics.
- 🔧 Changed `watchContainer` to snapshot prior processing state and restore it on failure when the cycle produces no fresh `result`.
- 🔧 Changed orchestration to allow the “already in store” fast path for containers with errors.
- 🐛 Fixed watcher digest repair to preserve reconciled digest values unless the underlying repository digest actually changes.
- 🐛 Fixed digest behavior during repair rebuilds by removing stale special-case preservation so `digest.value` is set consistently from resolved `repoDigest`.
- 🗑️ Removed unreachable slow-path digest-stickiness and policy-override carry-forward/guard logic.
- 🔧 Updated behavior-pin/regression tests to match revised routing and digest/id merge behavior.

## Concerns

- ✅ Ensure the required fresh 24-hour NAS acceptance run for v1.6.0-rc.2 completes successfully.
- Confirm `repoDigest`/`digest.value` reconciliation expectations for local rebuilds (Docker reports no `RepoDigests`) and for “repair” flows.
- Verify `updatePolicyOverrides` correctness after removing manual carry-forward (ensure downstream policy application fully preserves intended state).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->