### PR TITLE
♻️ refactor(ci): dedupe workflow-test scaffolding into shared module

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -4,33 +4,11 @@ import { fileURLToPath } from 'node:url';
 import yaml from 'yaml';
 
 import { expectedActionUse } from './github-action-pins';
-
-interface WorkflowJob {
-  env?: Record<string, string>;
-  name?: string;
-  steps?: WorkflowJobStep[];
-  'timeout-minutes'?: number;
-  if?: string;
-  needs?: string[];
-}
-
-interface WorkflowJobStep {
-  name?: string;
-  id?: string;
-  run?: string;
-  if?: string;
-  uses?: string;
-  'working-directory'?: string;
-  env?: Record<string, string>;
-  with?: Record<string, string>;
-  'continue-on-error'?: boolean;
-}
-
-interface WorkflowDefinition {
-  env?: Record<string, string>;
-  jobs?: Record<string, WorkflowJob>;
-  on?: Record<string, unknown>;
-}
+import {
+  getWorkflowStep as getWorkflowStepFrom,
+  loadWorkflow as loadWorkflowFrom,
+  type WorkflowStep,
+} from './workflow-test-utils';
 
 interface LefthookCommand {
   priority?: number;
@@ -48,23 +26,16 @@ const lefthookPath = fileURLToPath(new URL('../../lefthook.yml', import.meta.url
 const processorPath = fileURLToPath(new URL('../../test/load-test.processor.cjs', import.meta.url));
 const emojiPrefix = /^\p{Extended_Pictographic}/u;
 const workflowTestsCommand = 'npm run test:workflows';
-
-function loadWorkflow(): WorkflowDefinition {
-  return yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
-}
+const loadWorkflow = loadWorkflowFrom.bind(undefined, workflowPath);
+const getWorkflowStep = getWorkflowStepFrom.bind(undefined, workflowPath);
 
 function loadLefthook(): LefthookDefinition {
   return yaml.parse(readFileSync(lefthookPath, 'utf8')) as LefthookDefinition;
 }
 
-function getTestJobStep(name: string): WorkflowJobStep | undefined {
+function getTestJobStep(name: string): WorkflowStep | undefined {
   const workflow = loadWorkflow();
   return workflow.jobs?.test?.steps?.find((step) => step.name === name);
-}
-
-function getWorkflowStep(jobId: string, name: string): WorkflowJobStep | undefined {
-  const workflow = loadWorkflow();
-  return workflow.jobs?.[jobId]?.steps?.find((step) => step.name === name);
 }
 
 test('ci-verify job names are emoji-prefixed for GitHub checks readability', () => {

--- a/.github/tests/crowdin-workflow.test.ts
+++ b/.github/tests/crowdin-workflow.test.ts
@@ -3,20 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import yaml from 'yaml';
 
-interface WorkflowStep {
-  name?: string;
-  uses?: string;
-  with?: Record<string, string>;
-  'continue-on-error'?: boolean;
-}
-
-interface WorkflowJob {
-  steps?: WorkflowStep[];
-}
-
-interface WorkflowDefinition {
-  jobs?: Record<string, WorkflowJob>;
-}
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
 
 interface CrowdinConfig {
   files?: Array<{
@@ -31,7 +18,7 @@ const crowdinConfigPath = fileURLToPath(new URL('../../crowdin.yml', import.meta
 const crowdinActionRef = 'crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f';
 
 function loadCrowdinWorkflowStep(): WorkflowStep {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
   const step = workflow.jobs?.sync?.steps?.find((step) =>
     step.uses?.startsWith('crowdin/github-action@'),
   );

--- a/.github/tests/e2e-playwright-workflow.test.ts
+++ b/.github/tests/e2e-playwright-workflow.test.ts
@@ -1,36 +1,13 @@
-import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-import yaml from 'yaml';
-
-interface WorkflowStep {
-  name?: string;
-  uses?: string;
-  with?: Record<string, string>;
-}
-
-interface WorkflowJob {
-  env?: Record<string, string>;
-  if?: string;
-  needs?: string[];
-  steps?: WorkflowStep[];
-}
-
-interface WorkflowDefinition {
-  env?: Record<string, string>;
-  jobs?: Record<string, WorkflowJob>;
-  on?: Record<string, unknown>;
-}
+import {
+  getWorkflowStep as getWorkflowStepFrom,
+  loadWorkflow as loadWorkflowFrom,
+} from './workflow-test-utils';
 
 const workflowPath = fileURLToPath(new URL('../workflows/e2e-playwright.yml', import.meta.url));
-
-function loadWorkflow(): WorkflowDefinition {
-  return yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
-}
-
-function getWorkflowStep(jobId: string, name: string): WorkflowStep | undefined {
-  return loadWorkflow().jobs?.[jobId]?.steps?.find((step) => step.name === name);
-}
+const loadWorkflow = loadWorkflowFrom.bind(undefined, workflowPath);
+const getWorkflowStep = getWorkflowStepFrom.bind(undefined, workflowPath);
 
 test('Playwright workflow disables browser downloads for host-side npm installs', () => {
   const workflow = loadWorkflow();

--- a/.github/tests/github-actions-pins.test.ts
+++ b/.github/tests/github-actions-pins.test.ts
@@ -5,23 +5,11 @@ import { fileURLToPath } from 'node:url';
 import yaml from 'yaml';
 
 import { expectedActionPins } from './github-action-pins';
-
-interface ActionStep {
-  uses?: string;
-  with?: Record<string, unknown>;
-}
-
-interface WorkflowJob {
-  steps?: ActionStep[];
-}
-
-interface WorkflowDocument {
-  jobs?: Record<string, WorkflowJob>;
-}
+import type { WorkflowDefinition, WorkflowStep } from './workflow-test-utils';
 
 interface CompositeActionDocument {
   runs?: {
-    steps?: ActionStep[];
+    steps?: WorkflowStep[];
   };
 }
 
@@ -40,13 +28,13 @@ function collectYamlFiles(directory: string): string[] {
     .sort();
 }
 
-function collectActionSteps(file: string): ActionStep[] {
+function collectActionSteps(file: string): WorkflowStep[] {
   const document = yaml.parse(readFileSync(file, 'utf8')) as
     | CompositeActionDocument
-    | WorkflowDocument
+    | WorkflowDefinition
     | null;
 
-  const workflowSteps = Object.values((document as WorkflowDocument)?.jobs ?? {}).flatMap(
+  const workflowSteps = Object.values((document as WorkflowDefinition)?.jobs ?? {}).flatMap(
     (job) => job.steps ?? [],
   );
   const compositeSteps = (document as CompositeActionDocument)?.runs?.steps ?? [];

--- a/.github/tests/harden-runner-workflow.test.ts
+++ b/.github/tests/harden-runner-workflow.test.ts
@@ -4,19 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import yaml from 'yaml';
 
-interface WorkflowJobStep {
-  uses?: string;
-  with?: Record<string, string>;
-}
-
-interface WorkflowJob {
-  'runs-on'?: string | string[];
-  steps?: WorkflowJobStep[];
-}
-
-interface WorkflowDefinition {
-  jobs?: Record<string, WorkflowJob>;
-}
+import type { WorkflowDefinition } from './workflow-test-utils';
 
 const workflowsDir = fileURLToPath(new URL('../workflows', import.meta.url));
 const hardenRunnerRef = 'step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411';

--- a/.github/tests/mutation-workflow.test.ts
+++ b/.github/tests/mutation-workflow.test.ts
@@ -1,42 +1,13 @@
 import { globSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-import yaml from 'yaml';
-
 import uiStrykerConfig from '../../ui/stryker.conf.mjs';
-
-interface WorkflowTrigger {
-  schedule?: Array<{
-    cron?: string;
-  }>;
-}
+import { loadWorkflow } from './workflow-test-utils';
 
 interface WorkflowMatrixEntry {
   name?: string;
   package?: string;
   mutate?: string;
-}
-
-interface WorkflowJobStep {
-  name?: string;
-  run?: string;
-  uses?: string;
-  with?: Record<string, string>;
-}
-
-interface WorkflowJob {
-  env?: Record<string, string>;
-  strategy?: {
-    matrix?: {
-      include?: WorkflowMatrixEntry[];
-    };
-  };
-  steps?: WorkflowJobStep[];
-}
-
-interface WorkflowDefinition {
-  on?: WorkflowTrigger;
-  jobs?: Record<string, WorkflowJob>;
 }
 
 const workflowPath = fileURLToPath(
@@ -94,7 +65,7 @@ function splitMutateEntry(entry: WorkflowMatrixEntry): string[] {
 }
 
 test('mutation workflow runs monthly with 27 logical slices and aggregate count parity', () => {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
 
   expect(workflow.on?.schedule).toStrictEqual([{ cron: '15 6 1 * *' }]);
 
@@ -114,7 +85,7 @@ test('mutation workflow runs monthly with 27 logical slices and aggregate count 
 });
 
 test('mutation aggregate job verifies downloaded artifact layout before merging', () => {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
   const aggregateSteps = workflow.jobs?.aggregate?.steps ?? [];
 
   expect(aggregateSteps.find((step) => step.name === 'Download mutation artifacts')).toMatchObject({
@@ -133,7 +104,7 @@ test('mutation aggregate job verifies downloaded artifact layout before merging'
 });
 
 test('mutation shards publish distinct dashboard reports when configured', () => {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
 
   expect(workflow.jobs?.stryker?.env).toMatchObject({
     STRYKER_DASHBOARD_API_KEY: '${{ secrets.STRYKER_DASHBOARD_API_KEY }}',
@@ -154,7 +125,7 @@ test('mutation shards publish distinct dashboard reports when configured', () =>
 });
 
 test('mutation workflow slices cover the app and ui Stryker targets without overlap', () => {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
   const matrixEntries = workflow.jobs?.stryker?.strategy?.matrix?.include ?? [];
 
   const appEntries = matrixEntries.filter((entry) => entry.package === 'app');

--- a/.github/tests/path-filter-workflow.test.ts
+++ b/.github/tests/path-filter-workflow.test.ts
@@ -3,19 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import yaml from 'yaml';
 
-interface WorkflowStep {
-  id?: string;
-  uses?: string;
-  with?: Record<string, string>;
-}
-
-interface WorkflowJob {
-  steps?: WorkflowStep[];
-}
-
-interface WorkflowDefinition {
-  jobs?: Record<string, WorkflowJob>;
-}
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
 
 interface RuntimeFilterDefinition {
   runtime?: string[];
@@ -26,10 +14,6 @@ const e2ePlaywrightWorkflowPath = fileURLToPath(
   new URL('../workflows/e2e-playwright.yml', import.meta.url),
 );
 const runtimeFiltersPath = fileURLToPath(new URL('../filters/runtime.yml', import.meta.url));
-
-function loadWorkflow(path: string): WorkflowDefinition {
-  return yaml.parse(readFileSync(path, 'utf8')) as WorkflowDefinition;
-}
 
 function getPathFilterStep(path: string): WorkflowStep | undefined {
   const workflow = loadWorkflow(path);

--- a/.github/tests/release-cut-retry-workflow.test.ts
+++ b/.github/tests/release-cut-retry-workflow.test.ts
@@ -2,24 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-import yaml from 'yaml';
-
-interface WorkflowStep {
-  env?: Record<string, string>;
-  id?: string;
-  name?: string;
-  uses?: string;
-  run?: string;
-  with?: Record<string, unknown>;
-}
-
-interface WorkflowJob {
-  steps?: WorkflowStep[];
-}
-
-interface WorkflowDefinition {
-  jobs?: Record<string, WorkflowJob>;
-}
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
 
 const workflowPath = fileURLToPath(new URL('../workflows/release-cut.yml', import.meta.url));
 const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
@@ -41,7 +24,7 @@ const transientRetryStepNames = [
 ];
 
 function loadReleaseSteps(): WorkflowStep[] {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
   return workflow.jobs?.release?.steps ?? [];
 }
 

--- a/.github/tests/workflow-test-utils.ts
+++ b/.github/tests/workflow-test-utils.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+
+import yaml from 'yaml';
+
+export interface WorkflowStep {
+  env?: Record<string, string>;
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  'continue-on-error'?: boolean;
+  'working-directory'?: string;
+  if?: string;
+}
+
+export interface WorkflowJob {
+  env?: Record<string, string>;
+  name?: string;
+  steps?: WorkflowStep[];
+  strategy?: {
+    matrix?: {
+      include?: Array<{
+        name?: string;
+        package?: string;
+        mutate?: string;
+      }>;
+    };
+  };
+  'runs-on'?: string | string[];
+  'timeout-minutes'?: number;
+  if?: string;
+  needs?: string | string[];
+}
+
+export interface WorkflowDefinition {
+  env?: Record<string, string>;
+  jobs?: Record<string, WorkflowJob>;
+  on?: {
+    schedule?: Array<{
+      cron?: string;
+    }>;
+    [trigger: string]: unknown;
+  };
+}
+
+export function loadWorkflow(path: string): WorkflowDefinition {
+  return yaml.parse(readFileSync(path, 'utf8')) as WorkflowDefinition;
+}
+
+export function getWorkflowStep(
+  path: string,
+  jobId: string,
+  name: string,
+): WorkflowStep | undefined {
+  return loadWorkflow(path).jobs?.[jobId]?.steps?.find((step) => step.name === name);
+}


### PR DESCRIPTION
CodeRabbit flagged duplicated workflow-test scaffolding on PR #532 as a nitpick; it merged unaddressed to keep the release train moving and was recorded as #544.

Extracts the `WorkflowDefinition`/`WorkflowJob`/`WorkflowStep` interfaces and `loadWorkflow`/`getWorkflowStep` helpers — previously copy-pasted (and patched in lockstep) across 8 workflow test files — into a shared `.github/tests/workflow-test-utils.ts`. Purely structural: every existing assertion is unchanged, net −151 lines. Files whose local wrapper took no path bind the workflow path once; the rest call the shared helpers with an explicit path.

Verification: `npm run test:workflows` (the pre-push `workflow-tests` gate step) — 9 files, 33 tests green; biome clean; full pre-push gate green from a worktree.

Ships in v1.6.0-rc.2 (CI-only, no runtime code touched).

Fixes #544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changelog

- ✨ Added shared workflow-test utilities for workflow types, YAML loading, and step lookup.
- 🔧 Changed eight workflow tests to use the shared utilities while preserving existing assertions.
- 🗑️ Removed duplicated workflow interfaces, YAML parsing, and helper implementations from individual tests.
- 🔧 Updated composite-action step handling to use shared `WorkflowStep` types.
- 🔧 Verified 9 workflow-test files, 33 tests, Biome, and the full pre-push gate.

### Concerns

- Confirm all workflow tests continue passing in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->