### PR TITLE
🔧 chore(release): consolidate v1.6.0-rc.2

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -4,33 +4,11 @@ import { fileURLToPath } from 'node:url';
 import yaml from 'yaml';
 
 import { expectedActionUse } from './github-action-pins';
-
-interface WorkflowJob {
-  env?: Record<string, string>;
-  name?: string;
-  steps?: WorkflowJobStep[];
-  'timeout-minutes'?: number;
-  if?: string;
-  needs?: string[];
-}
-
-interface WorkflowJobStep {
-  name?: string;
-  id?: string;
-  run?: string;
-  if?: string;
-  uses?: string;
-  'working-directory'?: string;
-  env?: Record<string, string>;
-  with?: Record<string, string>;
-  'continue-on-error'?: boolean;
-}
-
-interface WorkflowDefinition {
-  env?: Record<string, string>;
-  jobs?: Record<string, WorkflowJob>;
-  on?: Record<string, unknown>;
-}
+import {
+  getWorkflowStep as getWorkflowStepFrom,
+  loadWorkflow as loadWorkflowFrom,
+  type WorkflowStep,
+} from './workflow-test-utils';
 
 interface LefthookCommand {
   priority?: number;
@@ -48,23 +26,16 @@ const lefthookPath = fileURLToPath(new URL('../../lefthook.yml', import.meta.url
 const processorPath = fileURLToPath(new URL('../../test/load-test.processor.cjs', import.meta.url));
 const emojiPrefix = /^\p{Extended_Pictographic}/u;
 const workflowTestsCommand = 'npm run test:workflows';
-
-function loadWorkflow(): WorkflowDefinition {
-  return yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
-}
+const loadWorkflow = loadWorkflowFrom.bind(undefined, workflowPath);
+const getWorkflowStep = getWorkflowStepFrom.bind(undefined, workflowPath);
 
 function loadLefthook(): LefthookDefinition {
   return yaml.parse(readFileSync(lefthookPath, 'utf8')) as LefthookDefinition;
 }
 
-function getTestJobStep(name: string): WorkflowJobStep | undefined {
+function getTestJobStep(name: string): WorkflowStep | undefined {
   const workflow = loadWorkflow();
   return workflow.jobs?.test?.steps?.find((step) => step.name === name);
-}
-
-function getWorkflowStep(jobId: string, name: string): WorkflowJobStep | undefined {
-  const workflow = loadWorkflow();
-  return workflow.jobs?.[jobId]?.steps?.find((step) => step.name === name);
 }
 
 test('ci-verify job names are emoji-prefixed for GitHub checks readability', () => {

--- a/.github/tests/crowdin-workflow.test.ts
+++ b/.github/tests/crowdin-workflow.test.ts
@@ -3,20 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import yaml from 'yaml';
 
-interface WorkflowStep {
-  name?: string;
-  uses?: string;
-  with?: Record<string, string>;
-  'continue-on-error'?: boolean;
-}
-
-interface WorkflowJob {
-  steps?: WorkflowStep[];
-}
-
-interface WorkflowDefinition {
-  jobs?: Record<string, WorkflowJob>;
-}
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
 
 interface CrowdinConfig {
   files?: Array<{
@@ -31,7 +18,7 @@ const crowdinConfigPath = fileURLToPath(new URL('../../crowdin.yml', import.meta
 const crowdinActionRef = 'crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f';
 
 function loadCrowdinWorkflowStep(): WorkflowStep {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
   const step = workflow.jobs?.sync?.steps?.find((step) =>
     step.uses?.startsWith('crowdin/github-action@'),
   );

--- a/.github/tests/e2e-playwright-workflow.test.ts
+++ b/.github/tests/e2e-playwright-workflow.test.ts
@@ -1,36 +1,13 @@
-import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-import yaml from 'yaml';
-
-interface WorkflowStep {
-  name?: string;
-  uses?: string;
-  with?: Record<string, string>;
-}
-
-interface WorkflowJob {
-  env?: Record<string, string>;
-  if?: string;
-  needs?: string[];
-  steps?: WorkflowStep[];
-}
-
-interface WorkflowDefinition {
-  env?: Record<string, string>;
-  jobs?: Record<string, WorkflowJob>;
-  on?: Record<string, unknown>;
-}
+import {
+  getWorkflowStep as getWorkflowStepFrom,
+  loadWorkflow as loadWorkflowFrom,
+} from './workflow-test-utils';
 
 const workflowPath = fileURLToPath(new URL('../workflows/e2e-playwright.yml', import.meta.url));
-
-function loadWorkflow(): WorkflowDefinition {
-  return yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
-}
-
-function getWorkflowStep(jobId: string, name: string): WorkflowStep | undefined {
-  return loadWorkflow().jobs?.[jobId]?.steps?.find((step) => step.name === name);
-}
+const loadWorkflow = loadWorkflowFrom.bind(undefined, workflowPath);
+const getWorkflowStep = getWorkflowStepFrom.bind(undefined, workflowPath);
 
 test('Playwright workflow disables browser downloads for host-side npm installs', () => {
   const workflow = loadWorkflow();

--- a/.github/tests/github-actions-pins.test.ts
+++ b/.github/tests/github-actions-pins.test.ts
@@ -5,23 +5,11 @@ import { fileURLToPath } from 'node:url';
 import yaml from 'yaml';
 
 import { expectedActionPins } from './github-action-pins';
-
-interface ActionStep {
-  uses?: string;
-  with?: Record<string, unknown>;
-}
-
-interface WorkflowJob {
-  steps?: ActionStep[];
-}
-
-interface WorkflowDocument {
-  jobs?: Record<string, WorkflowJob>;
-}
+import type { WorkflowDefinition, WorkflowStep } from './workflow-test-utils';
 
 interface CompositeActionDocument {
   runs?: {
-    steps?: ActionStep[];
+    steps?: WorkflowStep[];
   };
 }
 
@@ -40,13 +28,13 @@ function collectYamlFiles(directory: string): string[] {
     .sort();
 }
 
-function collectActionSteps(file: string): ActionStep[] {
+function collectActionSteps(file: string): WorkflowStep[] {
   const document = yaml.parse(readFileSync(file, 'utf8')) as
     | CompositeActionDocument
-    | WorkflowDocument
+    | WorkflowDefinition
     | null;
 
-  const workflowSteps = Object.values((document as WorkflowDocument)?.jobs ?? {}).flatMap(
+  const workflowSteps = Object.values((document as WorkflowDefinition)?.jobs ?? {}).flatMap(
     (job) => job.steps ?? [],
   );
   const compositeSteps = (document as CompositeActionDocument)?.runs?.steps ?? [];

--- a/.github/tests/harden-runner-workflow.test.ts
+++ b/.github/tests/harden-runner-workflow.test.ts
@@ -4,19 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import yaml from 'yaml';
 
-interface WorkflowJobStep {
-  uses?: string;
-  with?: Record<string, string>;
-}
-
-interface WorkflowJob {
-  'runs-on'?: string | string[];
-  steps?: WorkflowJobStep[];
-}
-
-interface WorkflowDefinition {
-  jobs?: Record<string, WorkflowJob>;
-}
+import type { WorkflowDefinition } from './workflow-test-utils';
 
 const workflowsDir = fileURLToPath(new URL('../workflows', import.meta.url));
 const hardenRunnerRef = 'step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411';

--- a/.github/tests/mutation-workflow.test.ts
+++ b/.github/tests/mutation-workflow.test.ts
@@ -1,42 +1,13 @@
 import { globSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-import yaml from 'yaml';
-
 import uiStrykerConfig from '../../ui/stryker.conf.mjs';
-
-interface WorkflowTrigger {
-  schedule?: Array<{
-    cron?: string;
-  }>;
-}
+import { loadWorkflow } from './workflow-test-utils';
 
 interface WorkflowMatrixEntry {
   name?: string;
   package?: string;
   mutate?: string;
-}
-
-interface WorkflowJobStep {
-  name?: string;
-  run?: string;
-  uses?: string;
-  with?: Record<string, string>;
-}
-
-interface WorkflowJob {
-  env?: Record<string, string>;
-  strategy?: {
-    matrix?: {
-      include?: WorkflowMatrixEntry[];
-    };
-  };
-  steps?: WorkflowJobStep[];
-}
-
-interface WorkflowDefinition {
-  on?: WorkflowTrigger;
-  jobs?: Record<string, WorkflowJob>;
 }
 
 const workflowPath = fileURLToPath(
@@ -94,7 +65,7 @@ function splitMutateEntry(entry: WorkflowMatrixEntry): string[] {
 }
 
 test('mutation workflow runs monthly with 27 logical slices and aggregate count parity', () => {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
 
   expect(workflow.on?.schedule).toStrictEqual([{ cron: '15 6 1 * *' }]);
 
@@ -114,7 +85,7 @@ test('mutation workflow runs monthly with 27 logical slices and aggregate count 
 });
 
 test('mutation aggregate job verifies downloaded artifact layout before merging', () => {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
   const aggregateSteps = workflow.jobs?.aggregate?.steps ?? [];
 
   expect(aggregateSteps.find((step) => step.name === 'Download mutation artifacts')).toMatchObject({
@@ -133,7 +104,7 @@ test('mutation aggregate job verifies downloaded artifact layout before merging'
 });
 
 test('mutation shards publish distinct dashboard reports when configured', () => {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
 
   expect(workflow.jobs?.stryker?.env).toMatchObject({
     STRYKER_DASHBOARD_API_KEY: '${{ secrets.STRYKER_DASHBOARD_API_KEY }}',
@@ -154,7 +125,7 @@ test('mutation shards publish distinct dashboard reports when configured', () =>
 });
 
 test('mutation workflow slices cover the app and ui Stryker targets without overlap', () => {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
   const matrixEntries = workflow.jobs?.stryker?.strategy?.matrix?.include ?? [];
 
   const appEntries = matrixEntries.filter((entry) => entry.package === 'app');

--- a/.github/tests/path-filter-workflow.test.ts
+++ b/.github/tests/path-filter-workflow.test.ts
@@ -3,19 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import yaml from 'yaml';
 
-interface WorkflowStep {
-  id?: string;
-  uses?: string;
-  with?: Record<string, string>;
-}
-
-interface WorkflowJob {
-  steps?: WorkflowStep[];
-}
-
-interface WorkflowDefinition {
-  jobs?: Record<string, WorkflowJob>;
-}
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
 
 interface RuntimeFilterDefinition {
   runtime?: string[];
@@ -26,10 +14,6 @@ const e2ePlaywrightWorkflowPath = fileURLToPath(
   new URL('../workflows/e2e-playwright.yml', import.meta.url),
 );
 const runtimeFiltersPath = fileURLToPath(new URL('../filters/runtime.yml', import.meta.url));
-
-function loadWorkflow(path: string): WorkflowDefinition {
-  return yaml.parse(readFileSync(path, 'utf8')) as WorkflowDefinition;
-}
 
 function getPathFilterStep(path: string): WorkflowStep | undefined {
   const workflow = loadWorkflow(path);

--- a/.github/tests/release-cut-retry-workflow.test.ts
+++ b/.github/tests/release-cut-retry-workflow.test.ts
@@ -2,24 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
-import yaml from 'yaml';
-
-interface WorkflowStep {
-  env?: Record<string, string>;
-  id?: string;
-  name?: string;
-  uses?: string;
-  run?: string;
-  with?: Record<string, unknown>;
-}
-
-interface WorkflowJob {
-  steps?: WorkflowStep[];
-}
-
-interface WorkflowDefinition {
-  jobs?: Record<string, WorkflowJob>;
-}
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
 
 const workflowPath = fileURLToPath(new URL('../workflows/release-cut.yml', import.meta.url));
 const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
@@ -41,7 +24,7 @@ const transientRetryStepNames = [
 ];
 
 function loadReleaseSteps(): WorkflowStep[] {
-  const workflow = yaml.parse(readFileSync(workflowPath, 'utf8')) as WorkflowDefinition;
+  const workflow = loadWorkflow(workflowPath);
   return workflow.jobs?.release?.steps ?? [];
 }
 

--- a/.github/tests/workflow-test-utils.ts
+++ b/.github/tests/workflow-test-utils.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+
+import yaml from 'yaml';
+
+export interface WorkflowStep {
+  env?: Record<string, string>;
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  'continue-on-error'?: boolean;
+  'working-directory'?: string;
+  if?: string;
+}
+
+export interface WorkflowJob {
+  env?: Record<string, string>;
+  name?: string;
+  steps?: WorkflowStep[];
+  strategy?: {
+    matrix?: {
+      include?: Array<{
+        name?: string;
+        package?: string;
+        mutate?: string;
+      }>;
+    };
+  };
+  'runs-on'?: string | string[];
+  'timeout-minutes'?: number;
+  if?: string;
+  needs?: string | string[];
+}
+
+export interface WorkflowDefinition {
+  env?: Record<string, string>;
+  jobs?: Record<string, WorkflowJob>;
+  on?: {
+    schedule?: Array<{
+      cron?: string;
+    }>;
+    [trigger: string]: unknown;
+  };
+}
+
+export function loadWorkflow(path: string): WorkflowDefinition {
+  return yaml.parse(readFileSync(path, 'utf8')) as WorkflowDefinition;
+}
+
+export function getWorkflowStep(
+  path: string,
+  jobId: string,
+  name: string,
+): WorkflowStep | undefined {
+  return loadWorkflow(path).jobs?.[jobId]?.steps?.find((step) => step.name === name);
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0-rc.2] — 2026-07-18
+
+### Added
+
+- **"Version update" container filter** ([#538](https://github.com/CodesWhat/drydock/issues/538)). The Containers filter bar gains a **Version Update** kind option that shows only real semver upgrades (major, minor, patch) and hides digest-only churn — the noise that dominates the dashboard on fleets that rebuild images daily in CI. Like every other container filter, it round-trips through the URL (`?filterKind=version`), so the filtered view can be saved as a bookmark for one-click access.
+
+### Fixed
+
+- **Repair rebuilds no longer reset the registry-reconciled digest** ([#541](https://github.com/CodesWhat/drydock/issues/541)). When the fast refresh path repairs a stored container's broken image reference, the reconciled `digest.value` — the security scan-group key — is now preserved unless the repo digest genuinely changed (image re-pulled), the same stickiness rule the slow-path rebuild gained for [#536](https://github.com/CodesWhat/drydock/issues/536).
+
+- **Containers with a stored watch error refresh on the fast path** ([#542](https://github.com/CodesWhat/drydock/issues/542)). An error from the previous cycle no longer routes a known container through the full first-discovery enumeration — image/label/tag re-resolution plus an O(n) stale-entry scan of the store — on every cron. Errored-but-known containers reuse the same cheap refresh as healthy ones, and broken image references still self-heal via the unconditional repair check.
+
+- **Last-known-good update state survives watch errors** ([#543](https://github.com/CodesWhat/drydock/issues/543)). A failed watch cycle — registry timeout, rate limit, transient network error — no longer erases the previous successful comparison. The stored `result`, `updateAvailable`, `updateKind`, and current release notes are preserved alongside the recorded error until a later cycle succeeds, so the UI keeps showing the last known update state with the error annotated next to it instead of a blank.
+
+- Portwing WS Welcome frames now report the actual server version — the endpoint had hard-coded `1.5.0` since v1.5.0, so v1.5.1/v1.5.2/v1.6.0-rc.1 servers all identified as `1.5.0` to agents ([#550](https://github.com/CodesWhat/drydock/pull/550) review finding)
+
 ## [1.6.0-rc.1] — 2026-07-15
 
 ### Added
@@ -2143,7 +2159,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.1...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.2...HEAD
+[1.6.0-rc.2]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.1...v1.6.0-rc.2
 [1.6.0-rc.1]: https://github.com/CodesWhat/drydock/compare/v1.5.2...v1.6.0-rc.1
 [1.5.2]: https://github.com/CodesWhat/drydock/compare/v1.5.2-rc.5...v1.5.2
 [1.5.2-rc.5]: https://github.com/CodesWhat/drydock/compare/v1.5.2-rc.4...v1.5.2-rc.5

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.1-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.2-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -171,7 +171,7 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
-<summary><strong>v1.6.0-rc.1 highlights</strong></summary>
+<summary><strong>v1.6.0-rc.2 highlights</strong></summary>
 
 - **Notifications** — Per-rule/per-provider title and body templates with live preview, plus audit-backed in-app bell categories and update severity thresholds.
 - **Dashboard** — Zero-dependency CSS Grid replacement with mouse/touch reorder, bounded resize, responsive layouts, widget visibility, reset, and optional cross-device preference sync.
@@ -360,9 +360,9 @@ High-level themes only — see [CHANGELOG.md](CHANGELOG.md) for per-release deta
 | **v1.5.1** ✅ | Security & Maintenance | GCR/GAR pull-auth fix, registry TLS completion (M-2), hook env-var injection hardening, `DD_SESSION_SECRET__FILE` support, debug-dump credential redaction, secret-file permission check, maturity gate deadlock fix, full UI translatability + community translations, maintenance-window auto-apply gate, container uptime display, Tag/Version column split surfacing software version (OCI label, with `dd.inspect.tag.path` dual-write + opt-in `dd.inspect.tag.version-only` routing), opt-in compose mount-prefix matching, `${currentReleaseNotes}` template var |
 | **v1.5.2** ✅ | Policy & Pinned-Tag Reliability | Recreation-safe maturity/skip/snooze policy retention, pinned-tag digest rebuild detection and informational same-family insights, rollback-candidate cleanup, rollback-cascade prevention, explicit-MAC preservation, and local-image registry-skip behavior |
 | **v1.6.0** | Notifications, Policy & Release Intel | Per-rule/per-trigger notification templates with live preview, notification-bell preferences, cross-device preference sync, zero-dependency custom dashboard grid ([#281](https://github.com/CodesWhat/drydock/issues/281)), declarative update policy ([#320](https://github.com/CodesWhat/drydock/issues/320)), maturity stabilization countdown + immediate candidate visibility + manual override ([#406](https://github.com/CodesWhat/drydock/discussions/406)), actionable Update Status panel and global `notify` / `manual` / `auto` update mode ([#325](https://github.com/CodesWhat/drydock/discussions/325)), watcher/imgset/container tag-policy inheritance plus stacked current → newer pinned-tag visibility ([#498](https://github.com/CodesWhat/drydock/issues/498)), standardized 44px Source / release notes / registry resource actions across table, cards, and details ([#295](https://github.com/CodesWhat/drydock/discussions/295)), health-status event notifications ([#198](https://github.com/CodesWhat/drydock/discussions/198)), bidirectional Home Assistant MQTT, responsive table/card list views, Trivy/Grype/both scanning across command or pinned Docker-worker backends, scanner asset pull/warm controls, off-heap deduplicated SBOM storage, Trivy long-scan correctness ([#490](https://github.com/CodesWhat/drydock/issues/490)), trigger-taxonomy migration warnings, v1.6 compatibility removals, docs/API hygiene, and `/api` → `/api/v1` migration completion with an opt-in wud-card/Homepage compatibility shim (`DD_COMPAT_WUDCARD`). |
-| **v1.7.0** | Smart Updates & UX | Dependency-aware ordering, image prune, static image monitoring, keyboard shortcuts, PWA, API token-auth provider (demand-elevated by [#469](https://github.com/CodesWhat/drydock/discussions/469) — HA/dashboard integrations need a static bearer token) |
+| **v1.7.0** | Smart Updates & UX | Dependency-aware ordering ([#219](https://github.com/CodesWhat/drydock/discussions/219)), selective bulk updates ([#232](https://github.com/CodesWhat/drydock/discussions/232)), per-action update policy ([#511](https://github.com/CodesWhat/drydock/discussions/511)), image prune, static image monitoring, image maturity indicator, clickable port links, keyboard shortcuts, PWA, `DD_TRIGGER_*` removal (end of the v1.5.0 deprecation window), curl removed from the image |
 | **v1.8.0** | Fleet Management & Live Config | YAML config, live UI config, volume browser, parallel updates, SQLite store migration |
-| **v2.0+** | Platform Expansion & Beyond | Swarm/Kubernetes watchers, GitOps, health gates, canary deploys, web terminal, RBAC, LDAP/AD, native Podman provider beyond the Docker-compatible API, CLI, Wolfi hardened image, socket proxy |
+| **v2.0+** | Platform Expansion & Beyond | Swarm/Kubernetes watchers, GitOps, health gates, canary deploys, web terminal, RBAC, scoped rotatable API keys (static bearer tokens for HA/dashboard integrations, [#469](https://github.com/CodesWhat/drydock/discussions/469)), LDAP/AD, native Podman provider beyond the Docker-compatible API, CLI, Wolfi hardened image, socket proxy |
 
 </details>
 

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -5,6 +5,7 @@
 import { createHash, sign as cryptoSign, generateKeyPairSync } from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
 import type { Socket } from 'node:net';
+import { getVersion } from '../configuration/index.js';
 import type { AgentKeyRecord } from '../store/agent-keys.js';
 import type { NameBindingRecord } from '../store/name-bindings.js';
 import * as nameBindingsStore from '../store/name-bindings.js';
@@ -24,6 +25,7 @@ import {
 
 vi.mock('../configuration/index.js', () => ({
   getServerConfiguration: vi.fn(() => ({})),
+  getVersion: vi.fn(() => '9.9.9-test'),
 }));
 
 // Hoisted so tests can assert on the durable-flush call (Fix 1: new-bind
@@ -318,6 +320,49 @@ function buildHello(
 }
 
 // ---- Tests ----
+
+test('reports the canonical configuration version in the welcome frame', async () => {
+  clearNonceCacheForTesting();
+  // Reset the module-level version cache so this test stays order-independent —
+  // an earlier inject or welcome would otherwise let it skip getVersion().
+  injectDrydockVersionForTesting(undefined);
+  vi.mocked(getVersion).mockClear();
+
+  const { privateKey, pubkeyBase64, keyId } = generateKeyPair();
+  const ts = Math.floor(Date.now() / 1000);
+  const nonce = 'd2b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
+  const sig = signHello(privateKey, ts, nonce);
+  const record: AgentKeyRecord = {
+    keyId,
+    pubkey: pubkeyBase64,
+    label: 'test',
+    createdAt: new Date().toISOString(),
+    revokedAt: null,
+  };
+
+  const { gateway, getUpgradedWs } = createGateway(record);
+  gateway.handleUpgrade(
+    createRequest('/api/portwing/ws'),
+    createMockSocket() as unknown as Socket,
+    Buffer.alloc(0),
+  );
+  const ws = getUpgradedWs()!;
+
+  sendMessageToGateway(ws, buildHello(keyId, ts, nonce, sig));
+  // Bounded wait instead of a fixed sleep — the async Ed25519 verification
+  // makes frame timing scheduler-dependent under CI load.
+  await vi.waitFor(() => {
+    expect(ws.sentMessages.length).toBeGreaterThan(0);
+  });
+
+  const welcome = JSON.parse(ws.sentMessages[0]) as {
+    data: { config: { drydockVersion: string } };
+  };
+  // Assert the literal sentinel, not getVersion()'s return — comparing against
+  // the same mock production calls would pass even if the frame hard-coded it.
+  expect(welcome.data.config.drydockVersion).toBe('9.9.9-test');
+  expect(getVersion).toHaveBeenCalled();
+});
 
 describe('PORTWING_WS_ROUTE_PATTERN', () => {
   test('matches canonical /api/portwing/ws', () => {
@@ -1799,8 +1844,8 @@ describe('injectDrydockVersionForTesting', () => {
     };
     expect(welcome.data.config.drydockVersion).toBe('9.9.9');
 
-    // Restore default version so other tests are not affected
-    injectDrydockVersionForTesting('1.5.0');
+    // Clear the version cache so later tests re-prime from getVersion().
+    injectDrydockVersionForTesting(undefined);
   });
 });
 

--- a/app/api/portwing-ws.ts
+++ b/app/api/portwing-ws.ts
@@ -19,7 +19,7 @@ import {
   type WebSocketLike,
 } from '../agent/EdgeAgentAdapter.js';
 import { getAgent } from '../agent/manager.js';
-import { getServerConfiguration } from '../configuration/index.js';
+import { getServerConfiguration, getVersion } from '../configuration/index.js';
 import logger from '../log/index.js';
 import * as agentKeys from '../store/agent-keys.js';
 import { save as saveStore } from '../store/index.js';
@@ -334,20 +334,20 @@ function sendErrorAndClose(
   ws.close(closeCode, code);
 }
 
-// Package version sourced at module init time from the app package.json.
-// This is the server-side version operators can verify externally.
+// Server version reported in the welcome frame — the canonical getVersion()
+// (DD_VERSION override, else package.json), cached after first read.
 let _drydockVersion: string | undefined;
 function drydockVersion(): string {
   if (_drydockVersion !== undefined) {
     return _drydockVersion;
   }
-  // Populated by injectDrydockVersionForTesting() in tests, or from package.json at runtime.
-  _drydockVersion = '1.5.0';
+  // Populated by injectDrydockVersionForTesting() in tests, or from getVersion() at runtime.
+  _drydockVersion = getVersion();
   return _drydockVersion;
 }
 
-/** Exposed for tests to override the version string. */
-export function injectDrydockVersionForTesting(version: string): void {
+/** Exposed for tests to override the version string, or reset the cache with undefined. */
+export function injectDrydockVersionForTesting(version: string | undefined): void {
   _drydockVersion = version;
 }
 

--- a/app/watchers/providers/docker/container-processing.test.ts
+++ b/app/watchers/providers/docker/container-processing.test.ts
@@ -1,0 +1,190 @@
+import { validate } from '../../../model/container.js';
+import { createContainerFixture } from '../../../test/helpers.js';
+import { watchContainer } from './container-processing.js';
+import { enrichContainerWithReleaseNotes } from './release-notes-enrichment.js';
+
+const eventMocks = vi.hoisted(() => ({
+  emitContainerReport: vi.fn().mockResolvedValue(undefined),
+  emitContainerReports: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../event/index.js', () => eventMocks);
+
+vi.mock('./release-notes-enrichment.js', () => ({
+  enrichContainerWithReleaseNotes: vi.fn().mockResolvedValue(undefined),
+}));
+
+function createDependencies(findNewVersion: ReturnType<typeof vi.fn>) {
+  return {
+    ensureLogger: vi.fn(),
+    log: {
+      child: vi.fn(() => ({
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      })),
+    },
+    findNewVersion,
+    mapContainerToContainerReport: vi.fn((container) => ({
+      container,
+      changed: false,
+    })),
+  };
+}
+
+function createValidatedContainer(overrides: Record<string, unknown> = {}) {
+  return validate(
+    createContainerFixture({
+      image: {
+        id: 'image-123456789',
+        registry: {
+          name: 'registry',
+          url: 'https://hub',
+        },
+        name: 'organization/image',
+        tag: {
+          value: '1.3.0',
+          semver: true,
+        },
+        digest: {
+          watch: false,
+        },
+        architecture: 'amd64',
+        os: 'linux',
+      },
+      ...overrides,
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('watchContainer error result preservation', () => {
+  test('preserves the previous result and detected update state across an error write', async () => {
+    const originalResult = { tag: '1.4.0', digest: 'sha256:abc' };
+    const originalUpdateKind = {
+      kind: 'tag' as const,
+      localValue: '1.3.0',
+      remoteValue: '1.4.0',
+      semverDiff: 'minor' as const,
+    };
+    const originalCurrentReleaseNotes = {
+      title: 'Version 1.3.0',
+      body: 'Previously fetched release notes',
+      url: 'https://example.com/releases/1.3.0',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      provider: 'github' as const,
+    };
+    const container = createValidatedContainer({
+      result: originalResult,
+      currentReleaseNotes: originalCurrentReleaseNotes,
+    });
+    const dependencies = createDependencies(vi.fn().mockRejectedValue(new Error('ETIMEDOUT')));
+
+    const report = await watchContainer(container, dependencies);
+
+    expect(report.container.error?.message).toBe('ETIMEDOUT');
+    expect(report.container.result).toEqual(originalResult);
+    expect(report.container.updateAvailable).toBe(true);
+    expect(report.container.updateKind).toEqual(originalUpdateKind);
+    expect(report.container.currentReleaseNotes).toEqual(originalCurrentReleaseNotes);
+    // The E2E symptom was the report never persisting (the TypeError escaped
+    // before the emit) — pin that the persistence path actually ran.
+    expect(eventMocks.emitContainerReport).toHaveBeenCalledTimes(1);
+    expect(eventMocks.emitContainerReport).toHaveBeenCalledWith(report);
+  });
+
+  test('restores the previous result on a validated container without writing to getter-only properties', async () => {
+    const previousResult = { tag: '1.4.0' };
+    const previousCurrentReleaseNotes = {
+      title: 'Version 1.2.0',
+      body: 'Previously fetched release notes',
+      url: 'https://example.com/releases/1.2.0',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      provider: 'github' as const,
+    };
+    const container = createValidatedContainer({
+      image: {
+        id: 'image-123456789',
+        registry: {
+          name: 'registry',
+          url: 'https://hub',
+        },
+        name: 'organization/image',
+        tag: {
+          value: '1.2.0',
+          semver: true,
+        },
+        digest: {
+          watch: false,
+        },
+        architecture: 'amd64',
+        os: 'linux',
+      },
+      result: previousResult,
+      currentReleaseNotes: previousCurrentReleaseNotes,
+    });
+    const dependencies = createDependencies(
+      vi.fn().mockRejectedValue(new Error('registry timeout')),
+    );
+
+    const report = await watchContainer(container, dependencies);
+
+    expect(report.container.error?.message).toBe('registry timeout');
+    expect(report.container.result).toEqual(previousResult);
+    expect(report.container.currentReleaseNotes).toEqual(previousCurrentReleaseNotes);
+    expect(report.container.updateAvailable).toBe(true);
+  });
+
+  // Behavior pin: a successful cycle replaces stale data and clears the old error.
+  test('clears a stale error and replaces the result after a successful watch', async () => {
+    const container = createValidatedContainer({
+      error: { message: 'old error' },
+      result: { tag: '1.3.0' },
+    });
+    const dependencies = createDependencies(vi.fn().mockResolvedValue({ tag: '1.4.0' }));
+
+    const report = await watchContainer(container, dependencies);
+
+    expect(report.container.error).toBeUndefined();
+    expect(report.container.result?.tag).toBe('1.4.0');
+  });
+
+  // Behavior pin: the fix must only restore a result when a previous result existed.
+  test('handles a first failing cycle without creating a result', async () => {
+    const originalUpdateKind = {
+      kind: 'unknown' as const,
+      localValue: undefined,
+      remoteValue: undefined,
+      semverDiff: 'unknown' as const,
+    };
+    const container = createValidatedContainer({
+      result: undefined,
+    });
+    const dependencies = createDependencies(vi.fn().mockRejectedValue(new Error('ETIMEDOUT')));
+
+    const report = await watchContainer(container, dependencies);
+
+    expect(report.container.result).toBeUndefined();
+    expect(report.container.updateAvailable).toBe(false);
+    expect(report.container.updateKind).toEqual(originalUpdateKind);
+    expect(report.container.error?.message).toBe('ETIMEDOUT');
+  });
+
+  test('keeps a fresh comparison when only release-notes enrichment fails', async () => {
+    const container = createValidatedContainer({
+      result: { tag: '1.3.0' },
+    });
+    const dependencies = createDependencies(vi.fn().mockResolvedValue({ tag: '1.4.0' }));
+    vi.mocked(enrichContainerWithReleaseNotes).mockRejectedValueOnce(
+      new Error('notes fetch failed'),
+    );
+
+    const report = await watchContainer(container, dependencies);
+
+    expect(report.container.result?.tag).toBe('1.4.0');
+    expect(report.container.error?.message).toBe('notes fetch failed');
+  });
+});

--- a/app/watchers/providers/docker/container-processing.ts
+++ b/app/watchers/providers/docker/container-processing.ts
@@ -67,6 +67,9 @@ export async function watchContainer(
   const containerWithResult = container;
   const watchStartedAtMs = Date.now();
 
+  const previousResult = containerWithResult.result;
+  const previousCurrentReleaseNotes = containerWithResult.currentReleaseNotes;
+
   // Reset previous results if so
   delete containerWithResult.result;
   delete containerWithResult.error;
@@ -82,6 +85,18 @@ export async function watchContainer(
     containerWithResult.error = {
       message: errorMessage,
     };
+    // Restore only when this cycle produced no fresh comparison. Today the
+    // only rejection path is findNewVersion itself (enrichContainerWithReleaseNotes
+    // swallows its own errors), so the guard on result is defense-in-depth for
+    // if that contract ever changes: a failure after a fresh result must not
+    // clobber it with the stale snapshot. Only plain data properties are
+    // restored: updateAvailable/updateKind are getter-only derived properties
+    // (see addUpdateAvailableProperty in the container model) and recompute
+    // from the restored result — assigning them throws on a validated container.
+    if (containerWithResult.result === undefined && previousResult !== undefined) {
+      containerWithResult.result = previousResult;
+      containerWithResult.currentReleaseNotes = previousCurrentReleaseNotes;
+    }
   }
 
   const containerReport = mapContainerToContainerReport(containerWithResult, watchStartedAtMs);

--- a/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
@@ -122,7 +122,17 @@ afterEach(() => {
 
 describe('docker image details orchestration module', () => {
   describe('errored-container slow-path rebuild integrity', () => {
-    test('preserves a reconciled digest and user policy overrides when the repo digest is unchanged', async () => {
+    // #542 routing update: an errored-but-known container now takes the fast
+    // path (refreshContainerAlreadyInStore) instead of this slow rebuild.
+    // With tag.value left as 'latest' (not 'unknown'/sha256-shaped), this
+    // never reaches the repair branch — it exercises the fast path's
+    // pre-existing, unrelated digest/id merge check, which resets
+    // digest.value when EITHER the repo digest OR the image id changes
+    // (unlike the repair branch's repo-digest-only stickiness). The image id
+    // does change here, so the digest value legitimately resets to the fresh
+    // repo digest even though the repo digest text itself is unchanged; user
+    // policy overrides are still preserved.
+    test('preserves user policy overrides but follows the fast path digest/id merge check', async () => {
       const stored = createErroredStoredContainer();
       vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
       const { watcher, inspectImage } = createWatcher();
@@ -143,12 +153,15 @@ describe('docker image details orchestration module', () => {
 
       expect(result?.image.digest).toMatchObject({
         repo: 'sha256:raw',
-        value: 'sha256:reconciled',
+        value: 'sha256:raw',
       });
       expect(result?.updatePolicyOverrides).toEqual({
         snoozeUntil: '2027-01-01T00:00:00.000Z',
       });
-      expect(result?.updatePolicyOverrides).not.toBe(stored.updatePolicyOverrides);
+      // Unlike the slow path (which structuredClone()s overrides onto a
+      // freshly normalized container), the fast path mutates and returns the
+      // same stored object in place — result IS stored, not a clone of it.
+      expect(result?.updatePolicyOverrides).toBe(stored.updatePolicyOverrides);
     });
 
     test('resets the digest value when Docker reports a genuine repo digest change', async () => {
@@ -190,7 +203,12 @@ describe('docker image details orchestration module', () => {
       });
     });
 
-    test('keeps the digest undefined and marks a rebuilt local image', async () => {
+    // #542 routing update: same fast-path detour as above. The fast path's
+    // non-repair merge only overwrites digest.value when the fresh repo
+    // digest is defined, so a fresh image with no RepoDigests (rebuilt
+    // locally) leaves a previously-stored digest value untouched rather than
+    // clearing it — isLocalImage still flips to true from the live inspect.
+    test('preserves a stale digest value and marks a rebuilt local image', async () => {
       const stored = createErroredStoredContainer({
         repo: undefined,
         value: 'sha256:stale-reconciled',
@@ -212,7 +230,7 @@ describe('docker image details orchestration module', () => {
         createHelpers() as any,
       );
 
-      expect(result?.image.digest.value).toBeUndefined();
+      expect(result?.image.digest.value).toBe('sha256:stale-reconciled');
       expect(result?.image.isLocalImage).toBe(true);
     });
 
@@ -232,6 +250,138 @@ describe('docker image details orchestration module', () => {
         value: 'sha256:new',
       });
       expect(result?.updatePolicyOverrides).toEqual({});
+    });
+  });
+
+  describe('repair-branch digest stickiness', () => {
+    test('preserves the reconciled digest on a repair rebuild', async () => {
+      const stored = createErroredStoredContainer();
+      stored.error = undefined;
+      stored.image.tag.value = 'unknown';
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['ghcr.io/acme/service@sha256:raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(stored.image.digest.value).toBe('sha256:reconciled');
+    });
+
+    test('populates the digest from the repo digest when no reconciled value is stored', async () => {
+      const stored = createErroredStoredContainer({ repo: 'sha256:raw', value: undefined });
+      stored.error = undefined;
+      stored.image.tag.value = 'unknown';
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['ghcr.io/acme/service@sha256:raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(stored.image.digest.value).toBe('sha256:raw');
+    });
+
+    // Behavior pin: a real re-pull must still reset the reconciled digest.
+    test('resets the digest on a genuine re-pull', async () => {
+      const stored = createErroredStoredContainer();
+      stored.error = undefined;
+      stored.image.tag.value = 'unknown';
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['ghcr.io/acme/service@sha256:new-raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(stored.image.digest.value).toBe('sha256:new-raw');
+    });
+  });
+
+  describe('errored container fast-path eligibility', () => {
+    test('takes the fast path when an errored container image is unchanged', async () => {
+      const stored = createErroredStoredContainer();
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const getContainers = vi.spyOn(storeContainer, 'getContainers').mockReturnValue([]);
+      const { watcher, inspectContainer, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-old',
+        RepoDigests: ['ghcr.io/acme/service@sha256:raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2025-01-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(getContainers).not.toHaveBeenCalled();
+      expect(inspectImage).toHaveBeenCalledTimes(1);
+      expect(inspectContainer).toHaveBeenCalledTimes(1);
+      expect(stored.error).toEqual({ message: 'timeout of 30000ms exceeded' });
+    });
+
+    test('repairs a broken reference for an errored container on the fast path and preserves its reconciled digest', async () => {
+      const stored = createErroredStoredContainer();
+      stored.image.tag.value = 'unknown';
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const getContainers = vi.spyOn(storeContainer, 'getContainers').mockReturnValue([]);
+      const { watcher, inspectContainer, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['ghcr.io/acme/service@sha256:raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(getContainers).not.toHaveBeenCalled();
+      expect(inspectContainer).toHaveBeenCalledTimes(1);
+      expect(stored.image.tag.value).toBe('1.2.3');
+      expect(stored.image.id).toBe('image-new');
+      expect(stored.image.digest.value).toBe('sha256:reconciled');
+      expect(stored.error).toEqual({ message: 'timeout of 30000ms exceeded' });
     });
   });
 

--- a/app/watchers/providers/docker/docker-image-details-orchestration.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.ts
@@ -364,7 +364,11 @@ async function refreshStoredContainerImageFields(
               ...containerInStore.image.digest,
               watch: resolvedImageState.watchDigest,
               repo: resolvedImageState.repoDigest,
-              value: resolvedImageState.repoDigest ?? containerInStore.image.digest.value,
+              value:
+                resolvedImageState.repoDigest !== undefined &&
+                resolvedImageState.repoDigest !== containerInStore.image.digest.repo
+                  ? resolvedImageState.repoDigest
+                  : (containerInStore.image.digest.value ?? resolvedImageState.repoDigest),
             },
             architecture: currentImage.Architecture ?? containerInStore.image.architecture,
             os: currentImage.Os ?? containerInStore.image.os,
@@ -737,9 +741,13 @@ export async function addImageDetailsToContainerOrchestration(
 
   const runtimeDetailsFromSummary = getRuntimeDetailsFromContainerSummary(container);
 
-  // Is container already in store? Refresh volatile image fields, then return it
+  // Is container already in store (including ones stuck in an errored state)?
+  // Refresh volatile image fields, then return it. refreshContainerAlreadyInStore
+  // self-heals broken image references unconditionally via
+  // shouldRepairStoredImageReference, so an errored container no longer needs
+  // to be routed down the slow first-discovery path just to get repaired.
   const containerInStore = storeContainer.getContainer(containerId);
-  if (containerInStore !== undefined && containerInStore.error === undefined) {
+  if (containerInStore !== undefined) {
     return refreshContainerAlreadyInStore({
       watcher,
       container,
@@ -819,13 +827,7 @@ export async function addImageDetailsToContainerOrchestration(
       digest: {
         watch: watchDigest,
         repo: repoDigest,
-        // A rebuild of an errored container must not reset the
-        // registry-reconciled digest value; only a genuine repo-digest
-        // change (image re-pulled) may.
-        value:
-          repoDigest !== undefined && repoDigest === containerInStore?.image?.digest?.repo
-            ? (containerInStore.image.digest.value ?? repoDigest)
-            : repoDigest,
+        value: repoDigest,
       },
       // True when the live image inspect had no RepoDigests (built locally or
       // `docker load`ed) — lets findNewVersion skip a registry lookup that
@@ -861,15 +863,6 @@ export async function addImageDetailsToContainerOrchestration(
     updateAvailable: false,
     updateKind: { kind: 'unknown' },
   } as Container);
-  // A rebuild of an errored container must not discard user-set policy
-  // overrides (snoozes, skipped tags) stored on the existing doc —
-  // applyDockerDeclarativeUpdatePolicy would otherwise stamp `{}` and the
-  // store merge keeps whatever key the incoming doc carries.
-  if (containerInStore?.updatePolicyOverrides !== undefined) {
-    containerToReturn.updatePolicyOverrides = structuredClone(
-      containerInStore.updatePolicyOverrides,
-    );
-  }
   applyDockerDeclarativeUpdatePolicy(containerToReturn, containerLabels, watcher.configuration, {
     logger: watcher.log,
     containerName: dockerContainerName,

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.0-rc.1',
+    version: '1.6.0-rc.2',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.0-rc.1 started',
+    details: 'Drydock v1.6.0-rc.2 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.1',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.2',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.0-rc.1',
+    tag: '1.6.0-rc.2',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.0-rc.1',
+  version: '1.6.0-rc.2',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.0-rc.1',
+      version: '1.6.0-rc.2',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.0-rc.1', mode: 'demo' },
+        server: { version: '1.6.0-rc.2', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.0-rc.1",
+  version: "1.6.0-rc.2",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.0-rc.1",
+    version: "v1.6.0-rc.2",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.0-rc.1",
+      "version": "1.6.0-rc.2",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.0-rc.1",
+    "version": "1.6.0-rc.2",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.0-rc.1"
+  "version":"1.6.0-rc.2"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -162,7 +162,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.0-rc.1",
+    "version": "1.6.0-rc.2",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -185,7 +185,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.0-rc.1",
+      "drydockVersion": "1.6.0-rc.2",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -102,7 +102,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.0-rc.1` | Immutable release candidate; best for reproducible testing |
+| `1.6.0-rc.2` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.0-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -3,6 +3,12 @@ title: "Updates"
 description: "Release update notes and feature highlights, with direct links to current configuration and API docs."
 ---
 
+## v1.6.0-rc.2 Highlights — July 18, 2026
+
+- **Watch errors no longer erase update state** — a container whose registry check fails keeps its last successful comparison alongside the recorded error instead of appearing never-compared, errored containers reuse the same fast refresh path as healthy ones, and repair rebuilds preserve the registry-reconciled digest that keys security scan grouping.
+- **"Version Update" container filter** — a new filter kind shows only real semver upgrades (major/minor/patch) and hides digest-only churn; bookmarkable via `?filterKind=version`.
+- **Docs aligned with shipped behavior** — FAQ and README corrections (registry list, scanner parity, runnable `config migrate` commands), the removed `WS /api/log/stream` alias documented in Deprecations, and the quickstart registry/tag matrix refreshed.
+
 ## v1.6.0-rc.1 Highlights — July 15, 2026
 
 - **Notification rules are now a complete control surface** — configure delivery routing, audit-backed in-app bell categories, update severity threshold, and per-provider simple/batch templates in one detail panel; preview drafts before saving. Container-unhealthy events are bell-capable, and agent status changes refresh the bell promptly.

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6 RC and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.1...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.2...HEAD`],
+    ['1.6.0-rc.2', `${repositoryUrl}/compare/v1.6.0-rc.1...v1.6.0-rc.2`],
     ['1.6.0-rc.1', `${repositoryUrl}/compare/v1.5.2...v1.6.0-rc.1`],
     ['1.5.2', `${repositoryUrl}/compare/v1.5.2-rc.5...v1.5.2`],
     ['1.5.2-rc.5', `${repositoryUrl}/compare/v1.5.2-rc.4...v1.5.2-rc.5`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.0-rc.1';
-const RC_DATE = '2026-07-15';
-const RC_DISPLAY_DATE = 'July 15, 2026';
+const RC_VERSION = '1.6.0-rc.2';
+const RC_DATE = '2026-07-18';
+const RC_DISPLAY_DATE = 'July 18, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 
 function read(path) {
@@ -21,16 +21,16 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   const quickstart = read('content/docs/current/quickstart/index.mdx');
   const changelog = read('CHANGELOG.md');
 
-  assert.match(readme, /version-1\.6\.0--rc\.1-blue/u);
-  assert.match(readme, /v1\.6\.0-rc\.1 highlights/u);
+  assert.match(readme, /version-1\.6\.0--rc\.2-blue/u);
+  assert.match(readme, /v1\.6\.0-rc\.2 highlights/u);
   assert.match(siteConfig, new RegExp(`version: "${RC_VERSION.replaceAll('.', '\\.')}"`, 'u'));
   assert.ok(updates.includes(`## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`));
-  assert.match(appApi, /"version":"1\.6\.0-rc\.1"/u);
-  assert.match(agentApi, /"version": "1\.6\.0-rc\.1"/u);
-  assert.match(portwingApi, /"version": "1\.6\.0-rc\.1"/u);
-  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.1"/u);
-  assert.match(quickstart, /\| `1\.6\.0-rc\.1` \| Immutable release candidate/u);
-  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!1\b)\d+` \| Immutable release candidate/u);
+  assert.match(appApi, /"version":"1\.6\.0-rc\.2"/u);
+  assert.match(agentApi, /"version": "1\.6\.0-rc\.2"/u);
+  assert.match(portwingApi, /"version": "1\.6\.0-rc\.2"/u);
+  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.2"/u);
+  assert.match(quickstart, /\| `1\.6\.0-rc\.2` \| Immutable release candidate/u);
+  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!2\b)\d+` \| Immutable release candidate/u);
   assert.ok(changelog.includes(`## [${RC_VERSION}] — ${RC_DATE}`));
   assert.ok(
     changelog.includes(
@@ -39,7 +39,7 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   );
   assert.ok(
     changelog.includes(
-      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.5.2...v${RC_VERSION}`,
+      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.1...v${RC_VERSION}`,
     ),
   );
 });
@@ -53,7 +53,7 @@ test('v1.5.2 is archived and public release routing advances to v1.6', () => {
 
   assert.match(readme, /<summary><strong>v1\.5\.2 highlights<\/strong><\/summary>/u);
   assert.match(siteContent, /version: "v1\.5\.2",[\s\S]{0,500}?status: "released"/u);
-  assert.match(siteContent, /version: "v1\.6\.0-rc\.1",[\s\S]{0,500}?status: "next"/u);
+  assert.match(siteContent, /version: "v1\.6\.0-rc\.2",[\s\S]{0,500}?status: "next"/u);
   assert.match(
     docsVersions,
     /\{ slug: "v1\.6", source: "current", title: "v1\.6" \},\s+\{ slug: "v1\.5", source: "v1\.5", title: "v1\.5" \}/u,

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.0';
-const RC_VERSION = '1.6.0-rc.1';
+const RC_VERSION = '1.6.0-rc.2';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',
@@ -52,7 +52,7 @@ test('release-gated workspace packages and locks use the v1.6 base version', () 
   }
 });
 
-test('demo runtime fixtures identify the exact v1.6.0-rc.1 candidate', () => {
+test('demo runtime fixtures identify the exact v1.6.0-rc.2 candidate', () => {
   for (const { path, valuePattern } of DEMO_RELEASE_FIXTURES) {
     const contents = readFileSync(path, 'utf8');
     assert.deepEqual(extractVersionValues(contents, valuePattern), [RC_VERSION], path);
@@ -63,18 +63,18 @@ test('release version patterns match exact optionally v-prefixed tokens', () => 
   const rcPattern = versionPattern(RC_VERSION);
   const legacyPattern = versionPattern('1.5.0');
 
-  assert.match('version: 1.6.0-rc.1', rcPattern);
-  assert.match('version: v1.6.0-rc.1', rcPattern);
-  assert.doesNotMatch('version: 1.6.0-rc.10', rcPattern);
-  assert.doesNotMatch('version: x1.6.0-rc.1', rcPattern);
+  assert.match('version: 1.6.0-rc.2', rcPattern);
+  assert.match('version: v1.6.0-rc.2', rcPattern);
+  assert.doesNotMatch('version: 1.6.0-rc.20', rcPattern);
+  assert.doesNotMatch('version: x1.6.0-rc.2', rcPattern);
   assert.match('version: v1.5.0', legacyPattern);
   assert.doesNotMatch('version: 1.5.0-rc.1', legacyPattern);
 });
 
 test('fixture version extraction retains mixed candidate identities', () => {
-  const contents = "version: '1.6.0-rc.1', version: '1.6.0-rc.10'";
+  const contents = "version: '1.6.0-rc.2', version: '1.6.0-rc.20'";
   assert.deepEqual(extractVersionValues(contents, /version:\s*["']([^"']+)["']/gu), [
-    '1.6.0-rc.1',
-    '1.6.0-rc.10',
+    '1.6.0-rc.2',
+    '1.6.0-rc.20',
   ]);
 });

--- a/ui/src/components/containers/ContainersListContent.vue
+++ b/ui/src/components/containers/ContainersListContent.vue
@@ -115,6 +115,7 @@ const activeFilterChips = computed(() => {
   if (filterKind.value !== 'all') {
     const kindKeyMap: Record<string, string> = {
       any: 'hasUpdate',
+      version: 'versionUpdate',
       major: 'major',
       minor: 'minor',
       patch: 'patch',
@@ -202,6 +203,7 @@ const activeFilterChips = computed(() => {
           class="px-2 py-1.5 dd-rounded text-2xs-plus font-semibold uppercase tracking-wide outline-none cursor-pointer dd-bg dd-text">
           <option value="all">{{ t('containerComponents.listContent.allContainers') }}</option>
           <option value="any">{{ t('containerComponents.listContent.hasUpdate') }}</option>
+          <option value="version">{{ t('containerComponents.listContent.versionUpdate') }}</option>
           <option value="major">{{ t('containerComponents.listContent.major') }}</option>
           <option value="minor">{{ t('containerComponents.listContent.minor') }}</option>
           <option value="patch">{{ t('containerComponents.listContent.patch') }}</option>

--- a/ui/src/composables/useContainerFilters.ts
+++ b/ui/src/composables/useContainerFilters.ts
@@ -80,6 +80,15 @@ function matchesKindFilter(container: Container, selectedKind: string): boolean 
   if (selectedKind === 'any') {
     return Boolean(container.newTag);
   }
+  if (selectedKind === 'version') {
+    // Real version upgrades only — major/minor/patch. Excludes digest-only
+    // churn, which floods the view on fleets that rebuild images daily (#538).
+    return (
+      container.updateKind === 'major' ||
+      container.updateKind === 'minor' ||
+      container.updateKind === 'patch'
+    );
+  }
   if (selectedKind === 'blocked') {
     return Boolean(container.newTag) && container.bouncer === 'blocked';
   }

--- a/ui/src/locales/en/containerComponents.json
+++ b/ui/src/locales/en/containerComponents.json
@@ -276,6 +276,7 @@
       "allHosts": "All Hosts",
       "allContainers": "All Containers",
       "hasUpdate": "Has Update",
+      "versionUpdate": "Version Update",
       "major": "Major",
       "minor": "Minor",
       "patch": "Patch",

--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -580,7 +580,15 @@ function clearContainerIdsFilter() {
   void router.replace({ query: rest as Record<string, string> });
 }
 
-const VALID_FILTER_KIND_VALUES = ['all', 'a\u006Ey', 'major', 'minor', 'patch', 'digest'] as const;
+const VALID_FILTER_KIND_VALUES = [
+  'all',
+  'a\u006Ey',
+  'version',
+  'major',
+  'minor',
+  'patch',
+  'digest',
+] as const;
 type FilterKindQueryValue = (typeof VALID_FILTER_KIND_VALUES)[number];
 const DEFAULT_FILTER_KIND: FilterKindQueryValue = 'all';
 const VALID_FILTER_KINDS: ReadonlySet<FilterKindQueryValue> = new Set(VALID_FILTER_KIND_VALUES);

--- a/ui/tests/components/containers/ContainersListContent.spec.ts
+++ b/ui/tests/components/containers/ContainersListContent.spec.ts
@@ -283,6 +283,23 @@ describe('ContainersListContent', () => {
     expect(wrapper.find('[data-test="dd-toolbar-sort-select"]').exists()).toBe(false);
   });
 
+  it('renders the version update kind option with its translated label', () => {
+    const context = makeTemplateContext();
+    wrapper = mountWithContext(context);
+
+    expect(wrapper.get('option[value="version"]').text()).toBe('Version Update');
+  });
+
+  it('shows the translated version update active-filter chip', () => {
+    const context = makeTemplateContext({
+      filterKind: ref('version'),
+      activeFilterCount: computed(() => 1),
+    });
+    wrapper = mountWithContext(context);
+
+    expect(wrapper.text()).toContain('Kind: Version Update');
+  });
+
   it('passes only labelled catalog columns (translated) to the picker', () => {
     const context = makeTemplateContext();
     wrapper = mountWithContext(context);

--- a/ui/tests/composables/useContainerFilters.spec.ts
+++ b/ui/tests/composables/useContainerFilters.spec.ts
@@ -186,6 +186,25 @@ describe('useContainerFilters', () => {
       expect(filters.filteredContainers.value[0].name).toBe('postgres');
     });
 
+    it('should filter version updates to major, minor, and patch kinds', async () => {
+      const versionKinds = ref<Container[]>([
+        makeContainer({ id: 'c1', name: 'major-update', updateKind: 'major' }),
+        makeContainer({ id: 'c2', name: 'minor-update', updateKind: 'minor' }),
+        makeContainer({ id: 'c3', name: 'patch-update', updateKind: 'patch' }),
+        makeContainer({ id: 'c4', name: 'digest-update', updateKind: 'digest' }),
+        makeContainer({ id: 'c5', name: 'no-update', updateKind: null }),
+      ]);
+      const mod = await import('@/composables/useContainerFilters');
+      const filters = mod.useContainerFilters(versionKinds);
+      filters.filterKind.value = 'version';
+
+      expect(filters.filteredContainers.value.map((c) => c.name)).toEqual([
+        'major-update',
+        'minor-update',
+        'patch-update',
+      ]);
+    });
+
     it('should filter "any" to containers with a newTag', async () => {
       const filters = await loadFilters();
       filters.filterKind.value = 'any';

--- a/ui/tests/views/ContainersView.spec.ts
+++ b/ui/tests/views/ContainersView.spec.ts
@@ -827,6 +827,12 @@ describe('ContainersView', () => {
       expect(mockFilterKind.value).toBe('any');
     });
 
+    it('applies version filterKind from route query', async () => {
+      mockRoute.query = { filterKind: 'version' };
+      await mountContainersView([makeContainer({ newTag: '2.0.0', updateKind: 'major' })]);
+      expect(mockFilterKind.value).toBe('version');
+    });
+
     it('applies filterKind from array route query', async () => {
       mockRoute.query = { filterKind: ['major'] };
       await mountContainersView([makeContainer({ newTag: '2.0.0', updateKind: 'major' })]);
@@ -904,6 +910,18 @@ describe('ContainersView', () => {
           groupByStack: 'true',
           sort: 'status-desc',
         }),
+      });
+    });
+
+    it('syncs version filterKind to the URL query', async () => {
+      await mountContainersView([makeContainer()]);
+
+      mockFilterKind.value = 'version';
+      await flushPromises();
+
+      const lastCall = mockRouterReplace.mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual({
+        query: expect.objectContaining({ filterKind: 'version' }),
       });
     });
   });


### PR DESCRIPTION
## Summary

- consolidates the accepted v1.6.0-rc.2 delta from `dev/v1.6` over the shipped rc.1: the #541/#542/#543 error-rebuild hardening round 2 (PR #547), the #538 "Version Update" container filter (PR #539), the #544 workflow-test scaffolding dedupe (PR #548), and the rc.2 release identity sweep (PR #549)
- restarts the soak: this is a new RC with a fresh 7-day clock and a fresh 24-hour NAS acceptance run, because #541–#543 change the exact watcher/store paths the run validates
- excludes all private `.planning` changes from the release diff and history

## Immutable release construction

- frozen base: `main` at `d6e166ff29d97d00215d7c69bfce91e3b5de3e8a`
- frozen accepted tree: `dev/v1.6` at `51fea2cf22136a15ccef0be4a67b5dec8b009528`
- release head: `d63b3d3e29ea21402ea4bf5474e997dbdc9af912`
- release head parent is the frozen main SHA
- commit count over frozen main is exactly one
- non-planning tree matches the frozen `dev/v1.6` tree exactly (empty diff)
- `.planning` is absent from frozen main and the release head and contributes zero files or commits
- the 37-file main→dev delta attributes exactly to PRs #539/#547/#548/#549 — nothing unaccounted in either direction

## Local verification on the exact release head

- complete pre-push gate passed in 272.44s
- 105 maintenance tests
- 31 workflow tests
- 37 website-script tests (run manually — the push glob skips them)
- backend and UI coverage at 100 percent
- app and UI production builds
- UI typecheck, Biome, accepted Qlty baseline, and Zizmor with zero findings (run manually — the push glob skipped it)
- acceptance-harness `monitor.test.mjs` 7/7 locally
- CodeRabbit reviews resolved on every constituent PR (#539, #546, #547, #548, #549)

## Final merge gate

Do not merge this PR or cut `v1.6.0-rc.2` until the exact-head GitHub CI, Playwright, Cucumber, load/security matrix, CodeRabbit/Qlty/CodeQL review, two required non-author approvals, and the isolated fresh 24-hour NAS acceptance report are clean with `passed: true`. The 24-hour NAS run starts last from the frozen approved tree. After rc.2, the 7-day soak restarts from its publication date (GA earliest ~2026-07-25); GA promotes the exact RC digest, and any further code change requires a new RC and a fresh soak.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
✨ Added
- Added shared GitHub Actions workflow testing utilities (`.github/tests/workflow-test-utils.ts`) with `loadWorkflow()`/`getWorkflowStep()` and workflow YAML types; refactored workflow inspection tests to use them.
- Added/expanded Docker `watchContainer` Vitest coverage (`app/watchers/providers/docker/container-processing.test.ts`) to assert failure/success preservation of `result` and `currentReleaseNotes`, including validated-container getter safety.
- Added/expanded Docker image orchestration tests for fast-path/repair-branch digest stickiness and errored-container fast-path eligibility (`docker-image-details-orchestration.*.test.ts`).
- Added UI + i18n support for the new **“Version Update”** container filter (`filterKind="version"`), including kind-filter matching semantics, filter-chip/select option rendering, and route-query synchronization tests.
- Added Portwing WS unit test assertions that the `welcome` frame’s `config.drydockVersion` matches the canonical `getVersion()` value (`app/api/portwing-ws.test.ts`).
- Added/updated release-candidate identity/docs/changelog validation to cover `v1.6.0-rc.2` (including compare-link chain completion expectations).

🔧 Changed
- Refactored workflow inspection tests to deduplicate YAML parsing/type scaffolding by using shared `loadWorkflow`/`getWorkflowStep` helpers and shared workflow typings.
- Hardened `watchContainer` by snapshotting/restoring only `containerWithResult.result` and `containerWithResult.currentReleaseNotes` across watch cycles, restoring them only when the current cycle still produced no fresh `result` (so later enrichment failures don’t overwrite earlier successful comparison state).
- Updated Docker orchestration logic:
  - Included errored containers in the “already in store” refresh path.
  - Adjusted digest repair/stickiness behavior in `refreshStoredContainerImageFields`.
  - Simplified returned `containerToReturn.image.digest.value` assignment to always use the computed `repoDigest`.
  - Removed the explicit `structuredClone` carry-over of `updatePolicyOverrides` into returned containers before applying declarative policy.
- Updated Portwing WS version reporting to lazily populate the cached drydock version from `getVersion()` on first use; extended `injectDrydockVersionForTesting` to accept `string | undefined`.
- Implemented `filterKind="version"` as a grouped match: containers with `updateKind` of `major`/`minor`/`patch` match the version filter.
- Bumped `v1.6.0-rc.1` → `v1.6.0-rc.2` across release identity surfaces (README/site badge + highlights, demo/mock data, API docs, quickstart/update content) and updated release-doc/changelog identity tests accordingly.

🐛 Fixed
- Fixed an E2E restore-path defect where restoring getter-derived fields could throw and prevent container report persistence; restoration now targets only `result`/`currentReleaseNotes` so validated-container getters can safely derive `updateAvailable`/`updateKind`.
- Fixed/validated Portwing welcome/version correctness by ensuring the `welcome` frame uses `getVersion()` and adding direct unit coverage.

🔒 Security
- Preserved registry-reconciled digest context through watch/compare failure paths to keep security-scan grouping stable.

⚠️ Breaking
- None

⚠️ Concerns
- Ensure exact-head CI, testing, security checks, and all required approvals/reviews pass before merging/publishing.
- Re-run both prior E2E jobs if needed to confirm the Playwright failure was not flaky (previously attributed to CI 429 rate limiting).
- Complete the fresh 24-hour NAS acceptance run before merging/publishing `v1.6.0-rc.2`.
- Confirm the post-publication 7-day soak restart behavior matches the release plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->