### PR TITLE
🐛 fix(watcher): restore only data properties after a failed watch cycle

### DIFF
--- a/app/watchers/providers/docker/container-processing.test.ts
+++ b/app/watchers/providers/docker/container-processing.test.ts
@@ -1,3 +1,4 @@
+import { validate } from '../../../model/container.js';
 import { createContainerFixture } from '../../../test/helpers.js';
 import { watchContainer } from './container-processing.js';
 import { enrichContainerWithReleaseNotes } from './release-notes-enrichment.js';
@@ -31,6 +32,31 @@ function createDependencies(findNewVersion: ReturnType<typeof vi.fn>) {
   };
 }
 
+function createValidatedContainer(overrides: Record<string, unknown> = {}) {
+  return validate(
+    createContainerFixture({
+      image: {
+        id: 'image-123456789',
+        registry: {
+          name: 'registry',
+          url: 'https://hub',
+        },
+        name: 'organization/image',
+        tag: {
+          value: '1.3.0',
+          semver: true,
+        },
+        digest: {
+          watch: false,
+        },
+        architecture: 'amd64',
+        os: 'linux',
+      },
+      ...overrides,
+    }),
+  );
+}
+
 afterEach(() => {
   vi.clearAllMocks();
 });
@@ -51,15 +77,13 @@ describe('watchContainer error result preservation', () => {
       publishedAt: '2026-01-01T00:00:00.000Z',
       provider: 'github' as const,
     };
-    const container = createContainerFixture({
+    const container = createValidatedContainer({
       result: originalResult,
-      updateAvailable: true,
-      updateKind: originalUpdateKind,
       currentReleaseNotes: originalCurrentReleaseNotes,
     });
     const dependencies = createDependencies(vi.fn().mockRejectedValue(new Error('ETIMEDOUT')));
 
-    const report = await watchContainer(container as any, dependencies);
+    const report = await watchContainer(container, dependencies);
 
     expect(report.container.error?.message).toBe('ETIMEDOUT');
     expect(report.container.result).toEqual(originalResult);
@@ -68,33 +92,76 @@ describe('watchContainer error result preservation', () => {
     expect(report.container.currentReleaseNotes).toEqual(originalCurrentReleaseNotes);
   });
 
+  test('restores the previous result on a validated container without writing to getter-only properties', async () => {
+    const previousResult = { tag: '1.4.0' };
+    const previousCurrentReleaseNotes = {
+      title: 'Version 1.2.0',
+      body: 'Previously fetched release notes',
+      url: 'https://example.com/releases/1.2.0',
+      publishedAt: '2026-01-01T00:00:00.000Z',
+      provider: 'github' as const,
+    };
+    const container = createValidatedContainer({
+      image: {
+        id: 'image-123456789',
+        registry: {
+          name: 'registry',
+          url: 'https://hub',
+        },
+        name: 'organization/image',
+        tag: {
+          value: '1.2.0',
+          semver: true,
+        },
+        digest: {
+          watch: false,
+        },
+        architecture: 'amd64',
+        os: 'linux',
+      },
+      result: previousResult,
+      currentReleaseNotes: previousCurrentReleaseNotes,
+    });
+    const dependencies = createDependencies(
+      vi.fn().mockRejectedValue(new Error('registry timeout')),
+    );
+
+    const report = await watchContainer(container, dependencies);
+
+    expect(report.container.error?.message).toBe('registry timeout');
+    expect(report.container.result).toEqual(previousResult);
+    expect(report.container.currentReleaseNotes).toEqual(previousCurrentReleaseNotes);
+    expect(report.container.updateAvailable).toBe(true);
+  });
+
   // Behavior pin: a successful cycle replaces stale data and clears the old error.
   test('clears a stale error and replaces the result after a successful watch', async () => {
-    const container = createContainerFixture({
+    const container = createValidatedContainer({
       error: { message: 'old error' },
-      result: { tag: 'old-good-tag' },
-      updateAvailable: true,
-      updateKind: { kind: 'tag' },
+      result: { tag: '1.3.0' },
     });
-    const dependencies = createDependencies(vi.fn().mockResolvedValue({ tag: 'new-tag' }));
+    const dependencies = createDependencies(vi.fn().mockResolvedValue({ tag: '1.4.0' }));
 
-    const report = await watchContainer(container as any, dependencies);
+    const report = await watchContainer(container, dependencies);
 
     expect(report.container.error).toBeUndefined();
-    expect(report.container.result?.tag).toBe('new-tag');
+    expect(report.container.result?.tag).toBe('1.4.0');
   });
 
   // Behavior pin: the fix must only restore a result when a previous result existed.
   test('handles a first failing cycle without creating a result', async () => {
-    const originalUpdateKind = { kind: 'unknown' as const };
-    const container = createContainerFixture({
+    const originalUpdateKind = {
+      kind: 'unknown' as const,
+      localValue: undefined,
+      remoteValue: undefined,
+      semverDiff: 'unknown' as const,
+    };
+    const container = createValidatedContainer({
       result: undefined,
-      updateAvailable: false,
-      updateKind: originalUpdateKind,
     });
     const dependencies = createDependencies(vi.fn().mockRejectedValue(new Error('ETIMEDOUT')));
 
-    const report = await watchContainer(container as any, dependencies);
+    const report = await watchContainer(container, dependencies);
 
     expect(report.container.result).toBeUndefined();
     expect(report.container.updateAvailable).toBe(false);
@@ -103,17 +170,15 @@ describe('watchContainer error result preservation', () => {
   });
 
   test('keeps a fresh comparison when only release-notes enrichment fails', async () => {
-    const container = createContainerFixture({
+    const container = createValidatedContainer({
       result: { tag: '1.3.0' },
-      updateAvailable: true,
-      updateKind: { kind: 'tag' },
     });
     const dependencies = createDependencies(vi.fn().mockResolvedValue({ tag: '1.4.0' }));
     vi.mocked(enrichContainerWithReleaseNotes).mockRejectedValueOnce(
       new Error('notes fetch failed'),
     );
 
-    const report = await watchContainer(container as any, dependencies);
+    const report = await watchContainer(container, dependencies);
 
     expect(report.container.result?.tag).toBe('1.4.0');
     expect(report.container.error?.message).toBe('notes fetch failed');

--- a/app/watchers/providers/docker/container-processing.ts
+++ b/app/watchers/providers/docker/container-processing.ts
@@ -68,8 +68,6 @@ export async function watchContainer(
   const watchStartedAtMs = Date.now();
 
   const previousResult = containerWithResult.result;
-  const previousUpdateAvailable = containerWithResult.updateAvailable;
-  const previousUpdateKind = containerWithResult.updateKind;
   const previousCurrentReleaseNotes = containerWithResult.currentReleaseNotes;
 
   // Reset previous results if so
@@ -89,11 +87,12 @@ export async function watchContainer(
     };
     // Restore only when this cycle produced no fresh comparison — a failure
     // after findNewVersion resolved (e.g. enrichment) must not clobber the
-    // fresh result with the stale snapshot.
+    // fresh result with the stale snapshot. Only plain data properties are
+    // restored: updateAvailable/updateKind are getter-only derived properties
+    // (see addUpdateAvailableProperty in the container model) and recompute
+    // from the restored result — assigning them throws on a validated container.
     if (containerWithResult.result === undefined && previousResult !== undefined) {
       containerWithResult.result = previousResult;
-      containerWithResult.updateAvailable = previousUpdateAvailable;
-      containerWithResult.updateKind = previousUpdateKind;
       containerWithResult.currentReleaseNotes = previousCurrentReleaseNotes;
     }
   }


### PR DESCRIPTION
Fixes the real regression the 🥒 Cucumber E2E gate caught on release PR #550 (details in [this comment](https://github.com/CodesWhat/drydock/pull/550#issuecomment-4998798055)).

**Root cause:** the #543 error-restore in `watchContainer`'s catch assigned `updateAvailable`/`updateKind`, but `validate()` installs those as getter-only derived properties (no setter). On a validated container the assignment threw `TypeError: Cannot set property updateAvailable of #<Object> which has only a getter`, escaped `watchContainer`, and the container report never persisted — so `start-drydock.sh`'s readiness gate timed out on the `local_ecr_sub_sub_test` fixture.

**Fix:** restore only the plain data properties `result` and `currentReleaseNotes`. `updateAvailable`/`updateKind` recompute from the restored result via the getters, which also makes the restore inherently consistent (no way to restore a stale flag against a fresh result).

**Why unit tests missed it:** the container fixtures were plain object literals without the model's getters. TDD round (Codex tests first): a new regression test builds its container through the real `validate()` and failed pre-fix with the exact getter TypeError; the four pre-existing tests were migrated off plain literals to `validate()`-built containers so the file exercises real model object shapes from now on. 2 failed pre-fix → 5/5 post-fix.

**Verification:** full docker provider suite 34 files / 1313 tests green; `container-processing.ts` at 100/100/100/100; complete pre-push gate green from a worktree (coverage 100% app+ui, builds, biome, qlty).

No CHANGELOG entry: this corrects the unreleased #543 implementation already covered by the rc.2 bullet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed `watchContainer` error recovery for validated containers by restoring only `result` and `currentReleaseNotes`.
- 🔧 Updated watcher tests to use validated container fixtures and cover getter-derived update state.
- ✨ Added regression coverage for failed enrichment/write cycles and state restoration.
- ✅ Verified with 1,313 Docker provider tests and the complete pre-push gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->