### PR TITLE
✅ test(watcher): pin report emission on the error-restore path

### DIFF
--- a/app/watchers/providers/docker/container-processing.test.ts
+++ b/app/watchers/providers/docker/container-processing.test.ts
@@ -90,6 +90,10 @@ describe('watchContainer error result preservation', () => {
     expect(report.container.updateAvailable).toBe(true);
     expect(report.container.updateKind).toEqual(originalUpdateKind);
     expect(report.container.currentReleaseNotes).toEqual(originalCurrentReleaseNotes);
+    // The E2E symptom was the report never persisting (the TypeError escaped
+    // before the emit) — pin that the persistence path actually ran.
+    expect(eventMocks.emitContainerReport).toHaveBeenCalledTimes(1);
+    expect(eventMocks.emitContainerReport).toHaveBeenCalledWith(report);
   });
 
   test('restores the previous result on a validated container without writing to getter-only properties', async () => {


### PR DESCRIPTION
CodeRabbit follow-up from release PR #550 ([the finding](https://github.com/CodesWhat/drydock/pull/550#discussion_r3600582282)): the getter-TypeError regression manifested as the container report never persisting, so the regression test now also asserts `emitContainerReport` ran once with the returned report, instead of only checking returned container state.

Test-only, 4 lines. 5/5 tests green; full pre-push gate green from a worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added
- Extended the Docker container watcher regression test to verify `emitContainerReport` is called once with the returned report.
- Confirmed the container state remains correctly preserved after a getter `TypeError`.

- Test-only change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->