### PR TITLE
🐛 fix(api): report the real server version in portwing WS welcome frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Last-known-good update state survives watch errors** ([#543](https://github.com/CodesWhat/drydock/issues/543)). A failed watch cycle — registry timeout, rate limit, transient network error — no longer erases the previous successful comparison. The stored `result`, `updateAvailable`, `updateKind`, and current release notes are preserved alongside the recorded error until a later cycle succeeds, so the UI keeps showing the last known update state with the error annotated next to it instead of a blank.
 
+- Portwing WS Welcome frames now report the actual server version — the endpoint had hard-coded `1.5.0` since v1.5.0, so v1.5.1/v1.5.2/v1.6.0-rc.1 servers all identified as `1.5.0` to agents ([#550](https://github.com/CodesWhat/drydock/pull/550) review finding)
+
 ## [1.6.0-rc.1] — 2026-07-15
 
 ### Added

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -5,6 +5,7 @@
 import { createHash, sign as cryptoSign, generateKeyPairSync } from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
 import type { Socket } from 'node:net';
+import { getVersion } from '../configuration/index.js';
 import type { AgentKeyRecord } from '../store/agent-keys.js';
 import type { NameBindingRecord } from '../store/name-bindings.js';
 import * as nameBindingsStore from '../store/name-bindings.js';
@@ -24,6 +25,7 @@ import {
 
 vi.mock('../configuration/index.js', () => ({
   getServerConfiguration: vi.fn(() => ({})),
+  getVersion: vi.fn(() => '9.9.9-test'),
 }));
 
 // Hoisted so tests can assert on the durable-flush call (Fix 1: new-bind
@@ -318,6 +320,38 @@ function buildHello(
 }
 
 // ---- Tests ----
+
+test('reports the canonical configuration version in the welcome frame', async () => {
+  clearNonceCacheForTesting();
+
+  const { privateKey, pubkeyBase64, keyId } = generateKeyPair();
+  const ts = Math.floor(Date.now() / 1000);
+  const nonce = 'd2b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
+  const sig = signHello(privateKey, ts, nonce);
+  const record: AgentKeyRecord = {
+    keyId,
+    pubkey: pubkeyBase64,
+    label: 'test',
+    createdAt: new Date().toISOString(),
+    revokedAt: null,
+  };
+
+  const { gateway, getUpgradedWs } = createGateway(record);
+  gateway.handleUpgrade(
+    createRequest('/api/portwing/ws'),
+    createMockSocket() as unknown as Socket,
+    Buffer.alloc(0),
+  );
+  const ws = getUpgradedWs()!;
+
+  sendMessageToGateway(ws, buildHello(keyId, ts, nonce, sig));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  const welcome = JSON.parse(ws.sentMessages[0]) as {
+    data: { config: { drydockVersion: string } };
+  };
+  expect(welcome.data.config.drydockVersion).toBe(getVersion());
+});
 
 describe('PORTWING_WS_ROUTE_PATTERN', () => {
   test('matches canonical /api/portwing/ws', () => {

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -345,7 +345,11 @@ test('reports the canonical configuration version in the welcome frame', async (
   const ws = getUpgradedWs()!;
 
   sendMessageToGateway(ws, buildHello(keyId, ts, nonce, sig));
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  // Bounded wait instead of a fixed sleep — the async Ed25519 verification
+  // makes frame timing scheduler-dependent under CI load.
+  await vi.waitFor(() => {
+    expect(ws.sentMessages.length).toBeGreaterThan(0);
+  });
 
   const welcome = JSON.parse(ws.sentMessages[0]) as {
     data: { config: { drydockVersion: string } };

--- a/app/api/portwing-ws.ts
+++ b/app/api/portwing-ws.ts
@@ -19,7 +19,7 @@ import {
   type WebSocketLike,
 } from '../agent/EdgeAgentAdapter.js';
 import { getAgent } from '../agent/manager.js';
-import { getServerConfiguration } from '../configuration/index.js';
+import { getServerConfiguration, getVersion } from '../configuration/index.js';
 import logger from '../log/index.js';
 import * as agentKeys from '../store/agent-keys.js';
 import { save as saveStore } from '../store/index.js';
@@ -334,15 +334,15 @@ function sendErrorAndClose(
   ws.close(closeCode, code);
 }
 
-// Package version sourced at module init time from the app package.json.
-// This is the server-side version operators can verify externally.
+// Server version reported in the welcome frame — the canonical getVersion()
+// (DD_VERSION override, else package.json), cached after first read.
 let _drydockVersion: string | undefined;
 function drydockVersion(): string {
   if (_drydockVersion !== undefined) {
     return _drydockVersion;
   }
-  // Populated by injectDrydockVersionForTesting() in tests, or from package.json at runtime.
-  _drydockVersion = '1.5.0';
+  // Populated by injectDrydockVersionForTesting() in tests, or from getVersion() at runtime.
+  _drydockVersion = getVersion();
   return _drydockVersion;
 }
 


### PR DESCRIPTION
Fixes the shipped bug CodeRabbit caught on release PR #550 ([the finding](https://github.com/CodesWhat/drydock/pull/550#discussion_r3600800306)): `drydockVersion()` claimed to be populated from package.json at runtime but hard-coded `'1.5.0'` — every portwing WS Welcome frame since the endpoint shipped in v1.5.0 (so v1.5.1, v1.5.2, and v1.6.0-rc.1 servers) identified itself as `1.5.0` to agents. The documented Welcome example was describing intended behavior the code never delivered.

**Fix:** `drydockVersion()` now delegates to the canonical `getVersion()` from `app/configuration` (`DD_VERSION` override, else package.json — the same source `app/debug/dump.ts` and the rest of the API use), still cached at first read and still overridable by `injectDrydockVersionForTesting()`. Stale comments corrected.

**TDD (Codex tests first):** new regression test mocks `getVersion()` to a sentinel and asserts the Welcome frame carries it — failed pre-fix with `expected '1.5.0' to be '9.9.9-test'`; 98/98 file tests green post-fix, `portwing-ws.ts` at 100/100/100/100.

CHANGELOG bullet under `[1.6.0-rc.2]` Fixed. Full pre-push gate green from a worktree; release-guard scripts 105/105.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

### 🐛 Fixed
- Portwing WebSocket Welcome frames now report the canonical server version (no more hard-coded `1.5.0`).
- `drydockVersion()` delegates to the canonical `getVersion()` from `app/configuration` (honors `DD_VERSION` override or `package.json` fallback) while keeping first-read caching and the existing `injectDrydockVersionForTesting()` override.
- Updated `[1.6.0-rc.2]` changelog entry to reflect the Portwing WS welcome-version fix.

### 🔧 Changed
- Added/extended regression coverage: mock `getVersion()` and assert the first outbound `welcome` frame contains `data.config.drydockVersion` equal to the mocked value during a full upgrade + hello handshake.
- Replaced scheduler-sensitive fixed delay in the welcome-version regression test with `vi.waitFor`.
- Refreshed related comments and configuration imports around the version source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->