### PR TITLE
✅ test(watcher): pin fast-path repair of a broken errored reference

### DIFF
--- a/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
@@ -379,6 +379,35 @@ describe('docker image details orchestration module', () => {
       expect(inspectContainer).toHaveBeenCalledTimes(1);
       expect(stored.error).toEqual({ message: 'timeout of 30000ms exceeded' });
     });
+
+    test('repairs a broken reference for an errored container on the fast path', async () => {
+      const stored = createErroredStoredContainer();
+      stored.image.tag.value = 'unknown';
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
+      const getContainers = vi.spyOn(storeContainer, 'getContainers').mockReturnValue([]);
+      const { watcher, inspectContainer, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['ghcr.io/acme/service@sha256:raw'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(getContainers).not.toHaveBeenCalled();
+      expect(inspectContainer).toHaveBeenCalledTimes(1);
+      expect(stored.image.tag.value).toBe('1.2.3');
+      expect(stored.image.id).toBe('image-new');
+      expect(stored.image.digest.value).toBe('sha256:reconciled');
+      expect(stored.error).toEqual({ message: 'timeout of 30000ms exceeded' });
+    });
   });
 
   test.each([


### PR DESCRIPTION
CodeRabbit follow-up from release PR #550 ([the finding](https://github.com/CodesWhat/drydock/pull/550#discussion_r3601293833)): the errored-container fast-path tests pinned routing (no `getContainers` scan) and digest stickiness, but not the repair itself — a silently-skipped repair would still pass.

New test pins the full self-heal contract for an errored container with a broken stored reference: fast-path routing held, tag repaired via `resolveTagName` (`1.2.3` per the helpers fixture — verified by execution), image id updated from inspect, #541 digest stickiness (`sha256:reconciled` preserved), and the stored error retained until a successful watch clears it.

Test-only, 29 lines (Codex-authored, contract verified by running against the implementation). 56/56 file tests, full docker provider coverage suite green, full pre-push gate green from a worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added a Docker watcher test covering self-healing for errored containers with broken image references:
- Verifies fast-path routing without `getContainers`
- Confirms tag normalization via `resolveTagName`
- Updates the image ID from inspection
- Preserves `sha256:reconciled` digest stickiness
- Retains the stored error until a successful watch clears it

- Test-only change
- File tests, Docker provider coverage, and pre-push checks pass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->