### PR TITLE
✅ test(api): assert the welcome-version sentinel literally

### DIFF
--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -323,6 +323,7 @@ function buildHello(
 
 test('reports the canonical configuration version in the welcome frame', async () => {
   clearNonceCacheForTesting();
+  vi.mocked(getVersion).mockClear();
 
   const { privateKey, pubkeyBase64, keyId } = generateKeyPair();
   const ts = Math.floor(Date.now() / 1000);
@@ -354,7 +355,10 @@ test('reports the canonical configuration version in the welcome frame', async (
   const welcome = JSON.parse(ws.sentMessages[0]) as {
     data: { config: { drydockVersion: string } };
   };
-  expect(welcome.data.config.drydockVersion).toBe(getVersion());
+  // Assert the literal sentinel, not getVersion()'s return — comparing against
+  // the same mock production calls would pass even if the frame hard-coded it.
+  expect(welcome.data.config.drydockVersion).toBe('9.9.9-test');
+  expect(getVersion).toHaveBeenCalled();
 });
 
 describe('PORTWING_WS_ROUTE_PATTERN', () => {


### PR DESCRIPTION
CodeRabbit follow-up from release PR #550 ([the finding](https://github.com/CodesWhat/drydock/pull/550#discussion_r3601330113)): the welcome-version regression test compared the frame against `getVersion()` — the same mock production calls — so a hard-coded frame value could still pass. Now asserts the `'9.9.9-test'` sentinel literally (after clearing the mock's history) and verifies the mocked `getVersion` was called to produce the frame.

Test-only, 5 lines. 98/98 file tests green; full pre-push gate green from a worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added
- Strengthened the welcome-version regression test with the literal `9.9.9-test` sentinel.
- Verified the mocked `getVersion` function is called during handshake processing.
- Cleared mock call history before exercising the gateway handshake.

Concerns:
- None identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->