### PR TITLE
✅ test(api): version-cache reset + adversarial-pass test hygiene

### DIFF
--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -1844,8 +1844,8 @@ describe('injectDrydockVersionForTesting', () => {
     };
     expect(welcome.data.config.drydockVersion).toBe('9.9.9');
 
-    // Restore default version so other tests are not affected
-    injectDrydockVersionForTesting('1.5.0');
+    // Clear the version cache so later tests re-prime from getVersion().
+    injectDrydockVersionForTesting(undefined);
   });
 });
 

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -323,6 +323,9 @@ function buildHello(
 
 test('reports the canonical configuration version in the welcome frame', async () => {
   clearNonceCacheForTesting();
+  // Reset the module-level version cache so this test stays order-independent —
+  // an earlier inject or welcome would otherwise let it skip getVersion().
+  injectDrydockVersionForTesting(undefined);
   vi.mocked(getVersion).mockClear();
 
   const { privateKey, pubkeyBase64, keyId } = generateKeyPair();

--- a/app/api/portwing-ws.ts
+++ b/app/api/portwing-ws.ts
@@ -346,8 +346,8 @@ function drydockVersion(): string {
   return _drydockVersion;
 }
 
-/** Exposed for tests to override the version string. */
-export function injectDrydockVersionForTesting(version: string): void {
+/** Exposed for tests to override the version string, or reset the cache with undefined. */
+export function injectDrydockVersionForTesting(version: string | undefined): void {
   _drydockVersion = version;
 }
 

--- a/app/watchers/providers/docker/container-processing.ts
+++ b/app/watchers/providers/docker/container-processing.ts
@@ -85,9 +85,11 @@ export async function watchContainer(
     containerWithResult.error = {
       message: errorMessage,
     };
-    // Restore only when this cycle produced no fresh comparison — a failure
-    // after findNewVersion resolved (e.g. enrichment) must not clobber the
-    // fresh result with the stale snapshot. Only plain data properties are
+    // Restore only when this cycle produced no fresh comparison. Today the
+    // only rejection path is findNewVersion itself (enrichContainerWithReleaseNotes
+    // swallows its own errors), so the guard on result is defense-in-depth for
+    // if that contract ever changes: a failure after a fresh result must not
+    // clobber it with the stale snapshot. Only plain data properties are
     // restored: updateAvailable/updateKind are getter-only derived properties
     // (see addUpdateAvailableProperty in the container model) and recompute
     // from the restored result — assigning them throws on a validated container.

--- a/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
@@ -326,31 +326,6 @@ describe('docker image details orchestration module', () => {
 
       expect(stored.image.digest.value).toBe('sha256:new-raw');
     });
-
-    test('keeps an errored broken reference on the fast path and preserves its digest', async () => {
-      const stored = createErroredStoredContainer();
-      stored.image.tag.value = 'unknown';
-      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);
-      const getContainers = vi.spyOn(storeContainer, 'getContainers').mockReturnValue([]);
-      const { watcher, inspectImage } = createWatcher();
-      inspectImage.mockResolvedValue({
-        Id: 'image-new',
-        RepoDigests: ['ghcr.io/acme/service@sha256:raw'],
-        Architecture: 'amd64',
-        Os: 'linux',
-        Created: '2026-02-01T00:00:00.000Z',
-      });
-
-      await addImageDetailsToContainerOrchestration(
-        watcher as any,
-        createDockerSummaryContainer(),
-        {},
-        createHelpers() as any,
-      );
-
-      expect(getContainers).not.toHaveBeenCalled();
-      expect(stored.image.digest.value).toBe('sha256:reconciled');
-    });
   });
 
   describe('errored container fast-path eligibility', () => {
@@ -380,7 +355,7 @@ describe('docker image details orchestration module', () => {
       expect(stored.error).toEqual({ message: 'timeout of 30000ms exceeded' });
     });
 
-    test('repairs a broken reference for an errored container on the fast path', async () => {
+    test('repairs a broken reference for an errored container on the fast path and preserves its reconciled digest', async () => {
       const stored = createErroredStoredContainer();
       stored.image.tag.value = 'unknown';
       vi.spyOn(storeContainer, 'getContainer').mockReturnValue(stored as any);


### PR DESCRIPTION
Closes the round-7 review finding on #550 plus two adjacent test-hygiene issues found by an adversarial pass over the same surface, so the whole batch lands in one review round.

## Changes

**Version cache reset (CodeRabbit finding on #550, `app/api/portwing-ws.test.ts:324`)**
- `injectDrydockVersionForTesting` now accepts `undefined` to clear the module-level `_drydockVersion` cache (the `!== undefined` guard in `drydockVersion()` makes it naturally re-prime from `getVersion()`).
- The welcome-version test resets the cache before `vi.mocked(getVersion).mockClear()`, so it stays order-independent: an earlier inject or welcome frame can no longer leave the cache primed and let the test pass without exercising the canonical `getVersion()` path.

**Same bug class one describe block down**
- The injector suite ended by "restoring" the cache to a literal `'1.5.0'` — leaving every later test in the file primed with a stale magic value, the exact order-dependency this PR fixes. It now resets to `undefined` like the new idiom.

**Duplicate test scenario in the orchestration suite**
- `keeps an errored broken reference on the fast path and preserves its digest` (repair-branch digest stickiness) and `repairs a broken reference for an errored container on the fast path` (fast-path eligibility) ran byte-identical arrange/act; the newer test asserts a strict superset. Folded into one test whose name now carries both intents. Coverage verified 100% across all metrics at directory scope after the merge.

**Comment accuracy in `container-processing.ts`**
- The catch-block comment implied release-notes enrichment can reject after a fresh result; `enrichContainerWithReleaseNotes` swallows its own errors and never rejects, so the guard is defense-in-depth. The comment now says so instead of overstating the live path.

## Verification

- `npx vitest run api/portwing-ws.test.ts watchers/providers/docker/container-processing.test.ts watchers/providers/docker/docker-image-details-orchestration.test.ts` — 158/158 pass.
- Directory-scope coverage: `docker-image-details-orchestration.ts` and `container-processing.ts` both 100% branches/lines/functions/statements.
- Full pre-push gate (biome, qlty, coverage, build) green on push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added support for clearing the cached Drydock version with `undefined`.
- 🔧 Changed API tests to reset the version cache, preventing order-dependent behavior.
- 🔧 Clarified the defensive result-restore comment in Docker container processing.
- 🗑️ Removed a duplicate errored fast-path repair test and consolidated digest assertions.

## Concerns

- Verify the targeted test suite and pre-push checks remain green.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->