### PR TITLE
🐛 fix(security): report the configured scanner timeout in deadline errors

### DIFF
--- a/app/security/backends/docker.test.ts
+++ b/app/security/backends/docker.test.ts
@@ -561,6 +561,33 @@ describe('createDockerScannerBackend', () => {
     expect((outcome as Error).message).toBe('Scanner worker timed out after 10ms');
   });
 
+  test('reports the configured timeout even when the deadline is armed mid-flight', async () => {
+    const harness = createHarness();
+    harness.container.start.mockImplementationOnce(() => new Promise(() => undefined));
+    const now = vi.spyOn(Date, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(1_003);
+
+    try {
+      const outcome = await Promise.race([
+        harness.backend
+          .run({
+            image: PINNED_IMAGE,
+            args: ['scan'],
+            timeoutMs: 10,
+            maxOutputBytes: 1_024,
+          })
+          .catch((error) => error),
+        new Promise<Error>((resolve) => {
+          setTimeout(() => resolve(new Error('scanner run remained pending')), 100);
+        }),
+      ]);
+
+      expect(outcome).toBeInstanceOf(Error);
+      expect((outcome as Error).message).toBe('Scanner worker timed out after 10ms');
+    } finally {
+      now.mockRestore();
+    }
+  });
+
   test.each([
     ['successful cleanup', undefined],
     ['failed cleanup', new Error('remove failed')],

--- a/app/security/backends/docker.ts
+++ b/app/security/backends/docker.ts
@@ -350,14 +350,20 @@ async function terminateWorker(container: DockerScannerContainer): Promise<void>
   }
 }
 
-function waitForTimeout(timeoutMs: number): {
+function waitForTimeout(
+  timeoutMs: number,
+  reportedTimeoutMs: number = timeoutMs,
+): {
   promise: Promise<never>;
   clear: () => void;
 } {
   let timer: ReturnType<typeof setTimeout>;
   const promise = new Promise<never>((_resolve, reject) => {
     timer = setTimeout(
-      () => reject(new DockerScannerTimeoutError(`Scanner worker timed out after ${timeoutMs}ms`)),
+      () =>
+        reject(
+          new DockerScannerTimeoutError(`Scanner worker timed out after ${reportedTimeoutMs}ms`),
+        ),
       timeoutMs,
     );
   });
@@ -462,7 +468,7 @@ export function createDockerScannerBackend(options: DockerScannerBackendOptions)
       );
     }
 
-    const timeout = waitForTimeout(remainingTimeoutMs);
+    const timeout = waitForTimeout(remainingTimeoutMs, runOptions.timeoutMs);
     let container: DockerScannerContainer | undefined;
     let createContainerPromise: Promise<DockerScannerContainer> | undefined;
     try {


### PR DESCRIPTION
## Summary

- CI flake: `docker.test.ts` asserts the exact message `Scanner worker timed out after 10ms`, but `waitForTimeout(timeoutMs)` bakes whatever value it's armed with into the `DockerScannerTimeoutError` message. The `run()` call site at the container-start phase arms the timer with `remainingTimeoutMs` (configured `timeoutMs` minus elapsed setup time), so if even ~1ms elapses before that timer arms, the message reads e.g. `"9ms"` instead of the configured `"10ms"`. Failed twice on `main` run 29657499692.
- Root-cause fix: `waitForTimeout` now takes an optional `reportedTimeoutMs` (defaults to `timeoutMs`) used only in the error message, while `setTimeout` still arms with the real remaining budget. The call site that passes `remainingTimeoutMs` now also passes `runOptions.timeoutMs` as the reported value, so the displayed timeout always matches what was configured — decoupled from how much budget was actually left when the timer armed.
- Added a deterministic regression test (`reports the configured timeout even when the deadline is armed mid-flight`) that mocks `Date.now` to force a non-zero elapsed-setup remainder before the container-start phase arms its timer, then asserts the rejection message still reads `Scanner worker timed out after 10ms`.

This is test-hygiene for the rc.3 line — no runtime behavior change beyond the error message text (the timer still fires after the same remaining budget as before).

## Test plan

- [x] `npx vitest run security/backends/docker.test.ts` — 63/63 passed
- [x] `npx vitest run --coverage security/backends/` — `docker.ts` at 100% lines/branches/functions/statements in `coverage/coverage-summary.json`
- [x] `npx biome check security/backends/docker.ts security/backends/docker.test.ts` — clean
- [x] Full local pre-push gate (biome, qlty, qlty-smells, workflow-tests, typecheck, coverage, build) — all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed scanner timeout errors to report the configured timeout instead of the reduced remaining budget.
- 🔧 Updated `waitForTimeout` to separate timer duration from reported timeout.
- ✨ Added a deterministic regression test covering elapsed setup time.
- ✅ Docker tests, coverage, formatting, and pre-push checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->