### PR TITLE
📝 docs: add README translations (es, pl, zh-CN, de, fr, pt-BR)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -154,7 +154,7 @@ docker run -d \
 > echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
 > ```
 >
-> Oder mit Node.js 24+ (keine zusätzlichen Pakete erforderlich):
+> Oder mit Node.js 24.7+ (keine zusätzlichen Pakete erforderlich):
 >
 > ```bash
 > node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"
@@ -179,7 +179,7 @@ Weitere Informationen zu Docker Compose, Socket-Sicherheit, Reverse-Proxy und al
 - **Dashboard** – CSS-Rasterersatz ohne Abhängigkeit mit Maus-/Touch-Neuordnung, begrenzter Größenänderung, responsiven Layouts, Widget-Sichtbarkeit, Zurücksetzen und optionaler geräteübergreifender Präferenzsynchronisierung.
 - **Aktualisierungsrichtlinie** – Deklarative Watcher-/Label-/UI-Priorität, Audit-Trail überschreiben/zurücksetzen, Fälligkeits-Countdown/manuelles Überschreiben und Informationssichtbarkeit angehefteter Tags mit einer gestapelten aktuellen → neueren Tag-Ansicht.
 - **Leistung und Wiederherstellung** – Deduplizierung der Tag-Liste pro Umfrage, einfachere Aggregatprojektionen, virtualisierte große Protokollverläufe, unveränderlicher Live-Protokoll-Rollover, Authentifizierungs-Bootstrap-Timeout, vollständige Präferenzmigrationen und Selbstheilung veralteter Chunks.
-– **v1.6-Migrationen erzwungen** – WUD-Env-/Label-Aliase, veraltete Authentifizierungsformate, veraltete Watcher-Schalter, Vorlagenaliase, Kafka `clientId` und fehlerhafte öffentliche Hub/DHI-Konfigurationen, die nur auf Tokens basieren, werden nicht mehr ausgeführt. Die Trigger-Taxonomie-Aliase bleiben für eine letzte Warnungsversion auf Fehlerebene bestehen.
+- **v1.6-Migrationen erzwungen** – WUD-Env-/Label-Aliase, veraltete Authentifizierungsformate, veraltete Watcher-Schalter, Vorlagenaliase, Kafka `clientId` und fehlerhafte öffentliche Hub/DHI-Konfigurationen, die nur auf Tokens basieren, werden nicht mehr ausgeführt. Die Trigger-Taxonomie-Aliase bleiben für eine letzte Warnungsversion auf Fehlerebene bestehen.
 
 Vollständige Migrationsanleitung in [DEPRECATIONS.md](./DEPRECATIONS.md).
 

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,447 @@
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
+  <img src="docs/assets/whale-logo.png" alt="drydock" width="220">
+</picture>
+
+<h1>drydock</h1>
+
+**Container-Image-Update-Watcher – 23 Register, 20 Benachrichtigungs- und Aktionsanbieter.**
+
+<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <strong>Deutsch</strong> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
+</div>
+
+<p align="center">
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.2-blue" alt="Version"></a>
+  <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
+  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
+  <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
+  <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+</p>
+
+<hr>
+
+> [!WARNING]
+> **Aktualisierung von einer älteren Version? Lesen Sie zuerst die Upgrade-Hinweise.** Drei Korrekturen zur Sicherheitsverstärkung wurden erstmals in **1.4.6** ausgeliefert und durchlaufen die gesamte **1.5**-Reihe, sodass jeder, der von einer Version älter als 1.4.6 aktualisiert, davon betroffen ist, unabhängig davon, auf welcher Version er landet (1.4.6, jede 1.5.x oder höher). Sie sind keine veralteten Versionen und haben keine Kulanzfrist: OIDC erfordert jetzt `authorization_endpoint` in den Erkennungsmetadaten Ihres Anbieters, nicht authentifizierte ratenbegrenzende Schlüssel auf der TCP-Peer-Adresse (gemeinsamer Bucket hinter einem Reverse-Proxy) und HTTP-Trigger-Proxy-URLs müssen `http(s)://` verwenden. Lesen Sie vor der Aktualisierung **[UPGRADE-NOTES.md](UPGRADE-NOTES.md)**.
+
+<h2 align="center">📑 Inhalt</h2>
+
+- [📖 Dokumentation](https://getdrydock.com/docs)
+- [🚀 Schnellstart](#quick-start)
+- [🆕 Aktuelle Updates](#recent-updates)
+- [📸 Screenshots & Live-Demo](#screenshots)
+- [🤔 Warum Drydock](#why-drydock)
+- [✨ Eigenschaften](#features)
+- [🔌 Unterstützte Integrationen](#supported-integrations)
+- [⚖️ Funktionsvergleich](#feature-comparison)
+- [🔄 Migration](#migration)
+- [🗺️ Roadmap](#roadmap)
+- [⭐ Sterngeschichte](#star-history)
+- [🔧 Gebaut mit](#gebaut-mit)
+- [🤝 Community QA](#community-qa)
+
+<hr>
+
+<h2 align="center" id="quick-start">🚀 Schnellstart</h2>
+
+**Empfohlen: Verwenden Sie einen Socket-Proxy**, um einzuschränken, auf welche Docker-API-Endpunkte Drydock zugreifen kann. Dadurch wird vermieden, dass der Container vollen Zugriff auf den Docker-Socket erhält.
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      socket-proxy:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=socket-proxy
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - CONTAINERS=1
+      - IMAGES=1
+      - EVENTS=1
+      - SERVICES=1
+      - INFO=1          # Required for daemon identity detection (notification prefixes)
+      # Add POST=1 and NETWORKS=1 for container actions and auto-updates
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+<details>
+<summary>Alternativ:<a href="https://github.com/CodesWhat/sockguard">sockguard</a>Socket-Proxy</summary>
+
+[sockguard](https://github.com/CodesWhat/sockguard) ist ein standardmäßig verweigernder Docker-Socket-Filter aus demselben CodesWhat-Ökosystem mit einer für drydock erstellten Voreinstellung:
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      sockguard:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=sockguard
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  sockguard:
+    image: codeswhat/sockguard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./sockguard.yaml:/etc/sockguard/config.yaml:ro
+    environment:
+      - SOCKGUARD_CONFIG_FILE=/etc/sockguard/config.yaml
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+Siehe sockguards [`app/configs/portwing.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing.yaml)-Voreinstellung für einen Start-`sockguard.yaml` (die gleiche Voreinstellung portwing wird in eigenen Beispielen geliefert).
+
+</details>
+
+<details>
+<summary>Alternative: Schnellstart mit direkter Steckdosenmontage</summary>
+
+```bash
+docker run -d \
+  --name drydock \
+  -p 3000:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e DD_AUTH_BASIC_ADMIN_USER=admin \
+  -e "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>" \
+  codeswhat/drydock:latest
+```
+
+> **Warnung:** Der direkte Socket-Zugriff gewährt dem Container die volle Kontrolle über den Docker-Daemon. Verwenden Sie das oben beschriebene Socket-Proxy-Setup für Produktionsbereitstellungen. Im [Docker Socket Security Guide](https://getdrydock.com/docs/configuration/watchers#docker-socket-security) finden Sie alle Optionen, einschließlich Remote-TLS und rootless Docker.
+
+</details>
+
+> Generieren Sie einen Passwort-Hash (`argon2` CLI – Installation über Ihren Paketmanager):
+>
+> ```bash
+> echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
+> ```
+>
+> Oder mit Node.js 24+ (keine zusätzlichen Pakete erforderlich):
+>
+> ```bash
+> node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"
+> ```
+>
+> Drydock v1.6 akzeptiert nur argon2id Basic-Authentifizierungs-Hashes. Ältere `{SHA}`-, `$apr1$`/`$1$`-, `crypt`- und Klartext-Hashes werden abgelehnt; Regenerieren Sie sie vor dem Upgrade.
+> Authentifizierung ist **standardmäßig erforderlich**. Informationen zu OIDC, anonymem Zugriff und anderen Optionen finden Sie in den [auth docs](https://getdrydock.com/docs/configuration/authentications).
+> Um den anonymen Zugriff bei Neuinstallationen explizit zuzulassen, legen Sie `DD_ANONYMOUS_AUTH_CONFIRM=true` fest.
+
+Das Image enthält die Binärdateien `trivy` und `cosign` für die lokale Suche nach Schwachstellen und die Image-Verifizierung.
+
+Weitere Informationen zu Docker Compose, Socket-Sicherheit, Reverse-Proxy und alternativen Registrierungen finden Sie im [Quick Start Guide](https://getdrydock.com/docs/quickstart).
+
+<hr>
+
+<h2 align="center" id="recent-updates">🆕 Aktuelle Updates</h2>
+
+<details open>
+<summary><strong>v1.6.0-rc.2 Highlights</strong></summary>
+
+- **Benachrichtigungen** – Titel- und Textvorlagen pro Regel/pro Anbieter mit Live-Vorschau sowie prüfungsgestützten In-App-Klingelkategorien und Schwellenwerten für den Aktualisierungsschweregrad.
+- **Dashboard** – CSS-Rasterersatz ohne Abhängigkeit mit Maus-/Touch-Neuordnung, begrenzter Größenänderung, responsiven Layouts, Widget-Sichtbarkeit, Zurücksetzen und optionaler geräteübergreifender Präferenzsynchronisierung.
+- **Aktualisierungsrichtlinie** – Deklarative Watcher-/Label-/UI-Priorität, Audit-Trail überschreiben/zurücksetzen, Fälligkeits-Countdown/manuelles Überschreiben und Informationssichtbarkeit angehefteter Tags mit einer gestapelten aktuellen → neueren Tag-Ansicht.
+- **Leistung und Wiederherstellung** – Deduplizierung der Tag-Liste pro Umfrage, einfachere Aggregatprojektionen, virtualisierte große Protokollverläufe, unveränderlicher Live-Protokoll-Rollover, Authentifizierungs-Bootstrap-Timeout, vollständige Präferenzmigrationen und Selbstheilung veralteter Chunks.
+– **v1.6-Migrationen erzwungen** – WUD-Env-/Label-Aliase, veraltete Authentifizierungsformate, veraltete Watcher-Schalter, Vorlagenaliase, Kafka `clientId` und fehlerhafte öffentliche Hub/DHI-Konfigurationen, die nur auf Tokens basieren, werden nicht mehr ausgeführt. Die Trigger-Taxonomie-Aliase bleiben für eine letzte Warnungsversion auf Fehlerebene bestehen.
+
+Vollständige Migrationsanleitung in [DEPRECATIONS.md](./DEPRECATIONS.md).
+
+</details>
+
+<details>
+<summary><strong>v1.5.2 Highlights</strong></summary>
+
+- **Erholungssichere Update-Richtlinie** – Reife-Gates, übersprungene Tags/Digests und Snoozes überleben jetzt die Container-Erstellung für lokale und Remote-Agent-Workloads.
+- **Zuverlässigkeit angehefteter Tags** – Vollständig angeheftete Tags erkennen Digest-Neuerstellungen mit demselben Tag erneut, während die Benutzeroberfläche ein nicht umsetzbares neueres Tag derselben Familie anzeigen kann, ohne das Aktualisierungs- oder Auslöseverhalten zu ändern.
+- **Rollback-Wiederherstellung** – Bei fehlgeschlagener Ersatzerstellung, Netzwerkanbindung oder Start wird jetzt der Kandidat bereinigt, bevor der ursprüngliche Container wiederhergestellt wird, und wiederholte Fehler können nicht durch verschachtelte Rollback-Umbenennungen kaskadiert werden.
+- **Sicherere Containerwiederherstellung** – Vom Daemon zugewiesene MAC-Adressen werden nicht mehr an Ersatzadressen geheftet, während explizit konfigurierte MAC-Adressen des primären Netzwerks erhalten bleiben.
+- **Leisere Abfrage lokaler Bilder** – Lokal erstellte oder geladene Bilder ohne Registry-Digest überspringen Remote-Suchen, anstatt wiederkehrende Autorisierungsfehler zu generieren.
+
+Vollständiger Verlauf in [CHANGELOG.md](./CHANGELOG.md).
+
+</details>
+
+<hr>
+
+<h2 align="center" id="screenshots">📸 Screenshots und Live-Demo</h2>
+
+<p align="center">
+  <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
+</p>
+
+<p align="center"><em>Erkennen Sie ein Update, sehen Sie genau, welche Änderungen sich ergeben, und wenden Sie es an. Sicherung, Gesundheitsprüfung und Rollback werden durchgeführt.</em></p>
+
+<table>
+<tr>
+<td width="50%" align="center"><strong>Licht</strong></td>
+<td width="50%" align="center"><strong>Dunkel</strong></td>
+</tr>
+<tr>
+<td><img src="docs/assets/drydock-dashboard-light.png" alt="Dashboard Light"></td>
+<td><img src="docs/assets/drydock-dashboard-dark.png" alt="Dashboard Dark"></td>
+</tr>
+</table>
+
+<div align="center">
+
+**Warum Screenshots anschauen, wenn Sie es selbst erleben können?**
+
+<a href="https://demo.getdrydock.com"><img src="https://img.shields.io/badge/Try_the_Live_Demo-4f46e5?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlnb24gcG9pbnRzPSI2IDMgMjAgMTIgNiAyMSA2IDMiLz48L3N2Zz4=&logoColor=white" alt="Try the Live Demo" height="36"></a>
+
+Vollständig interaktiv – echte Benutzeroberfläche, Scheindaten, keine Installation erforderlich. Läuft vollständig im Browser.
+
+</div>
+
+<hr>
+
+<h2 align="center" id="why-drydock">🤔 Warum Drydock</h2>
+
+Containerbilder veralten stillschweigend. Ein Basisimage patcht ein CVE, eine App schneidet eine Version, ein Tag wird verschoben. Sofern Sie nicht jede Registrierung manuell überwachen, bleiben Ihre laufenden Container zurück, bis etwas kaputt geht oder ausgenutzt wird.
+
+Die meisten Tools erzwingen einen Kompromiss. Die Auto-Updater (Watchtower, Ouroboros) ziehen und starten mit wenig Sichtbarkeit oder Kontrolle neu und werden jetzt weitgehend nicht mehr gewartet. Die Dashboards (Portainer) verwalten Container, sind jedoch nicht für Update-Intelligenz konzipiert. Drydock ist **monitor-first**: Es überwacht 23 Register und teilt Ihnen genau mit, was sich geändert hat (Major, Minor, Patch oder Digest), bevor etwas passiert, und reagiert dann nur, wenn Sie es zulassen. Und es geht weiter als alle anderen. Trivy/Grype Schwachstellenscans blockieren unsichere Updates, Cosign überprüft Signaturen, Image-Backups vor dem Update werden automatisch zurückgesetzt, wenn die Integritätsprüfung fehlschlägt, verteilte Agents decken Remote-Hosts ab und 20 Benachrichtigungs- und Aktionsintegrationen schließen den Kreis. Der vollständige Update-Lebenszyklus mit einer Web-Benutzeroberfläche und einer REST-API.
+
+<hr>
+
+<h2 align="center" id="features">✨ Funktionen</h2>
+
+| | Funktion | Beschreibung |
+|---|---|---|
+| 🔭 | **Monitor-First-Erkennung** | Überwacht jeden laufenden Container und klassifiziert jedes verfügbare Update als Haupt-, Neben-, Patch- oder Digest-Update, bevor etwas passiert. Es ändert sich nichts, bis Sie es sagen. |
+| 📦 | **23 Registrierungsanbieter** | Docker Hub, GHCR, ECR, ACR, GCR, GAR, GitLab, Quay, Harbour, Artifactory, Nexus und 12 weitere. Öffentlich und privat, in der Cloud und selbst gehostet, mit TLS und Authentifizierung pro Registrierung. |
+| 🔔 | **20 Auslöser** | 17 Benachrichtigungskanäle (Slack, Discord, Telegram, Teams, SMTP, MQTT, ntfy und mehr) plus Docker-, Docker Compose- und Command-Aktionen, mit Vorlagen pro Ereignis/Anbieter, Live-Vorschau, Schwellenwertfilterung und Batch-Modus. |
+| 🥊 | **Update Bouncer** | Der Schwachstellenscan Trivy/Grype blockiert unsichere Updates vor der Bereitstellung, mit Cosign-Signaturüberprüfung und SBOM-Generierung (CycloneDX und SPDX). |
+| ↩️ | **Image-Sicherung und automatisches Rollback** | Image-Snapshots vor dem Update mit konfigurierbarer Aufbewahrung, automatischem Rollback bei fehlgeschlagener Integritätsprüfung und manuellem Rollback mit einem Klick über die Benutzeroberfläche. |
+| 🪝 | **Lebenszyklus-Hooks** | Shell-Befehle vor und nach dem Update über Container-Labels, mit Zeitüberschreitungen pro Hook und Steuerung des Abbruchs bei Fehler. |
+| 🗂️ | **Docker Compose-Updates** | Ziehen Sie Compose-Dienste über die Docker Engine-API mit YAML-erhaltendem Image-Patching ab und erstellen Sie sie neu. |
+| 🎛️ | **Richtlinie pro Container** | Regex-Tag-Regeln und Trigger-Routing verwenden `dd.*`-Labels; Reifegrenzen, Skip/Snooze/Pin und Wartungsfenster werden über die Benutzeroberfläche/API oder die Watcher-Konfiguration gespeichert. |
+| 🛰️ | **Verteilte Agenten** | Überwachen Sie Remote-Docker-Hosts über SSE. Edge-Agents hinter NAT wählen sich über WebSocket mit Ed25519-Schlüsselauthentifizierung aus, kein eingehender Port erforderlich (`DD_EXPERIMENTAL_PORTWING=true`). |
+| 🖥️ | **Web-Dashboard** | Vue 3-Benutzeroberfläche mit einem anpassbaren Widget-Raster ohne Abhängigkeiten, reaktionsfähigen Tabellen-/Kartenansichten, Live-SSE-Updates, Steuerelementen für Benachrichtigungsglocken sowie Details, Protokollen und Statistiken pro Container. |
+| 🔗 | **REST-API und Webhooks** | Token-authentifizierte Endpunkte für CI/CD-Überwachungs- und Update-Trigger sowie signierte Registrierungs-Webhook-Aufnahme für Push-Ereignisse. |
+| 🔐 | **OIDC-Authentifizierung** | Sichern Sie das Dashboard mit OpenID Connect (Authelia, Auth0, Authentik). Alle Authentifizierungsflüsse werden standardmäßig nicht geschlossen. |
+| 📈 | **Prometheus-Metriken** | Integrierter `/metrics`-Endpunkt mit optionaler Authentifizierungsumgehung für die Überwachungsstacks Prometheus und Grafana. |
+| 🌍 | **17 UI-Gebietsschemas** | Vollständig verkabeltes Übersetzungssystem mit vollständigem Englisch und 16 von der Community gepflegten Gebietsschemas, synchronisiert über Crowdin, umschaltbar in Config. |
+| 🔒 | **ReDoS-Immune Regex** | Jedes vom Benutzer bereitgestellte Tag-Muster wird über re2js (einen reinen JS-RE2-Port) für einen linearen Zeitabgleich kompiliert, der nicht durch ein katastrophales Backtracking-Muster blockiert werden kann. |
+
+<hr>
+
+<h2 align="center" id="supported-integrations">🔌 Unterstützte Integrationen</h2>
+
+### 📦 Register (23)
+
+Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Quay · LSCR · Harbor · Artifactory · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Custom · DOCR · DHI · IBM Cloud · Oracle Cloud · Alibaba Cloud
+
+### ⚡ Aktionen (3)
+
+Docker · Docker Compose · Befehl
+
+### 🔔 Benachrichtigungen (17)
+
+Apprise · Discord · Google Chat · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
+
+### 🔐 Authentifizierung
+
+Anonym (Opt-in über `DD_ANONYMOUS_AUTH_CONFIRM=true`) · Basic (Benutzername + Passwort-Hash) · OIDC (Authelia, Auth0, Authentik). Alle Authentifizierungsflüsse werden standardmäßig nicht geschlossen.
+
+### 🥊 Update Bouncer
+
+Trivy- oder Grype-gestützte Schwachstellenscans blockieren unsichere Updates, bevor sie bereitgestellt werden. Beinhaltet Cosign-Signaturüberprüfung und SBOM-Generierung (CycloneDX & SPDX).
+
+<hr>
+
+<h2 align="center" id="feature-comparison">⚖️ Funktionsvergleich</h2>
+
+<details>
+<summary><strong>Wie schneidet drydock im Vergleich zu anderen Container-Update-Tools ab?</strong></summary>
+
+> ✅ = unterstützt &nbsp; ❌ = nicht unterstützt &nbsp; ⚠️ = teilweise / begrenzt &nbsp; † = archiviert, nicht mehr gepflegt
+
+| Feature | drydock | WUD | Diun | *Watchtower †* | *Ouroboros †* |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Weboberfläche / Dashboard | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Automatische Container-Updates | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Docker-Compose-Updates | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Trigger-/Benachrichtigungskanäle | 20 | 16 | 17 | ~19 | ~6 |
+| Registry-Anbieter | 23 | 13 | ⚠️ | ⚠️ | ⚠️ |
+| OIDC-/SSO-Authentifizierung | ✅ | ✅ | ❌ | ❌ | ❌ |
+| REST-API | ✅ | ✅ | ⚠️ | ⚠️ | ❌ |
+| Prometheus-Metriken | ✅ | ✅ | ❌ | ✅ | ✅ |
+| MQTT / Home Assistant | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Image-Sicherung und Rollback | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Container-Gruppierung / Stacks | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Lifecycle-Hooks (vor/nach) | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Webhook-API für CI/CD | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Container starten/stoppen/neustarten/aktualisieren | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Verteilte Agenten (remote) | ✅ | ❌ | ✅ | ⚠️ | ❌ |
+| Audit-Protokoll | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Sicherheitsscans (Trivy/Grype) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| SemVer-fähige Updates | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Digest-Überwachung | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Multi-Architektur (amd64/arm64) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Container-Loganzeige | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Aktiv gepflegt | ✅ | ✅ | ✅ | ❌ | ❌ |
+
+> Daten basieren auf öffentlich zugänglicher Dokumentation, Stand März 2026.
+> Beiträge willkommen, wenn Informationen ungenau sind.
+
+</details>
+
+<hr>
+
+<h2 align="center" id="migration">🔄Migration</h2>
+
+<details>
+<summary><strong>Migration von WUD (What's Up Docker?)</strong></summary>
+
+Drydock v1.6 lädt zur Laufzeit keine `WUD_*`-Umgebungsvariablen oder `wud.*`-Labels mehr. Schreiben Sie sie neu, bevor Sie den aktualisierten Dienst starten. Der persistente Status wird weiterhin automatisch migriert. Verwenden Sie `docker exec -it drydock node dist/index.js config migrate --dry-run` für die Vorschau und dann `docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml`, um die Konfiguration in die Namen `DD_*` und `dd.*` umzuschreiben.
+
+</details>
+
+<hr>
+
+<h2 align="center" id="roadmap">🗺️ Roadmap</h2>
+
+<details>
+<summary><strong>Versionsthemen und Highlights</strong></summary>
+
+Nur High-Level-Themes – siehe [CHANGELOG.md](CHANGELOG.md) für Details pro Release.
+
+| Version | Thema | Höhepunkte |
+| --- | --- | --- |
+| **v1.3.x** ✅ | Sicherheit und Stabilität | Trivy-Scanning, Update Bouncer, SBOM, 7 neue Register, 4 neue Trigger, re2js-Regex-Engine |
+| **v1.4.x** ✅ | UI-Modernisierung und -Härtung | Tailwind 4 + benutzerdefinierte Komponenten, 6 Themes, Cmd/K-Palette, OpenAPI 3.1, Compose-native YAML-Updates, Dual-Slot-Scanning, OIDC-Härtung |
+| **v1.5.0** ✅ | Beobachtbarkeit & i18n | Trigger-Taxonomie-Aufteilung (`DD_ACTION_*`/`DD_NOTIFICATION_*`), WebSocket-Protokollanzeige, Dashboard-Anpassung, Ressourcenüberwachung, Benachrichtigungsausgang + DLQ, Sicherheitsscan-Digest, 17 Gebietsschemas, SSE Last-Event-ID-Wiedergabe, Edge-Agent-Dial-Out mit Ed25519-Authentifizierung (experimentell, `DD_EXPERIMENTAL_PORTWING=true`) |
+| **v1.5.1** ✅ | Sicherheit und Wartung | GCR/GAR-Pull-Auth-Fix, Registry-TLS-Vervollständigung (M-2), Hook-Env-Var-Injection-Hardening, `DD_SESSION_SECRET__FILE`-Unterstützung, Debug-Dump-Anmeldeinformationsredaktion, Berechtigungsprüfung für geheime Dateien, Deadlock-Fix für Reifegradtore, vollständige UI-Übersetzbarkeit + Community-Übersetzungen, automatisches Apply-Gate für Wartungsfenster, Container-Verfügbarkeitsanzeige, Tag/Version-Spalten-Split-Surface-Softwareversion (OCI-Label, mit `dd.inspect.tag.path` Dual-Write + Opt-in `dd.inspect.tag.version-only` Routing), Opt-in Compose Mount-Präfix-Matching, `${currentReleaseNotes}` Template Var |
+| **v1.5.2** ✅ | Zuverlässigkeit von Richtlinien und angehefteten Tags | Erholungssichere Aufbewahrung von Fälligkeits-/Skip-/Snooze-Richtlinien, Digest-Neuerstellungserkennung mit angehefteten Tags und informative Einblicke in die gleiche Familie, Rollback-Kandidaten-Bereinigung, Rollback-Kaskaden-Verhinderung, explizite MAC-Bewahrung und Verhalten beim Überspringen lokaler Images in der Registrierung |
+| **v1.6.0** | Benachrichtigungen, Richtlinien und Veröffentlichungen Intel | Benachrichtigungsvorlagen pro Regel/pro Auslöser mit Live-Vorschau, Benachrichtigungsglocken-Einstellungen, geräteübergreifender Präferenzsynchronisierung, benutzerdefiniertem Dashboard-Raster ohne Abhängigkeit ([#281](https://github.com/CodesWhat/drydock/issues/281)), deklarativer Aktualisierungsrichtlinie ([#320](https://github.com/CodesWhat/drydock/issues/320)), Reifegradstabilisierungs-Countdown + sofortiger Kandidatensichtbarkeit + manueller Überschreibung ([#406](https://github.com/CodesWhat/drydock/discussions/406)), umsetzbarem Update-Status-Panel und global `notify` / `manual` / `auto` Aktualisierungsmodus ([#325](https://github.com/CodesWhat/drydock/discussions/325)), Watcher-/imgset-/Container-Tag-Richtlinienvererbung plus gestapelte aktuelle → neuere Sichtbarkeit angehefteter Tags ([#498](https://github.com/CodesWhat/drydock/issues/498)), standardisierte 44px-Quelle/Versionshinweise/Registrierungsressourcenaktionen für Tabelle, Karten und Details ([#295](https://github.com/CodesWhat/drydock/discussions/295)), Ereignisbenachrichtigungen zum Gesundheitsstatus ([#198](https://github.com/CodesWhat/drydock/discussions/198)), bidirektionales Home Assistant MQTT, reaktionsfähige Tabellen-/Kartenlistenansichten, Trivy/Grype/Scannen über Befehl oder angeheftete Docker-Worker-Backends, Scanner-Asset-Pull/Warm-Steuerung, Off-Heap-Deduplizierung SBOM-Speicher, Trivy Long-Scan-Korrektheit ([#490](https://github.com/CodesWhat/drydock/issues/490)), Trigger-Taxonomie-Migrationswarnungen, v1.6-Kompatibilitätsentfernungen, Dokumentation/API-Hygiene und `/api` → `/api/v1`-Migrationsabschluss mit einem optionalen Wud-Card/Homepage-Kompatibilitäts-Shim (`DD_COMPAT_WUDCARD`). |
+| **v1.7.0** | Intelligente Updates und UX | Abhängigkeitsbewusste Reihenfolge ([#219](https://github.com/CodesWhat/drydock/discussions/219)), selektive Massenaktualisierungen ([#232](https://github.com/CodesWhat/drydock/discussions/232)), Aktualisierungsrichtlinie pro Aktion ([#511](https://github.com/CodesWhat/drydock/discussions/511)), Bildbereinigung, statische Bildüberwachung, Bildreifeanzeige, einheitliche Reife-/Update-Alters-Uhr, anklickbare Port-Links, Tastaturkürzel, PWA, Entfernung von `DD_TRIGGER_*` (Ende der veralteten Version 1.5.0). Fenster), Curl aus dem Bild entfernt |
+| **v1.8.0** | Flottenmanagement und Live-Konfiguration | YAML-Konfiguration, Live-UI-Konfiguration, Volume-Browser, parallele Updates, SQLite-Store-Migration |
+| **v2.0+** | Plattformerweiterung und darüber hinaus | Swarm/Kubernetes-Watcher, GitOps, Health Gates, Canary Deployments, Webterminal, RBAC, bereichsbezogene rotierbare API-Schlüssel (statische Bearer-Tokens für HA/Dashboard-Integrationen, [#469](https://github.com/CodesWhat/drydock/discussions/469)), LDAP/AD, nativer Podman-Anbieter über die Docker-kompatible API hinaus, CLI, gehärtetes Wolfi-Image, Socket-Proxy |
+
+</details>
+
+<hr>
+
+<h2 align="center" id="documentation">📖 Dokumentation</h2>
+
+| Ressource | Link |
+| --- | --- |
+| Website | [getdrydock.com](https://getdrydock.com/) |
+| Live-Demo | [demo.getdrydock.com](https://demo.getdrydock.com) |
+| Dokumente | [getdrydock.com/docs](https://getdrydock.com/docs) |
+| Konfiguration | [Konfiguration](https://getdrydock.com/docs/configuration) |
+| Schnellstart | [Schnellstart](https://getdrydock.com/docs/quickstart) |
+| Änderungsprotokoll | [`CHANGELOG.md`](CHANGELOG.md) |
+| Abschreibungen | [`DEPRECATIONS.md`](DEPRECATIONS.md) |
+| Roadmap | Siehe den Abschnitt [„Roadmap“](#roadmap) oben |
+| Mitwirken | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Probleme | [GitHub Issues](https://github.com/CodesWhat/drydock/issues) |
+| Diskussionen | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) – Funktionsanfragen und Ideen willkommen |
+
+<hr>
+
+<a id="star-history"></a>
+
+<div align="center">
+  <a href="https://star-history.com/#CodesWhat/drydock&Date">
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CodesWhat/drydock&type=Date" />
+  </a>
+</div>
+
+---
+
+<div align="center">
+
+### Gebaut mit
+
+[![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
+[![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
+[![Express 5](https://img.shields.io/badge/Express_5-000?logo=express&logoColor=fff)](https://expressjs.com/)
+[![Vitest](https://img.shields.io/badge/Vitest_4-6E9F18?logo=vitest&logoColor=fff)](https://vitest.dev/)
+[![Biome](https://img.shields.io/badge/Biome_2.5-60a5fa?logo=biome&logoColor=fff)](https://biomejs.dev/)
+[![Node 24](https://img.shields.io/badge/Node_24_Alpine-339933?logo=nodedotjs&logoColor=fff)](https://nodejs.org/)
+[![Anthropic](https://img.shields.io/badge/Anthropic-CC785C?style=flat&logo=anthropic&logoColor=white)](https://claude.ai/)
+[![OpenAI](https://img.shields.io/badge/OpenAI-10A37F?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU%2BT3BlbkFJPC90aXRsZT48cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJNMjIuMjgxOSA5LjgyMTFhNS45ODQ3IDUuOTg0NyAwIDAgMC0uNTE1Ny00LjkxMDggNi4wNDYyIDYuMDQ2MiAwIDAgMC02LjUwOTgtMi45QTYuMDY1MSA2LjA2NTEgMCAwIDAgNC45ODA3IDQuMTgxOGE1Ljk4NDcgNS45ODQ3IDAgMCAwLTMuOTk3NyAyLjkgNi4wNDYyIDYuMDQ2MiAwIDAgMCAuNzQyNyA3LjA5NjYgNS45OCA1Ljk4IDAgMCAwIC41MTEgNC45MTA3IDYuMDUxIDYuMDUxIDAgMCAwIDYuNTE0NiAyLjkwMDFBNS45ODQ3IDUuOTg0NyAwIDAgMCAxMy4yNTk5IDI0YTYuMDU1NyA2LjA1NTcgMCAwIDAgNS43NzE4LTQuMjA1OCA1Ljk4OTQgNS45ODk0IDAgMCAwIDMuOTk3Ny0yLjkwMDEgNi4wNTU3IDYuMDU1NyAwIDAgMC0uNzQ3NS03LjA3Mjl6bS05LjAyMiAxMi42MDgxYTQuNDc1NSA0LjQ3NTUgMCAwIDEtMi44NzY0LTEuMDQwOGwuMTQxOS0uMDgwNCA0Ljc3ODMtMi43NTgyYS43OTQ4Ljc5NDggMCAwIDAgLjM5MjctLjY4MTN2LTYuNzM2OWwyLjAyIDEuMTY4NmEuMDcxLjA3MSAwIDAgMSAuMDM4LjA1MnY1LjU4MjZhNC41MDQgNC41MDQgMCAwIDEtNC40OTQ1IDQuNDk0NHptLTkuNjYwNy00LjEyNTRhNC40NzA4IDQuNDcwOCAwIDAgMS0uNTM0Ni0zLjAxMzdsLjE0Mi4wODUyIDQuNzgzIDIuNzU4MmEuNzcxMi43NzEyIDAgMCAwIC43ODA2IDBsNS44NDI4LTMuMzY4NXYyLjMzMjRhLjA4MDQuMDgwNCAwIDAgMS0uMDMzMi4wNjE1TDkuNzQgMTkuOTUwMmE0LjQ5OTIgNC40OTkyIDAgMCAxLTYuMTQwOC0xLjY0NjR6TTIuMzQwOCA3Ljg5NTZhNC40ODUgNC40ODUgMCAwIDEgMi4zNjU1LTEuOTcyOFYxMS42YS43NjY0Ljc2NjQgMCAwIDAgLjM4NzkuNjc2NWw1LjgxNDQgMy4zNTQzLTIuMDIwMSAxLjE2ODVhLjA3NTcuMDc1NyAwIDAgMS0uMDcxIDBsLTQuODMwMy0yLjc4NjVBNC41MDQgNC41MDQgMCAwIDEgMi4zNDA4IDcuODcyem0xNi41OTYzIDMuODU1OEwxMy4xMDM4IDguMzY0IDE1LjExOTIgNy4yYS4wNzU3LjA3NTcgMCAwIDEgLjA3MSAwbDQuODMwMyAyLjc5MTNhNC40OTQ0IDQuNDk0NCAwIDAgMS0uNjc2NSA4LjEwNDJ2LTUuNjc3MmEuNzkuNzkgMCAwIDAtLjQwNy0uNjY3em0yLjAxMDctMy4wMjMxbC0uMTQyLS4wODUyLTQuNzczNS0yLjc4MThhLjc3NTkuNzc1OSAwIDAgMC0uNzg1NCAwTDkuNDA5IDkuMjI5N1Y2Ljg5NzRhLjA2NjIuMDY2MiAwIDAgMSAuMDI4NC0uMDYxNWw0LjgzMDMtMi43ODY2YTQuNDk5MiA0LjQ5OTIgMCAwIDEgNi42ODAyIDQuNjZ6TTguMzA2NSAxMi44NjNsLTIuMDItMS4xNjM4YS4wODA0LjA4MDQgMCAwIDEtLjAzOC0uMDU2N1Y2LjA3NDJhNC40OTkyIDQuNDk5MiAwIDAgMSA3LjM3NTctMy40NTM3bC0uMTQyLjA4MDVMOC43MDQgNS40NTlhLjc5NDguNzk0OCAwIDAgMC0uMzkyNy42ODEzem0xLjA5NzYtMi4zNjU0bDIuNjAyLTEuNDk5OCAyLjYwNjkgMS40OTk4djIuOTk5NGwtMi41OTc0IDEuNDk5Ny0yLjYwNjctMS40OTk3WiIvPjwvc3ZnPg%3D%3D)](https://openai.com)
+
+[![SemVer](https://img.shields.io/badge/semver-2.0.0-blue)](https://semver.org/)
+[![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
+[![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
+
+### Gemeinschaft
+
+Fragen, Feedback und frühzeitige Unterstützung: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+
+Bitte reichen Sie konkrete Fehler und Funktionsanfragen in **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** ein, damit diese nicht im Chat verloren gehen.
+
+### Community-QA
+
+Vielen Dank an die Benutzer, die beim Testen der Release-Kandidaten v1.4.0 und v1.5.0 geholfen und Fehler gemeldet haben:
+
+[@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
+
+### Teil des CodesWhat-Ökosystems
+
+<table>
+  <tr><th>Werkzeug</th><th>Rolle</th></tr>
+  <tr><td><b>drydock</b></td><td>Überwachung von Containeraktualisierungen – Web-Benutzeroberfläche und Benachrichtigungs-Engine</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/portwing"><b>portwing</b></a></td><td>Remote-Docker-Agent – sicherer Zugriff auf Socket-Ebene von Drydock oder Standalone</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/sockguard"><b>sockguard</b></a></td><td>Docker-Socket-Proxy – Standard-Zulassungslistenfilter zum Schutz des Sockets</td></tr>
+</table>
+
+Diese drei Tools sind für die Schichtung konzipiert: sockguard filtert den Socket, portwing macht ihn remote verfügbar und drydock überwacht den Containerstatus und reagiert darauf.
+
+Die vollständige Kompatibilitätsmatrix für alle drei Tools finden Sie in [portwings COMPATIBILITY.md](https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md).
+
+---
+
+**[AGPL-3.0-Lizenz](LICENSE)**
+
+<a href="https://github.com/CodesWhat">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/codeswhat-logo-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/codeswhat-logo-original.svg" />
+    <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
+  </picture>
+</a>
+
+[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
+
+<a href="#drydock">Zurück nach oben</a>
+
+</div>

--- a/README.es.md
+++ b/README.es.md
@@ -154,7 +154,7 @@ docker run -d \
 > echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
 > ```
 >
-> O con Node.js 24+ (no se necesitan paquetes adicionales):
+> O con Node.js 24.7+ (no se necesitan paquetes adicionales):
 >
 > ```bash
 > node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"
@@ -181,7 +181,7 @@ Consulte la [guía de inicio rápido](https://getdrydock.com/docs/quickstart) pa
 - **Rendimiento y recuperación**: deduplicación de listas de etiquetas por encuesta, proyecciones agregadas más ligeras, historiales de registros grandes virtualizados, transferencia de registros en vivo inmutable, tiempo de espera de arranque de autenticación, migraciones de preferencias completas y autocuración de fragmentos obsoletos.
 - **Se aplicaron migraciones v1.6**: los alias de entorno/etiqueta WUD, los formatos de autenticación heredados, los conmutadores de vigilancia obsoletos, los alias de plantilla, Kafka `clientId` y las configuraciones públicas de Hub/DHI de solo token con formato incorrecto ya no se ejecutan. Los alias de taxonomía de activación permanecen hasta una publicación final de advertencia de nivel de error.
 
-Guía completa de migración en [DEPRECATION.md](./DEPRECATIONS.md).
+Guía completa de migración en [DEPRECATIONS.md](./DEPRECATIONS.md).
 
 </details>
 
@@ -426,7 +426,7 @@ Gracias a los usuarios que ayudaron a probar las versiones candidatas v1.4.0 y v
 
 Estas tres herramientas están diseñadas para capas: sockguard filtra el socket, portwing lo expone de forma remota y drydock monitorea y actúa sobre el estado del contenedor.
 
-Consulte COMPATIBILITY.md](<https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md>) de [portwing para obtener la matriz de compatibilidad completa entre las tres herramientas.
+Consulte el [COMPATIBILITY.md de portwing](https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md) para obtener la matriz de compatibilidad completa entre las tres herramientas.
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,447 @@
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
+  <img src="docs/assets/whale-logo.png" alt="drydock" width="220">
+</picture>
+
+<h1>drydock</h1>
+
+**Observador de actualizaciones de imágenes de contenedores: 23 registros, 20 proveedores de notificaciones y acciones.**
+
+<p><a href="README.md">English</a> · <strong>Español</strong> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
+</div>
+
+<p align="center">
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.2-blue" alt="Version"></a>
+  <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
+  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
+  <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
+  <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+</p>
+
+<hr>
+
+> [!WARNING]
+> **¿Actualizando desde una versión anterior? Lea primero las notas de actualización.** Tres correcciones de refuerzo de seguridad se enviaron por primera vez en **1.4.6** y se ejecutan en toda la línea **1.5**, por lo que cualquiera que actualice desde una versión anterior a 1.4.6 se verá afectado independientemente de la versión a la que acceda (1.4.6, cualquier 1.5.x o posterior). No están en desuso y no tienen período de gracia: OIDC ahora requiere `authorization_endpoint` en los metadatos de descubrimiento de su proveedor, claves de limitación de velocidad no autenticadas en la dirección del par TCP (depósito compartido detrás de un proxy inverso) y las URL del proxy de activación HTTP deben usar `http(s)://`. Consulte **[UPGRADE-NOTES.md](UPGRADE-NOTES.md)** antes de actualizar.
+
+<h2 align="center">📑 Contenidos</h2>
+
+- [📖 Documentación](https://getdrydock.com/docs)
+- [🚀 Inicio rápido](#quick-start)
+- [🆕 Actualizaciones recientes](#recent-updates)
+- [📸 Capturas de pantalla y demostración en vivo](#screenshots)
+- [🤔 Por qué Drydock](#why-drydock)
+- [✨ Características](#features)
+- [🔌 Integraciones admitidas](#supported-integrations)
+- [⚖️ Comparación de funciones](#feature-comparison)
+- [🔄 Migración](#migration)
+- [🗺️ Hoja de ruta](#roadmap)
+- [⭐ Historia de las estrellas](#star-history)
+- [🔧 Construido con](#construido-con)
+- [🤝 Comunidad QA](#control-de-calidad-de-la-comunidad)
+
+<hr>
+
+<h2 align="center" id="quick-start">🚀 Inicio rápido</h2>
+
+**Recomendado: use un proxy de socket** para restringir a qué puntos finales de la API de Docker puede acceder Drydock. Esto evita darle al contenedor acceso completo al socket Docker.
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      socket-proxy:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=socket-proxy
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - CONTAINERS=1
+      - IMAGES=1
+      - EVENTS=1
+      - SERVICES=1
+      - INFO=1          # Required for daemon identity detection (notification prefixes)
+      # Add POST=1 and NETWORKS=1 for container actions and auto-updates
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+<details>
+<summary>Alternativa:<a href="https://github.com/CodesWhat/sockguard">sockguard</a>proxy de socket</summary>
+
+[sockguard](https://github.com/CodesWhat/sockguard) es un filtro de socket Docker de denegación predeterminado del mismo ecosistema CodesWhat, con un ajuste preestablecido creado para drydock:
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      sockguard:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=sockguard
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  sockguard:
+    image: codeswhat/sockguard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./sockguard.yaml:/etc/sockguard/config.yaml:ro
+    environment:
+      - SOCKGUARD_CONFIG_FILE=/etc/sockguard/config.yaml
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+Consulte el ajuste preestablecido [`app/configs/portwing.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing.yaml) de sockguard para obtener un `sockguard.yaml` inicial (el mismo ajuste preestablecido portwing se envía en sus propios ejemplos).
+
+</details>
+
+<details>
+<summary>Alternativa: inicio rápido con montaje directo en enchufe</summary>
+
+```bash
+docker run -d \
+  --name drydock \
+  -p 3000:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e DD_AUTH_BASIC_ADMIN_USER=admin \
+  -e "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>" \
+  codeswhat/drydock:latest
+```
+
+> **Advertencia:** El acceso directo al socket otorga al contenedor control total sobre el demonio Docker. Utilice la configuración de proxy de socket anterior para implementaciones de producción. Consulte la [Guía de seguridad de Docker Socket](https://getdrydock.com/docs/configuration/watchers#docker-socket-security) para conocer todas las opciones, incluido TLS remoto y Docker sin raíz.
+
+</details>
+
+> Genere un hash de contraseña (`argon2` CLI: instálelo a través de su administrador de paquetes):
+>
+> ```bash
+> echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
+> ```
+>
+> O con Node.js 24+ (no se necesitan paquetes adicionales):
+>
+> ```bash
+> node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"
+> ```
+>
+> Drydock v1.6 acepta solo hash de autenticación básica argon2id. Se rechazan los hashes heredados `{SHA}`, `$apr1$`/`$1$`, `crypt` y de texto sin formato; regenerarlos antes de actualizar.
+> La autenticación es **requerida de forma predeterminada**. Consulte los [auth docs](https://getdrydock.com/docs/configuration/authentications) para OIDC, acceso anónimo y otras opciones.
+> Para permitir explícitamente el acceso anónimo en instalaciones nuevas, configure `DD_ANONYMOUS_AUTH_CONFIRM=true`.
+
+La imagen incluye archivos binarios `trivy` y `cosign` para escaneo de vulnerabilidades locales y verificación de imágenes.
+
+Consulte la [guía de inicio rápido](https://getdrydock.com/docs/quickstart) para Docker Compose, seguridad de socket, proxy inverso y registros alternativos.
+
+<hr>
+
+<h2 align="center" id="recent-updates">🆕 Actualizaciones recientes</h2>
+
+<details open>
+<summary><strong>Aspectos destacados de v1.6.0-rc.2</strong></summary>
+
+- **Notificaciones**: plantillas de cuerpo y título por regla/por proveedor con vista previa en vivo, además de categorías de campana en la aplicación respaldadas por auditorías y umbrales de gravedad de actualización.
+- **Panel**: reemplazo de cuadrícula CSS sin dependencia con reordenamiento táctil/ratón, cambio de tamaño limitado, diseños responsivos, visibilidad de widgets, restablecimiento y sincronización opcional de preferencias entre dispositivos.
+- **Política de actualización**: precedencia declarativa de observador/etiqueta/UI, anulación/reversión de seguimiento de auditoría, cuenta regresiva de madurez/anulación manual y visibilidad informativa de etiquetas fijadas con una vista de etiquetas actual → más nueva apilada.
+- **Rendimiento y recuperación**: deduplicación de listas de etiquetas por encuesta, proyecciones agregadas más ligeras, historiales de registros grandes virtualizados, transferencia de registros en vivo inmutable, tiempo de espera de arranque de autenticación, migraciones de preferencias completas y autocuración de fragmentos obsoletos.
+- **Se aplicaron migraciones v1.6**: los alias de entorno/etiqueta WUD, los formatos de autenticación heredados, los conmutadores de vigilancia obsoletos, los alias de plantilla, Kafka `clientId` y las configuraciones públicas de Hub/DHI de solo token con formato incorrecto ya no se ejecutan. Los alias de taxonomía de activación permanecen hasta una publicación final de advertencia de nivel de error.
+
+Guía completa de migración en [DEPRECATION.md](./DEPRECATIONS.md).
+
+</details>
+
+<details>
+<summary><strong>v1.5.2 aspectos destacados</strong></summary>
+
+- **Política de actualización segura para la recreación**: las puertas de madurez, las etiquetas/resúmenes omitidos y las posposiciones ahora sobreviven a la recreación de contenedores para cargas de trabajo de agentes locales y remotos.
+- **Confiabilidad de etiquetas fijadas**: las etiquetas completamente fijadas detectan reconstrucciones de resúmenes de la misma etiqueta nuevamente, mientras que la interfaz de usuario puede mostrar una etiqueta de la misma familia más nueva y no procesable sin cambiar el comportamiento de actualización o activación.
+- **Recuperación de reversión**: la creación de reemplazo, la conexión de red o el inicio fallidos ahora limpian el candidato antes de restaurar el contenedor original, y las fallas repetidas no pueden ocurrir en cascada a través de cambios de nombre de reversión anidados.
+- **Recreación de contenedores más segura**: las direcciones MAC asignadas por Daemon ya no se fijan en los reemplazos, mientras que las direcciones MAC de la red primaria configuradas explícitamente permanecen conservadas.
+- **Encuesta de imágenes locales más silenciosa**: las imágenes creadas o cargadas localmente sin resumen de registro omiten búsquedas remotas en lugar de generar errores de autorización recurrentes.
+
+Historial completo en [CHANGELOG.md](./CHANGELOG.md).
+
+</details>
+
+<hr>
+
+<h2 align="center" id="screenshots">📸 Capturas de pantalla y demostración en vivo</h2>
+
+<p align="center">
+  <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
+</p>
+
+<p align="center"><em>Detecte una actualización, vea exactamente qué cambios y aplíquela. Se manejan copias de seguridad, verificación de estado y reversión.</em></p>
+
+<table>
+<tr>
+<td width="50%" align="center"><strong>Luz</strong></td>
+<td width="50%" align="center"><strong>oscuro</strong></td>
+</tr>
+<tr>
+<td><img src="docs/assets/drydock-dashboard-light.png" alt="Dashboard Light"></td>
+<td><img src="docs/assets/drydock-dashboard-dark.png" alt="Dashboard Dark"></td>
+</tr>
+</table>
+
+<div align="center">
+
+**¿Por qué mirar capturas de pantalla cuando puedes experimentarlo tú mismo?**
+
+<a href="https://demo.getdrydock.com"><img src="https://img.shields.io/badge/Try_the_Live_Demo-4f46e5?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlnb24gcG9pbnRzPSI2IDMgMjAgMTIgNiAyMSA2IDMiLz48L3N2Zz4=&logoColor=white" alt="Try the Live Demo" height="36"></a>
+
+Totalmente interactivo: interfaz de usuario real, datos simulados, no requiere instalación. Se ejecuta completamente en el navegador.
+
+</div>
+
+<hr>
+
+<h2 align="center" id="why-drydock">🤔 Por qué Drydock</h2>
+
+Las imágenes de los contenedores quedan obsoletas silenciosamente. Una imagen base parchea un CVE, una aplicación corta una versión, una etiqueta se mueve. A menos que esté observando cada registro manualmente, sus contenedores en ejecución se retrasan hasta que algo se rompe o es explotado.
+
+La mayoría de las herramientas obligan a hacer concesiones. Los actualizadores automáticos (Watchtower, Ouroboros) se activan y reinician con poca visibilidad o control, y ahora prácticamente no reciben mantenimiento. Los paneles (Portainer) administran contenedores pero no están diseñados para inteligencia de actualización. Drydock es **monitor primero**: observa 23 registros y le dice exactamente qué cambió (mayor, menor, parche o resumen) antes de que suceda algo, luego actúa solo cuando usted lo permite. Y va más allá que cualquiera de ellos. El escaneo de vulnerabilidades Trivy/Grype bloquea actualizaciones no seguras, cosign verifica firmas, las copias de seguridad de imágenes previas a la actualización se revierten automáticamente en caso de falla en la verificación de estado, los agentes distribuidos cubren hosts remotos y 20 integraciones de notificaciones y acciones cierran el ciclo. El ciclo de vida completo de la actualización, con una interfaz de usuario web y una API REST.
+
+<hr>
+
+<h2 align="center" id="features">✨ Características</h2>
+
+| | Característica | Descripción |
+|---|---|---|
+| 🔭 | **Monitorizar primero la detección** | Observa cada contenedor en ejecución y clasifica cada actualización disponible como principal, menor, parche o resumen antes de que suceda algo. Nada cambia hasta que tú lo digas. |
+| 📦 | **23 proveedores de registro** | Docker Hub, GHCR, ECR, ACR, GCR, GAR, GitLab, Quay, Harbour, Artifactory, Nexus y 12 más. Público y privado, en la nube y autohospedado, con autenticación y TLS por registro. |
+| 🔔 | **20 activadores** | 17 canales de notificación (Slack, Discord, Telegram, Teams, SMTP, MQTT, ntfy y más) además de acciones de Docker, Docker Compose y Command, con plantillas por evento/proveedor, vista previa en vivo, filtrado de umbral y modo por lotes. |
+| 🥊 | **Update Bouncer** | El escaneo de vulnerabilidades Trivy/Grype bloquea las actualizaciones no seguras antes de que se implementen, con verificación de firma conjunta y generación de SBOM (CycloneDX y SPDX). |
+| ↩️ | **Copia de seguridad de imágenes y reversión automática** | Instantáneas de imágenes previas a la actualización con retención configurable, reversión automática en caso de falla en la verificación de estado y reversión manual con un solo clic desde la interfaz de usuario. |
+| 🪝 | **Ganchos de ciclo de vida** | Comandos de shell previos y posteriores a la actualización a través de etiquetas de contenedor, con tiempos de espera por gancho y control de cancelación en caso de falla. |
+| 🗂️ | **Actualizaciones Docker Compose** | Extraiga y vuelva a crear servicios de Compose a través de la API Docker Engine con parches de imágenes que preservan YAML. |
+| 🎛️ | **Política por contenedor** | Las reglas de etiquetas Regex y el enrutamiento de activación utilizan etiquetas `dd.*`; Las puertas de madurez, saltar/posponer/fijar y las ventanas de mantenimiento se almacenan a través de UI/API o la configuración del observador. |
+| 🛰️ | **Agentes distribuidos** | Supervise hosts Docker remotos a través de SSE. Los agentes perimetrales detrás de NAT marcan a través de WebSocket con autenticación de clave Ed25519, no se requiere puerto de entrada (`DD_EXPERIMENTAL_PORTWING=true`). |
+| 🖥️ | **Panel web** | Interfaz de usuario de Vue 3 con una cuadrícula de widgets personalizable sin dependencia, vistas de tablas/tarjetas responsivas, actualizaciones SSE en vivo, controles de campana de notificación y detalles, registros y estadísticas por contenedor. |
+| 🔗 | **API REST y webhooks** | Puntos finales autenticados por token para activación de actualizaciones y vigilancia de CI/CD, además de ingesta de webhooks de registro firmados para eventos push. |
+| 🔐 | **Autenticación OIDC** | Asegure el tablero con OpenID Connect (Authelia, Auth0, Authentik). Todos los flujos de autenticación fallan al cerrarse de forma predeterminada. |
+| 📈 | **Métricas Prometheus** | Punto final `/metrics` incorporado con omisión de autenticación opcional para pilas de monitoreo Prometheus y Grafana. |
+| 🌍 | **17 configuraciones regionales de UI** | Sistema de traducción completamente cableado con inglés completo y 16 configuraciones regionales mantenidas por la comunidad sincronizadas a través de Crowdin, conmutables en Config. |
+| 🔒 | **Expresión regular inmune a ReDoS** | Cada patrón de etiquetas proporcionado por el usuario se compila a través de re2js (un puerto RE2 JS puro) para una coincidencia de tiempo lineal que no puede detenerse por un patrón de retroceso catastrófico. |
+
+<hr>
+
+<h2 align="center" id="supported-integrations">🔌 Integraciones admitidas</h2>
+
+### 📦 Registros (23)
+
+Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Muelle · LSCR · Puerto · Artifactory · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Personalizado · DOCR · DHI · IBM Cloud · Oracle Cloud · Alibaba Cloud
+
+### ⚡ Acciones (3)
+
+Docker · Docker Compose · Comando
+
+### 🔔 Notificaciones (17)
+
+Informar · Discord · Google Chat · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
+
+### 🔐 Autenticación
+
+Anónimo (suscripción a través de `DD_ANONYMOUS_AUTH_CONFIRM=true`) · Básico (nombre de usuario + hash de contraseña) · OIDC (Authelia, Auth0, Authentik). Todos los flujos de autenticación fallan al cerrarse de forma predeterminada.
+
+### 🥊 Update Bouncer
+
+El escaneo de vulnerabilidades impulsado por Trivy o Grype bloquea las actualizaciones no seguras antes de que se implementen. Incluye verificación de firma cofirmante y generación de SBOM (CycloneDX y SPDX).
+
+<hr>
+
+<h2 align="center" id="feature-comparison">⚖️ Comparación de funciones</h2>
+
+<details>
+<summary><strong>¿Cómo se compara drydock con otras herramientas de actualización de contenedores?</strong></summary>
+
+> ✅ = compatible &nbsp; ❌ = no compatible &nbsp; ⚠️ = parcial/limitado &nbsp; † = archivado, ya no se mantiene
+
+| Feature | drydock | WUD | Diun | *Watchtower †* | *Ouroboros †* |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Interfaz web / panel | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Actualización automática de contenedores | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Actualizaciones de Docker Compose | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Canales de activación / notificación | 20 | 16 | 17 | ~19 | ~6 |
+| Proveedores de registro | 23 | 13 | ⚠️ | ⚠️ | ⚠️ |
+| Autenticación OIDC / SSO | ✅ | ✅ | ❌ | ❌ | ❌ |
+| API REST | ✅ | ✅ | ⚠️ | ⚠️ | ❌ |
+| Métricas de Prometheus | ✅ | ✅ | ❌ | ✅ | ✅ |
+| MQTT / Home Assistant | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Copia y reversión de imágenes | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Agrupación de contenedores / stacks | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Hooks del ciclo de vida (antes/después) | ✅ | ❌ | ❌ | ✅ | ❌ |
+| API de webhooks para CI/CD | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Iniciar/detener/reiniciar/actualizar contenedores | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Agentes distribuidos (remotos) | ✅ | ❌ | ✅ | ⚠️ | ❌ |
+| Registro de auditoría | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Análisis de seguridad (Trivy/Grype) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Actualizaciones compatibles con SemVer | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Vigilancia de resúmenes | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Multi-arquitectura (amd64/arm64) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Visor de registros del contenedor | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Mantenimiento activo | ✅ | ✅ | ✅ | ❌ | ❌ |
+
+> Datos basados en documentación disponible públicamente a marzo de 2026.
+> Se aceptan contribuciones si alguna información es inexacta.
+
+</details>
+
+<hr>
+
+<h2 align="center" id="migration">🔄 Migración</h2>
+
+<details>
+<summary><strong>Migrando desde WUD (¿Qué pasa Docker?)</strong></summary>
+
+Drydock v1.6 ya no carga variables de entorno `WUD_*` o etiquetas `wud.*` en tiempo de ejecución. Vuelva a escribirlos antes de iniciar el servicio actualizado; El estado persistente aún migra automáticamente. Utilice `docker exec -it drydock node dist/index.js config migrate --dry-run` para obtener una vista previa y luego `docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml` para reescribir la configuración con los nombres `DD_*` y `dd.*`.
+
+</details>
+
+<hr>
+
+<h2 align="center" id="roadmap">🗺️ Hoja de ruta</h2>
+
+<details>
+<summary><strong>Temas y aspectos destacados de la versión</strong></summary>
+
+Solo temas de alto nivel: consulte [CHANGELOG.md](CHANGELOG.md) para obtener detalles por versión.
+
+| Versión | Tema | Aspectos destacados |
+| --- | --- | --- |
+| **v1.3.x** ✅ | Seguridad y Estabilidad | Escaneo Trivy, Update Bouncer, SBOM, 7 nuevos registros, 4 nuevos activadores, motor re2js regex |
+| **v1.4.x** ✅ | Modernización y refuerzo de la interfaz de usuario | Tailwind 4 + componentes personalizados, 6 temas, paleta Cmd/K, OpenAPI 3.1, actualizaciones YAML nativas de redacción, escaneo de doble ranura, refuerzo OIDC |
+| **v1.5.0** ✅ | Observabilidad e i18n | división de taxonomía de activación (`DD_ACTION_*`/`DD_NOTIFICATION_*`), visor de registros WebSocket, personalización del panel, monitoreo de recursos, bandeja de salida de notificaciones + DLQ, resumen de escaneo de seguridad, 17 configuraciones regionales, reproducción de ID del último evento SSE, acceso telefónico al agente perimetral con autenticación Ed25519 (experimental, `DD_EXPERIMENTAL_PORTWING=true`) |
+| **v1.5.1** ✅ | Seguridad y mantenimiento | Corrección de autenticación de extracción GCR/GAR, finalización de TLS de registro (M-2), refuerzo de inyección de env-var de gancho, compatibilidad con `DD_SESSION_SECRET__FILE`, redacción de credenciales de volcado de depuración, verificación de permisos de archivos secretos, corrección de bloqueo de puerta de madurez, traducibilidad completa de la interfaz de usuario + traducciones de la comunidad, puerta de aplicación automática de ventana de mantenimiento, visualización del tiempo de actividad del contenedor, versión de software de superficie dividida de columna Etiqueta/Versión (etiqueta OCI, con escritura dual `dd.inspect.tag.path` + opción de enrutamiento `dd.inspect.tag.version-only`), opción de coincidencia de prefijo de montaje de composición, var de plantilla `${currentReleaseNotes}` |
+| **v1.5.2** ✅ | Política y confiabilidad de etiquetas fijadas | Retención de política de madurez/omisión/posposición segura para recreación, detección de reconstrucción de resumen de etiquetas fijadas e información informativa de la misma familia, limpieza de candidatos de reversión, prevención de cascada de reversión, preservación de MAC explícito y comportamiento de omisión de registro de imágenes locales |
+| **v1.6.0** | Notificaciones, políticas y comunicados Intel | Plantillas de notificación por regla/por activador con vista previa en vivo, preferencias de campana de notificación, sincronización de preferencias entre dispositivos, cuadrícula de panel personalizado sin dependencia ([#281](https://github.com/CodesWhat/drydock/issues/281)), política de actualización declarativa ([#320](https://github.com/CodesWhat/drydock/issues/320)), cuenta regresiva de estabilización de madurez + visibilidad inmediata del candidato + anulación manual ([#406](https://github.com/CodesWhat/drydock/discussions/406)), panel de estado de actualización procesable y global Modo de actualización `notify` / `manual` / `auto` ([#325](https://github.com/CodesWhat/drydock/discussions/325)), herencia de políticas de etiquetas de observador/imgset/contenedor más actual apilada → visibilidad de etiquetas fijadas más nuevas ([#498](https://github.com/CodesWhat/drydock/issues/498)), fuente estandarizada de 44 px/notas de la versión/acciones de recursos de registro en tablas, tarjetas y detalles ([#295](https://github.com/CodesWhat/drydock/discussions/295)), notificaciones de eventos de estado de salud ([#198](https://github.com/CodesWhat/drydock/discussions/198)), Home Assistant MQTT bidireccional, vistas responsivas de tablas/listas de tarjetas, Trivy/Grype/análisis a través de comandos o backends de Docker-worker anclados, controles activos/de extracción de activos del escáner, deduplicación fuera del montón Almacenamiento SBOM, corrección de escaneo largo de Trivy ([#490](https://github.com/CodesWhat/drydock/issues/490)), advertencias de migración de taxonomía de activación, eliminaciones de compatibilidad v1.6, higiene de documentos/API y finalización de migración de `/api` → `/api/v1` con una cuña de compatibilidad de página de inicio/tarjeta wud opcional (`DD_COMPAT_WUDCARD`). |
+| **v1.7.0** | Actualizaciones inteligentes y UX | Ordenamiento consciente de la dependencia ([#219](https://github.com/CodesWhat/drydock/discussions/219)), actualizaciones masivas selectivas ([#232](https://github.com/CodesWhat/drydock/discussions/232)), política de actualización por acción ([#511](https://github.com/CodesWhat/drydock/discussions/511)), eliminación de imágenes, monitoreo de imágenes estáticas, indicador de madurez de la imagen, reloj unificado de madurez/antigüedad de actualizaciones, enlaces de puertos en los que se puede hacer clic, atajos de teclado, PWA, eliminación de `DD_TRIGGER_*` (fin de la ventana de obsolescencia de v1.5.0), curl eliminado de la imagen |
+| **v1.8.0** | Gestión de flotas y configuración en vivo | Configuración YAML, configuración de UI en vivo, navegador de volúmenes, actualizaciones paralelas, migración de la tienda SQLite |
+| **v2.0+** | Expansión de plataforma y más allá | Vigilantes de enjambre/Kubernetes, GitOps, puertas de estado, implementaciones canary, terminal web, RBAC, claves API giratorias con alcance (tokens de portador estáticos para integraciones de HA/panel, [#469](https://github.com/CodesWhat/drydock/discussions/469)), LDAP/AD, proveedor nativo de Podman más allá de la API compatible con Docker, CLI, imagen reforzada de Wolfi, proxy de socket |
+
+</details>
+
+<hr>
+
+<h2 align="center" id="documentation">📖 Documentación</h2>
+
+| Recurso | Enlace |
+| --- | --- |
+| Sitio web | [obtenerdrydock.com](https://getdrydock.com/) |
+| Demostración en vivo | [demo.getdrydock.com](https://demo.getdrydock.com) |
+| Documentos | [getdrydock.com/docs](https://getdrydock.com/docs) |
+| Configuración | [Configuración](https://getdrydock.com/docs/configuration) |
+| Inicio rápido | [Inicio rápido](https://getdrydock.com/docs/quickstart) |
+| Registro de cambios | [`CHANGELOG.md`](CHANGELOG.md) |
+| Depreciaciones | [`DEPRECATIONS.md`](DEPRECATIONS.md) |
+| Hoja de ruta | Consulte la sección [Hoja de ruta](#roadmap) más arriba |
+| Contribuyendo | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Problemas | [Problemas de GitHub](https://github.com/CodesWhat/drydock/issues) |
+| Discusiones | [Discusiones de GitHub](https://github.com/CodesWhat/drydock/discussions): se aceptan solicitudes de funciones e ideas |
+
+<hr>
+
+<a id="star-history"></a>
+
+<div align="center">
+  <a href="https://star-history.com/#CodesWhat/drydock&Date">
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CodesWhat/drydock&type=Date" />
+  </a>
+</div>
+
+---
+
+<div align="center">
+
+### Construido con
+
+[![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
+[![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
+[![Express 5](https://img.shields.io/badge/Express_5-000?logo=express&logoColor=fff)](https://expressjs.com/)
+[![Vitest](https://img.shields.io/badge/Vitest_4-6E9F18?logo=vitest&logoColor=fff)](https://vitest.dev/)
+[![Biome](https://img.shields.io/badge/Biome_2.5-60a5fa?logo=biome&logoColor=fff)](https://biomejs.dev/)
+[![Node 24](https://img.shields.io/badge/Node_24_Alpine-339933?logo=nodedotjs&logoColor=fff)](https://nodejs.org/)
+[![Anthropic](https://img.shields.io/badge/Anthropic-CC785C?style=flat&logo=anthropic&logoColor=white)](https://claude.ai/)
+[![OpenAI](https://img.shields.io/badge/OpenAI-10A37F?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU%2BT3BlbkFJPC90aXRsZT48cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJNMjIuMjgxOSA5LjgyMTFhNS45ODQ3IDUuOTg0NyAwIDAgMC0uNTE1Ny00LjkxMDggNi4wNDYyIDYuMDQ2MiAwIDAgMC02LjUwOTgtMi45QTYuMDY1MSA2LjA2NTEgMCAwIDAgNC45ODA3IDQuMTgxOGE1Ljk4NDcgNS45ODQ3IDAgMCAwLTMuOTk3NyAyLjkgNi4wNDYyIDYuMDQ2MiAwIDAgMCAuNzQyNyA3LjA5NjYgNS45OCA1Ljk4IDAgMCAwIC41MTEgNC45MTA3IDYuMDUxIDYuMDUxIDAgMCAwIDYuNTE0NiAyLjkwMDFBNS45ODQ3IDUuOTg0NyAwIDAgMCAxMy4yNTk5IDI0YTYuMDU1NyA2LjA1NTcgMCAwIDAgNS43NzE4LTQuMjA1OCA1Ljk4OTQgNS45ODk0IDAgMCAwIDMuOTk3Ny0yLjkwMDEgNi4wNTU3IDYuMDU1NyAwIDAgMC0uNzQ3NS03LjA3Mjl6bS05LjAyMiAxMi42MDgxYTQuNDc1NSA0LjQ3NTUgMCAwIDEtMi44NzY0LTEuMDQwOGwuMTQxOS0uMDgwNCA0Ljc3ODMtMi43NTgyYS43OTQ4Ljc5NDggMCAwIDAgLjM5MjctLjY4MTN2LTYuNzM2OWwyLjAyIDEuMTY4NmEuMDcxLjA3MSAwIDAgMSAuMDM4LjA1MnY1LjU4MjZhNC41MDQgNC41MDQgMCAwIDEtNC40OTQ1IDQuNDk0NHptLTkuNjYwNy00LjEyNTRhNC40NzA4IDQuNDcwOCAwIDAgMS0uNTM0Ni0zLjAxMzdsLjE0Mi4wODUyIDQuNzgzIDIuNzU4MmEuNzcxMi43NzEyIDAgMCAwIC43ODA2IDBsNS44NDI4LTMuMzY4NXYyLjMzMjRhLjA4MDQuMDgwNCAwIDAgMS0uMDMzMi4wNjE1TDkuNzQgMTkuOTUwMmE0LjQ5OTIgNC40OTkyIDAgMCAxLTYuMTQwOC0xLjY0NjR6TTIuMzQwOCA3Ljg5NTZhNC40ODUgNC40ODUgMCAwIDEgMi4zNjU1LTEuOTcyOFYxMS42YS43NjY0Ljc2NjQgMCAwIDAgLjM4NzkuNjc2NWw1LjgxNDQgMy4zNTQzLTIuMDIwMSAxLjE2ODVhLjA3NTcuMDc1NyAwIDAgMS0uMDcxIDBsLTQuODMwMy0yLjc4NjVBNC41MDQgNC41MDQgMCAwIDEgMi4zNDA4IDcuODcyem0xNi41OTYzIDMuODU1OEwxMy4xMDM4IDguMzY0IDE1LjExOTIgNy4yYS4wNzU3LjA3NTcgMCAwIDEgLjA3MSAwbDQuODMwMyAyLjc5MTNhNC40OTQ0IDQuNDk0NCAwIDAgMS0uNjc2NSA4LjEwNDJ2LTUuNjc3MmEuNzkuNzkgMCAwIDAtLjQwNy0uNjY3em0yLjAxMDctMy4wMjMxbC0uMTQyLS4wODUyLTQuNzczNS0yLjc4MThhLjc3NTkuNzc1OSAwIDAgMC0uNzg1NCAwTDkuNDA5IDkuMjI5N1Y2Ljg5NzRhLjA2NjIuMDY2MiAwIDAgMSAuMDI4NC0uMDYxNWw0LjgzMDMtMi43ODY2YTQuNDk5MiA0LjQ5OTIgMCAwIDEgNi42ODAyIDQuNjZ6TTguMzA2NSAxMi44NjNsLTIuMDItMS4xNjM4YS4wODA0LjA4MDQgMCAwIDEtLjAzOC0uMDU2N1Y2LjA3NDJhNC40OTkyIDQuNDk5MiAwIDAgMSA3LjM3NTctMy40NTM3bC0uMTQyLjA4MDVMOC43MDQgNS40NTlhLjc5NDguNzk0OCAwIDAgMC0uMzkyNy42ODEzem0xLjA5NzYtMi4zNjU0bDIuNjAyLTEuNDk5OCAyLjYwNjkgMS40OTk4djIuOTk5NGwtMi41OTc0IDEuNDk5Ny0yLjYwNjctMS40OTk3WiIvPjwvc3ZnPg%3D%3D)](https://openai.com)
+
+[![SemVer](https://img.shields.io/badge/semver-2.0.0-blue)](https://semver.org/)
+[![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
+[![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
+
+### Comunidad
+
+Preguntas, comentarios y soporte temprano: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+
+Presente errores concretos y solicitudes de funciones en **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** para que no se pierdan en el chat.
+
+### Control de calidad de la comunidad
+
+Gracias a los usuarios que ayudaron a probar las versiones candidatas v1.4.0 y v1.5.0 y reportaron errores:
+
+[@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
+
+### Parte del ecosistema CodesWhat
+
+<table>
+  <tr><th>Herramienta</th><th>Rol</th></tr>
+  <tr><td><b>drydock</b></td><td>Monitoreo de actualizaciones de contenedores: interfaz de usuario web y motor de notificaciones</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/portwing"><b>portwing</b></a></td><td>Agente Docker remoto: acceso seguro a nivel de socket desde Drydock o de forma independiente</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/sockguard"><b>sockguard</b></a></td><td>Proxy de socket de Docker: filtro de lista permitida de denegación predeterminada que protege el socket</td></tr>
+</table>
+
+Estas tres herramientas están diseñadas para capas: sockguard filtra el socket, portwing lo expone de forma remota y drydock monitorea y actúa sobre el estado del contenedor.
+
+Consulte COMPATIBILITY.md](<https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md>) de [portwing para obtener la matriz de compatibilidad completa entre las tres herramientas.
+
+---
+
+**[Licencia AGPL-3.0](LICENSE)**
+
+<a href="https://github.com/CodesWhat">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/codeswhat-logo-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/codeswhat-logo-original.svg" />
+    <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
+  </picture>
+</a>
+
+[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
+
+<a href="#drydock">Volver arriba</a>
+
+</div>

--- a/README.fr.md
+++ b/README.fr.md
@@ -40,8 +40,8 @@
 - [🚀 Démarrage rapide](#quick-start)
 - [🆕 Mises à jour récentes](#recent-updates)
 - [📸 Captures d'écran et démo en direct](#screenshots)
--[🤔Pourquoi Drydock](#why-drydock) See More
--[✨ Caractéristiques](#features)
+- [🤔 Pourquoi Drydock](#why-drydock)
+- [✨ Caractéristiques](#features)
 - [🔌 Intégrations prises en charge](#supported-integrations)
 - [⚖️ Comparaison des fonctionnalités](#feature-comparison)
 - [🔄Migration](#migration)
@@ -154,7 +154,7 @@ docker run -d \
 > echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
 > ```
 >
-> Ou avec Node.js 24+ (aucun package supplémentaire nécessaire) :
+> Ou avec Node.js 24.7+ (aucun package supplémentaire nécessaire) :
 >
 > ```bash
 > node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"
@@ -426,7 +426,7 @@ Merci aux utilisateurs qui ont aidé à tester les versions candidates v1.4.0 et
 
 Ces trois outils sont conçus pour superposer : sockguard filtre le socket, portwing l'expose à distance et drydock surveille et agit sur l'état du conteneur.
 
-Voir COMPATIBILITY.md](<https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md>) de portwing pour connaître la matrice de compatibilité complète des trois outils.
+Voir le [COMPATIBILITY.md de portwing](https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md) pour connaître la matrice de compatibilité complète des trois outils.
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,447 @@
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
+  <img src="docs/assets/whale-logo.png" alt="drydock" width="220">
+</picture>
+
+<h1>drydock</h1>
+
+**Observateur de mise à jour d'image de conteneur : 23 registres, 20 fournisseurs de notifications et d'actions.**
+
+<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <strong>Français</strong> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
+</div>
+
+<p align="center">
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.2-blue" alt="Version"></a>
+  <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
+  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
+  <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
+  <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+</p>
+
+<hr>
+
+> [!WARNING]
+> **Vous effectuez une mise à jour à partir d'une ancienne version ? Lisez d'abord les notes de mise à niveau.** Trois correctifs de renforcement de la sécurité ont été livrés pour la première fois dans **1.4.6** et sont exécutés sur toute la ligne **1.5**, de sorte que toute mise à jour à partir d'une version antérieure à 1.4.6 est affectée quelle que soit la version sur laquelle elle atterrit (1.4.6, toute version 1.5.x ou ultérieure). Ce ne sont pas des dépréciations et n'ont pas de période de grâce : OIDC nécessite désormais `authorization_endpoint` dans les métadonnées de découverte de votre fournisseur, des clés de limitation de débit non authentifiées sur l'adresse homologue TCP (compartiment partagé derrière un proxy inverse) et les URL de proxy déclencheur HTTP doivent utiliser `http(s)://`. Voir **[UPGRADE-NOTES.md](UPGRADE-NOTES.md)** avant la mise à jour.
+
+<h2 align="center">📑 Contenu</h2>
+
+- [📖Documentation](https://getdrydock.com/docs)
+- [🚀 Démarrage rapide](#quick-start)
+- [🆕 Mises à jour récentes](#recent-updates)
+- [📸 Captures d'écran et démo en direct](#screenshots)
+-[🤔Pourquoi Drydock](#why-drydock) See More
+-[✨ Caractéristiques](#features)
+- [🔌 Intégrations prises en charge](#supported-integrations)
+- [⚖️ Comparaison des fonctionnalités](#feature-comparison)
+- [🔄Migration](#migration)
+- [🗺️ Feuille de route](#roadmap)
+- [⭐ Historique des étoiles](#star-history)
+- [🔧 Construit avec](#construit-avec)
+- [🤝 Communauté QA](#contrôle-qualité-de-la-communauté)
+
+<hr>
+
+<h2 align="center" id="quick-start">🚀 Démarrage rapide</h2>
+
+**Recommandé : utilisez un proxy de socket** pour restreindre les points de terminaison de l'API Docker auxquels Drydock peut accéder. Cela évite de donner au conteneur un accès complet au socket Docker.
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      socket-proxy:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=socket-proxy
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - CONTAINERS=1
+      - IMAGES=1
+      - EVENTS=1
+      - SERVICES=1
+      - INFO=1          # Required for daemon identity detection (notification prefixes)
+      # Add POST=1 and NETWORKS=1 for container actions and auto-updates
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+<details>
+<summary>Alternative :<a href="https://github.com/CodesWhat/sockguard">sockguard</a>proxy de socket</summary>
+
+[sockguard](https://github.com/CodesWhat/sockguard) est un filtre de socket Docker à refus par défaut du même écosystème CodesWhat, avec un préréglage conçu pour drydock :
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      sockguard:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=sockguard
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  sockguard:
+    image: codeswhat/sockguard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./sockguard.yaml:/etc/sockguard/config.yaml:ro
+    environment:
+      - SOCKGUARD_CONFIG_FILE=/etc/sockguard/config.yaml
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+Voir le préréglage [`app/configs/portwing.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing.yaml) de sockguard pour un `sockguard.yaml` de départ (le même préréglage portwing est livré dans ses propres exemples).
+
+</details>
+
+<details>
+<summary>Alternative : démarrage rapide avec montage direct sur prise</summary>
+
+```bash
+docker run -d \
+  --name drydock \
+  -p 3000:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e DD_AUTH_BASIC_ADMIN_USER=admin \
+  -e "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>" \
+  codeswhat/drydock:latest
+```
+
+> **Avertissement :** L'accès direct au socket accorde au conteneur un contrôle total sur le démon Docker. Utilisez la configuration du proxy de socket ci-dessus pour les déploiements de production. Consultez le [Docker Socket Security guide](https://getdrydock.com/docs/configuration/watchers#docker-socket-security) pour toutes les options, y compris TLS distant et Docker sans racine.
+
+</details>
+
+> Générez un hachage de mot de passe (`argon2` CLI — installation via votre gestionnaire de packages) :
+>
+> ```bash
+> echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
+> ```
+>
+> Ou avec Node.js 24+ (aucun package supplémentaire nécessaire) :
+>
+> ```bash
+> node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"
+> ```
+>
+> Drydock v1.6 accepte uniquement les hachages d'authentification de base argon2id. Les anciens hachages `{SHA}`, `$apr1$`/`$1$`, `crypt` et en texte brut sont rejetés ; régénérez-les avant la mise à niveau.
+> L'authentification est **requise par défaut**. Consultez le [auth docs](https://getdrydock.com/docs/configuration/authentications) pour OIDC, accès anonyme et autres options.
+> Pour autoriser explicitement l'accès anonyme sur les nouvelles installations, définissez `DD_ANONYMOUS_AUTH_CONFIRM=true`.
+
+L'image comprend les binaires `trivy` et `cosign` pour l'analyse des vulnérabilités locales et la vérification des images.
+
+Consultez le [Guide de démarrage rapide](https://getdrydock.com/docs/quickstart) pour Docker Compose, la sécurité des sockets, le proxy inverse et les registres alternatifs.
+
+<hr>
+
+<h2 align="center" id="recent-updates">🆕 Mises à jour récentes</h2>
+
+<details open>
+<summary><strong>Points forts de la v1.6.0-rc.2</strong></summary>
+
+- **Notifications** — Modèles de titre et de corps par règle/par fournisseur avec aperçu en direct, ainsi que des catégories de cloches dans l'application basées sur un audit et des seuils de gravité de mise à jour.
+- **Tableau de bord** — Remplacement de la grille CSS sans dépendance avec réorganisation souris/tactile, redimensionnement limité, mises en page réactives, visibilité des widgets, réinitialisation et synchronisation facultative des préférences entre appareils.
+- **Politique de mise à jour** — Priorité déclarative de l'observateur/étiquette/interface utilisateur, remplacement/annulation de la piste d'audit, compte à rebours de maturité/remplacement manuel et visibilité des informations sur les balises épinglées avec une vue empilée des balises actuelles → plus récentes.
+- **Performances et récupération** — Déduplication de liste de balises par interrogation, projections globales plus légères, historiques de journaux virtualisés volumineux, basculement de journaux en direct immuable, délai d'expiration de l'authentification, migrations complètes des préférences et auto-réparation des fragments obsolètes.
+- **Migrations v1.6 appliquées** — Les alias d'environnement/label WUD, les formats d'authentification hérités, les commutateurs d'observateur obsolètes, les alias de modèle, Kafka `clientId` et les configurations publiques Hub/DHI malformées réservées aux jetons uniquement ne s'exécutent plus. Les alias de taxonomie de déclencheur restent conservés pour une dernière version d'avertissement de niveau d'erreur.
+
+Conseils de migration complets dans [DEPRECATIONS.md](./DEPRECATIONS.md).
+
+</details>
+
+<details>
+<summary><strong>Points forts de la v1.5.2</strong></summary>
+
+- **Politique de mise à jour sécurisée pour les loisirs** — Les portes de maturité, les balises/récapitulatifs ignorés et les répétitions survivent désormais à la récréation des conteneurs pour les charges de travail des agents locaux et distants.
+- **Fiabilité des balises épinglées** — Les balises entièrement épinglées détectent à nouveau les reconstructions de résumé de même balise, tandis que l'interface utilisateur peut afficher une balise de même famille plus récente et non exploitable sans modifier le comportement de mise à jour ou de déclenchement.
+- **Récupération par restauration** — L'échec de la création d'un remplacement, de l'attachement au réseau ou du démarrage nettoie désormais le candidat avant de restaurer le conteneur d'origine, et les échecs répétés ne peuvent pas se répercuter sur les renommages de restauration imbriqués.
+- **Recréation de conteneurs plus sûre** — Les adresses MAC attribuées par le démon ne sont plus épinglées sur les remplacements, tandis que les adresses MAC du réseau principal explicitement configurées restent préservées.
+- **Interrogation d'images locales plus silencieuse** — Les images créées ou chargées localement sans résumé de registre ignorent les recherches à distance au lieu de générer des erreurs d'autorisation récurrentes.
+
+Historique complet dans [CHANGELOG.md](./CHANGELOG.md).
+
+</details>
+
+<hr>
+
+<h2 align="center" id="screenshots">📸 Captures d'écran et démo en direct</h2>
+
+<p align="center">
+  <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
+</p>
+
+<p align="center"><em>Repérez une mise à jour, voyez exactement quels changements, appliquez-la. Sauvegarde, vérification de l'état et restauration gérées.</em></p>
+
+<table>
+<tr>
+<td width="50%" align="center"><strong>Lumière</strong></td>
+<td width="50%" align="center"><strong>Sombre</strong></td>
+</tr>
+<tr>
+<td><img src="docs/assets/drydock-dashboard-light.png" alt="Dashboard Light"></td>
+<td><img src="docs/assets/drydock-dashboard-dark.png" alt="Dashboard Dark"></td>
+</tr>
+</table>
+
+<div align="center">
+
+**Pourquoi regarder des captures d'écran quand vous pouvez en faire l'expérience vous-même ?**
+
+<a href="https://demo.getdrydock.com"><img src="https://img.shields.io/badge/Try_the_Live_Demo-4f46e5?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlnb24gcG9pbnRzPSI2IDMgMjAgMTIgNiAyMSA2IDMiLz48L3N2Zz4=&logoColor=white" alt="Try the Live Demo" height="36"></a>
+
+Entièrement interactif : véritable interface utilisateur, données fictives, aucune installation requise. Fonctionne entièrement dans le navigateur.
+
+</div>
+
+<hr>
+
+<h2 align="center" id="why-drydock">🤔 Pourquoi Drydock</h2>
+
+Les images de conteneurs deviennent obsolètes en silence. Une image de base corrige un CVE, une application supprime une version, une balise se déplace. À moins que vous ne surveilliez chaque registre à la main, vos conteneurs en cours d'exécution prennent du retard jusqu'à ce que quelque chose se brise ou soit exploité.
+
+La plupart des outils imposent un compromis. Les mises à jour automatiques (Watchtower, Ouroboros) s'exécutent et redémarrent avec peu de visibilité ou de contrôle, et ne sont désormais en grande partie pas entretenues. Les tableaux de bord (Portainer) gèrent les conteneurs mais ne sont pas conçus pour l'intelligence des mises à jour. Drydock est **surveillant d'abord** : il surveille 23 registres et vous indique exactement ce qui a changé (majeur, mineur, correctif ou résumé) avant que quoi que ce soit ne se produise, puis n'agit que lorsque vous l'autorisez. Et cela va plus loin que n’importe lequel d’entre eux. L'analyse des vulnérabilités Trivy/Grype bloque les mises à jour dangereuses, la cosignature vérifie les signatures, les sauvegardes d'images préalables à la mise à jour sont automatiquement annulées en cas d'échec du contrôle de santé, les agents distribués couvrent les hôtes distants et 20 intégrations de notifications et d'actions bouclent la boucle. Le cycle de vie complet des mises à jour, avec une interface utilisateur Web et une API REST.
+
+<hr>
+
+<h2 align="center" id="features">✨ Caractéristiques</h2>
+
+| | Fonctionnalité | Descriptif |
+|---|---|---|
+| 🔭 | **Détection sur le moniteur en premier** | Surveille chaque conteneur en cours d'exécution et classe chaque mise à jour disponible comme majeure, mineure, correctif ou résumé avant que quoi que ce soit ne se produise. Rien ne change jusqu'à ce que vous le disiez. |
+| 📦 | **23 fournisseurs de registre** | Docker Hub, GHCR, ECR, ACR, GCR, GAR, GitLab, Quay, Harbor, Artifactory, Nexus et 12 autres. Public et privé, cloud et auto-hébergé, avec TLS et authentification par registre. |
+| 🔔 | **20 déclencheurs** | 17 canaux de notification (Slack, Discord, Telegram, Teams, SMTP, MQTT, ntfy et plus) ainsi que des actions Docker, Docker Compose et Command, avec des modèles par événement/fournisseur, un aperçu en direct, un filtrage de seuil et un mode batch. |
+| 🥊 | **Update Bouncer** | L'analyse des vulnérabilités Trivy/Grype bloque les mises à jour dangereuses avant leur déploiement, avec vérification de la signature cosignée et génération SBOM (CycloneDX et SPDX). |
+| ↩️ | **Sauvegarde d'image et restauration automatique** | Pré-mettez à jour les instantanés d'image avec conservation configurable, restauration automatique en cas d'échec du contrôle de santé et restauration manuelle en un clic depuis l'interface utilisateur. |
+| 🪝 | **Crochets de cycle de vie** | Commandes shell avant et après la mise à jour via des étiquettes de conteneur, avec délais d'attente par hook et contrôle d'abandon en cas d'échec. |
+| 🗂️ | **Mises à jour Docker Compose** | Extrayez et recréez les services Compose via l'API Docker Engine avec des correctifs d'image préservant YAML. |
+| 🎛️ | **Politique par conteneur** | Les règles de balise Regex et le routage des déclencheurs utilisent les étiquettes `dd.*` ; les portes de maturité, les sauts/répétitions/épingles et les fenêtres de maintenance sont stockés via l'interface utilisateur/API ou la configuration de l'observateur. |
+| 🛰️ | **Agents distribués** | Surveillez les hôtes Docker distants via SSE. Les agents Edge derrière NAT appellent via WebSocket avec l'authentification par clé Ed25519, aucun port entrant requis (`DD_EXPERIMENTAL_PORTWING=true`). |
+| 🖥️ | **Tableau de bord Web** | Interface utilisateur Vue 3 avec une grille de widgets personnalisable sans dépendance, des vues de table/carte réactives, des mises à jour SSE en direct, des contrôles de cloche de notification et des détails, journaux et statistiques par conteneur. |
+| 🔗 | **API REST et webhooks** | Points de terminaison authentifiés par jeton pour les déclencheurs de surveillance et de mise à jour CI/CD, ainsi que l'ingestion de webhooks de registre signés pour les événements push. |
+| 🔐 | **Authentification OIDC** | Sécurisez le tableau de bord avec OpenID Connect (Authelia, Auth0, Authentik). Tous les flux d'authentification échouent à la fermeture par défaut. |
+| 📈 | **Métriques Prometheus** | Point de terminaison `/metrics` intégré avec contournement d'authentification en option pour les piles de surveillance Prometheus et Grafana. |
+| 🌍 | **17 paramètres régionaux de l'interface utilisateur** | Système de traduction entièrement câblé avec anglais complet et 16 paramètres régionaux gérés par la communauté synchronisés via Crowdin, commutables dans Config. |
+| 🔒 | **Regex immunitaire ReDoS** | Chaque modèle de balise fourni par l'utilisateur est compilé via re2js (un port pur JS RE2) pour une correspondance temporelle linéaire qui ne peut pas être bloquée par un modèle de retour en arrière catastrophique. |
+
+<hr>
+
+<h2 align="center" id="supported-integrations">🔌 Intégrations prises en charge</h2>
+
+### 📦 Registres (23)
+
+Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Quay · LSCR · Port · Artefact · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Personnalisé · DOCR · DHI · IBM Cloud · Oracle Cloud · Alibaba Cloud
+
+### ⚡Actions (3)
+
+Docker · Docker Compose · Commande
+
+### 🔔Notifications (17)
+
+Apprise · Discord · Google Chat · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
+
+### 🔐 Authentification
+
+Anonyme (inscription via `DD_ANONYMOUS_AUTH_CONFIRM=true`) · Basique (nom d'utilisateur + hachage du mot de passe) · OIDC (Authelia, Auth0, Authentik). Tous les flux d'authentification échouent à la fermeture par défaut.
+
+### 🥊 Update Bouncer
+
+L'analyse des vulnérabilités basée sur Trivy ou Grype bloque les mises à jour dangereuses avant leur déploiement. Comprend la vérification de la signature de cosignature et la génération SBOM (CycloneDX et SPDX).
+
+<hr>
+
+<h2 align="center" id="feature-comparison">⚖️ Comparaison des fonctionnalités</h2>
+
+<details>
+<summary><strong>Comment drydock se compare-t-il aux autres outils de mise à jour de conteneurs ?</strong></summary>
+
+> ✅ = pris en charge &nbsp; ❌ = non pris en charge &nbsp; ⚠️ = partiel / limité &nbsp; † = archivé, n'est plus conservé
+
+| Feature | drydock | WUD | Diun | *Watchtower †* | *Ouroboros †* |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Interface web / tableau de bord | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Mise à jour automatique des conteneurs | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Mises à jour Docker Compose | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Canaux de déclenchement / notification | 20 | 16 | 17 | ~19 | ~6 |
+| Fournisseurs de registres | 23 | 13 | ⚠️ | ⚠️ | ⚠️ |
+| Authentification OIDC / SSO | ✅ | ✅ | ❌ | ❌ | ❌ |
+| API REST | ✅ | ✅ | ⚠️ | ⚠️ | ❌ |
+| Métriques Prometheus | ✅ | ✅ | ❌ | ✅ | ✅ |
+| MQTT / Home Assistant | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Sauvegarde et restauration d'images | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Regroupement de conteneurs / piles | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Hooks de cycle de vie (avant/après) | ✅ | ❌ | ❌ | ✅ | ❌ |
+| API webhook pour CI/CD | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Démarrer/arrêter/redémarrer/mettre à jour | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Agents distribués (distants) | ✅ | ❌ | ✅ | ⚠️ | ❌ |
+| Journal d'audit | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Analyse de sécurité (Trivy/Grype) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Mises à jour compatibles SemVer | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Surveillance des digests | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Multiarchitecture (amd64/arm64) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Visionneuse de journaux | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Maintenance active | ✅ | ✅ | ✅ | ❌ | ❌ |
+
+> Données basées sur une documentation accessible au public en mars 2026.
+> Les contributions sont les bienvenues si des informations sont inexactes.
+
+</details>
+
+<hr>
+
+<h2 align="center" id="migration">🔄 Migration</h2>
+
+<details>
+<summary><strong>Migration depuis WUD (What's Up Docker ?)</strong></summary>
+
+Drydock v1.6 ne charge plus les variables d'environnement `WUD_*` ou les étiquettes `wud.*` au moment de l'exécution. Réécrivez-les avant de démarrer le service mis à niveau ; l'état persistant migre toujours automatiquement. Utilisez `docker exec -it drydock node dist/index.js config migrate --dry-run` pour prévisualiser, puis `docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml` pour réécrire la configuration en dénomination `DD_*` et `dd.*`.
+
+</details>
+
+<hr>
+
+<h2 align="center" id="roadmap">🗺️ Feuille de route</h2>
+
+<details>
+<summary><strong>Thèmes et faits saillants de la version</strong></summary>
+
+Thèmes de haut niveau uniquement – voir [CHANGELOG.md](CHANGELOG.md) pour plus de détails par version.
+
+| Version | Thème | Faits saillants |
+| --- | --- | --- |
+| **v1.3.x** ✅ | Sécurité et stabilité | Analyse Trivy, Update Bouncer, SBOM, 7 nouveaux registres, 4 nouveaux déclencheurs, moteur regex re2js |
+| **v1.4.x** ✅ | Modernisation et renforcement de l'interface utilisateur | Tailwind 4 + composants personnalisés, 6 thèmes, palette Cmd/K, OpenAPI 3.1, mises à jour YAML natives, analyse à double emplacement, renforcement OIDC |
+| **v1.5.0** ✅ | Observabilité & i18n | répartition de la taxonomie de déclenchement (`DD_ACTION_*`/`DD_NOTIFICATION_*`), visionneuse de journaux WebSocket, personnalisation du tableau de bord, surveillance des ressources, boîte d'envoi de notification + DLQ, résumé d'analyse de sécurité, 17 paramètres régionaux, relecture de l'ID du dernier événement SSE, appel sortant de l'agent Edge avec authentification Ed25519 (expérimental, `DD_EXPERIMENTAL_PORTWING=true`) |
+| **v1.5.1** ✅ | Sécurité et maintenance | Correction d'authentification par extraction GCR/GAR, achèvement du registre TLS (M-2), renforcement par injection d'environnement de crochet, prise en charge de `DD_SESSION_SECRET__FILE`, suppression des informations d'identification de débogage, vérification des autorisations de fichiers secrets, correction de l'impasse de la porte de maturité, traductibilité complète de l'interface utilisateur + traductions communautaires, porte d'application automatique de la fenêtre de maintenance, affichage de la disponibilité du conteneur, version du logiciel de surfaçage de colonne Tag/Version (étiquette OCI, avec double écriture `dd.inspect.tag.path` + routage `dd.inspect.tag.version-only` opt-in), correspondance de préfixe de montage de composition opt-in, modèle `${currentReleaseNotes}` var |
+| **v1.5.2** ✅ | Politique et fiabilité des balises épinglées | Rétention des politiques de maturité/saut/répétition sécurisées pour les loisirs, détection de reconstruction de résumé de balises épinglées et informations informationnelles sur la même famille, nettoyage des candidats à l'annulation, prévention des cascades d'annulation, préservation MAC explicite et comportement de saut de registre d'images locales |
+| **v1.6.0** | Notifications, politiques et versions Intel | Modèles de notification par règle/par déclencheur avec aperçu en direct, préférences de cloche de notification, synchronisation des préférences entre appareils, grille de tableau de bord personnalisée sans dépendance ([#281](https://github.com/CodesWhat/drydock/issues/281)), politique de mise à jour déclarative ([#320](https://github.com/CodesWhat/drydock/issues/320)), compte à rebours de stabilisation de la maturité + visibilité immédiate des candidats + remplacement manuel ([#406](https://github.com/CodesWhat/drydock/discussions/406)), panneau d'état de mise à jour exploitable et global Mode de mise à jour `notify` / `manual` / `auto` ([#325](https://github.com/CodesWhat/drydock/discussions/325)), héritage de stratégie de balise observateur/imgset/conteneur plus courant empilé → visibilité de balise épinglée plus récente ([#498](https://github.com/CodesWhat/drydock/issues/498)), source 44px standardisée/notes de version/actions de ressources de registre dans la table, les cartes et les détails ([#295](https://github.com/CodesWhat/drydock/discussions/295)), notifications d'événements d'état de santé ([#198](https://github.com/CodesWhat/drydock/discussions/198)), Home Assistant bidirectionnel MQTT, vues de table/liste de cartes réactives, Trivy/Grype/les deux analyses via des commandes ou des backends Docker-worker épinglés, contrôles d'extraction/chauffage des ressources du scanner, SBOM dédupliqué hors tas stockage, exactitude de l'analyse longue Trivy ([#490](https://github.com/CodesWhat/drydock/issues/490)), avertissements de migration de taxonomie de déclenchement, suppressions de compatibilité v1.6, hygiène des documents/API et achèvement de la migration `/api` → `/api/v1` avec une cale de compatibilité opt-in wud-card/page d'accueil (`DD_COMPAT_WUDCARD`). |
+| **v1.7.0** | Mises à jour intelligentes et UX | Ordre tenant compte des dépendances ([#219](https://github.com/CodesWhat/drydock/discussions/219)), mises à jour sélectives en masse ([#232](https://github.com/CodesWhat/drydock/discussions/232)), politique de mise à jour par action ([#511](https://github.com/CodesWhat/drydock/discussions/511)), élagage d'image, surveillance d'image statique, indicateur de maturité d'image, horloge unifiée de maturité/âge des mises à jour, liens de port cliquables, raccourcis clavier, PWA, suppression de `DD_TRIGGER_*` (fin de la fenêtre de dépréciation de la v1.5.0), curl supprimé de l'image |
+| **v1.8.0** | Gestion de flotte et configuration en direct | Configuration YAML, configuration de l'interface utilisateur en direct, navigateur de volumes, mises à jour parallèles, migration du magasin SQLite |
+| **v2.0+** | Extension de la plateforme et au-delà | Observateurs Swarm/Kubernetes, GitOps, barrières de santé, déploiements Canary, terminal Web, RBAC, clés API rotatives étendues (jetons de support statiques pour les intégrations HA/tableau de bord, [#469](https://github.com/CodesWhat/drydock/discussions/469)), LDAP/AD, fournisseur Podman natif au-delà de l'API compatible Docker, CLI, image renforcée Wolfi, proxy de socket |
+
+</details>
+
+<hr>
+
+<h2 align="center" id="documentation">📖Documentations</h2>
+
+| Ressource | Lien |
+| --- | --- |
+| Site Web | [getdrydock.com](https://getdrydock.com/) |
+| Démo en direct | [demo.getdrydock.com](https://demo.getdrydock.com) |
+| Documents | [getdrydock.com/docs](https://getdrydock.com/docs) |
+| Configuration | [Configuration](https://getdrydock.com/docs/configuration) |
+| Démarrage rapide | [Démarrage rapide](https://getdrydock.com/docs/quickstart) |
+| Journal des modifications | [`CHANGELOG.md`](CHANGELOG.md) |
+| Dépréciations | [`DEPRECATIONS.md`](DEPRECATIONS.md) |
+| Feuille de route | Voir la section [Roadmap](#roadmap) ci-dessus |
+| Contribuer | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Problèmes | [Problèmes GitHub](https://github.com/CodesWhat/drydock/issues) |
+| Discussions | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) — demandes de fonctionnalités et idées bienvenues |
+
+<hr>
+
+<a id="star-history"></a>
+
+<div align="center">
+  <a href="https://star-history.com/#CodesWhat/drydock&Date">
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CodesWhat/drydock&type=Date" />
+  </a>
+</div>
+
+---
+
+<div align="center">
+
+### Construit avec
+
+[![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
+[![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
+[![Express 5](https://img.shields.io/badge/Express_5-000?logo=express&logoColor=fff)](https://expressjs.com/)
+[![Vitest](https://img.shields.io/badge/Vitest_4-6E9F18?logo=vitest&logoColor=fff)](https://vitest.dev/)
+[![Biome](https://img.shields.io/badge/Biome_2.5-60a5fa?logo=biome&logoColor=fff)](https://biomejs.dev/)
+[![Node 24](https://img.shields.io/badge/Node_24_Alpine-339933?logo=nodedotjs&logoColor=fff)](https://nodejs.org/)
+[![Anthropic](https://img.shields.io/badge/Anthropic-CC785C?style=flat&logo=anthropic&logoColor=white)](https://claude.ai/)
+[![OpenAI](https://img.shields.io/badge/OpenAI-10A37F?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU%2BT3BlbkFJPC90aXRsZT48cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJNMjIuMjgxOSA5LjgyMTFhNS45ODQ3IDUuOTg0NyAwIDAgMC0uNTE1Ny00LjkxMDggNi4wNDYyIDYuMDQ2MiAwIDAgMC02LjUwOTgtMi45QTYuMDY1MSA2LjA2NTEgMCAwIDAgNC45ODA3IDQuMTgxOGE1Ljk4NDcgNS45ODQ3IDAgMCAwLTMuOTk3NyAyLjkgNi4wNDYyIDYuMDQ2MiAwIDAgMCAuNzQyNyA3LjA5NjYgNS45OCA1Ljk4IDAgMCAwIC41MTEgNC45MTA3IDYuMDUxIDYuMDUxIDAgMCAwIDYuNTE0NiAyLjkwMDFBNS45ODQ3IDUuOTg0NyAwIDAgMCAxMy4yNTk5IDI0YTYuMDU1NyA2LjA1NTcgMCAwIDAgNS43NzE4LTQuMjA1OCA1Ljk4OTQgNS45ODk0IDAgMCAwIDMuOTk3Ny0yLjkwMDEgNi4wNTU3IDYuMDU1NyAwIDAgMC0uNzQ3NS03LjA3Mjl6bS05LjAyMiAxMi42MDgxYTQuNDc1NSA0LjQ3NTUgMCAwIDEtMi44NzY0LTEuMDQwOGwuMTQxOS0uMDgwNCA0Ljc3ODMtMi43NTgyYS43OTQ4Ljc5NDggMCAwIDAgLjM5MjctLjY4MTN2LTYuNzM2OWwyLjAyIDEuMTY4NmEuMDcxLjA3MSAwIDAgMSAuMDM4LjA1MnY1LjU4MjZhNC41MDQgNC41MDQgMCAwIDEtNC40OTQ1IDQuNDk0NHptLTkuNjYwNy00LjEyNTRhNC40NzA4IDQuNDcwOCAwIDAgMS0uNTM0Ni0zLjAxMzdsLjE0Mi4wODUyIDQuNzgzIDIuNzU4MmEuNzcxMi43NzEyIDAgMCAwIC43ODA2IDBsNS44NDI4LTMuMzY4NXYyLjMzMjRhLjA4MDQuMDgwNCAwIDAgMS0uMDMzMi4wNjE1TDkuNzQgMTkuOTUwMmE0LjQ5OTIgNC40OTkyIDAgMCAxLTYuMTQwOC0xLjY0NjR6TTIuMzQwOCA3Ljg5NTZhNC40ODUgNC40ODUgMCAwIDEgMi4zNjU1LTEuOTcyOFYxMS42YS43NjY0Ljc2NjQgMCAwIDAgLjM4NzkuNjc2NWw1LjgxNDQgMy4zNTQzLTIuMDIwMSAxLjE2ODVhLjA3NTcuMDc1NyAwIDAgMS0uMDcxIDBsLTQuODMwMy0yLjc4NjVBNC41MDQgNC41MDQgMCAwIDEgMi4zNDA4IDcuODcyem0xNi41OTYzIDMuODU1OEwxMy4xMDM4IDguMzY0IDE1LjExOTIgNy4yYS4wNzU3LjA3NTcgMCAwIDEgLjA3MSAwbDQuODMwMyAyLjc5MTNhNC40OTQ0IDQuNDk0NCAwIDAgMS0uNjc2NSA4LjEwNDJ2LTUuNjc3MmEuNzkuNzkgMCAwIDAtLjQwNy0uNjY3em0yLjAxMDctMy4wMjMxbC0uMTQyLS4wODUyLTQuNzczNS0yLjc4MThhLjc3NTkuNzc1OSAwIDAgMC0uNzg1NCAwTDkuNDA5IDkuMjI5N1Y2Ljg5NzRhLjA2NjIuMDY2MiAwIDAgMSAuMDI4NC0uMDYxNWw0LjgzMDMtMi43ODY2YTQuNDk5MiA0LjQ5OTIgMCAwIDEgNi42ODAyIDQuNjZ6TTguMzA2NSAxMi44NjNsLTIuMDItMS4xNjM4YS4wODA0LjA4MDQgMCAwIDEtLjAzOC0uMDU2N1Y2LjA3NDJhNC40OTkyIDQuNDk5MiAwIDAgMSA3LjM3NTctMy40NTM3bC0uMTQyLjA4MDVMOC43MDQgNS40NTlhLjc5NDguNzk0OCAwIDAgMC0uMzkyNy42ODEzem0xLjA5NzYtMi4zNjU0bDIuNjAyLTEuNDk5OCAyLjYwNjkgMS40OTk4djIuOTk5NGwtMi41OTc0IDEuNDk5Ny0yLjYwNjctMS40OTk3WiIvPjwvc3ZnPg%3D%3D)](https://openai.com)
+
+[![SemVer](https://img.shields.io/badge/semver-2.0.0-blue)](https://semver.org/)
+[![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
+[![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
+
+### Communauté
+
+Questions, commentaires et assistance précoce : **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+
+Veuillez déposer des bogues concrets et des demandes de fonctionnalités dans **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** afin qu'ils ne se perdent pas dans le chat.
+
+### Contrôle qualité de la communauté
+
+Merci aux utilisateurs qui ont aidé à tester les versions candidates v1.4.0 et v1.5.0 et qui ont signalé des bugs :
+
+[@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
+
+### Fait partie de l'écosystème CodesWhat
+
+<table>
+  <tr><th>Outil</th><th>Rôle</th></tr>
+  <tr><td><b>drydock</b></td><td>Surveillance des mises à jour des conteneurs : interface utilisateur Web et moteur de notification</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/portwing"><b>portwing</b></a></td><td>Agent Docker distant : accès sécurisé au niveau du socket à partir de Drydock ou autonome</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/sockguard"><b>sockguard</b></a></td><td>Docker socket proxy - filtre de liste blanche de refus par défaut protégeant le socket</td></tr>
+</table>
+
+Ces trois outils sont conçus pour superposer : sockguard filtre le socket, portwing l'expose à distance et drydock surveille et agit sur l'état du conteneur.
+
+Voir COMPATIBILITY.md](<https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md>) de portwing pour connaître la matrice de compatibilité complète des trois outils.
+
+---
+
+**[Licence AGPL-3.0](LICENSE)**
+
+<a href="https://github.com/CodesWhat">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/codeswhat-logo-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/codeswhat-logo-original.svg" />
+    <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
+  </picture>
+</a>
+
+[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
+
+<a href="#drydock">Retour en haut</a>
+
+</div>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 **Container image update watcher — 23 registries, 20 notification and action providers.**
 
+<p><strong>English</strong> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
 </div>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ docker run -d \
 > echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
 > ```
 >
-> Or with Node.js 24+ (no extra packages needed):
+> Or with Node.js 24.7+ (no extra packages needed):
 >
 > ```bash
 > node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"

--- a/README.pl.md
+++ b/README.pl.md
@@ -154,7 +154,7 @@ docker run -d \
 > echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
 > ```
 >
-> Lub z Node.js 24+ (nie są potrzebne żadne dodatkowe pakiety):
+> Lub z Node.js 24.7+ (nie są potrzebne żadne dodatkowe pakiety):
 >
 > ```bash
 > node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,0 +1,447 @@
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
+  <img src="docs/assets/whale-logo.png" alt="drydock" width="220">
+</picture>
+
+<h1>drydock</h1>
+
+**Obserwator aktualizacji obrazów kontenerów — 23 rejestry, 20 dostawców powiadomień i działań.**
+
+<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <strong>Polski</strong> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
+</div>
+
+<p align="center">
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.2-blue" alt="Version"></a>
+  <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
+  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
+  <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
+  <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+</p>
+
+<hr>
+
+> [!WARNING]
+> **Aktualizacja ze starszej wersji? Najpierw przeczytaj uwagi dotyczące aktualizacji.** Trzy poprawki zwiększające bezpieczeństwo zostały dostarczone po raz pierwszy w **1.4.6** i działają w całej linii **1.5**, więc każdy, kto dokonuje aktualizacji z wersji starszej niż 1.4.6, będzie miał wpływ na dowolną wersję, na której wyląduje (1.4.6, dowolna wersja 1.5.x lub nowsza). Nie są one wycofane i nie mają okresu karencji: OIDC wymaga teraz `authorization_endpoint` w metadanych wykrywania Twojego dostawcy, nieuwierzytelnionych kluczy ograniczających szybkość na adresie równorzędnym TCP (współdzielony zasobnik za odwrotnym proxy), a adresy URL proxy wyzwalacza HTTP muszą używać `http(s)://`. Przed aktualizacją zobacz **[UPGRADE-NOTES.md](UPGRADE-NOTES.md)**.
+
+<h2 align="center">📑Spis treści</h2>
+
+- [📖 Dokumentacja](https://getdrydock.com/docs)
+- [🚀 Szybki start](#quick-start)
+- [🆕 Ostatnie aktualizacje](#recent-updates)
+- [📸 Zrzuty ekranu i demonstracja na żywo](#screenshots)
+- [🤔 Dlaczego Drydock](#why-drydock)
+- [✨ Funkcje](#features)
+- [🔌 Obsługiwane integracje](#supported-integrations)
+- [⚖️ Porównanie funkcji](#feature-comparison)
+- [🔄 Migracja](#migration)
+- [🗺️ Plan działania](#roadmap)
+- [⭐ Historia gwiazd](#star-history)
+- [🔧 Zbudowany z](#zbudowany-z)
+- [🤝 Społeczność QA](#kontrola-jakości-społeczności)
+
+<hr>
+
+<h2 align="center" id="quick-start">🚀 Szybki start</h2>
+
+**Zalecane: użyj gniazda proxy**, aby ograniczyć punkty końcowe Docker API, do których Drydock może uzyskać dostęp. Pozwala to uniknąć zapewnienia kontenerowi pełnego dostępu do gniazda Docker.
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      socket-proxy:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=socket-proxy
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - CONTAINERS=1
+      - IMAGES=1
+      - EVENTS=1
+      - SERVICES=1
+      - INFO=1          # Required for daemon identity detection (notification prefixes)
+      # Add POST=1 and NETWORKS=1 for container actions and auto-updates
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+<details>
+<summary>Alternatywa:<a href="https://github.com/CodesWhat/sockguard">sockguard</a>proxy gniazda</summary>
+
+[sockguard](https://github.com/CodesWhat/sockguard) to filtr gniazda Docker z domyślną odmową z tego samego ekosystemu CodesWhat, z ustawieniem wstępnym zbudowanym dla drydock:
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      sockguard:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=sockguard
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  sockguard:
+    image: codeswhat/sockguard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./sockguard.yaml:/etc/sockguard/config.yaml:ro
+    environment:
+      - SOCKGUARD_CONFIG_FILE=/etc/sockguard/config.yaml
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+Zobacz ustawienie wstępne sockguard [`app/configs/portwing.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing.yaml) dla początkowego `sockguard.yaml` (to samo ustawienie wstępne portwing jest dostarczane we własnych przykładach).
+
+</details>
+
+<details>
+<summary>Alternatywa: szybki start z bezpośrednim montażem na gnieździe</summary>
+
+```bash
+docker run -d \
+  --name drydock \
+  -p 3000:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e DD_AUTH_BASIC_ADMIN_USER=admin \
+  -e "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>" \
+  codeswhat/drydock:latest
+```
+
+> **Ostrzeżenie:** Bezpośredni dostęp do gniazda zapewnia kontenerowi pełną kontrolę nad demonem Dockera. W przypadku wdrożeń produkcyjnych użyj powyższej konfiguracji gniazda proxy. Zobacz [Przewodnik dotyczący zabezpieczeń gniazd Docker](https://getdrydock.com/docs/configuration/watchers#docker-socket-security), aby zapoznać się ze wszystkimi opcjami, w tym zdalnym TLS i Dockerem bez rootowania.
+
+</details>
+
+> Wygeneruj skrót hasła (`argon2` CLI — zainstaluj za pośrednictwem menedżera pakietów):
+>
+> ```bash
+> echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
+> ```
+>
+> Lub z Node.js 24+ (nie są potrzebne żadne dodatkowe pakiety):
+>
+> ```bash
+> node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"
+> ```
+>
+> Drydock v1.6 akceptuje tylko skróty uwierzytelniające argon2id Basic. Starsze wersje `{SHA}`, `$apr1$`/`$1$`, `crypt` i skróty zwykłego tekstu są odrzucane; zregeneruj je przed aktualizacją.
+> Uwierzytelnienie jest **wymagane domyślnie**. Zobacz [auth docs](https://getdrydock.com/docs/configuration/authentications) dla OIDC, dostępu anonimowego i innych opcji.
+> Aby jawnie zezwolić na anonimowy dostęp w przypadku nowych instalacji, ustaw `DD_ANONYMOUS_AUTH_CONFIRM=true`.
+
+Obraz zawiera pliki binarne `trivy` i `cosign` do lokalnego skanowania pod kątem luk i weryfikacji obrazu.
+
+Zobacz [Przewodnik szybkiego startu](https://getdrydock.com/docs/quickstart) dla Docker Compose, bezpieczeństwo gniazd, odwrotne proxy i alternatywne rejestry.
+
+<hr>
+
+<h2 align="center" id="recent-updates">🆕 Ostatnie aktualizacje</h2>
+
+<details open>
+<summary><strong>Najważniejsze informacje w wersji 1.6.0-rc.2</strong></summary>
+
+- **Powiadomienia** — szablony tytułów i treści dla poszczególnych reguł/dostawców z podglądem na żywo oraz wspierane audytem kategorie dzwonków w aplikacji i progi ważności aktualizacji.
+- **Panel** — Wymiana siatki CSS o zerowej zależności z możliwością zmiany kolejności myszy/dotyku, ograniczonej zmiany rozmiaru, responsywnych układów, widoczności widżetów, resetowania i opcjonalnej synchronizacji preferencji na różnych urządzeniach.
+- **Zasady aktualizacji** — Deklarowane pierwszeństwo obserwatora/etykiety/UI, zastąpienie/przywrócenie ścieżki audytu, odliczanie terminu zapadalności/ręczne zastąpienie oraz widoczność informacji przypiętych tagów z skumulowanym bieżącym → nowszym widokiem tagów.
+- **Wydajność i odzyskiwanie** — Deduplikacja listy tagów dla poszczególnych ankiet, lżejsze prognozy zbiorcze, zwirtualizowane historie dużych dzienników, niezmienne przerzucanie logów na żywo, przekroczenie limitu czasu ładowania początkowego uwierzytelniania, pełna migracja preferencji i samonaprawa nieaktualnych fragmentów.
+- **Wymuszone migracje wersji 1.6** — aliasy env/label WUD, starsze formaty uwierzytelniania, przestarzałe przełączniki obserwatorów, aliasy szablonów, Kafka `clientId` i zniekształcone publiczne konfiguracje Hub/DHI zawierające tylko token nie są już uruchamiane. Aliasy taksonomii wyzwalaczy pozostają w wersji ostatecznej z ostrzeżeniem o poziomie błędów.
+
+Pełne wskazówki dotyczące migracji znajdują się w [DEPRECATIONS.md](./DEPRECATIONS.md).
+
+</details>
+
+<details>
+<summary><strong>Najważniejsze informacje w wersji 1.5.2</strong></summary>
+
+- **Zasady aktualizacji bezpiecznej dla rozrywki** — Bramy dojrzałości, pominięte tagi/streszczenia i drzemki teraz przetrwają odtwarzanie kontenera w przypadku obciążeń lokalnych i zdalnych agentów.
+- **Niezawodność przypiętego tagu** — Całkowicie przypięte tagi wykrywają ponowne przebudowanie podsumowania tego samego tagu, podczas gdy interfejs użytkownika może wyświetlać niewykonalny nowszy tag tej samej rodziny bez zmiany zachowania aktualizacji lub wyzwalacza.
+- **Odzyskiwanie wycofywania** — Nieudane utworzenie zamiennika, połączenie sieciowe lub uruchomienie powoduje teraz oczyszczenie kandydata przed przywróceniem oryginalnego kontenera, a powtarzające się błędy nie mogą kaskadować się poprzez zagnieżdżone zmiany nazw wycofywania.
+- **Bezpieczniejsze odtwarzanie kontenerów** — Adresy MAC przypisane przez demona nie są już przypinane do zamienników, natomiast jawnie skonfigurowane adresy MAC sieci podstawowej pozostają zachowane.
+- **Cichsze odpytywanie obrazów lokalnych** — Obrazy tworzone lub ładowane lokalnie bez skrótu rejestru pomijają zdalne wyszukiwanie, zamiast generować powtarzające się błędy autoryzacji.
+
+Pełna historia w [CHANGELOG.md](./CHANGELOG.md).
+
+</details>
+
+<hr>
+
+<h2 align="center" id="screenshots">📸 Zrzuty ekranu i demonstracja na żywo</h2>
+
+<p align="center">
+  <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
+</p>
+
+<p align="center"><em>Znajdź aktualizację, zobacz dokładnie, jakie zmiany i zastosuj ją. Obsługiwane kopie zapasowe, sprawdzanie stanu i przywracanie zmian.</em></p>
+
+<table>
+<tr>
+<td width="50%" align="center"><strong>Światło</strong></td>
+<td width="50%" align="center"><strong>Ciemny</strong></td>
+</tr>
+<tr>
+<td><img src="docs/assets/drydock-dashboard-light.png" alt="Dashboard Light"></td>
+<td><img src="docs/assets/drydock-dashboard-dark.png" alt="Dashboard Dark"></td>
+</tr>
+</table>
+
+<div align="center">
+
+**Po co oglądać zrzuty ekranu, skoro możesz tego doświadczyć na własnej skórze?**
+
+<a href="https://demo.getdrydock.com"><img src="https://img.shields.io/badge/Try_the_Live_Demo-4f46e5?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlnb24gcG9pbnRzPSI2IDMgMjAgMTIgNiAyMSA2IDMiLz48L3N2Zz4=&logoColor=white" alt="Try the Live Demo" height="36"></a>
+
+W pełni interaktywny — prawdziwy interfejs użytkownika, próbne dane, nie wymaga instalacji. Działa całkowicie w przeglądarce.
+
+</div>
+
+<hr>
+
+<h2 align="center" id="why-drydock">🤔 Dlaczego Drydock</h2>
+
+Obrazy kontenerów po cichu stają się nieaktualne. Obraz bazowy łata CVE, aplikacja wycofuje wersję, tag się przenosi. Jeśli nie będziesz oglądać każdego rejestru ręcznie, działające kontenery pozostaną w tyle, dopóki coś się nie zepsuje lub nie zostanie wykorzystane.
+
+Większość narzędzi wymusza kompromis. Automatyczne aktualizacje (Watchtower, Ouroboros) pobierają się i uruchamiają ponownie przy niewielkiej widoczności lub kontroli i obecnie w dużej mierze nie są konserwowane. Pulpity nawigacyjne (Portainer) zarządzają kontenerami, ale nie są zbudowane pod kątem analizy aktualizacji. Drydock to **najpierw monitor**: obserwuje 23 rejestry i dokładnie informuje Cię, co się zmieniło (główne, poboczne, poprawki lub podsumowanie), zanim cokolwiek się wydarzy, a następnie działa tylko wtedy, gdy na to pozwolisz. I sięga dalej niż którykolwiek z nich. Skanowanie pod kątem luk w zabezpieczeniach Trivy/Grype blokuje niebezpieczne aktualizacje, cosign weryfikuje podpisy, kopie zapasowe obrazów przed aktualizacją przywracają się automatycznie w przypadku niepowodzenia kontroli stanu, rozproszoni agenci obsługują zdalne hosty, a 20 integracji powiadomień i działań zamyka pętlę. Pełny cykl życia aktualizacji z interfejsem internetowym i interfejsem API REST.
+
+<hr>
+
+<h2 align="center" id="features">✨ Funkcje</h2>
+
+| | Funkcja | Opis |
+|---|---|---|
+| 🔭 | **Wykrywanie najpierw na monitorze** | Obserwuje każdy działający kontener i zanim cokolwiek się wydarzy, klasyfikuje każdą dostępną aktualizację jako główną, pomocniczą, poprawkę lub podsumowanie. Nic się nie zmieni, dopóki tak nie powiesz. |
+| 📦 | **23 Dostawcy rejestru** | Docker Hub, GHCR, ECR, ACR, GCR, GAR, GitLab, Quay, Harbor, Artifactory, Nexus i 12 innych. Publiczne i prywatne, w chmurze i na własnym serwerze, z TLS i uwierzytelnianiem dla poszczególnych rejestrów. |
+| 🔔 | **20 wyzwalaczy** | 17 kanałów powiadomień (Slack, Discord, Telegram, Teams, SMTP, MQTT, ntfy i więcej) oraz Docker, Docker Compose i akcje poleceń, z szablonami dla poszczególnych zdarzeń/dostawców, podglądem na żywo, filtrowaniem progów i trybem wsadowym. |
+| 🥊 | **Update Bouncer** | Skanowanie pod kątem luk w zabezpieczeniach Trivy/Grype blokuje niebezpieczne aktualizacje przed ich wdrożeniem, z weryfikacją podpisu Cosign i generowaniem SBOM (CycloneDX i SPDX). |
+| ↩️ | **Kopia zapasowa obrazu i automatyczne przywracanie** | Wstępnie aktualizuj migawki obrazów z konfigurowalnym przechowywaniem, automatycznym przywracaniem w przypadku niepowodzenia kontroli stanu i ręcznym przywracaniem jednym kliknięciem z poziomu interfejsu użytkownika. |
+| 🪝 | **Haki cyklu życia** | Polecenia powłoki przed i po aktualizacji za pośrednictwem etykiet kontenerów, z limitami czasu dla poszczególnych haków i kontrolą przerwania w przypadku awarii. |
+| 🗂️ | **Aktualizacje Docker Compose** | Pobieraj i odtwarzaj usługi Compose za pośrednictwem interfejsu API Docker Engine z łataniem obrazów zachowującym YAML. |
+| 🎛️ | **Zasady dotyczące kontenera** | Reguły tagów Regex i routing wyzwalaczy korzystają z etykiet `dd.*`; bramki dojrzałości, pomijanie/odkładanie/przypinanie i okna konserwacji są przechowywane za pośrednictwem interfejsu użytkownika/API lub konfiguracji obserwatora. |
+| 🛰️ | **Agenci rozproszoni** | Monitoruj zdalne hosty Dockera za pośrednictwem SSE. Agenci brzegowi za NAT wybierają numer przez WebSocket z uwierzytelnianiem za pomocą klucza Ed25519, nie jest wymagany port wejściowy (`DD_EXPERIMENTAL_PORTWING=true`). |
+| 🖥️ | **Panel sieciowy** | Interfejs użytkownika Vue 3 z konfigurowalną siatką widżetów o zerowej zależności, responsywnymi widokami tabel/kart, aktualizacjami SSE na żywo, sterowaniem dzwonkiem powiadomień oraz szczegółami, dziennikami i statystykami dotyczącymi poszczególnych kontenerów. |
+| 🔗 | **REST API i webhooki** | Punkty końcowe uwierzytelniane tokenem dla wyzwalaczy monitorowania i aktualizacji CI/CD oraz pozyskiwania podpisanego elementu webhook rejestru dla zdarzeń push. |
+| 🔐 | **Uwierzytelnianie OIDC** | Zabezpiecz deskę rozdzielczą za pomocą OpenID Connect (Authelia, Auth0, Authentik). Domyślnie wszystkie przepływy uwierzytelniania nie są zamykane. |
+| 📈 | **Dane Prometheus** | Wbudowany punkt końcowy `/metrics` z opcjonalnym obejściem uwierzytelniania dla stosów monitorowania Prometheus i Grafana. |
+| 🌍 | **17 ustawień regionalnych interfejsu użytkownika** | W pełni przewodowy system tłumaczeń z pełnym językiem angielskim i 16 obsługiwanymi przez społeczność lokalizacjami zsynchronizowanymi za pośrednictwem Crowdin, przełączalny w konfiguracji. |
+| 🔒 | **ReDoS-Regex immunologiczny** | Każdy wzorzec znacznika dostarczony przez użytkownika jest kompilowany przez re2js (port oparty wyłącznie na JS RE2) w celu uzyskania liniowego dopasowania, którego nie może zatrzymać katastrofalny wzorzec cofania się. |
+
+<hr>
+
+<h2 align="center" id="supported-integrations">🔌 Obsługiwane integracje</h2>
+
+### 📦 Rejestry (23)
+
+Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Quay · LSCR · Port · Artifactory · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Niestandardowy · DOCR · DHI · IBM Cloud · Oracle Cloud · Alibaba Cloud
+
+### ⚡ Akcje (3)
+
+Doker · Docker Compose · Polecenie
+
+### 🔔 Powiadomienia (17)
+
+Appprise · Discord · Czat Google · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
+
+### 🔐 Uwierzytelnianie
+
+Anonimowy (opcja poprzez `DD_ANONYMOUS_AUTH_CONFIRM=true`) · Podstawowy (nazwa użytkownika + skrót hasła) · OIDC (Authelia, Auth0, Authentik). Domyślnie wszystkie przepływy uwierzytelniania nie są zamykane.
+
+### 🥊 Update Bouncer
+
+Skanowanie pod kątem luk w zabezpieczeniach oparte na Trivy lub Grype blokuje niebezpieczne aktualizacje przed ich wdrożeniem. Obejmuje weryfikację podpisu Cosign i generowanie SBOM (CycloneDX i SPDX).
+
+<hr>
+
+<h2 align="center" id="feature-comparison">⚖️ Porównanie funkcji</h2>
+
+<details>
+<summary><strong>Jak drydock wypada w porównaniu z innymi narzędziami do aktualizacji kontenerów?</strong></summary>
+
+> ✅ = obsługiwane &nbsp; ❌ = nieobsługiwane &nbsp; ⚠️ = częściowy / ograniczony &nbsp; † = zarchiwizowane, nie jest już obsługiwane
+
+| Feature | drydock | WUD | Diun | *Watchtower †* | *Ouroboros †* |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Interfejs webowy / pulpit | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Automatyczna aktualizacja kontenerów | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Aktualizacje Docker Compose | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Kanały wyzwalaczy / powiadomień | 20 | 16 | 17 | ~19 | ~6 |
+| Dostawcy rejestrów | 23 | 13 | ⚠️ | ⚠️ | ⚠️ |
+| Uwierzytelnianie OIDC / SSO | ✅ | ✅ | ❌ | ❌ | ❌ |
+| REST API | ✅ | ✅ | ⚠️ | ⚠️ | ❌ |
+| Metryki Prometheus | ✅ | ✅ | ❌ | ✅ | ✅ |
+| MQTT / Home Assistant | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Kopia i przywracanie obrazów | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Grupowanie kontenerów / stosy | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Hooki cyklu życia (przed/po) | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Webhook API dla CI/CD | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Start/stop/restart/aktualizacja kontenerów | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Agenci rozproszeni (zdalni) | ✅ | ❌ | ✅ | ⚠️ | ❌ |
+| Dziennik audytu | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Skanowanie bezpieczeństwa (Trivy/Grype) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Aktualizacje zgodne z SemVer | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Monitorowanie digestów | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Wiele architektur (amd64/arm64) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Podgląd logów kontenera | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Aktywnie utrzymywane | ✅ | ✅ | ✅ | ❌ | ❌ |
+
+> Dane na podstawie publicznie dostępnej dokumentacji, stan na marzec 2026 r.
+> Komentarze są mile widziane, jeśli jakiekolwiek informacje są niedokładne.
+
+</details>
+
+<hr>
+
+<h2 align="center" id="migration">🔄 Migracja</h2>
+
+<details>
+<summary><strong>Migracja z WUD (Co słychać w oknie dokowanym?)</strong></summary>
+
+Drydock v1.6 nie ładuje już zmiennych środowiskowych `WUD_*` ani etykiet `wud.*` w czasie wykonywania. Przepisz je przed uruchomieniem uaktualnionej usługi; stan utrwalony nadal migruje automatycznie. Użyj `docker exec -it drydock node dist/index.js config migrate --dry-run`, aby wyświetlić podgląd, a następnie `docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml`, aby przepisać konfigurację na nazewnictwo `DD_*` i `dd.*`.
+
+</details>
+
+<hr>
+
+<h2 align="center" id="roadmap">🗺️ Plan działania</h2>
+
+<details>
+<summary><strong>Motywy i najważniejsze wersje wersji</strong></summary>
+
+Tylko motywy wysokiego poziomu — zobacz [CHANGELOG.md](CHANGELOG.md), aby uzyskać szczegółowe informacje na temat poszczególnych wersji.
+
+| Wersja | Motyw | Najważniejsze |
+| --- | --- | --- |
+| **v1.3.x** ✅ | Bezpieczeństwo i stabilność | Skanowanie Trivy, Update Bouncer, SBOM, 7 nowych rejestrów, 4 nowe wyzwalacze, silnik re2js regex |
+| **v1.4.x** ✅ | Modernizacja i wzmocnienie interfejsu użytkownika | Tailwind 4 + niestandardowe komponenty, 6 motywów, paleta Cmd/K, OpenAPI 3.1, natywne aktualizacje YAML, skanowanie z dwoma gniazdami, utwardzanie OIDC |
+| **v1.5.0** ✅ | Obserwowalność i i18n | wyzwalacz podziału taksonomii (`DD_ACTION_*`/`DD_NOTIFICATION_*`), przeglądarka logów WebSocket, dostosowywanie pulpitu nawigacyjnego, monitorowanie zasobów, skrzynka nadawcza powiadomień + DLQ, podsumowanie skanowania bezpieczeństwa, 17 ustawień regionalnych, odtwarzanie identyfikatora ostatniego zdarzenia SSE, wybieranie numeru agenta brzegowego z uwierzytelnianiem Ed25519 (eksperymentalne, `DD_EXPERIMENTAL_PORTWING=true`) |
+| **v1.5.1** ✅ | Bezpieczeństwo i konserwacja | Poprawka autoryzacji pull-auth GCR/GAR, zakończenie TLS rejestru (M-2), utwardzanie wtrysku hook env-var, obsługa `DD_SESSION_SECRET__FILE`, redakcja poświadczeń debug-dump, sprawdzanie uprawnień do plików tajnych, naprawa zakleszczenia bramy dojrzałości, pełna translacja interfejsu użytkownika + tłumaczenia społeczności, bramka automatycznego stosowania okna konserwacji, wyświetlanie czasu pracy kontenera, wersja oprogramowania z podziałem kolumny tagu/wersji (etykieta OCI, z `dd.inspect.tag.path` podwójny zapis + opcjonalne routing `dd.inspect.tag.version-only`), opcjonalne tworzenie dopasowywania prefiksów montowania, szablon `${currentReleaseNotes}` var |
+| **v1.5.2** ✅ | Niezawodność zasad i przypiętych tagów | Bezpieczne dla celów rekreacyjnych zachowywanie zasad dotyczących dojrzałości/pomiń/odłóż, wykrywanie odbudowy podsumowania przypiętych tagów i informacyjne spostrzeżenia dotyczące tej samej rodziny, czyszczenie kandydatów do wycofania, zapobieganie kaskadzie wycofywania, jawne zachowywanie adresów MAC i zachowanie pomijania rejestru obrazów lokalnych |
+| **v1.6.0** | Powiadomienia, zasady i wydania Intel | Szablony powiadomień dla poszczególnych reguł/wyzwalaczy z podglądem na żywo, preferencjami dzwonka powiadomień, synchronizacją preferencji między urządzeniami, niestandardową siatką pulpitu nawigacyjnego o zerowej zależności ([#281](https://github.com/CodesWhat/drydock/issues/281)), deklaratywną polityką aktualizacji ([#320](https://github.com/CodesWhat/drydock/issues/320)), odliczaniem stabilizacji dojrzałości + natychmiastową widocznością kandydata + ręcznym zastąpieniem ([#406](https://github.com/CodesWhat/drydock/discussions/406)), praktycznym panelem stanu aktualizacji i globalnym `notify` / `manual` / `auto` tryb aktualizacji ([#325](https://github.com/CodesWhat/drydock/discussions/325)), dziedziczenie zasad tagów obserwatora/imgset/kontenera plus skumulowany prąd → nowsza widoczność przypiętych tagów ([#498](https://github.com/CodesWhat/drydock/issues/498)), ujednolicone źródło 44px / informacje o wersji / akcje zasobów rejestru w tabelach, kartach i szczegóły ([#295](https://github.com/CodesWhat/drydock/discussions/295)), powiadomienia o zdarzeniach dotyczących stanu zdrowia ([#198](https://github.com/CodesWhat/drydock/discussions/198)), dwukierunkowy Home Assistant MQTT, responsywne widoki tabel/list kart, Trivy/Grype/oba skanowanie za pośrednictwem poleceń lub przypiętych backendów Docker-worker, kontrola ściągania/ogrzewania zasobów skanera, praca poza stertą deduplikowana pamięć SBOM, poprawność długiego skanowania Trivy ([#490](https://github.com/CodesWhat/drydock/issues/490)), ostrzeżenia o migracji wyzwalacza-taksonomii, usunięcie zgodności z wersją 1.6, higiena dokumentów/API oraz zakończenie migracji `/api` → `/api/v1` z opcjonalną podkładką zgodności wud-card/strony głównej (`DD_COMPAT_WUDCARD`). |
+| **v1.7.0** | Inteligentne aktualizacje i UX | Zamawianie uwzględniające zależności ([#219](https://github.com/CodesWhat/drydock/discussions/219)), selektywne aktualizacje zbiorcze ([#232](https://github.com/CodesWhat/drydock/discussions/232)), zasady aktualizacji według akcji ([#511](https://github.com/CodesWhat/drydock/discussions/511)), czyszczenie obrazu, monitorowanie obrazu statycznego, wskaźnik dojrzałości obrazu, ujednolicony zegar dojrzałości/wieku aktualizacji, klikalne łącza do portów, skróty klawiaturowe, PWA, usuwanie `DD_TRIGGER_*` (koniec wycofania wersji 1.5.0 okno), zawijanie usunięte z obrazu |
+| **v1.8.0** | Zarządzanie flotą i konfiguracja na żywo | Konfiguracja YAML, konfiguracja interfejsu użytkownika na żywo, przeglądarka woluminów, aktualizacje równoległe, migracja sklepu SQLite |
+| **v2.0+** | Rozszerzanie platformy i nie tylko | Obserwatorzy roju/Kubernetes, GitOps, bramki kondycji, wdrożenia Canary, terminal sieciowy, RBAC, rotacyjne klucze API o określonym zakresie (statyczne tokeny nośnika do integracji HA/pulpitu nawigacyjnego, [#469](https://github.com/CodesWhat/drydock/discussions/469)), LDAP/AD, natywny dostawca Podman poza interfejsem API zgodnym z Dockerem, CLI, wzmocniony obraz Wolfi, proxy gniazda |
+
+</details>
+
+<hr>
+
+<h2 align="center" id="documentation">📖 Dokumentacja</h2>
+
+| Zasób | Link |
+| --- | --- |
+| Strona internetowa | [getdrydock.com](https://getdrydock.com/) |
+| Demo na żywo | [demo.getdrydock.com](https://demo.getdrydock.com) |
+| Dokumenty | [getdrydock.com/docs](https://getdrydock.com/docs) |
+| Konfiguracja | [Konfiguracja](https://getdrydock.com/docs/configuration) |
+| Szybki start | [Szybki start](https://getdrydock.com/docs/quickstart) |
+| Dziennik zmian | [`CHANGELOG.md`](CHANGELOG.md) |
+| Wycofanie | [`DEPRECATIONS.md`](DEPRECATIONS.md) |
+| Mapa drogowa | Zobacz sekcję [Roadmap](#roadmap) powyżej |
+| Wkład | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Problemy | [Problemy z GitHubem](https://github.com/CodesWhat/drydock/issues) |
+| Dyskusje | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) — prośby o nowe funkcje i pomysły mile widziane |
+
+<hr>
+
+<a id="star-history"></a>
+
+<div align="center">
+  <a href="https://star-history.com/#CodesWhat/drydock&Date">
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CodesWhat/drydock&type=Date" />
+  </a>
+</div>
+
+---
+
+<div align="center">
+
+### Zbudowany z
+
+[![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
+[![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
+[![Express 5](https://img.shields.io/badge/Express_5-000?logo=express&logoColor=fff)](https://expressjs.com/)
+[![Vitest](https://img.shields.io/badge/Vitest_4-6E9F18?logo=vitest&logoColor=fff)](https://vitest.dev/)
+[![Biome](https://img.shields.io/badge/Biome_2.5-60a5fa?logo=biome&logoColor=fff)](https://biomejs.dev/)
+[![Node 24](https://img.shields.io/badge/Node_24_Alpine-339933?logo=nodedotjs&logoColor=fff)](https://nodejs.org/)
+[![Anthropic](https://img.shields.io/badge/Anthropic-CC785C?style=flat&logo=anthropic&logoColor=white)](https://claude.ai/)
+[![OpenAI](https://img.shields.io/badge/OpenAI-10A37F?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU%2BT3BlbkFJPC90aXRsZT48cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJNMjIuMjgxOSA5LjgyMTFhNS45ODQ3IDUuOTg0NyAwIDAgMC0uNTE1Ny00LjkxMDggNi4wNDYyIDYuMDQ2MiAwIDAgMC02LjUwOTgtMi45QTYuMDY1MSA2LjA2NTEgMCAwIDAgNC45ODA3IDQuMTgxOGE1Ljk4NDcgNS45ODQ3IDAgMCAwLTMuOTk3NyAyLjkgNi4wNDYyIDYuMDQ2MiAwIDAgMCAuNzQyNyA3LjA5NjYgNS45OCA1Ljk4IDAgMCAwIC41MTEgNC45MTA3IDYuMDUxIDYuMDUxIDAgMCAwIDYuNTE0NiAyLjkwMDFBNS45ODQ3IDUuOTg0NyAwIDAgMCAxMy4yNTk5IDI0YTYuMDU1NyA2LjA1NTcgMCAwIDAgNS43NzE4LTQuMjA1OCA1Ljk4OTQgNS45ODk0IDAgMCAwIDMuOTk3Ny0yLjkwMDEgNi4wNTU3IDYuMDU1NyAwIDAgMC0uNzQ3NS03LjA3Mjl6bS05LjAyMiAxMi42MDgxYTQuNDc1NSA0LjQ3NTUgMCAwIDEtMi44NzY0LTEuMDQwOGwuMTQxOS0uMDgwNCA0Ljc3ODMtMi43NTgyYS43OTQ4Ljc5NDggMCAwIDAgLjM5MjctLjY4MTN2LTYuNzM2OWwyLjAyIDEuMTY4NmEuMDcxLjA3MSAwIDAgMSAuMDM4LjA1MnY1LjU4MjZhNC41MDQgNC41MDQgMCAwIDEtNC40OTQ1IDQuNDk0NHptLTkuNjYwNy00LjEyNTRhNC40NzA4IDQuNDcwOCAwIDAgMS0uNTM0Ni0zLjAxMzdsLjE0Mi4wODUyIDQuNzgzIDIuNzU4MmEuNzcxMi43NzEyIDAgMCAwIC43ODA2IDBsNS44NDI4LTMuMzY4NXYyLjMzMjRhLjA4MDQuMDgwNCAwIDAgMS0uMDMzMi4wNjE1TDkuNzQgMTkuOTUwMmE0LjQ5OTIgNC40OTkyIDAgMCAxLTYuMTQwOC0xLjY0NjR6TTIuMzQwOCA3Ljg5NTZhNC40ODUgNC40ODUgMCAwIDEgMi4zNjU1LTEuOTcyOFYxMS42YS43NjY0Ljc2NjQgMCAwIDAgLjM4NzkuNjc2NWw1LjgxNDQgMy4zNTQzLTIuMDIwMSAxLjE2ODVhLjA3NTcuMDc1NyAwIDAgMS0uMDcxIDBsLTQuODMwMy0yLjc4NjVBNC41MDQgNC41MDQgMCAwIDEgMi4zNDA4IDcuODcyem0xNi41OTYzIDMuODU1OEwxMy4xMDM4IDguMzY0IDE1LjExOTIgNy4yYS4wNzU3LjA3NTcgMCAwIDEgLjA3MSAwbDQuODMwMyAyLjc5MTNhNC40OTQ0IDQuNDk0NCAwIDAgMS0uNjc2NSA4LjEwNDJ2LTUuNjc3MmEuNzkuNzkgMCAwIDAtLjQwNy0uNjY3em0yLjAxMDctMy4wMjMxbC0uMTQyLS4wODUyLTQuNzczNS0yLjc4MThhLjc3NTkuNzc1OSAwIDAgMC0uNzg1NCAwTDkuNDA5IDkuMjI5N1Y2Ljg5NzRhLjA2NjIuMDY2MiAwIDAgMSAuMDI4NC0uMDYxNWw0LjgzMDMtMi43ODY2YTQuNDk5MiA0LjQ5OTIgMCAwIDEgNi42ODAyIDQuNjZ6TTguMzA2NSAxMi44NjNsLTIuMDItMS4xNjM4YS4wODA0LjA4MDQgMCAwIDEtLjAzOC0uMDU2N1Y2LjA3NDJhNC40OTkyIDQuNDk5MiAwIDAgMSA3LjM3NTctMy40NTM3bC0uMTQyLjA4MDVMOC43MDQgNS40NTlhLjc5NDguNzk0OCAwIDAgMC0uMzkyNy42ODEzem0xLjA5NzYtMi4zNjU0bDIuNjAyLTEuNDk5OCAyLjYwNjkgMS40OTk4djIuOTk5NGwtMi41OTc0IDEuNDk5Ny0yLjYwNjctMS40OTk3WiIvPjwvc3ZnPg%3D%3D)](https://openai.com)
+
+[![SemVer](https://img.shields.io/badge/semver-2.0.0-blue)](https://semver.org/)
+[![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
+[![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
+
+### Społeczność
+
+Pytania, opinie i wczesne wsparcie: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+
+Prosimy o zgłaszanie konkretnych błędów i propozycji nowych funkcji w **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**, aby nie zgubiły się na czacie.
+
+### Kontrola jakości społeczności
+
+Dziękujemy użytkownikom, którzy pomogli w testowaniu wersji 1.4.0 i 1.5.0 oraz zgłosili błędy:
+
+[@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
+
+### Część ekosystemu CodesWhat
+
+<table>
+  <tr><th>Narzędzie</th><th>Rola</th></tr>
+  <tr><td><b>drydock</b></td><td>Monitorowanie aktualizacji kontenera — interfejs WWW i silnik powiadomień</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/portwing"><b>portwing</b></a></td><td>Zdalny agent Docker — bezpieczny dostęp na poziomie gniazda z poziomu Drydock lub samodzielnego</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/sockguard"><b>sockguard</b></a></td><td>Serwer proxy gniazda Docker — domyślny filtr listy dozwolonych chroniący gniazdo</td></tr>
+</table>
+
+Te trzy narzędzia zaprojektowano z myślą o nakładaniu warstw: sockguard filtruje gniazdo, portwing udostępnia je zdalnie, a drydock monitoruje stan kontenera i oddziałuje na niego.
+
+Zobacz plik [portwing's COMPATIBILITY.md](https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md), aby zapoznać się z pełną matrycą kompatybilności wszystkich trzech narzędzi.
+
+---
+
+**[Licencja AGPL-3.0](LICENSE)**
+
+<a href="https://github.com/CodesWhat">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/codeswhat-logo-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/codeswhat-logo-original.svg" />
+    <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
+  </picture>
+</a>
+
+[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
+
+<a href="#drydock">Powrót do góry</a>
+
+</div>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,447 @@
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
+  <img src="docs/assets/whale-logo.png" alt="drydock" width="220">
+</picture>
+
+<h1>drydock</h1>
+
+**Observador de atualização de imagem de contêiner — 23 registros, 20 provedores de notificação e ação.**
+
+<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <strong>Português (Brasil)</strong></p>
+
+</div>
+
+<p align="center">
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.2-blue" alt="Version"></a>
+  <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
+  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
+  <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
+  <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+</p>
+
+<hr>
+
+> [!WARNING]
+> **Atualizando de uma versão mais antiga? Leia as notas de atualização primeiro.** Três correções de reforço de segurança enviadas pela primeira vez em **1.4.6** e executadas em toda a linha **1.5**, portanto, qualquer pessoa que atualizar de uma versão anterior a 1.4.6 será afetada, independentemente da versão em que chegar (1.4.6, qualquer 1.5.x ou posterior). Eles não são obsoletos e não têm período de carência: o OIDC agora requer `authorization_endpoint` nos metadados de descoberta do seu provedor, chaves de limitação de taxa não autenticadas no endereço de peer TCP (depósito compartilhado atrás de um proxy reverso) e URLs de proxy de acionamento HTTP devem usar `http(s)://`. Consulte **[UPGRADE-NOTES.md](UPGRADE-NOTES.md)** antes de atualizar.
+
+<h2 align="center">📑 Conteúdo</h2>
+
+- [📖 Documentação](https://getdrydock.com/docs)
+- [🚀 Início rápido](#quick-start)
+- [🆕 Atualizações recentes](#recent-updates)
+- [📸 Capturas de tela e demonstração ao vivo](#screenshots)
+- [🤔 Por que Drydock](#why-drydock)
+- [✨ Recursos](#features)
+- [🔌 Integrações suportadas](#supported-integrations)
+- [⚖️ Comparação de recursos](#feature-comparison)
+- [🔄 Migração](#migration)
+- [🗺️ Roteiro](#roadmap)
+- [⭐ História da estrela](#star-history)
+- [🔧 Construído com](#construído-com)
+- [🤝 Comunidade QA](#controle-de-qualidade-da-comunidade)
+
+<hr>
+
+<h2 align="center" id="quick-start">🚀 Início rápido</h2>
+
+**Recomendado: use um proxy de soquete** para restringir quais endpoints da API Docker que Drydock podem acessar. Isso evita dar ao contêiner acesso total ao soquete Docker.
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      socket-proxy:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=socket-proxy
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - CONTAINERS=1
+      - IMAGES=1
+      - EVENTS=1
+      - SERVICES=1
+      - INFO=1          # Required for daemon identity detection (notification prefixes)
+      # Add POST=1 and NETWORKS=1 for container actions and auto-updates
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+<details>
+<summary>Alternativa:<a href="https://github.com/CodesWhat/sockguard">sockguard</a>proxy de soquete</summary>
+
+[sockguard](https://github.com/CodesWhat/sockguard) é um filtro de soquete Docker de negação padrão do mesmo ecossistema CodesWhat, com uma predefinição criada para drydock:
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      sockguard:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=sockguard
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  sockguard:
+    image: codeswhat/sockguard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./sockguard.yaml:/etc/sockguard/config.yaml:ro
+    environment:
+      - SOCKGUARD_CONFIG_FILE=/etc/sockguard/config.yaml
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+Consulte a [predefinição sockguard de `app/configs/portwing.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing.yaml) para um `sockguard.yaml` inicial (a mesma predefinição portwing vem em seus próprios exemplos).
+
+</details>
+
+<details>
+<summary>Alternativa: início rápido com montagem direta em soquete</summary>
+
+```bash
+docker run -d \
+  --name drydock \
+  -p 3000:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e DD_AUTH_BASIC_ADMIN_USER=admin \
+  -e "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>" \
+  codeswhat/drydock:latest
+```
+
+> **Aviso:** O acesso direto ao soquete concede ao contêiner controle total sobre o daemon do Docker. Use a configuração do proxy de soquete acima para implantações de produção. Consulte o [Guia de segurança do soquete Docker](https://getdrydock.com/docs/configuration/watchers#docker-socket-security) para todas as opções, incluindo TLS remoto e Docker sem raiz.
+
+</details>
+
+> Gere um hash de senha (`argon2` CLI — instale através do seu gerenciador de pacotes):
+>
+> ```bash
+> echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
+> ```
+>
+> Ou com Node.js 24+ (sem necessidade de pacotes extras):
+>
+> ```bash
+> node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"
+> ```
+>
+> Drydock v1.6 aceita apenas hashes de autenticação básicos argon2id. `{SHA}` legado, `$apr1$`/`$1$`, `crypt` e hashes de texto simples são rejeitados; regenere-os antes de atualizar.
+> A autenticação é **exigida por padrão**. Consulte o [auth docs](https://getdrydock.com/docs/configuration/authentications) para OIDC, acesso anônimo e outras opções.
+> Para permitir explicitamente o acesso anônimo em novas instalações, defina `DD_ANONYMOUS_AUTH_CONFIRM=true`.
+
+A imagem inclui binários `trivy` e `cosign` para verificação de vulnerabilidade local e verificação de imagem.
+
+Consulte o [Guia de início rápido](https://getdrydock.com/docs/quickstart) para Docker Compose, segurança de soquete, proxy reverso e registros alternativos.
+
+<hr>
+
+<h2 align="center" id="recent-updates">🆕 Atualizações recentes</h2>
+
+<details open>
+<summary><strong>Destaques da v1.6.0-rc.2</strong></summary>
+
+- **Notificações** — Título e modelos de corpo por regra/por provedor com visualização ao vivo, além de categorias de sino no aplicativo apoiadas por auditoria e limites de gravidade de atualização.
+- **Painel** — Substituição de grade CSS de dependência zero com reordenação de mouse/toque, redimensionamento limitado, layouts responsivos, visibilidade de widget, redefinição e sincronização opcional de preferências entre dispositivos.
+- **Política de atualização** — Precedência declarativa do observador/rótulo/UI, trilha de auditoria de substituição/reversão, contagem regressiva de maturidade/substituição manual e visibilidade informativa de tag fixada com uma visualização de tag atual → mais recente empilhada.
+- **Desempenho e recuperação** — Desduplicação de lista de tags por enquete, projeções agregadas mais leves, grandes históricos de log virtualizados, rollover imutável de log ao vivo, tempo limite de inicialização de autenticação, migrações completas de preferências e autocorreção de pedaços obsoletos.
+- **Migrações v1.6 aplicadas** — Aliases de ambiente/rótulo WUD, formatos de autenticação herdados, switches de inspetor obsoletos, aliases de modelo, Kafka `clientId` e configurações públicas de Hub/DHI somente de token malformadas não são mais executadas. Os aliases da taxonomia do gatilho permanecem para uma versão final do aviso de nível de erro.
+
+Orientação completa sobre migração em [DEPRECATIONS.md](./DEPRECATIONS.md).
+
+</details>
+
+<details>
+<summary><strong>Destaques da v1.5.2</strong></summary>
+
+- **Política de atualização segura para recreação** — Portões de maturidade, tags/resumos ignorados e adiamentos agora sobrevivem à recriação de contêineres para cargas de trabalho de agentes locais e remotos.
+- **Confiabilidade da tag fixada** — Tags totalmente fixadas detectam recriações de resumo da mesma tag novamente, enquanto a IU pode mostrar uma tag da mesma família mais recente e não acionável sem alterar a atualização ou o comportamento do acionador.
+- **Recuperação de reversão** — Falha na criação de substituição, conexão de rede ou inicialização agora limpa o candidato antes de restaurar o contêiner original, e falhas repetidas não podem ser propagadas por meio de renomeações de reversão aninhadas.
+- **Recriação de contêineres mais segura** — Os endereços MAC atribuídos ao daemon não são mais fixados em substitutos, enquanto os endereços MAC da rede primária configurados explicitamente permanecem preservados.
+- **Pesquisa de imagem local mais silenciosa** — Imagens criadas ou carregadas localmente sem resumo do registro ignoram pesquisas remotas em vez de gerar erros de autorização recorrentes.
+
+Histórico completo em [CHANGELOG.md](./CHANGELOG.md).
+
+</details>
+
+<hr>
+
+<h2 align="center" id="screenshots">📸 Capturas de tela e demonstração ao vivo</h2>
+
+<p align="center">
+  <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
+</p>
+
+<p align="center"><em>Identifique uma atualização, veja exatamente o que muda e aplique-a. Backup, verificação de integridade e reversão tratados.</em></p>
+
+<table>
+<tr>
+<td width="50%" align="center"><strong>Luz</strong></td>
+<td width="50%" align="center"><strong>Escuro</strong></td>
+</tr>
+<tr>
+<td><img src="docs/assets/drydock-dashboard-light.png" alt="Dashboard Light"></td>
+<td><img src="docs/assets/drydock-dashboard-dark.png" alt="Dashboard Dark"></td>
+</tr>
+</table>
+
+<div align="center">
+
+**Por que olhar as capturas de tela quando você mesmo pode experimentar?**
+
+<a href="https://demo.getdrydock.com"><img src="https://img.shields.io/badge/Try_the_Live_Demo-4f46e5?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlnb24gcG9pbnRzPSI2IDMgMjAgMTIgNiAyMSA2IDMiLz48L3N2Zz4=&logoColor=white" alt="Try the Live Demo" height="36"></a>
+
+Totalmente interativo – UI real, dados simulados, sem necessidade de instalação. Funciona inteiramente no navegador.
+
+</div>
+
+<hr>
+
+<h2 align="center" id="why-drydock">🤔 Por que Drydock</h2>
+
+As imagens dos contêineres ficam desatualizadas silenciosamente. Uma imagem base corrige um CVE, um aplicativo corta uma versão, uma tag se move. A menos que você observe cada registro manualmente, seus contêineres em execução ficarão para trás até que algo quebre ou seja explorado.
+
+A maioria das ferramentas força uma compensação. Os atualizadores automáticos (Watchtower, Ouroboros) puxam e reiniciam com pouca visibilidade ou controle e agora não recebem manutenção. Os painéis (Portainer) gerenciam contêineres, mas não foram criados para inteligência de atualização. Drydock é **monitorar primeiro**: ele monitora 23 registros e informa exatamente o que mudou (principal, secundário, patch ou resumo) antes que algo aconteça, e então age apenas quando você permite. E vai além de qualquer um deles. A verificação de vulnerabilidades Trivy/Grype bloqueia atualizações inseguras, o cosign verifica assinaturas, os backups de imagem pré-atualização são revertidos automaticamente em caso de falha na verificação de integridade, os agentes distribuídos cobrem hosts remotos e 20 integrações de notificação e ação fecham o ciclo. O ciclo de vida completo da atualização, com uma UI web e uma API REST.
+
+<hr>
+
+<h2 align="center" id="features">✨ Recursos</h2>
+
+| | Recurso | Descrição |
+|---|---|---|
+| 🔭 | **Detecção que prioriza o monitoramento** | Observa cada contêiner em execução e classifica cada atualização disponível como principal, secundária, patch ou resumo antes que algo aconteça. Nada muda até que você diga. |
+| 📦 | **23 provedores de registro** | Docker Hub, GHCR, ECR, ACR, GCR, GAR, GitLab, Quay, Harbor, Artifactory, Nexus e mais 12. Público e privado, em nuvem e auto-hospedado, com TLS e autenticação por registro. |
+| 🔔 | **20 gatilhos** | 17 canais de notificação (Slack, Discord, Telegram, Teams, SMTP, MQTT, ntfy e mais) além de Docker, Docker Compose e ações de comando, com modelos por evento/provedor, visualização ao vivo, filtragem de limite e modo em lote. |
+| 🥊 | **Update Bouncer** | A verificação de vulnerabilidades Trivy/Grype bloqueia atualizações inseguras antes de serem implantadas, com verificação de assinatura de garantia e geração de SBOM (CycloneDX e SPDX). |
+| ↩️ | **Backup de imagem e reversão automática** | Instantâneos de imagem pré-atualizados com retenção configurável, reversão automática em caso de falha na verificação de integridade e reversão manual com um clique na interface do usuário. |
+| 🪝 | **Ganchos de ciclo de vida** | Comandos shell pré e pós-atualização por meio de rótulos de contêiner, com tempos limite por gancho e controle de aborto em caso de falha. |
+| 🗂️ | **Atualizações Docker Compose** | Extraia e recrie serviços do Compose por meio da API Docker Engine com patch de imagem com preservação de YAML. |
+| 🎛️ | **Política por contêiner** | As regras de tag Regex e o roteamento de gatilho usam rótulos `dd.*`; portas de maturidade, pular/adiar/fixar e janelas de manutenção são armazenadas via UI/API ou configuração do inspetor. |
+| 🛰️ | **Agentes Distribuídos** | Monitore hosts Docker remotos por SSE. Agentes de borda por trás da discagem NAT por WebSocket com autenticação de chave Ed25519, sem necessidade de porta de entrada (`DD_EXPERIMENTAL_PORTWING=true`). |
+| 🖥️ | **Painel Web** | UI Vue 3 com uma grade de widget personalizável de dependência zero, visualizações responsivas de tabela/cartão, atualizações SSE ao vivo, controles de sino de notificação e detalhes, registros e estatísticas por contêiner. |
+| 🔗 | **API REST e webhooks** | Endpoints autenticados por token para monitoramento de CI/CD e gatilhos de atualização, além de ingestão de webhook de registro assinado para eventos push. |
+| 🔐 | **Autenticação OIDC** | Proteja o painel com OpenID Connect (Authelia, Auth0, Authentik). Todos os fluxos de autenticação falham quando fechados por padrão. |
+| 📈 | **Métricas Prometheus** | Endpoint `/metrics` integrado com bypass de autenticação opcional para pilhas de monitoramento Prometheus e Grafana. |
+| 🌍 | **17 localidades da IU** | Sistema de tradução totalmente conectado com inglês completo e 16 localidades mantidas pela comunidade sincronizadas por meio de Crowdin, alternáveis ​​no Config. |
+| 🔒 | **ReDoS-Imune Regex** | Cada padrão de tag fornecido pelo usuário é compilado via re2js (uma porta RE2 JS pura) para correspondência de tempo linear que não pode ser interrompida por um padrão de retrocesso catastrófico. |
+
+<hr>
+
+<h2 align="center" id="supported-integrations">🔌 Integrações suportadas</h2>
+
+### 📦 Registros (23)
+
+Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Cais · LSCR · Porto · Artifactory · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Personalizado · DOCR · DHI · IBM Cloud · Oracle Cloud · Alibaba Cloud
+
+### ⚡ Ações (3)
+
+Docker · Docker Compose · Comando
+
+### 🔔 Notificações (17)
+
+Apprise · Discord · Google Chat · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
+
+### 🔐 Autenticação
+
+Anônimo (opt-in via `DD_ANONYMOUS_AUTH_CONFIRM=true`) · Básico (nome de usuário + hash de senha) · OIDC (Authelia, Auth0, Authentik). Todos os fluxos de autenticação falham quando fechados por padrão.
+
+### 🥊 Update Bouncer
+
+A verificação de vulnerabilidades com tecnologia Trivy ou Grype bloqueia atualizações inseguras antes de serem implantadas. Inclui verificação de assinatura de fiança e geração de SBOM (CycloneDX e SPDX).
+
+<hr>
+
+<h2 align="center" id="feature-comparison">⚖️ Comparação de recursos</h2>
+
+<details>
+<summary><strong>Como o drydock se compara a outras ferramentas de atualização de contêiner?</strong></summary>
+
+> ✅ = suportado &nbsp; ❌ = não suportado &nbsp; ⚠️ = parcial/limitado † = arquivado, não é mais mantido
+
+| Feature | drydock | WUD | Diun | *Watchtower †* | *Ouroboros †* |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Interface web / painel | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Atualização automática de contêineres | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Atualizações do Docker Compose | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Canais de gatilho / notificação | 20 | 16 | 17 | ~19 | ~6 |
+| Provedores de registro | 23 | 13 | ⚠️ | ⚠️ | ⚠️ |
+| Autenticação OIDC / SSO | ✅ | ✅ | ❌ | ❌ | ❌ |
+| API REST | ✅ | ✅ | ⚠️ | ⚠️ | ❌ |
+| Métricas do Prometheus | ✅ | ✅ | ❌ | ✅ | ✅ |
+| MQTT / Home Assistant | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Backup e reversão de imagens | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Agrupamento de contêineres / stacks | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| Hooks de ciclo de vida (pré/pós) | ✅ | ❌ | ❌ | ✅ | ❌ |
+| API de webhook para CI/CD | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Iniciar/parar/reiniciar/atualizar contêineres | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Agentes distribuídos (remotos) | ✅ | ❌ | ✅ | ⚠️ | ❌ |
+| Log de auditoria | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Verificação de segurança (Trivy/Grype) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Atualizações compatíveis com SemVer | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Monitoramento de digest | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Multi-arquitetura (amd64/arm64) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Visualizador de logs | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Mantido ativamente | ✅ | ✅ | ✅ | ❌ | ❌ |
+
+> Dados baseados em documentação publicamente disponível em março de 2026.
+> Contribuições são bem-vindas se alguma informação for imprecisa.
+
+</details>
+
+<hr>
+
+<h2 align="center" id="migration">🔄 Migração</h2>
+
+<details>
+<summary><strong>Migrando do WUD (E aí, Docker?)</strong></summary>
+
+Drydock v1.6 não carrega mais variáveis ​​de ambiente `WUD_*` ou rótulos `wud.*` em tempo de execução. Reescreva-os antes de iniciar o serviço atualizado; o estado persistido ainda migra automaticamente. Use `docker exec -it drydock node dist/index.js config migrate --dry-run` para visualizar e, em seguida, `docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml` para reescrever a configuração para a nomenclatura `DD_*` e `dd.*`.
+
+</details>
+
+<hr>
+
+<h2 align="center" id="roadmap">🗺️ Roteiro</h2>
+
+<details>
+<summary><strong>Temas e destaques da versão</strong></summary>
+
+Somente temas de alto nível — consulte [CHANGELOG.md](CHANGELOG.md) para obter detalhes por versão.
+
+| Versão | Tema | Destaques |
+| --- | --- | --- |
+| **v1.3.x** ✅ | Segurança e Estabilidade | Varredura Trivy, Update Bouncer, SBOM, 7 novos registros, 4 novos gatilhos, mecanismo regex re2js |
+| **v1.4.x** ✅ | Modernização e fortalecimento da UI | Tailwind 4 + componentes personalizados, 6 temas, paleta Cmd/K, OpenAPI 3.1, atualizações YAML nativas de composição, digitalização de slot duplo, proteção OIDC |
+| **v1.5.0** ✅ | Observabilidade e i18n | acionar divisão de taxonomia (`DD_ACTION_*`/`DD_NOTIFICATION_*`), visualizador de log WebSocket, personalização de painel, monitoramento de recursos, caixa de saída de notificação + DLQ, resumo de verificação de segurança, 17 localidades, repetição de ID de último evento SSE, discagem de agente de borda com autenticação Ed25519 (experimental, `DD_EXPERIMENTAL_PORTWING=true`) |
+| **v1.5.1** ✅ | Segurança e Manutenção | Correção pull-auth GCR/GAR, conclusão de TLS de registro (M-2), endurecimento de injeção env-var de gancho, suporte `DD_SESSION_SECRET__FILE`, redação de credencial de despejo de depuração, verificação de permissão de arquivo secreto, correção de deadlock de portão de maturidade, capacidade de tradução completa da UI + traduções da comunidade, portão de aplicação automática da janela de manutenção, exibição de tempo de atividade do contêiner, versão do software de superfície dividida de coluna Tag/Versão (rótulo OCI, com `dd.inspect.tag.path` gravação dupla + roteamento `dd.inspect.tag.version-only` opcional), correspondência de prefixo de montagem de composição opcional, modelo `${currentReleaseNotes}` var |
+| **v1.5.2** ✅ | Confiabilidade de políticas e tags fixadas | Retenção de política de maturidade/pular/suspender segura para recreação, detecção de reconstrução de resumo de tag fixada e insights informativos da mesma família, limpeza de candidato a reversão, prevenção de cascata de reversão, preservação de MAC explícito e comportamento de salto de registro de imagem local |
+| **v1.6.0** | Notificações, Política e Liberação Intel | Modelos de notificação por regra/por acionador com visualização ao vivo, preferências de sino de notificação, sincronização de preferências entre dispositivos, grade de painel personalizada de dependência zero ([#281](https://github.com/CodesWhat/drydock/issues/281)), política de atualização declarativa ([#320](https://github.com/CodesWhat/drydock/issues/320)), contagem regressiva de estabilização de maturidade + visibilidade imediata do candidato + substituição manual ([#406](https://github.com/CodesWhat/drydock/discussions/406)), painel de status de atualização acionável e global Modo de atualização `notify` / `manual` / `auto` ([#325](https://github.com/CodesWhat/drydock/discussions/325)), herança de política de tag de observador/imgset/container mais corrente empilhada → visibilidade de tag fixada mais recente ([#498](https://github.com/CodesWhat/drydock/issues/498)), fonte padronizada de 44px / notas de lançamento / ações de recurso de registro em tabela, cartões e detalhes ([#295](https://github.com/CodesWhat/drydock/discussions/295)), notificações de eventos de status de integridade ([#198](https://github.com/CodesWhat/drydock/discussions/198)), Home Assistant MQTT bidirecional, visualizações responsivas de tabela/lista de cartões, Trivy/Grype/ambas verificações em back-ends de comando ou de Docker-worker fixados, controles de extração/aquecimento de ativos do scanner, desduplicação off-heap Armazenamento SBOM, correção de varredura longa Trivy ([#490](https://github.com/CodesWhat/drydock/issues/490)), avisos de migração de taxonomia de gatilho, remoções de compatibilidade v1.6, higiene de documentos/API e conclusão de migração `/api` → `/api/v1` com um shim de compatibilidade wud-card/página inicial opcional (`DD_COMPAT_WUDCARD`). |
+| **v1.7.0** | Atualizações inteligentes e UX | Ordenação com reconhecimento de dependência ([#219](https://github.com/CodesWhat/drydock/discussions/219)), atualizações seletivas em massa ([#232](https://github.com/CodesWhat/drydock/discussions/232)), política de atualização por ação ([#511](https://github.com/CodesWhat/drydock/discussions/511)), remoção de imagem, monitoramento de imagem estática, indicador de maturidade de imagem, relógio unificado de maturidade/idade de atualização, links de porta clicáveis, atalhos de teclado, PWA, remoção de `DD_TRIGGER_*` (fim da janela de descontinuação da v1.5.0), curl removido da imagem |
+| **v1.8.0** | Gerenciamento de frota e configuração ao vivo | Configuração YAML, configuração de UI ao vivo, navegador de volume, atualizações paralelas, migração de armazenamento SQLite |
+| **v2.0+** | Expansão da plataforma e muito mais | Observadores Swarm/Kubernetes, GitOps, portas de saúde, implementações canary, terminal web, RBAC, chaves de API rotativas com escopo (tokens de portador estático para integrações HA/painel, [#469](https://github.com/CodesWhat/drydock/discussions/469)), LDAP/AD, provedor Podman nativo além da API compatível com Docker, CLI, imagem reforçada Wolfi, proxy de soquete |
+
+</details>
+
+<hr>
+
+<h2 align="center" id="documentation">📖 Documentação</h2>
+
+| Recurso | Ligação |
+| --- | --- |
+| Site | [getdrydock.com](https://getdrydock.com/) |
+| Demonstração ao vivo | [demo.getdrydock.com](https://demo.getdrydock.com) |
+| Documentos | [getdrydock.com/docs](https://getdrydock.com/docs) |
+| Configuração | [Configuração](https://getdrydock.com/docs/configuration) |
+| Início rápido | [Início rápido](https://getdrydock.com/docs/quickstart) |
+| Registro de alterações | [`CHANGELOG.md`](CHANGELOG.md) |
+| Depreciações | [`DEPRECATIONS.md`](DEPRECATIONS.md) |
+| Roteiro | Consulte a seção [Roteiro](#roadmap) acima |
+| Contribuindo | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Problemas | [Problemas do GitHub](https://github.com/CodesWhat/drydock/issues) |
+| Discussões | [Discussões no GitHub](https://github.com/CodesWhat/drydock/discussions) - solicitações de recursos e ideias são bem-vindas |
+
+<hr>
+
+<a id="star-history"></a>
+
+<div align="center">
+  <a href="https://star-history.com/#CodesWhat/drydock&Date">
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CodesWhat/drydock&type=Date" />
+  </a>
+</div>
+
+---
+
+<div align="center">
+
+### Construído com
+
+[![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
+[![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
+[![Express 5](https://img.shields.io/badge/Express_5-000?logo=express&logoColor=fff)](https://expressjs.com/)
+[![Vitest](https://img.shields.io/badge/Vitest_4-6E9F18?logo=vitest&logoColor=fff)](https://vitest.dev/)
+[![Biome](https://img.shields.io/badge/Biome_2.5-60a5fa?logo=biome&logoColor=fff)](https://biomejs.dev/)
+[![Node 24](https://img.shields.io/badge/Node_24_Alpine-339933?logo=nodedotjs&logoColor=fff)](https://nodejs.org/)
+[![Anthropic](https://img.shields.io/badge/Anthropic-CC785C?style=flat&logo=anthropic&logoColor=white)](https://claude.ai/)
+[![OpenAI](https://img.shields.io/badge/OpenAI-10A37F?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU%2BT3BlbkFJPC90aXRsZT48cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJNMjIuMjgxOSA5LjgyMTFhNS45ODQ3IDUuOTg0NyAwIDAgMC0uNTE1Ny00LjkxMDggNi4wNDYyIDYuMDQ2MiAwIDAgMC02LjUwOTgtMi45QTYuMDY1MSA2LjA2NTEgMCAwIDAgNC45ODA3IDQuMTgxOGE1Ljk4NDcgNS45ODQ3IDAgMCAwLTMuOTk3NyAyLjkgNi4wNDYyIDYuMDQ2MiAwIDAgMCAuNzQyNyA3LjA5NjYgNS45OCA1Ljk4IDAgMCAwIC41MTEgNC45MTA3IDYuMDUxIDYuMDUxIDAgMCAwIDYuNTE0NiAyLjkwMDFBNS45ODQ3IDUuOTg0NyAwIDAgMCAxMy4yNTk5IDI0YTYuMDU1NyA2LjA1NTcgMCAwIDAgNS43NzE4LTQuMjA1OCA1Ljk4OTQgNS45ODk0IDAgMCAwIDMuOTk3Ny0yLjkwMDEgNi4wNTU3IDYuMDU1NyAwIDAgMC0uNzQ3NS03LjA3Mjl6bS05LjAyMiAxMi42MDgxYTQuNDc1NSA0LjQ3NTUgMCAwIDEtMi44NzY0LTEuMDQwOGwuMTQxOS0uMDgwNCA0Ljc3ODMtMi43NTgyYS43OTQ4Ljc5NDggMCAwIDAgLjM5MjctLjY4MTN2LTYuNzM2OWwyLjAyIDEuMTY4NmEuMDcxLjA3MSAwIDAgMSAuMDM4LjA1MnY1LjU4MjZhNC41MDQgNC41MDQgMCAwIDEtNC40OTQ1IDQuNDk0NHptLTkuNjYwNy00LjEyNTRhNC40NzA4IDQuNDcwOCAwIDAgMS0uNTM0Ni0zLjAxMzdsLjE0Mi4wODUyIDQuNzgzIDIuNzU4MmEuNzcxMi43NzEyIDAgMCAwIC43ODA2IDBsNS44NDI4LTMuMzY4NXYyLjMzMjRhLjA4MDQuMDgwNCAwIDAgMS0uMDMzMi4wNjE1TDkuNzQgMTkuOTUwMmE0LjQ5OTIgNC40OTkyIDAgMCAxLTYuMTQwOC0xLjY0NjR6TTIuMzQwOCA3Ljg5NTZhNC40ODUgNC40ODUgMCAwIDEgMi4zNjU1LTEuOTcyOFYxMS42YS43NjY0Ljc2NjQgMCAwIDAgLjM4NzkuNjc2NWw1LjgxNDQgMy4zNTQzLTIuMDIwMSAxLjE2ODVhLjA3NTcuMDc1NyAwIDAgMS0uMDcxIDBsLTQuODMwMy0yLjc4NjVBNC41MDQgNC41MDQgMCAwIDEgMi4zNDA4IDcuODcyem0xNi41OTYzIDMuODU1OEwxMy4xMDM4IDguMzY0IDE1LjExOTIgNy4yYS4wNzU3LjA3NTcgMCAwIDEgLjA3MSAwbDQuODMwMyAyLjc5MTNhNC40OTQ0IDQuNDk0NCAwIDAgMS0uNjc2NSA4LjEwNDJ2LTUuNjc3MmEuNzkuNzkgMCAwIDAtLjQwNy0uNjY3em0yLjAxMDctMy4wMjMxbC0uMTQyLS4wODUyLTQuNzczNS0yLjc4MThhLjc3NTkuNzc1OSAwIDAgMC0uNzg1NCAwTDkuNDA5IDkuMjI5N1Y2Ljg5NzRhLjA2NjIuMDY2MiAwIDAgMSAuMDI4NC0uMDYxNWw0LjgzMDMtMi43ODY2YTQuNDk5MiA0LjQ5OTIgMCAwIDEgNi42ODAyIDQuNjZ6TTguMzA2NSAxMi44NjNsLTIuMDItMS4xNjM4YS4wODA0LjA4MDQgMCAwIDEtLjAzOC0uMDU2N1Y2LjA3NDJhNC40OTkyIDQuNDk5MiAwIDAgMSA3LjM3NTctMy40NTM3bC0uMTQyLjA4MDVMOC43MDQgNS40NTlhLjc5NDguNzk0OCAwIDAgMC0uMzkyNy42ODEzem0xLjA5NzYtMi4zNjU0bDIuNjAyLTEuNDk5OCAyLjYwNjkgMS40OTk4djIuOTk5NGwtMi41OTc0IDEuNDk5Ny0yLjYwNjctMS40OTk3WiIvPjwvc3ZnPg%3D%3D)](https://openai.com)
+
+[![SemVer](https://img.shields.io/badge/semver-2.0.0-blue)](https://semver.org/)
+[![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
+[![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
+
+### Comunidade
+
+Perguntas, comentários e suporte antecipado: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+
+Por favor, registre bugs concretos e solicitações de recursos em **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** para que eles não se percam no bate-papo.
+
+### Controle de qualidade da comunidade
+
+Obrigado aos usuários que ajudaram a testar os release candidate v1.4.0 e v1.5.0 e relataram bugs:
+
+[@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
+
+### Parte do ecossistema CodesWhat
+
+<table>
+  <tr><th>Ferramenta</th><th>Função</th></tr>
+  <tr><td><b>drydock</b></td><td>Monitoramento de atualização de contêiner — UI da web e mecanismo de notificação</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/portwing"><b>portwing</b></a></td><td>Agente Docker remoto – acesso seguro em nível de soquete de Drydock ou independente</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/sockguard"><b>sockguard</b></a></td><td>Proxy de soquete Docker – filtro de lista de permissões de negação padrão que protege o soquete</td></tr>
+</table>
+
+Essas três ferramentas são projetadas para serem colocadas em camadas: sockguard filtra o soquete, portwing o expõe remotamente e drydock monitora e atua no estado do contêiner.
+
+Consulte COMPATIBILITY.md](<https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md>) de [portwing para obter a matriz de compatibilidade completa entre todas as três ferramentas.
+
+---
+
+**[Licença AGPL-3.0](LICENSE)**
+
+<a href="https://github.com/CodesWhat">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/codeswhat-logo-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/codeswhat-logo-original.svg" />
+    <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
+  </picture>
+</a>
+
+[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
+
+<a href="#drydock">Voltar ao topo</a>
+
+</div>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -154,7 +154,7 @@ docker run -d \
 > echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
 > ```
 >
-> Ou com Node.js 24+ (sem necessidade de pacotes extras):
+> Ou com Node.js 24.7+ (sem necessidade de pacotes extras):
 >
 > ```bash
 > node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"
@@ -426,7 +426,7 @@ Obrigado aos usuários que ajudaram a testar os release candidate v1.4.0 e v1.5.
 
 Essas três ferramentas são projetadas para serem colocadas em camadas: sockguard filtra o soquete, portwing o expõe remotamente e drydock monitora e atua no estado do contêiner.
 
-Consulte COMPATIBILITY.md](<https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md>) de [portwing para obter a matriz de compatibilidade completa entre todas as três ferramentas.
+Consulte o [COMPATIBILITY.md do portwing](https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md) para obter a matriz de compatibilidade completa entre todas as três ferramentas.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,447 @@
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
+  <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
+  <img src="docs/assets/whale-logo.png" alt="drydock" width="220">
+</picture>
+
+<h1>drydock</h1>
+
+**容器镜像更新观察程序 — 23 个注册表、20 个通知和操作提供程序。**
+
+<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <strong>简体中文</strong> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
+</div>
+
+<p align="center">
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.2-blue" alt="Version"></a>
+  <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
+  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
+  <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <br>
+  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
+  <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+</p>
+
+<hr>
+
+> [!WARNING]
+> **从旧版本更新？首先阅读升级说明。** 三个安全强化修复程序首先在 **1.4.6** 中发布，并贯穿整个 **1.5** 系列，因此从早于 1.4.6 的版本进行更新的任何人都会受到影响，无论他们登陆的是哪个版本（1.4.6、任何 1.5.x 或更高版本）。它们不是弃用，也没有宽限期：OIDC 现在要求您的提供商的发现元数据中包含 `authorization_endpoint`，TCP 对等地址上未经身份验证的速率限制密钥（反向代理后面的共享存储桶），并且 HTTP 触发代理 URL 必须使用 `http(s)://`。更新前请参阅 **[UPGRADE-NOTES.md](UPGRADE-NOTES.md)**。
+
+<h2 align="center">📑 内容</h2>
+
+- [📖 文档](https://getdrydock.com/docs)
+- [🚀 快速入门](#quick-start)
+- [🆕 最近更新](#recent-updates)
+- [📸 屏幕截图和现场演示](#screenshots)
+- [🤔 为什么是 Drydock](#why-drydock)
+- [✨ 特点](#features)
+- [🔌支持的集成](#supported-integrations)
+- [⚖️功能比较](#feature-comparison)
+- [🔄迁移](#migration)
+- [🗺️路线图](#roadmap)
+- [⭐ 星史](#star-history)
+- [🔧 技术栈](#技术栈)
+- [🤝 社区 QA](#社区质量检查)
+
+<hr>
+
+<h2 align="center" id="quick-start">🚀 快速入门</h2>
+
+**推荐：使用套接字代理**来限制哪些 Docker API 端点 Drydock 可以访问。这可以避免容器完全访问 Docker 套接字。
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      socket-proxy:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=socket-proxy
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - CONTAINERS=1
+      - IMAGES=1
+      - EVENTS=1
+      - SERVICES=1
+      - INFO=1          # Required for daemon identity detection (notification prefixes)
+      # Add POST=1 and NETWORKS=1 for container actions and auto-updates
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+<details>
+<summary>替代方案：<a href="https://github.com/CodesWhat/sockguard">sockguard</a>套接字代理</summary>
+
+[sockguard](https://github.com/CodesWhat/sockguard) 是来自同一 CodesWhat 生态系统的默认拒绝 Docker 套接字过滤器，具有为 drydock 构建的预设：
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    depends_on:
+      sockguard:
+        condition: service_healthy
+    environment:
+      - DD_WATCHER_LOCAL_HOST=sockguard
+      - DD_WATCHER_LOCAL_PORT=2375
+      - DD_AUTH_BASIC_ADMIN_USER=admin
+      - "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>"
+    ports:
+      - 3000:3000
+
+  sockguard:
+    image: codeswhat/sockguard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./sockguard.yaml:/etc/sockguard/config.yaml:ro
+    environment:
+      - SOCKGUARD_CONFIG_FILE=/etc/sockguard/config.yaml
+    healthcheck:
+      test: wget --spider http://localhost:2375/version || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+```
+
+请参阅 sockguard 的 [`app/configs/portwing.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing.yaml) 预设，了解起始 `sockguard.yaml`（相同的预设 portwing 在其自己的示例中提供）。
+
+</details>
+
+<details>
+<summary>替代方案：通过直接插座安装快速启动</summary>
+
+```bash
+docker run -d \
+  --name drydock \
+  -p 3000:3000 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e DD_AUTH_BASIC_ADMIN_USER=admin \
+  -e "DD_AUTH_BASIC_ADMIN_HASH=<paste-argon2id-hash>" \
+  codeswhat/drydock:latest
+```
+
+> **警告：** 直接套接字访问授予容器对 Docker 守护进程的完全控制权。使用上面的套接字代理设置进行生产部署。请参阅 [Docker Socket 安全指南](https://getdrydock.com/docs/configuration/watchers#docker-socket-security) 了解所有选项，包括远程 TLS 和 rootless Docker。
+
+</details>
+
+> 生成密码哈希（`argon2` CLI — 通过包管理器安装）：
+>
+> ```bash
+> echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
+> ```
+>
+> 或者使用 Node.js 24+（不需要额外的包）：
+>
+> ```bash
+> node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"
+> ```
+>
+> Drydock v1.6 仅接受 argon2id 基本身份验证哈希值。旧版 `{SHA}`、`$apr1$`/`$1$`、`crypt` 和纯文本哈希被拒绝；在升级之前重新生成它们。
+> **默认情况下需要身份验证**。有关 OIDC、匿名访问和其他选项，请参阅 [auth docs](https://getdrydock.com/docs/configuration/authentications)。
+> 要明确允许全新安装的匿名访问，请设置 `DD_ANONYMOUS_AUTH_CONFIRM=true`。
+
+该镜像包含`trivy`和`cosign`二进制文件，用于本地漏洞扫描和镜像验证。
+
+有关 Docker Compose、套接字安全、反向代理和替代注册表，请参阅[快速入门指南](https://getdrydock.com/docs/quickstart)。
+
+<hr>
+
+<h2 align="center" id="recent-updates">🆕 最近更新</h2>
+
+<details open>
+<summary><strong>v1.6.0-rc.2亮点</strong></summary>
+
+- **通知** — 每个规则/每个提供商的标题和正文模板，带有实时预览，加上审计支持的应用内响铃类别和更新严重性阈值。
+- **仪表板** — 零依赖 CSS 网格替换为鼠标/触摸重新排序、有界调整大小、响应式布局、小部件可见性、重置和可选的跨设备首选项同步。
+- **更新策略** — 声明式观察程序/标签/UI 优先级、覆盖/恢复审核跟踪、到期倒计时/手动覆盖以及具有堆叠的当前→较新标签视图的固定标签信息可见性。
+- **性能和恢复** - 每次轮询标签列表重复数据删除、更轻的聚合预测、虚拟化大型日志历史、不可变的实时日志滚动、身份验证引导超时、完整的偏好迁移和陈旧块自我修复。
+- **强制执行 v1.6 迁移** — WUD 环境/标签别名、旧版身份验证格式、过时的观察程序开关、模板别名、Kafka `clientId` 和格式错误的仅令牌 Hub/DHI 公共配置不再运行。触发器分类别名保留用于最终错误级别警告版本。
+
+[DEPRECATIONS.md](./DEPRECATIONS.md) 中的完整迁移指南。
+
+</details>
+
+<details>
+<summary><strong>v1.5.2亮点</strong></summary>
+
+- **重新创建安全的更新策略** - 成熟度门、跳过的标签/摘要和暂停现在可以在本地和远程代理工作负载的容器重新创建中继续存在。
+- **固定标签可靠性** — 完全固定标签再次检测相同标签摘要重建，而 UI 可以显示不可操作的较新同系列标签，而无需更改更新或触发行为。
+- **回滚恢复** - 失败的替换创建、网络连接或启动现在会在恢复原始容器之前清除候选容器，并且重复的失败无法通过嵌套回滚重命名进行级联。
+- **更安全的容器重建** - 守护程序分配的 MAC 地址不再固定到替换上，而显式配置的主网络 MAC 地址仍然保留。
+- **更安静的本地图像轮询** — 本地构建或加载的图像没有注册表摘要，会跳过远程查找，而不是生成重复的授权错误。
+
+完整历史记录在 [CHANGELOG.md](./CHANGELOG.md)。
+
+</details>
+
+<hr>
+
+<h2 align="center" id="screenshots">📸 屏幕截图和现场演示</h2>
+
+<p align="center">
+  <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
+</p>
+
+<p align="center"><em>发现更新，查看到底发生了什么变化，然后应用它。处理备份、健康检查和回滚。</em></p>
+
+<table>
+<tr>
+<td width="50%" align="center"><strong>光</strong></td>
+<td width="50%" align="center"><strong>黑暗</strong></td>
+</tr>
+<tr>
+<td><img src="docs/assets/drydock-dashboard-light.png" alt="Dashboard Light"></td>
+<td><img src="docs/assets/drydock-dashboard-dark.png" alt="Dashboard Dark"></td>
+</tr>
+</table>
+
+<div align="center">
+
+**既然可以亲自体验，为什么还要看截图呢？**
+
+<a href="https://demo.getdrydock.com"><img src="https://img.shields.io/badge/Try_the_Live_Demo-4f46e5?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlnb24gcG9pbnRzPSI2IDMgMjAgMTIgNiAyMSA2IDMiLz48L3N2Zz4=&logoColor=white" alt="Try the Live Demo" height="36"></a>
+
+完全交互——真实的用户界面，模拟数据，无需安装。完全在浏览器中运行。
+
+</div>
+
+<hr>
+
+<h2 align="center" id="why-drydock">🤔 为什么是Drydock</h2>
+
+容器镜像悄然过时。基础镜像修补 CVE、应用程序剪切版本、标签移动。除非您手动监视每个注册表，否则正在运行的容器会落后，直到出现问题或被利用。
+
+大多数工具都会迫使人们做出权衡。自动更新程序（Watchtower、Ouroboros）在几乎没有可见性或控制的情况下拉取并重新启动，并且现在基本上不再维护。仪表板 (Portainer) 管理容器，但不是为更新智能而构建的。 Drydock 是**监控优先**：它会监控 23 个注册表，并在发生任何事情之前准确地告诉您发生了什么变化（主要、次要、补丁或摘要），然后仅在您允许时才采取行动。它比他们中的任何一个都走得更远。 Trivy/Grype 漏洞扫描阻止不安全更新，共同签名验证签名，更新前映像备份在运行状况检查失败时自动回滚，分布式代理覆盖远程主机，20 个通知和操作集成形成闭环。完整的更新生命周期，带有 Web UI 和 REST API。
+
+<hr>
+
+<h2 align="center" id="features">✨ 特点</h2>
+
+| |特色|描述 |
+|---|---|---|
+| 🔭 | **监控优先检测** |监视每个正在运行的容器，并在发生任何情况之前将每个可用更新分类为主要、次要、补丁或摘要。除非你这么说，否则一切都不会改变。 |
+| 📦 | **23 家注册提供商** | Docker Hub、GHCR、ECR、ACR、GCR、GAR、GitLab、Quay、Harbor、Artifactory、Nexus 等 12 个。公共和私有、云和自托管，具有每个注册表 TLS 和身份验证。 |
+| 🔔 | **20 个触发器** | 17 个通知通道（Slack、Discord、Telegram、Teams、SMTP、MQTT、ntfy 等）以及 Docker、Docker Compose 和命令操作，具有每个事件/提供商模板、实时预览、阈值过滤和批处理模式。 |
+| 🥊 | **Update Bouncer** | Trivy/Grype 漏洞扫描可在部署之前阻止不安全的更新，并具有联合签名验证和 SBOM 生成功能（CycloneDX 和 SPDX）。 |
+| ↩️ | **镜像备份和自动回滚** |预更新映像快照，具有可配置的保留、运行状况检查失败时自动回滚以及从 UI 中一键手动回滚。 |
+| 🪝 | **生命周期挂钩** |通过容器标签执行更新前和更新后的 shell 命令，并具有每个钩子超时和失败时中止控制。 |
+| 🗂️ | **Docker Compose 更新** |通过 Docker Engine API 以及保留 YAML 的映像修补来拉取并重新创建 Compose 服务。 |
+| 🎛️ | **每个容器的政策** |正则表达式标签规则和触发路由使用`dd.*`标签；成熟度门、跳过/暂停/固定和维护窗口通过 UI/API 或观察者配置存储。 |
+| 🛰️ | **分布式代理** |通过 SSE 监控远程 Docker 主机。 NAT 后面的边缘代理使用 Ed25519 密钥身份验证通过 WebSocket 拨出，无需入站端口 (`DD_EXPERIMENTAL_PORTWING=true`)。 |
+| 🖥️ | **网络仪表板** | Vue 3 UI 具有零依赖可定制小部件网格、响应式表格/卡片视图、实时 SSE 更新、通知铃控件以及每个容器的详细信息、日志和统计信息。 |
+| 🔗 | **REST API 和 Webhook** |用于 CI/CD 监视和更新触发器的令牌身份验证端点，以及用于推送事件的签名注册表 Webhook 摄取。 |
+| 🔐 | **OIDC 身份验证** |使用 OpenID Connect（Authelia、Auth0、Authentik）保护仪表板。默认情况下，所有身份验证流程都会失败关闭。 |
+| 📈 | **Prometheus 指标** |内置 `/metrics` 端点，具有适用于 Prometheus 和 Grafana 监控堆栈的可选身份验证旁路。 |
+| 🌍 | **17 个 UI 语言环境** |全有线翻译系统，具有完整的英语和 16 个社区维护的语言环境，通过 Crowdin 同步，可在 Config 中切换。 |
+| 🔒 | **ReDoS-免疫正则表达式** |每个用户提供的标签模式都通过 re2js（纯 JS RE2 端口）进行编译，以实现线性时间匹配，不会因灾难性回溯模式而停止。 |
+
+<hr>
+
+<h2 align="center" id="supported-integrations">🔌 支持的集成</h2>
+
+### 📦 注册表 (23)
+
+Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Quay · LSCR · Harbor · Artifactory · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Custom · DOCR · DHI · IBM Cloud · Oracle Cloud · 阿里云
+
+### ⚡ 行动 (3)
+
+Docker·Docker Compose·命令
+
+### 🔔 通知 (17)
+
+Apprise · Discord · Google Chat · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
+
+### 🔐 身份验证
+
+匿名（通过 `DD_ANONYMOUS_AUTH_CONFIRM=true` 选择加入） · 基本（用户名 + 密码哈希） · OIDC（Authelia、Auth0、Authentik）。默认情况下，所有身份验证流程都会失败关闭。
+
+### 🥊Update Bouncer
+
+Trivy 或 Grype 支持的漏洞扫描会在部署之前阻止不安全的更新。包括联合签名验证和 SBOM 生成（CycloneDX 和 SPDX）。
+
+<hr>
+
+<h2 align="center" id="feature-comparison">⚖️功能比较</h2>
+
+<details>
+<summary><strong>drydock 与其他容器更新工具相比如何？</strong></summary>
+
+> ✅ = 支持❌ = 不支持⚠️ = 部分/有限 &nbsp; † = 已存档，不再维护
+
+| Feature | drydock | WUD | Diun | *Watchtower †* | *Ouroboros †* |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Web 界面 / 仪表盘 | ✅ | ✅ | ❌ | ❌ | ❌ |
+| 自动更新容器 | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Docker Compose 更新 | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| 触发器 / 通知渠道 | 20 | 16 | 17 | ~19 | ~6 |
+| 镜像仓库提供商 | 23 | 13 | ⚠️ | ⚠️ | ⚠️ |
+| OIDC / SSO 身份验证 | ✅ | ✅ | ❌ | ❌ | ❌ |
+| REST API | ✅ | ✅ | ⚠️ | ⚠️ | ❌ |
+| Prometheus 指标 | ✅ | ✅ | ❌ | ✅ | ✅ |
+| MQTT / Home Assistant | ✅ | ✅ | ✅ | ❌ | ❌ |
+| 镜像备份与回滚 | ✅ | ❌ | ❌ | ❌ | ❌ |
+| 容器分组 / 堆栈 | ✅ | ✅ | ❌ | ⚠️ | ❌ |
+| 生命周期钩子（更新前/后） | ✅ | ❌ | ❌ | ✅ | ❌ |
+| 用于 CI/CD 的 Webhook API | ✅ | ❌ | ❌ | ✅ | ❌ |
+| 启动/停止/重启/更新容器 | ✅ | ❌ | ❌ | ❌ | ❌ |
+| 分布式代理（远程） | ✅ | ❌ | ✅ | ⚠️ | ❌ |
+| 审计日志 | ✅ | ❌ | ❌ | ❌ | ❌ |
+| 安全扫描（Trivy/Grype） | ✅ | ❌ | ❌ | ❌ | ❌ |
+| 支持 SemVer 的更新 | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Digest 监控 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 多架构（amd64/arm64） | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 容器日志查看器 | ✅ | ❌ | ❌ | ❌ | ❌ |
+| 积极维护 | ✅ | ✅ | ✅ | ❌ | ❌ |
+
+> 数据基于截至 2026 年 3 月的公开文档。
+> 如果有任何信息不准确，欢迎贡献。
+
+</details>
+
+<hr>
+
+<h2 align="center" id="migration">🔄 迁移</h2>
+
+<details>
+<summary><strong>从 WUD 迁移（Docker 怎么样？）</strong></summary>
+
+Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。在启动升级服务之前重写它们；持久状态仍然会自动迁移。使用`docker exec -it drydock node dist/index.js config migrate --dry-run`进行预览，然后使用`docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml`将配置重写为`DD_*`和`dd.*`命名。
+
+</details>
+
+<hr>
+
+<h2 align="center" id="roadmap">🗺️路线图</h2>
+
+<details>
+<summary><strong>版本主题及亮点</strong></summary>
+
+仅高级主题 - 请参阅 [CHANGELOG.md](CHANGELOG.md) 了解每个版本的详细信息。
+
+|版本 |主题 |亮点|
+| --- | --- | --- |
+| **v1.3.x** ✅ |安全稳定 | Trivy 扫描、Update Bouncer、SBOM、7 个新注册表、4 个新触发器、re2js 正则表达式引擎 |
+| **v1.4.x** ✅ | UI 现代化和强化 | Tailwind 4 + 自定义组件、6 个主题、Cmd/K 调色板、OpenAPI 3.1、撰写原生 YAML 更新、双槽扫描、OIDC 强化 |
+| **v1.5.0** ✅ |可观察性和 i18n |触发分类拆分 (`DD_ACTION_*`/`DD_NOTIFICATION_*`)、WebSocket 日志查看器、仪表板自定义、资源监控、通知发件箱 + DLQ、安全扫描摘要、17 个区域设置、SSE 最后事件 ID 重播、使用 Ed25519 身份验证的边缘代理拨出（实验性、`DD_EXPERIMENTAL_PORTWING=true`）|
+| **v1.5.1** ✅ |安全与维护| GCR/GAR pull-auth 修复、注册表 TLS 完成 (M-2)、hook env-var 注入强化、`DD_SESSION_SECRET__FILE` 支持、调试转储凭据编辑、机密文件权限检查、成熟度门死锁修复、完整 UI 可翻译性 + 社区翻译、维护窗口自动应用门、容器正常运行时间显示、标签/版本列分割显示软件版本（OCI 标签，带有 `dd.inspect.tag.path`双写 + 选择加入 `dd.inspect.tag.version-only` 路由），选择加入 compose 挂载前缀匹配，`${currentReleaseNotes}` 模板变量 |
+| **v1.5.2** ✅ |政策和固定标签可靠性 |娱乐安全成熟度/跳过/暂停策略保留、固定标签摘要重建检测和信息同族洞察、回滚候选清理、回滚级联预防、显式 MAC 保存和本地映像注册表跳过行为 |
+| **v1.6.0** |通知、政策和发布 英特尔 |每规则/每触发器通知模板，具有实时预览、通知铃声首选项、跨设备首选项同步、零依赖自定义仪表板网格 ([#281](https://github.com/CodesWhat/drydock/issues/281))、声明性更新策略 ([#320](https://github.com/CodesWhat/drydock/issues/320))、成熟稳定倒计时 + 即时候选人可见性 + 手动覆盖 ([#406](https://github.com/CodesWhat/drydock/discussions/406))、可操作更新状态面板和全局`notify` / `manual` / `auto` 更新模式 ([#325](https://github.com/CodesWhat/drydock/discussions/325))、观察者/imgset/容器标签策略继承以及堆叠当前 → 较新的固定标签可见性 ([#498](https://github.com/CodesWhat/drydock/issues/498))、标准化 44px 跨表、卡片和详细信息的源/发行说明/注册表资源操作([#295](https://github.com/CodesWhat/drydock/discussions/295))、运行状况事件通知 ([#198](https://github.com/CodesWhat/drydock/discussions/198))、双向 Home Assistant MQTT、响应式表/卡列表视图、Trivy/Grype/跨命令或固定 Docker-worker 后端扫描、扫描器资产拉取/热控制、堆外重复数据删除SBOM 存储、Trivy 长扫描正确性 ([#490](https://github.com/CodesWhat/drydock/issues/490))、触发分类迁移警告、v1.6 兼容性删除、文档/API 卫生以及 `/api` → `/api/v1` 迁移完成，并选择加入 wud-card/Homepage 兼容性填充程序 (`DD_COMPAT_WUDCARD`)。 |
+| **v1.7.0** |智能更新和用户体验 |依赖性感知排序（[#219](https://github.com/CodesWhat/drydock/discussions/219)）、选择性批量更新（[#232](https://github.com/CodesWhat/drydock/discussions/232)）、每次操作更新策略（[#511](https://github.com/CodesWhat/drydock/discussions/511)）、图像修剪、静态图像监控、图像成熟度指示器、统一的成熟度/更新时间时钟、可点击端口链接、键盘快捷键、PWA、`DD_TRIGGER_*` 删除（v1.5.0 弃用窗口结束），从图像中删除了curl |
+| **v1.8.0** |车队管理和实时配置 | YAML 配置、实时 UI 配置、卷浏览器、并行更新、SQLite 存储迁移 |
+| **v2.0+** |平台扩展及其他 | Swarm/Kubernetes 观察者、GitOps、健康门、金丝雀部署、Web 终端、RBAC、作用域可旋转 API 密钥（用于 HA/仪表板集成的静态承载令牌，[#469](https://github.com/CodesWhat/drydock/discussions/469)）、LDAP/AD、超越 Docker 兼容 API 的本机 Podman 提供程序、CLI、Wolfi 强化映像、套接字代理 |
+
+</details>
+
+<hr>
+
+<h2 align="center" id="documentation">📖 文档</h2>
+
+|资源 |链接 |
+| --- | --- |
+|网站 | [获取drydock.com](https://getdrydock.com/) |
+|现场演示 | [demo.getdrydock.com](https://demo.getdrydock.com) |
+|文档 | [getdrydock.com/docs](https://getdrydock.com/docs) |
+|配置| [配置](https://getdrydock.com/docs/configuration) |
+|快速入门 | [快速入门](https://getdrydock.com/docs/quickstart) |
+|更新日志 | [`CHANGELOG.md`](CHANGELOG.md) |
+|弃用 | [`DEPRECATIONS.md`](DEPRECATIONS.md) |
+|路线图 |请参阅上面的[路线图](#roadmap) 部分|
+|贡献 | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+|问题 | [GitHub 问题](https://github.com/CodesWhat/drydock/issues) |
+|讨论 | [GitHub 讨论](https://github.com/CodesWhat/drydock/discussions) — 欢迎功能请求和想法 |
+
+<hr>
+
+<a id="star-history"></a>
+
+<div align="center">
+  <a href="https://star-history.com/#CodesWhat/drydock&Date">
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CodesWhat/drydock&type=Date" />
+  </a>
+</div>
+
+---
+
+<div align="center">
+
+### 技术栈
+
+[![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
+[![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
+[![Express 5](https://img.shields.io/badge/Express_5-000?logo=express&logoColor=fff)](https://expressjs.com/)
+[![Vitest](https://img.shields.io/badge/Vitest_4-6E9F18?logo=vitest&logoColor=fff)](https://vitest.dev/)
+[![Biome](https://img.shields.io/badge/Biome_2.5-60a5fa?logo=biome&logoColor=fff)](https://biomejs.dev/)
+[![Node 24](https://img.shields.io/badge/Node_24_Alpine-339933?logo=nodedotjs&logoColor=fff)](https://nodejs.org/)
+[![Anthropic](https://img.shields.io/badge/Anthropic-CC785C?style=flat&logo=anthropic&logoColor=white)](https://claude.ai/)
+[![OpenAI](https://img.shields.io/badge/OpenAI-10A37F?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAyNCAyNCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU%2BT3BlbkFJPC90aXRsZT48cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJNMjIuMjgxOSA5LjgyMTFhNS45ODQ3IDUuOTg0NyAwIDAgMC0uNTE1Ny00LjkxMDggNi4wNDYyIDYuMDQ2MiAwIDAgMC02LjUwOTgtMi45QTYuMDY1MSA2LjA2NTEgMCAwIDAgNC45ODA3IDQuMTgxOGE1Ljk4NDcgNS45ODQ3IDAgMCAwLTMuOTk3NyAyLjkgNi4wNDYyIDYuMDQ2MiAwIDAgMCAuNzQyNyA3LjA5NjYgNS45OCA1Ljk4IDAgMCAwIC41MTEgNC45MTA3IDYuMDUxIDYuMDUxIDAgMCAwIDYuNTE0NiAyLjkwMDFBNS45ODQ3IDUuOTg0NyAwIDAgMCAxMy4yNTk5IDI0YTYuMDU1NyA2LjA1NTcgMCAwIDAgNS43NzE4LTQuMjA1OCA1Ljk4OTQgNS45ODk0IDAgMCAwIDMuOTk3Ny0yLjkwMDEgNi4wNTU3IDYuMDU1NyAwIDAgMC0uNzQ3NS03LjA3Mjl6bS05LjAyMiAxMi42MDgxYTQuNDc1NSA0LjQ3NTUgMCAwIDEtMi44NzY0LTEuMDQwOGwuMTQxOS0uMDgwNCA0Ljc3ODMtMi43NTgyYS43OTQ4Ljc5NDggMCAwIDAgLjM5MjctLjY4MTN2LTYuNzM2OWwyLjAyIDEuMTY4NmEuMDcxLjA3MSAwIDAgMSAuMDM4LjA1MnY1LjU4MjZhNC41MDQgNC41MDQgMCAwIDEtNC40OTQ1IDQuNDk0NHptLTkuNjYwNy00LjEyNTRhNC40NzA4IDQuNDcwOCAwIDAgMS0uNTM0Ni0zLjAxMzdsLjE0Mi4wODUyIDQuNzgzIDIuNzU4MmEuNzcxMi43NzEyIDAgMCAwIC43ODA2IDBsNS44NDI4LTMuMzY4NXYyLjMzMjRhLjA4MDQuMDgwNCAwIDAgMS0uMDMzMi4wNjE1TDkuNzQgMTkuOTUwMmE0LjQ5OTIgNC40OTkyIDAgMCAxLTYuMTQwOC0xLjY0NjR6TTIuMzQwOCA3Ljg5NTZhNC40ODUgNC40ODUgMCAwIDEgMi4zNjU1LTEuOTcyOFYxMS42YS43NjY0Ljc2NjQgMCAwIDAgLjM4NzkuNjc2NWw1LjgxNDQgMy4zNTQzLTIuMDIwMSAxLjE2ODVhLjA3NTcuMDc1NyAwIDAgMS0uMDcxIDBsLTQuODMwMy0yLjc4NjVBNC41MDQgNC41MDQgMCAwIDEgMi4zNDA4IDcuODcyem0xNi41OTYzIDMuODU1OEwxMy4xMDM4IDguMzY0IDE1LjExOTIgNy4yYS4wNzU3LjA3NTcgMCAwIDEgLjA3MSAwbDQuODMwMyAyLjc5MTNhNC40OTQ0IDQuNDk0NCAwIDAgMS0uNjc2NSA4LjEwNDJ2LTUuNjc3MmEuNzkuNzkgMCAwIDAtLjQwNy0uNjY3em0yLjAxMDctMy4wMjMxbC0uMTQyLS4wODUyLTQuNzczNS0yLjc4MThhLjc3NTkuNzc1OSAwIDAgMC0uNzg1NCAwTDkuNDA5IDkuMjI5N1Y2Ljg5NzRhLjA2NjIuMDY2MiAwIDAgMSAuMDI4NC0uMDYxNWw0LjgzMDMtMi43ODY2YTQuNDk5MiA0LjQ5OTIgMCAwIDEgNi42ODAyIDQuNjZ6TTguMzA2NSAxMi44NjNsLTIuMDItMS4xNjM4YS4wODA0LjA4MDQgMCAwIDEtLjAzOC0uMDU2N1Y2LjA3NDJhNC40OTkyIDQuNDk5MiAwIDAgMSA3LjM3NTctMy40NTM3bC0uMTQyLjA4MDVMOC43MDQgNS40NTlhLjc5NDguNzk0OCAwIDAgMC0uMzkyNy42ODEzem0xLjA5NzYtMi4zNjU0bDIuNjAyLTEuNDk5OCAyLjYwNjkgMS40OTk4djIuOTk5NGwtMi41OTc0IDEuNDk5Ny0yLjYwNjctMS40OTk3WiIvPjwvc3ZnPg%3D%3D)](https://openai.com)
+
+[![SemVer](https://img.shields.io/badge/semver-2.0.0-blue)](https://semver.org/)
+[![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
+[![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
+
+### 社区
+
+问题、反馈和早期支持：**[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+
+请在 **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** 中提交具体的错误和功能请求，这样他们就不会在聊天中迷失方向。
+
+### 社区质量检查
+
+感谢帮助测试 v1.4.0 和 v1.5.0 候选版本并报告错误的用户：
+
+[@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
+
+### CodesWhat 生态系统的一部分
+
+<table>
+  <tr><th>工具</th><th>角色</th></tr>
+  <tr><td><b>drydock</b></td><td>容器更新监控——Web UI 和通知引擎</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/portwing"><b>portwing</b></a></td><td>远程 Docker 代理 — 从 Drydock 或独立的安全套接字级访问</td></tr>
+  <tr><td><a href="https://github.com/CodesWhat/sockguard"><b>sockguard</b></a></td><td>Docker 套接字代理 — 默认拒绝白名单过滤器保护套接字</td></tr>
+</table>
+
+这三个工具旨在分层：sockguard 过滤套接字，portwing 远程公开它，drydock 监视容器状态并对其进行操作。
+
+请参阅 [portwing 的 COMPATIBILITY.md](https://github.com/CodesWhat/portwing/blob/main/COMPATIBILITY.md)，了解所有三种工具的完整兼容性矩阵。
+
+---
+
+**[AGPL-3.0 许可证](LICENSE)**
+
+<a href="https://github.com/CodesWhat">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/codeswhat-logo-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="docs/assets/codeswhat-logo-original.svg" />
+    <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
+  </picture>
+</a>
+
+[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
+
+<a href="#drydock">返回顶部</a>
+
+</div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,7 +154,7 @@ docker run -d \
 > echo -n "yourpassword" | argon2 $(openssl rand -base64 32) -id -m 16 -t 3 -p 4 -l 64 -e
 > ```
 >
-> 或者使用 Node.js 24+（不需要额外的包）：
+> 或者使用 Node.js 24.7+（不需要额外的包）：
 >
 > ```bash
 > node -e 'const c=require("node:crypto");const s=c.randomBytes(32);const h=c.argon2Sync("argon2id",{message:process.argv[1],nonce:s,memory:65536,passes:3,parallelism:4,tagLength:64});console.log("argon2id$65536$3$4$"+s.toString("base64")+"$"+h.toString("base64"));' "yourpassword"


### PR DESCRIPTION
Full-document README translations in six community locales, plus a language switcher bar under the English tagline.

- Translations synced with the rc.2 copy audit before landing: 150K+ pulls badge, Biome 2.5, exact 20-provider tagline, and the unified maturity/update-age clock item in each v1.7 roadmap row
- TOC anchors repaired where translated headings changed the slug (the section `<h2 id>` anchors keep the English ids, so deep links stay stable)
- Fixed translation artifacts: a mangled German quick-links table row, a malformed French TOC bullet, and a garbled Chinese Built-With entry (now 技术栈), plus a broken parenthesis pair in the Chinese roadmap row
- markdownlint clean (formatting, MD051 fragments, MD012)

Crowdin registration for README round-tripping is deliberately not included; it lands separately once the Crowdin project is seeded with these files so a sync can't overwrite them with source text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added full-document README translations in Spanish, Polish, Simplified Chinese, German, French, and Brazilian Portuguese (including rc.2 copy-audit updates like pulls badge, Biome version, provider tagline, and v1.7 roadmap wording).
- ✨ Added a language switcher beneath the English tagline and linked it to localized README variants.
- 🔧 Preserved stable English section anchors across translated documents.
- 🔧 Updated translation content to reflect Node.js **24.7+** requirement for `crypto.argon2Sync` and corrected translation compatibility/format artifacts (malformed compatibility links, French TOC bullets, French “See More” artifact, German list marker, Spanish `DEPRECATIONS.md` link text, and Markdown lint issues).
- 🔒 Expanded translated security/upgrade guidance (auth/hash constraints incl. **argon2id-only**, OIDC/metadata and proxy/rate-limit requirements, and Docker socket-access warnings with socket-proxy/sockguard vs direct mounts).
- 🔧 Updated auth/tagline/roadmap text and various documentation sections (highlights, feature comparisons, migration from WUD, roadmap tables, and documentation link index).

## Concerns

- Crowdin registration is intentionally excluded and should be added separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->