### PR TITLE
🐛 fix(store): only restart the maturity clock when the update candidate identity changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Manual recheck no longer restarts the maturity countdown on display-only metadata drift** ([#565](https://github.com/CodesWhat/drydock/issues/565)). A per-container recheck bypasses the registry poll cache, so the suggested tag and image created date can wobble between scans even when the update candidate itself hasn't changed, falsely resetting the soak. The lifecycle clock now restarts only when the candidate's actual identity — tag or digest — changes; suggested tag and created date no longer factor into the restart decision.
+
 ### Security
 
 - **Anonymous access now fails closed on upgrades, not just fresh installs.** An instance with no authentication configured — or with anonymous auth enabled but unconfirmed — refuses to start instead of logging a warning and serving an open dashboard. If you run an intentionally open instance, set `DD_ANONYMOUS_AUTH_CONFIRM=true`; otherwise configure `DD_AUTH_BASIC_<name>_USER`/`_HASH` before upgrading.

--- a/app/model/container.test.ts
+++ b/app/model/container.test.ts
@@ -520,6 +520,55 @@ test('testable_resultChangedFunction should compare created timestamps and handl
   ).toBe(true);
 });
 
+test('hasCandidateIdentityChanged should compare only tag and digest, ignoring display metadata', () => {
+  expect(container.hasCandidateIdentityChanged(undefined, undefined)).toBe(false);
+  expect(
+    container.hasCandidateIdentityChanged(undefined, {
+      tag: '1.0.0',
+      digest: 'sha256:current',
+    }),
+  ).toBe(true);
+  expect(
+    container.hasCandidateIdentityChanged(
+      {
+        tag: '1.0.0',
+        digest: 'sha256:current',
+      },
+      undefined,
+    ),
+  ).toBe(true);
+
+  const currentResult = {
+    tag: '1.0.0',
+    suggestedTag: '1.0.1',
+    digest: 'sha256:current',
+    created: '2024-01-01T00:00:00.000Z',
+  };
+
+  expect(container.hasCandidateIdentityChanged(currentResult, { ...currentResult })).toBe(false);
+  expect(
+    container.hasCandidateIdentityChanged(currentResult, {
+      ...currentResult,
+      tag: '2.0.0',
+    }),
+  ).toBe(true);
+  expect(
+    container.hasCandidateIdentityChanged(currentResult, {
+      ...currentResult,
+      digest: 'sha256:other',
+    }),
+  ).toBe(true);
+  // suggestedTag and created are display-only metadata and must not count as
+  // a candidate identity change.
+  expect(
+    container.hasCandidateIdentityChanged(currentResult, {
+      ...currentResult,
+      suggestedTag: '1.0.2',
+      created: '2024-02-01T00:00:00.000Z',
+    }),
+  ).toBe(false);
+});
+
 test('model should be validated when compliant', async () => {
   const containerValidated = container.validate({
     id: 'container-123456789',

--- a/app/model/container.ts
+++ b/app/model/container.ts
@@ -901,6 +901,23 @@ function hasResultChanged(
   );
 }
 
+/**
+ * Check whether the update candidate's identity changed, i.e. the tag or
+ * digest a recheck would actually promote. Unlike hasResultChanged, this
+ * ignores display-only metadata (suggestedTag, created) that can wobble
+ * between scans without the candidate itself changing, so callers that gate
+ * the maturity clock restart on this don't falsely reset it.
+ * @param currentResult
+ * @param otherResult
+ * @returns {boolean}
+ */
+export function hasCandidateIdentityChanged(
+  currentResult: Container['result'],
+  otherResult: Container['result'],
+): boolean {
+  return currentResult?.tag !== otherResult?.tag || currentResult?.digest !== otherResult?.digest;
+}
+
 function resultChangedFunction(this: Container, otherContainer: Container | undefined) {
   return otherContainer === undefined || hasResultChanged(this.result, otherContainer.result);
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3714,9 +3714,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -1207,6 +1207,172 @@ test('updateContainer should reset firstSeenAt when candidate update changes mid
   }
 });
 
+test('updateContainer should preserve updateDetectedAt when a recheck only changes display metadata (suggestedTag/created) (#565)', async () => {
+  // A manual per-container recheck bypasses the registry poll cache, so
+  // suggestedTag and created can wobble between scans even when the actual
+  // candidate (tag + digest) hasn't changed. That must not restart the
+  // maturity soak.
+  const existingDetectedAt = '2026-02-20T09:15:00.000Z';
+  const existingFixture = createContainerFixture();
+  const existingContainer = {
+    data: {
+      ...existingFixture,
+      image: {
+        ...existingFixture.image,
+        tag: { ...existingFixture.image.tag, value: '1.0.0' },
+        digest: { watch: true, value: 'sha256:aaa' },
+      },
+      result: {
+        tag: '2.0.0',
+        suggestedTag: '2.0.0-alpine',
+        digest: 'sha256:bbb',
+        created: '2024-01-01T00:00:00.000Z',
+      },
+      updateDetectedAt: existingDetectedAt,
+    },
+  };
+  const collection = {
+    findOne: () => existingContainer,
+    insert: () => {},
+    chain: () => ({
+      find: () => ({
+        remove: () => ({}),
+      }),
+    }),
+  };
+  const db = {
+    getCollection: () => collection,
+    addCollection: () => null,
+  };
+  const nextFixture = createContainerFixture();
+  const containerToSave = {
+    ...nextFixture,
+    image: {
+      ...nextFixture.image,
+      tag: { ...nextFixture.image.tag, value: '1.0.0' },
+      digest: { watch: true, value: 'sha256:aaa' },
+    },
+    // Same tag and digest as the stored record, only the display metadata drifted.
+    result: {
+      tag: '2.0.0',
+      suggestedTag: '2.0.0-bullseye',
+      digest: 'sha256:bbb',
+      created: '2024-06-01T00:00:00.000Z',
+    },
+  };
+
+  container.createCollections(db);
+  const updated = container.updateContainer(containerToSave);
+
+  expect(updated.updateDetectedAt).toBe(existingDetectedAt);
+});
+
+test('updateContainer should reset updateDetectedAt when the candidate tag genuinely changes (#565)', async () => {
+  const existingDetectedAt = '2026-02-20T09:15:00.000Z';
+  const existingFixture = createContainerFixture();
+  const existingContainer = {
+    data: {
+      ...existingFixture,
+      image: {
+        ...existingFixture.image,
+        tag: { ...existingFixture.image.tag, value: '1.0.0' },
+        digest: { watch: true, value: 'sha256:aaa' },
+      },
+      result: {
+        tag: '2.0.0',
+        digest: 'sha256:bbb',
+      },
+      updateDetectedAt: existingDetectedAt,
+    },
+  };
+  const collection = {
+    findOne: () => existingContainer,
+    insert: () => {},
+    chain: () => ({
+      find: () => ({
+        remove: () => ({}),
+      }),
+    }),
+  };
+  const db = {
+    getCollection: () => collection,
+    addCollection: () => null,
+  };
+  const nextFixture = createContainerFixture();
+  const containerToSave = {
+    ...nextFixture,
+    image: {
+      ...nextFixture.image,
+      tag: { ...nextFixture.image.tag, value: '1.0.0' },
+      digest: { watch: true, value: 'sha256:aaa' },
+    },
+    // Digest unchanged, but the candidate tag itself moved.
+    result: {
+      tag: '2.1.0',
+      digest: 'sha256:bbb',
+    },
+  };
+
+  container.createCollections(db);
+  const updated = container.updateContainer(containerToSave);
+
+  expect(updated.updateDetectedAt).toBeDefined();
+  expect(updated.updateDetectedAt).not.toBe(existingDetectedAt);
+});
+
+test('updateContainer should reset updateDetectedAt when the candidate digest genuinely changes (#565)', async () => {
+  const existingDetectedAt = '2026-02-20T09:15:00.000Z';
+  const existingFixture = createContainerFixture();
+  const existingContainer = {
+    data: {
+      ...existingFixture,
+      image: {
+        ...existingFixture.image,
+        tag: { ...existingFixture.image.tag, value: '1.0.0' },
+        digest: { watch: true, value: 'sha256:aaa' },
+      },
+      result: {
+        tag: '2.0.0',
+        digest: 'sha256:bbb',
+      },
+      updateDetectedAt: existingDetectedAt,
+    },
+  };
+  const collection = {
+    findOne: () => existingContainer,
+    insert: () => {},
+    chain: () => ({
+      find: () => ({
+        remove: () => ({}),
+      }),
+    }),
+  };
+  const db = {
+    getCollection: () => collection,
+    addCollection: () => null,
+  };
+  const nextFixture = createContainerFixture();
+  const containerToSave = {
+    ...nextFixture,
+    image: {
+      ...nextFixture.image,
+      tag: { ...nextFixture.image.tag, value: '1.0.0' },
+      digest: { watch: true, value: 'sha256:aaa' },
+    },
+    // Tag unchanged, but the candidate digest itself moved.
+    result: {
+      tag: '2.0.0',
+      digest: 'sha256:ccc',
+    },
+  };
+
+  container.createCollections(db);
+  const updated = container.updateContainer(containerToSave);
+
+  expect(updated.updateDetectedAt).toBeDefined();
+  expect(updated.updateDetectedAt).not.toBe(existingDetectedAt);
+});
+
 test('updateContainer should stamp updateDetectedAt when containerCurrent had no raw update', async () => {
   // Covers the path where a container transitions from no-update to having one.
   const existingFixture = createContainerFixture();

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -19,6 +19,7 @@ import {
 } from '../event/index.js';
 import {
   deriveContainerIdentityKey,
+  hasCandidateIdentityChanged,
   hasRawUpdate,
   isRollbackContainerName,
 } from '../model/container.js';
@@ -834,11 +835,14 @@ function getUpdateLifecycleTimestamp(containerCurrent, containerNext, timestampF
   // instead of inheriting the previous candidate's elapsed time. This must run
   // before the timestamp-preserve below: in the local watch path containerNext
   // carries the prior updateDetectedAt, which would otherwise short-circuit here.
+  // Compares candidate identity (tag/digest) only — display metadata like
+  // suggestedTag/created can wobble between scans (a recheck bypasses the
+  // registry poll cache) without the candidate itself changing, and must not
+  // falsely restart the maturity soak.
   if (
     containerCurrent &&
     hasRawUpdate(containerCurrent) &&
-    typeof containerCurrent.resultChanged === 'function' &&
-    containerCurrent.resultChanged(containerNext)
+    hasCandidateIdentityChanged(containerCurrent.result, containerNext.result)
   ) {
     return new Date().toISOString();
   }

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -3857,9 +3857,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,6 +52,6 @@
   "overrides": {
     "postcss": "8.5.10",
     "esbuild": "0.28.1",
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.0"
   }
 }

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -3716,9 +3716,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -36,7 +36,7 @@
     "lodash": "4.18.1"
   },
   "overrides": {
-    "brace-expansion": "5.0.6",
+    "brace-expansion": "5.0.7",
     "fast-xml-parser": "5.7.3",
     "joi": "18.2.1",
     "minimatch": "10.2.4",

--- a/e2e/tests/security/brace-expansion-lockfile.test.js
+++ b/e2e/tests/security/brace-expansion-lockfile.test.js
@@ -3,7 +3,7 @@ const { readFileSync } = require('node:fs');
 const { join } = require('node:path');
 const test = require('node:test');
 
-const MINIMUM_SAFE_BRACE_EXPANSION_VERSION = '5.0.5';
+const MINIMUM_SAFE_BRACE_EXPANSION_VERSION = '5.0.7';
 
 function compareSemver(a, b) {
   const aParts = a.split('.').map(Number);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3447,9 +3447,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

Fixes the #565 report: a manual per-container "check for updates" restarted the maturity soak countdown, which reads to the user as their maturity settings being wiped (the config itself was never touched — only the clock).

Root cause: `getUpdateLifecycleTimestamp`'s restart branch gated on `Container#resultChanged`, which compares `tag`, `suggestedTag`, `digest`, AND `created`. The last two are display metadata that can drift between scans (a manual recheck bypasses the registry poll cache), so a cosmetic wobble re-stamped `updateDetectedAt` to now and the countdown snapped back to the full window. Registries with trusted publish dates (Docker Hub/GHCR) mask this via the publishedAt floor; everyone else is fully exposed.

Fix: new `hasCandidateIdentityChanged()` comparing only `tag` + `digest`; the lifecycle restart branch uses it directly. `resultChanged`/`hasResultChanged` are untouched — the trigger-notification `changed` flag in `container-processing.ts` must stay sensitive to `suggestedTag`/`created` changes for notification content. Intentional behavior is preserved: a genuinely new candidate (tag or digest change) still restarts the soak.

## Why

Diagnosed against the live module (drove `updateContainer` through the exact recheck sequence): identical results leave the clock alone; a `suggestedTag`-only or `created`-only difference reset it every time. Pre-existing since the v1.5.x maturity gate (restart branch from v1.5.1-rc.1, comparison set from v1.5.0) — not an rc.2 regression. Targets the v1.6.1/rc.3 train.

## Tests

Unit coverage for `hasCandidateIdentityChanged` (undefined handling both directions, each field diff, metadata-only diff → false) plus three store-level regression tests on `updateContainer`: metadata-only recheck preserves `updateDetectedAt`; tag change resets; digest change resets. Full pre-push gate green; `app/model/container.ts` and `app/store/container.ts` at 100% on all four metrics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- 🐛 Fixed maturity soak countdowns restarting when only display metadata changes.
- ✨ Added `hasCandidateIdentityChanged()` to compare update candidate identity using only `tag` + `digest`.
- 🔧 Updated lifecycle timestamp logic to restart only on candidate identity (`tag`/`digest`) changes (leaving existing `resultChanged` behavior for trigger notifications intact).
- ✨ Added unit + store regression tests covering metadata-only changes, tag/digest changes, and undefined handling.
- 🔒 Security: Updated `brace-expansion` minimum safe version (5.0.7) and related e2e override validation.
- 🔧 Dependency: Bumped pinned `js-yaml` override (4.2.0 → 4.3.0) and `brace-expansion` override (5.0.6 → 5.0.7).

- Ensure maturity restart logic uses the correct “raw update” `result` shape consistently across persistence/rechecks.
- Verify `hasCandidateIdentityChanged()` undefined/missing-field semantics align with actual runtime inputs.
- Confirm trigger notification paths still rely on existing `resultChanged` behavior as intended.
- Run/verify unit + store tests and e2e security suite with the updated dependency overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->