### PR TITLE
📝 docs(release): bump release identity to v1.6.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0-rc.3] — 2026-07-21
+
 ### Changed
 
 - **Update-status vocabulary overhaul across the containers UI** ([#498](https://github.com/CodesWhat/drydock/issues/498), [#556](https://github.com/CodesWhat/drydock/issues/556)). "Digest" reads as **"Digest update"**; the NEW/MATURE freshness badges are gone (the detection age lives in the update-kind badge's tooltip instead); an unrecognized update kind now renders a neutral "Unknown" badge instead of nothing; and the bouncer's "Blocked" label is now **"Security hold"**.
@@ -2190,7 +2192,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.2...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.3...HEAD
+[1.6.0-rc.3]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.2...v1.6.0-rc.3
 [1.6.0-rc.2]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.1...v1.6.0-rc.2
 [1.6.0-rc.1]: https://github.com/CodesWhat/drydock/compare/v1.5.2...v1.6.0-rc.1
 [1.5.2]: https://github.com/CodesWhat/drydock/compare/v1.5.2-rc.5...v1.5.2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.2-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.3-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -176,7 +176,7 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
-<summary><strong>v1.6.0-rc.2 highlights</strong></summary>
+<summary><strong>v1.6.0-rc.3 highlights</strong></summary>
 
 - **Notifications** — Per-rule/per-provider title and body templates with live preview, plus audit-backed in-app bell categories and update severity thresholds.
 - **Dashboard** — Zero-dependency CSS Grid replacement with mouse/touch reorder, bounded resize, responsive layouts, widget visibility, reset, and optional cross-device preference sync.

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.0-rc.2',
+    version: '1.6.0-rc.3',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.0-rc.2 started',
+    details: 'Drydock v1.6.0-rc.3 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.2',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.3',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.0-rc.2',
+    tag: '1.6.0-rc.3',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.0-rc.2',
+  version: '1.6.0-rc.3',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.0-rc.2',
+      version: '1.6.0-rc.3',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.0-rc.2', mode: 'demo' },
+        server: { version: '1.6.0-rc.3', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.0-rc.2",
+  version: "1.6.0-rc.3",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.0-rc.2",
+    version: "v1.6.0-rc.3",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.0-rc.2",
+      "version": "1.6.0-rc.3",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.0-rc.2",
+    "version": "1.6.0-rc.3",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.0-rc.2"
+  "version":"1.6.0-rc.3"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -162,7 +162,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.0-rc.2",
+    "version": "1.6.0-rc.3",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -185,7 +185,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.0-rc.2",
+      "drydockVersion": "1.6.0-rc.3",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -102,7 +102,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.0-rc.2` | Immutable release candidate; best for reproducible testing |
+| `1.6.0-rc.3` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.0-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -3,6 +3,15 @@ title: "Updates"
 description: "Release update notes and feature highlights, with direct links to current configuration and API docs."
 ---
 
+## v1.6.0-rc.3 Highlights — July 21, 2026
+
+- **Honest update states across the UI** — digest-only changes read "Digest update" instead of a version label, an unrecognized update kind shows a neutral "Unknown" badge, the security bouncer's block state reads "Security hold", and the NEW/MATURE freshness badges are gone in favor of one maturity clock panel that names the clock the gate actually measures against.
+- **Pinned is a tag property, not an update status** — pinned containers carry a persistent pin glyph beside the tag (driven by the real pin-gate verdict, with the `dd.tag.family` remedy in its tooltip), and insight-only pinned rows read "Current" everywhere, including the container-detail Update Status panel.
+- **Security hardening batch** — anonymous access fails closed on upgrades (`401` API responses, `/health` `503`) unless explicitly confirmed, the HTTP notification trigger blocks SSRF against metadata/link-local targets including via redirects, WebSocket upgrades validate the complete origin, the session cookie is namespaced to `drydock.sid`, store files are owner-only, and icon CDN sources are pinned to exact revisions.
+  Docs: [Authentication](/docs/configuration/authentications), [HTTP trigger](/docs/configuration/triggers/http).
+- **Maturity countdown stability** — a manual recheck no longer restarts the maturity soak when only display metadata wobbled; the clock resets only when the update candidate's tag or digest actually changes.
+- **Container-list fit and follow-through fixes** — the column picker labels columns auto-hidden to fit (and its "+N" badge tooltip stays fresh), registry deep-links from container detail land on the registry they name, and the removed-API-path banner pluralizes correctly.
+
 ## v1.6.0-rc.2 Highlights — July 18, 2026
 
 - **Watch errors no longer erase update state** — a container whose registry check fails keeps its last successful comparison alongside the recorded error instead of appearing never-compared, errored containers reuse the same fast refresh path as healthy ones, and repair rebuilds preserve the registry-reconciled digest that keys security scan grouping.

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6 RC and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.2...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.3...HEAD`],
+    ['1.6.0-rc.3', `${repositoryUrl}/compare/v1.6.0-rc.2...v1.6.0-rc.3`],
     ['1.6.0-rc.2', `${repositoryUrl}/compare/v1.6.0-rc.1...v1.6.0-rc.2`],
     ['1.6.0-rc.1', `${repositoryUrl}/compare/v1.5.2...v1.6.0-rc.1`],
     ['1.5.2', `${repositoryUrl}/compare/v1.5.2-rc.5...v1.5.2`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.0-rc.2';
-const RC_DATE = '2026-07-18';
-const RC_DISPLAY_DATE = 'July 18, 2026';
+const RC_VERSION = '1.6.0-rc.3';
+const RC_DATE = '2026-07-21';
+const RC_DISPLAY_DATE = 'July 21, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 
 function read(path) {
@@ -21,16 +21,16 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   const quickstart = read('content/docs/current/quickstart/index.mdx');
   const changelog = read('CHANGELOG.md');
 
-  assert.match(readme, /version-1\.6\.0--rc\.2-blue/u);
-  assert.match(readme, /v1\.6\.0-rc\.2 highlights/u);
+  assert.match(readme, /version-1\.6\.0--rc\.3-blue/u);
+  assert.match(readme, /v1\.6\.0-rc\.3 highlights/u);
   assert.match(siteConfig, new RegExp(`version: "${RC_VERSION.replaceAll('.', '\\.')}"`, 'u'));
   assert.ok(updates.includes(`## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`));
-  assert.match(appApi, /"version":"1\.6\.0-rc\.2"/u);
-  assert.match(agentApi, /"version": "1\.6\.0-rc\.2"/u);
-  assert.match(portwingApi, /"version": "1\.6\.0-rc\.2"/u);
-  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.2"/u);
-  assert.match(quickstart, /\| `1\.6\.0-rc\.2` \| Immutable release candidate/u);
-  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!2\b)\d+` \| Immutable release candidate/u);
+  assert.match(appApi, /"version":"1\.6\.0-rc\.3"/u);
+  assert.match(agentApi, /"version": "1\.6\.0-rc\.3"/u);
+  assert.match(portwingApi, /"version": "1\.6\.0-rc\.3"/u);
+  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.3"/u);
+  assert.match(quickstart, /\| `1\.6\.0-rc\.3` \| Immutable release candidate/u);
+  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!3\b)\d+` \| Immutable release candidate/u);
   assert.ok(changelog.includes(`## [${RC_VERSION}] — ${RC_DATE}`));
   assert.ok(
     changelog.includes(
@@ -39,7 +39,7 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   );
   assert.ok(
     changelog.includes(
-      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.1...v${RC_VERSION}`,
+      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.2...v${RC_VERSION}`,
     ),
   );
 });
@@ -53,7 +53,7 @@ test('v1.5.2 is archived and public release routing advances to v1.6', () => {
 
   assert.match(readme, /<summary><strong>v1\.5\.2 highlights<\/strong><\/summary>/u);
   assert.match(siteContent, /version: "v1\.5\.2",[\s\S]{0,500}?status: "released"/u);
-  assert.match(siteContent, /version: "v1\.6\.0-rc\.2",[\s\S]{0,500}?status: "next"/u);
+  assert.match(siteContent, /version: "v1\.6\.0-rc\.3",[\s\S]{0,500}?status: "next"/u);
   assert.match(
     docsVersions,
     /\{ slug: "v1\.6", source: "current", title: "v1\.6" \},\s+\{ slug: "v1\.5", source: "v1\.5", title: "v1\.5" \}/u,

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.0';
-const RC_VERSION = '1.6.0-rc.2';
+const RC_VERSION = '1.6.0-rc.3';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',
@@ -52,7 +52,7 @@ test('release-gated workspace packages and locks use the v1.6 base version', () 
   }
 });
 
-test('demo runtime fixtures identify the exact v1.6.0-rc.2 candidate', () => {
+test('demo runtime fixtures identify the exact v1.6.0-rc.3 candidate', () => {
   for (const { path, valuePattern } of DEMO_RELEASE_FIXTURES) {
     const contents = readFileSync(path, 'utf8');
     assert.deepEqual(extractVersionValues(contents, valuePattern), [RC_VERSION], path);
@@ -63,18 +63,18 @@ test('release version patterns match exact optionally v-prefixed tokens', () => 
   const rcPattern = versionPattern(RC_VERSION);
   const legacyPattern = versionPattern('1.5.0');
 
-  assert.match('version: 1.6.0-rc.2', rcPattern);
-  assert.match('version: v1.6.0-rc.2', rcPattern);
-  assert.doesNotMatch('version: 1.6.0-rc.20', rcPattern);
-  assert.doesNotMatch('version: x1.6.0-rc.2', rcPattern);
+  assert.match('version: 1.6.0-rc.3', rcPattern);
+  assert.match('version: v1.6.0-rc.3', rcPattern);
+  assert.doesNotMatch('version: 1.6.0-rc.30', rcPattern);
+  assert.doesNotMatch('version: x1.6.0-rc.3', rcPattern);
   assert.match('version: v1.5.0', legacyPattern);
   assert.doesNotMatch('version: 1.5.0-rc.1', legacyPattern);
 });
 
 test('fixture version extraction retains mixed candidate identities', () => {
-  const contents = "version: '1.6.0-rc.2', version: '1.6.0-rc.20'";
+  const contents = "version: '1.6.0-rc.3', version: '1.6.0-rc.30'";
   assert.deepEqual(extractVersionValues(contents, /version:\s*["']([^"']+)["']/gu), [
-    '1.6.0-rc.2',
-    '1.6.0-rc.20',
+    '1.6.0-rc.3',
+    '1.6.0-rc.30',
   ]);
 });


### PR DESCRIPTION
Release plumbing for the v1.6.0-rc.3 cut — the full identity bump the guard tests enforce.

- Dated `[1.6.0-rc.3] — 2026-07-21` CHANGELOG heading, fresh empty `[Unreleased]` section, matching link-reference definitions
- rc.3 across README badge/highlights summary, website site-config + timeline, updates page (new rc.3 highlights section), API doc example payloads, quickstart tag matrix, and the demo runtime fixtures
- Guard tests updated in lockstep: release-identity, release-docs-identity (compare base now `v1.6.0-rc.2...v1.6.0-rc.3`), changelog-links

rc.3 delta over rc.2: #566 display-honesty batch, #567 security hardening, #568 maturity-clock restart fix (#565), #569 docs freshness.

Verified: 105/105 script tests, 43/43 web-script tests, full pre-push gate green.

Last dev-side change before the release head freeze.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

🔧 **Changed**
- Updated release identity from `v1.6.0-rc.2` to `v1.6.0-rc.3` across README, website metadata, roadmap, docs, API examples, quickstart tags, and demo fixtures.
- Added the dated `v1.6.0-rc.3` updates section and refreshed changelog link references.
- Updated release identity and documentation guard tests, including rc comparison ranges and candidate fixtures.

✨ **Added**
- Documented the rc.3 changes covering issues `#566`, `#567`, `#568/`#565, and `#569`.

🔒 **Security**
- Documented the rc.3 security hardening batch.

## Verification

- Script tests: 105/105 passed
- Web-script tests: 43/43 passed
- Full pre-push gate: passed

## Concerns

- Verify the release date `July 21, 2026` is correct.
- Confirm all remaining `1.6.0-rc.2` references are intentional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->