### PR TITLE
🧪 test(security): avoid secret-like cache fixtures

### DIFF
--- a/app/registries/BaseRegistry.test.ts
+++ b/app/registries/BaseRegistry.test.ts
@@ -3567,8 +3567,8 @@ test('authenticateBearerFromAuthUrl should not use cache when now equals expires
   const { default: axios } = await import('axios');
   vi.useFakeTimers();
   axios
-    .mockResolvedValueOnce({ data: { token: 'tok-boundary-1' } })
-    .mockResolvedValueOnce({ data: { token: 'tok-boundary-2' } });
+    .mockResolvedValueOnce({ data: { token: 'first' } })
+    .mockResolvedValueOnce({ data: { token: 'second' } });
   const t0 = new Date('2026-03-05T10:00:00.000Z').getTime();
 
   try {
@@ -3578,7 +3578,7 @@ test('authenticateBearerFromAuthUrl should not use cache when now equals expires
       'https://auth.example.com/token',
       'credX',
     );
-    expect(r1.headers.Authorization).toBe('Bearer tok-boundary-1');
+    expect(r1.headers.Authorization).toBe('Bearer first');
 
     // Exactly at expiresAt: `now < expiresAt` is false → should NOT use cache
     vi.setSystemTime(t0 + REGISTRY_BEARER_TOKEN_CACHE_TTL_MS);
@@ -3589,7 +3589,7 @@ test('authenticateBearerFromAuthUrl should not use cache when now equals expires
     );
 
     expect(axios).toHaveBeenCalledTimes(2);
-    expect(r2.headers.Authorization).toBe('Bearer tok-boundary-2');
+    expect(r2.headers.Authorization).toBe('Bearer second');
   } finally {
     vi.useRealTimers();
   }


### PR DESCRIPTION
## Summary

- replace two secret-like bearer-token fixtures with low-entropy test values
- preserve the strict cache-expiry boundary assertions
- restore the tracked-working-tree Gitleaks gate after earlier tests shifted the allowlisted source lines

## Verification

- `node ./node_modules/vitest/vitest.mjs run registries/BaseRegistry.test.ts --maxWorkers=1 --fileParallelism=false` (221 passed)
- `./scripts/scan-secrets.sh` (history and tracked tree clean)
- full pre-push gate (100% app/UI coverage, app/UI builds, scripts, workflows, typecheck, Zizmor)