### PR TITLE
🚀 release: v1.6.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0-rc.4] — 2026-07-22
+
 ### Added
 
 - **Container groups can be edited directly in the browser** ([#498](https://github.com/CodesWhat/drydock/issues/498)). A container's More menu can set, change, or clear a local group override; clearing it falls back to the durable `dd.group` / Compose project / Swarm namespace group. Overrides are regular UI preferences, so they remain browser-local unless cross-device preference sync is enabled.
@@ -2209,7 +2211,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.3...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.4...HEAD
+[1.6.0-rc.4]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.3...v1.6.0-rc.4
 [1.6.0-rc.3]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.2...v1.6.0-rc.3
 [1.6.0-rc.2]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.1...v1.6.0-rc.2
 [1.6.0-rc.1]: https://github.com/CodesWhat/drydock/compare/v1.5.2...v1.6.0-rc.1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.3-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.4-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -178,7 +178,7 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
-<summary><strong>v1.6.0-rc.3 highlights</strong></summary>
+<summary><strong>v1.6.0-rc.4 highlights</strong></summary>
 
 - **Notifications** — Per-rule/per-provider title and body templates with live preview, plus audit-backed in-app bell categories and update severity thresholds.
 - **Dashboard** — Zero-dependency CSS Grid replacement with mouse/touch reorder, bounded resize, responsive layouts, widget visibility, reset, and optional cross-device preference sync.

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.0-rc.3',
+    version: '1.6.0-rc.4',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.0-rc.3 started',
+    details: 'Drydock v1.6.0-rc.4 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.3',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.4',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.0-rc.3',
+    tag: '1.6.0-rc.4',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.0-rc.3',
+  version: '1.6.0-rc.4',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.0-rc.3',
+      version: '1.6.0-rc.4',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.0-rc.3', mode: 'demo' },
+        server: { version: '1.6.0-rc.4', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.0-rc.3",
+  version: "1.6.0-rc.4",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.0-rc.3",
+    version: "v1.6.0-rc.4",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.0-rc.3",
+      "version": "1.6.0-rc.4",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.0-rc.3",
+    "version": "1.6.0-rc.4",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.0-rc.3"
+  "version":"1.6.0-rc.4"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -162,7 +162,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.0-rc.3",
+    "version": "1.6.0-rc.4",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -185,7 +185,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.0-rc.3",
+      "drydockVersion": "1.6.0-rc.4",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.0-rc.3` | Immutable release candidate; best for reproducible testing |
+| `1.6.0-rc.4` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.0-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -3,11 +3,12 @@ title: "Updates"
 description: "Release update notes and feature highlights, with direct links to current configuration and API docs."
 ---
 
-## Next release candidate — Unreleased
+## v1.6.0-rc.4 Highlights — July 22, 2026
 
 - **Pinned freshness is honest at a glance** — an informational newer-version insight now reads Major, Minor, or Patch instead of contradicting the visible newer tag with “Current.” It remains non-actionable and cannot fire update actions or notifications.
 - **Same-tag rebuilds are explained** — “Image update” replaces “Digest update,” with tooltip copy explaining that the tag now points to a different image build and a redeploy pulls it.
 - **The Containers layout keeps context** — **Software Version** is explicitly named and folds before **Host** at constrained laptop widths. Users can also set, change, or clear a presentation-only group from a container's More menu; clearing an override restores Docker-derived grouping.
+- **Release-gated E2E failures are attributable** — Cucumber reuses the exact QA image built by CI, verifies a six-fixture manifest, restores scenario-mutated state, and publishes structured reports and diagnostics without blanket scenario retries. Playwright owns browser rendering and retains first-failure media without whole-test retries.
 
 ## v1.6.0-rc.3 Highlights — July 21, 2026
 

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6 RC and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.3...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.4...HEAD`],
+    ['1.6.0-rc.4', `${repositoryUrl}/compare/v1.6.0-rc.3...v1.6.0-rc.4`],
     ['1.6.0-rc.3', `${repositoryUrl}/compare/v1.6.0-rc.2...v1.6.0-rc.3`],
     ['1.6.0-rc.2', `${repositoryUrl}/compare/v1.6.0-rc.1...v1.6.0-rc.2`],
     ['1.6.0-rc.1', `${repositoryUrl}/compare/v1.5.2...v1.6.0-rc.1`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.0-rc.3';
-const RC_DATE = '2026-07-21';
-const RC_DISPLAY_DATE = 'July 21, 2026';
+const RC_VERSION = '1.6.0-rc.4';
+const RC_DATE = '2026-07-22';
+const RC_DISPLAY_DATE = 'July 22, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;
@@ -23,16 +23,16 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   const quickstart = read('content/docs/current/quickstart/index.mdx');
   const changelog = read('CHANGELOG.md');
 
-  assert.match(readme, /version-1\.6\.0--rc\.3-blue/u);
-  assert.match(readme, /v1\.6\.0-rc\.3 highlights/u);
+  assert.match(readme, /version-1\.6\.0--rc\.4-blue/u);
+  assert.match(readme, /v1\.6\.0-rc\.4 highlights/u);
   assert.match(siteConfig, new RegExp(`version: "${RC_VERSION.replaceAll('.', '\\.')}"`, 'u'));
   assert.ok(updates.includes(`## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`));
-  assert.match(appApi, /"version":"1\.6\.0-rc\.3"/u);
-  assert.match(agentApi, /"version": "1\.6\.0-rc\.3"/u);
-  assert.match(portwingApi, /"version": "1\.6\.0-rc\.3"/u);
-  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.3"/u);
-  assert.match(quickstart, /\| `1\.6\.0-rc\.3` \| Immutable release candidate/u);
-  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!3\b)\d+` \| Immutable release candidate/u);
+  assert.match(appApi, /"version":"1\.6\.0-rc\.4"/u);
+  assert.match(agentApi, /"version": "1\.6\.0-rc\.4"/u);
+  assert.match(portwingApi, /"version": "1\.6\.0-rc\.4"/u);
+  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.4"/u);
+  assert.match(quickstart, /\| `1\.6\.0-rc\.4` \| Immutable release candidate/u);
+  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!4\b)\d+` \| Immutable release candidate/u);
   assert.ok(changelog.includes(`## [${RC_VERSION}] — ${RC_DATE}`));
   assert.ok(
     changelog.includes(
@@ -41,7 +41,7 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   );
   assert.ok(
     changelog.includes(
-      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.2...v${RC_VERSION}`,
+      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.3...v${RC_VERSION}`,
     ),
   );
 });
@@ -55,7 +55,7 @@ test('v1.5.2 is archived and public release routing advances to v1.6', () => {
 
   assert.match(readme, /<summary><strong>v1\.5\.2 highlights<\/strong><\/summary>/u);
   assert.match(siteContent, /version: "v1\.5\.2",[\s\S]{0,500}?status: "released"/u);
-  assert.match(siteContent, /version: "v1\.6\.0-rc\.3",[\s\S]{0,500}?status: "next"/u);
+  assert.match(siteContent, /version: "v1\.6\.0-rc\.4",[\s\S]{0,500}?status: "next"/u);
   assert.match(
     docsVersions,
     /\{ slug: "v1\.6", source: "current", title: "v1\.6" \},\s+\{ slug: "v1\.5", source: "v1\.5", title: "v1\.5" \}/u,

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.0';
-const RC_VERSION = '1.6.0-rc.3';
+const RC_VERSION = '1.6.0-rc.4';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',
@@ -52,7 +52,7 @@ test('release-gated workspace packages and locks use the v1.6 base version', () 
   }
 });
 
-test('demo runtime fixtures identify the exact v1.6.0-rc.3 candidate', () => {
+test('demo runtime fixtures identify the exact v1.6.0-rc.4 candidate', () => {
   for (const { path, valuePattern } of DEMO_RELEASE_FIXTURES) {
     const contents = readFileSync(path, 'utf8');
     assert.deepEqual(extractVersionValues(contents, valuePattern), [RC_VERSION], path);
@@ -63,18 +63,18 @@ test('release version patterns match exact optionally v-prefixed tokens', () => 
   const rcPattern = versionPattern(RC_VERSION);
   const legacyPattern = versionPattern('1.5.0');
 
-  assert.match('version: 1.6.0-rc.3', rcPattern);
-  assert.match('version: v1.6.0-rc.3', rcPattern);
-  assert.doesNotMatch('version: 1.6.0-rc.30', rcPattern);
-  assert.doesNotMatch('version: x1.6.0-rc.3', rcPattern);
+  assert.match('version: 1.6.0-rc.4', rcPattern);
+  assert.match('version: v1.6.0-rc.4', rcPattern);
+  assert.doesNotMatch('version: 1.6.0-rc.40', rcPattern);
+  assert.doesNotMatch('version: x1.6.0-rc.4', rcPattern);
   assert.match('version: v1.5.0', legacyPattern);
   assert.doesNotMatch('version: 1.5.0-rc.1', legacyPattern);
 });
 
 test('fixture version extraction retains mixed candidate identities', () => {
-  const contents = "version: '1.6.0-rc.3', version: '1.6.0-rc.30'";
+  const contents = "version: '1.6.0-rc.4', version: '1.6.0-rc.40'";
   assert.deepEqual(extractVersionValues(contents, /version:\s*["']([^"']+)["']/gu), [
-    '1.6.0-rc.3',
-    '1.6.0-rc.30',
+    '1.6.0-rc.4',
+    '1.6.0-rc.40',
   ]);
 });


### PR DESCRIPTION
## Summary

Prepare **v1.6.0-rc.4** from the latest `main`.

rc.4 delta over rc.3:

- **#580 issue #498 visual follow-ups** - informational pinned Major/Minor/Patch states, "Image update" vocabulary and explanation, Host-first constrained layout, explicit Software Version metadata, browser-managed grouping, docs, regression coverage, and desktop/mobile visual QA.
- **#581 Cucumber reliability** - complete retained-run audit, exact build-artifact reuse, six-fixture readiness manifest, scenario state restoration, structured reports/diagnostics, no blanket Cucumber/Playwright retries, fail-closed remote fixture seeding, and the targeted health-refresh product/race fixes.
- Release identity advanced across the changelog, README, website/demo, current docs, API examples, quickstart, and guard tests.

## Verification

- 123/123 repository script tests
- 45/45 workflow invariant tests
- 44/44 website script tests
- Full pre-push gate: 100% app/UI coverage, type-check, Biome, Qlty, and app/UI builds
- Local prerelease precheck completed; its five unchecked "shipped in v1.6.0" Discussion follow-ups remain GA closeout actions and are not RC blockers

After merge: verify exact-`main` CI Verify and Playwright, then dispatch `release-cut.yml` with `release_tag=v1.6.0-rc.4`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

### 🔧 Changed
- Prepared release identity for `v1.6.0-rc.4` across README, website/demo mocks, API documentation, Portwing examples, quickstart materials, and release updates.
- Updated changelog comparison links and release identity guard tests for `v1.6.0-rc.4`.
- Added release-gated Cucumber E2E failure-reporting highlights to the updates page.

## Concerns
- Verify exact CI Verify and Playwright workflows after merge.
- Post the five tracked Discussion replies against the published release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->