### PR TITLE
🐛 fix(ui): make Resources column optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The Containers table's Resources column is now optional** ([#498](https://github.com/CodesWhat/drydock/issues/498)). It remains visible by default, but the column picker can hide it and preserves that choice. Source, release-note, and registry shortcuts move into each row's **More** menu while hidden and remain available in card and detail views.
+
 ## [1.6.0-rc.4] — 2026-07-22
 
 ### Added

--- a/e2e/playwright/v16-modes-pins.spec.ts
+++ b/e2e/playwright/v16-modes-pins.spec.ts
@@ -389,15 +389,30 @@ test.describe('v1.6 update modes, scheduling, and pinned tags', () => {
     const resources = page.locator('[data-test="actions-menu-resource-actions"]');
     await expect(resources).toContainText('Resources');
     const shortcuts = resources.locator(
-      '[data-test="project-link"], [data-test="current-release-notes-link"], [data-test="registry-link"]',
+      '[data-test="project-link"], [data-test="release-notes-link"], [data-test="current-release-notes-link"], [data-test="registry-link"]',
     );
     await expect(shortcuts).toHaveCount(3);
-    expect(
-      await shortcuts.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-test'))),
-    ).toEqual(['project-link', 'current-release-notes-link', 'registry-link']);
+    const shortcutIds = await shortcuts.evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute('data-test')),
+    );
+    expect(shortcutIds[0]).toBe('project-link');
+    expect(shortcutIds[1]).toMatch(/^(?:current-)?release-notes-link$/);
+    expect(shortcutIds[2]).toBe('registry-link');
 
     await page.reload();
     await expect(table.locator('th[data-col-key="links"]')).toHaveCount(0);
     await expect(table.locator('th[data-col-key="server"]')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Cards view' }).click();
+    const card = page.locator('[data-test="dd-card"]').filter({
+      hasText: RESOURCE_TARGET_CONTAINER,
+    });
+    await expect(
+      card.locator(
+        '[data-test="container-card-resource-actions"] [data-test="container-quick-links"]',
+      ),
+    ).toBeVisible();
+    await card.getByRole('button', { name: 'More', exact: true }).click();
+    await expect(page.locator('[data-test="actions-menu-resource-actions"]')).toHaveCount(0);
   });
 });

--- a/e2e/playwright/v16-modes-pins.spec.ts
+++ b/e2e/playwright/v16-modes-pins.spec.ts
@@ -14,12 +14,15 @@ interface ContainersPayload {
 }
 
 interface ContainerFixture {
+  currentReleaseNotes?: Record<string, unknown>;
   displayName?: string;
   image: {
     digest?: Record<string, unknown>;
+    registry?: Record<string, unknown>;
     tag: Record<string, unknown>;
   };
   result?: Record<string, unknown>;
+  sourceRepo?: string;
   tagFamily?: string;
   tagPinGated?: boolean;
   tagPinned?: boolean;
@@ -30,6 +33,7 @@ interface ContainerFixture {
 }
 
 const TARGET_CONTAINER = 'Nginx (Hooked)';
+const RESOURCE_TARGET_CONTAINER = 'A Resources Column Fixture';
 
 async function interceptSettings(page: Page, initialMode: UpdateMode): Promise<() => UpdateMode> {
   let updateMode = initialMode;
@@ -88,6 +92,24 @@ async function interceptContainer(
     const container = payload.data.find((candidate) => candidate.displayName === displayName);
     expect(container, `QA fixture ${displayName} must exist`).toBeTruthy();
     mutate(container!);
+    await route.fulfill({ response, json: payload });
+  });
+}
+
+async function interceptFirstContainer(
+  page: Page,
+  mutate: (container: ContainerFixture) => void,
+): Promise<void> {
+  await page.route('**/api/v1/containers', async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    const payload = (await response.json()) as ContainersPayload;
+    expect(payload.data[0], 'QA fixture must contain at least one container').toBeTruthy();
+    mutate(payload.data[0]);
     await route.fulfill({ response, json: payload });
   });
 }
@@ -333,5 +355,49 @@ test.describe('v1.6 update modes, scheduling, and pinned tags', () => {
     await expect(
       firstContainerRow.locator('[data-test="container-software-version-col"]'),
     ).toHaveCount(0);
+  });
+
+  test('#498 lets Resources be hidden without losing its row shortcuts', async ({ page }) => {
+    await page.setViewportSize({ width: 1197, height: 900 });
+    await interceptFirstContainer(page, (container) => {
+      container.displayName = RESOURCE_TARGET_CONTAINER;
+      container.sourceRepo = 'github.com/CodesWhat/drydock';
+      container.image.registry = { name: 'hub', url: 'https://registry-1.docker.io' };
+      container.currentReleaseNotes = {
+        title: 'Drydock v1.6.0-rc.4',
+        body: 'Deterministic Resources-column regression fixture.',
+        url: 'https://github.com/CodesWhat/drydock/releases/tag/v1.6.0-rc.4',
+        publishedAt: '2026-07-21T12:00:00.000Z',
+        provider: 'github',
+      };
+    });
+
+    await page.goto('/containers');
+    await dismissAnnouncementBanners(page);
+
+    const table = page.locator('[data-test="containers-grouped-views"] table');
+    await expect(table.locator('th[data-col-key="links"]')).toContainText('Resources');
+    await page.locator('[data-test="data-table-column-picker"] > button').click();
+    await page.getByRole('button', { name: 'Resources', exact: true }).click();
+    await expect(table.locator('th[data-col-key="links"]')).toHaveCount(0);
+    await page.keyboard.press('Escape');
+
+    const row = table.getByRole('row', {
+      name: new RegExp(escapeRegExp(RESOURCE_TARGET_CONTAINER), 'i'),
+    });
+    await row.getByRole('button', { name: 'More', exact: true }).click();
+    const resources = page.locator('[data-test="actions-menu-resource-actions"]');
+    await expect(resources).toContainText('Resources');
+    const shortcuts = resources.locator(
+      '[data-test="project-link"], [data-test="current-release-notes-link"], [data-test="registry-link"]',
+    );
+    await expect(shortcuts).toHaveCount(3);
+    expect(
+      await shortcuts.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-test'))),
+    ).toEqual(['project-link', 'current-release-notes-link', 'registry-link']);
+
+    await page.reload();
+    await expect(table.locator('th[data-col-key="links"]')).toHaveCount(0);
+    await expect(table.locator('th[data-col-key="server"]')).toBeVisible();
   });
 });

--- a/ui/src/components/containers/ContainersGroupedViews.vue
+++ b/ui/src/components/containers/ContainersGroupedViews.vue
@@ -28,6 +28,7 @@ import SuggestedTagBadge from './SuggestedTagBadge.vue';
 import ContainerLinkActions from './ContainerLinkActions.vue';
 import ContainersGroupHeader from './ContainersGroupHeader.vue';
 import NoUpdateReasonBadge from './NoUpdateReasonBadge.vue';
+import { registryLookup } from './registry-link';
 
 const {
   filteredContainers,
@@ -93,6 +94,18 @@ const openActionsContainer = computed(() =>
     ? (displayContainers.value.find((container) => container.id === openActionsMenu.value) ?? null)
     : null,
 );
+const resourcesHidden = computed(() => hiddenColumnKeys.value.includes('links'));
+const openActionsContainerHasResources = computed(() => {
+  const container = openActionsContainer.value;
+  if (!container) return false;
+  return Boolean(
+    container.sourceRepo?.trim() ||
+      container.releaseNotes ||
+      container.currentReleaseNotes ||
+      container.releaseLink?.trim() ||
+      registryLookup(container.registry, container.registryName, container.registryUrl),
+  );
+});
 
 type DisplayContainer = (typeof displayContainers.value)[number];
 
@@ -867,8 +880,9 @@ onScopeDispose(() => {
             </span>
           </div>
         </template>
-        <!-- Resource links stay separate from lifecycle actions so every row keeps a stable
-             Source → Release notes → Registry order without shifting Update/Stop/More. -->
+        <!-- When the Resources column is visible, links stay separate from lifecycle actions
+             in a stable Source → Release notes → Registry order. If the user hides the column,
+             the same component is rendered in More below (#498). -->
         <template #cell-links="{ row: c }">
           <div class="flex items-center justify-center">
             <ContainerLinkActions
@@ -1344,6 +1358,33 @@ onScopeDispose(() => {
                boxShadow: 'var(--dd-shadow-tooltip)',
              }"
              @click.stop>
+          <div
+            v-if="resourcesHidden && openActionsContainerHasResources"
+            class="px-3 pb-2 pt-1"
+            data-test="actions-menu-resource-actions"
+          >
+            <div class="mb-1 text-2xs-plus font-semibold dd-text-muted">
+              {{ t('containersView.columns.resources') }}
+            </div>
+            <ContainerLinkActions
+              :source-repo="openActionsContainer.sourceRepo"
+              :release-notes="openActionsContainer.releaseNotes"
+              :current-release-notes="openActionsContainer.currentReleaseNotes"
+              :release-link="openActionsContainer.releaseLink"
+              :container-id="openActionsContainer.id"
+              :from-tag="openActionsContainer.currentTag"
+              :to-tag="openActionsContainer.newTag"
+              :registry="openActionsContainer.registry"
+              :registry-name="openActionsContainer.registryName"
+              :registry-url="openActionsContainer.registryUrl"
+              icon-size="sm"
+            />
+          </div>
+          <div
+            v-if="resourcesHidden && openActionsContainerHasResources"
+            class="my-1"
+            :style="{ borderTop: '1px solid var(--dd-border)' }"
+          />
           <AppButton size="md" variant="plain" weight="medium" class="w-full text-left flex items-center gap-2 dd-text" v-if="openActionsContainer.status === 'running'"
                   @click="confirmStop(openActionsContainer); closeActionsMenu()">
             <AppIcon name="stop" :size="12" class="w-3 text-center inline-flex justify-center" :style="{ color: 'var(--dd-danger)' }" />

--- a/ui/src/components/containers/ContainersGroupedViews.vue
+++ b/ui/src/components/containers/ContainersGroupedViews.vue
@@ -94,7 +94,12 @@ const openActionsContainer = computed(() =>
     ? (displayContainers.value.find((container) => container.id === openActionsMenu.value) ?? null)
     : null,
 );
-const resourcesHidden = computed(() => hiddenColumnKeys.value.includes('links'));
+const resourcesHidden = computed(
+  () =>
+    containerViewMode.value === 'table' &&
+    !containerCardReflowForced.value &&
+    hiddenColumnKeys.value.includes('links'),
+);
 const openActionsContainerHasResources = computed(() => {
   const container = openActionsContainer.value;
   if (!container) return false;

--- a/ui/src/composables/useColumnVisibility.ts
+++ b/ui/src/composables/useColumnVisibility.ts
@@ -127,7 +127,9 @@ const allColumns: ColumnDef[] = [
     minSize: 152,
     maxSize: 152,
     autoSize: 'fixed',
-    required: true,
+    // Visible by default, but user-hideable (#498). The same shortcuts remain
+    // available from the row's More menu, cards, and container detail views.
+    required: false,
   },
   {
     key: 'uptime',
@@ -145,7 +147,7 @@ const allColumns: ColumnDef[] = [
 // hand-authored `#card` template (ContainersGroupedViews.vue) instead of DataTable's generic
 // cardPriority-driven card composition, so those annotations would be inert and misleading.
 
-const visibleColumns = ref<Set<string>>(new Set([...preferences.containers.columns, 'links']));
+const visibleColumns = ref<Set<string>>(new Set(preferences.containers.columns));
 watch(
   visibleColumns,
   (v) => {

--- a/ui/src/preferences/migrate.ts
+++ b/ui/src/preferences/migrate.ts
@@ -558,7 +558,10 @@ function migrateContainersPreference(): Record<string, unknown> | undefined {
 
   const columns = readJSON('dd-table-cols-v1', isStringArray);
   if (columns) {
-    containers.columns = columns;
+    // Legacy column preferences predate the Resources column, so show the
+    // shipped default once on migration. Current-schema users can hide it and
+    // that explicit choice is preserved by sanitizeContainers.
+    containers.columns = columns.includes('links') ? columns : [...columns, 'links'];
   }
 
   return Object.keys(containers).length > 0 ? containers : undefined;

--- a/ui/src/preferences/schema.ts
+++ b/ui/src/preferences/schema.ts
@@ -109,7 +109,7 @@ export const CONTAINER_TABLE_COLUMN_KEYS = [
 
 export const CONTAINER_TABLE_OPT_IN_COLUMN_KEYS = ['uptime'] as const;
 
-export const CONTAINER_TABLE_REQUIRED_COLUMN_KEYS = ['icon', 'name', 'links'] as const;
+export const CONTAINER_TABLE_REQUIRED_COLUMN_KEYS = ['icon', 'name'] as const;
 
 export const DEFAULTS: PreferencesSchema = {
   schemaVersion: CURRENT_SCHEMA_VERSION,

--- a/ui/tests/components/containers/ContainersGroupedViews.spec.ts
+++ b/ui/tests/components/containers/ContainersGroupedViews.spec.ts
@@ -2480,6 +2480,72 @@ describe('ContainersGroupedViews', () => {
     expect(spies.selectContainer).toHaveBeenCalledTimes(rowSelectionsBeforeLinkClicks);
   });
 
+  it('keeps resource shortcuts in the row More menu when the Resources column is hidden (#498)', async () => {
+    const container = makeContainer({
+      id: 'c-hidden-resources',
+      name: 'grafana',
+      sourceRepo: 'github.com/grafana/grafana',
+      releaseLink: 'https://github.com/grafana/grafana/releases/tag/v12.3.3',
+      registry: 'custom',
+      registryName: 'registry.example.com',
+      registryUrl: 'https://registry.example.com/v2',
+    });
+    const { context, refs } = makeContext();
+    refs.filteredContainers.value = [container];
+    refs.displayContainers.value = [container];
+    refs.renderGroups.value = [
+      {
+        key: '__flat__',
+        name: null,
+        containers: [container],
+        containerCount: 1,
+        updatesAvailable: 0,
+        updatableCount: 0,
+      },
+    ];
+    context.hiddenColumnKeys.value = ['links'];
+    refs.openActionsMenu.value = container.id;
+    mocked.context = context;
+
+    const wrapper = mountSubject();
+    await nextTick();
+
+    const resources = wrapper.get('[data-test="actions-menu-resource-actions"]');
+    expect(resources.text()).toContain('Resources');
+    expectContainerQuickLinks(
+      resources.get('[data-test="container-quick-links"]'),
+      'registry.example.com',
+    );
+  });
+
+  it('does not duplicate resource shortcuts in More while the Resources column is visible', async () => {
+    const container = makeContainer({
+      id: 'c-visible-resources',
+      name: 'grafana',
+      sourceRepo: 'github.com/grafana/grafana',
+    });
+    const { context, refs } = makeContext();
+    refs.filteredContainers.value = [container];
+    refs.displayContainers.value = [container];
+    refs.renderGroups.value = [
+      {
+        key: '__flat__',
+        name: null,
+        containers: [container],
+        containerCount: 1,
+        updatesAvailable: 0,
+        updatableCount: 0,
+      },
+    ];
+    refs.openActionsMenu.value = container.id;
+    mocked.context = context;
+
+    const wrapper = mountSubject();
+    await nextTick();
+
+    expect(wrapper.find('[data-test="actions-menu-resource-actions"]').exists()).toBe(false);
+  });
+
   it('renders each table quick link independently when the other link data is absent (#295)', async () => {
     const sourceOnly = makeContainer({
       id: 'c-source-only',

--- a/ui/tests/components/containers/ContainersGroupedViews.spec.ts
+++ b/ui/tests/components/containers/ContainersGroupedViews.spec.ts
@@ -2560,6 +2560,7 @@ describe('ContainersGroupedViews', () => {
     expect(
       cardByName(wrapper, 'grafana-card')
         .find('[data-test="container-card-resource-actions"]')
+        .find('[data-test="container-quick-links"]')
         .exists(),
     ).toBe(true);
     expect(wrapper.find('[data-test="actions-menu-resource-actions"]').exists()).toBe(false);
@@ -2573,7 +2574,6 @@ describe('ContainersGroupedViews', () => {
     });
     const { context, refs } = makeContext();
     context.hiddenColumnKeys.value = ['links'];
-    refs.containerCardReflowForced.value = true;
     refs.filteredContainers.value = [container];
     refs.displayContainers.value = [container];
     refs.renderGroups.value = [
@@ -2589,9 +2589,16 @@ describe('ContainersGroupedViews', () => {
     refs.openActionsMenu.value = container.id;
     mocked.context = context;
 
-    const wrapper = mountSubject();
+    const wrapper = mountSubjectWithRealDataTable(500);
     await nextTick();
 
+    expect(refs.containerCardReflowForced.value).toBe(true);
+    expect(
+      cardByName(wrapper, 'grafana-forced-card')
+        .find('[data-test="container-card-resource-actions"]')
+        .find('[data-test="container-quick-links"]')
+        .exists(),
+    ).toBe(true);
     expect(wrapper.find('[data-test="actions-menu-resource-actions"]').exists()).toBe(false);
   });
 

--- a/ui/tests/components/containers/ContainersGroupedViews.spec.ts
+++ b/ui/tests/components/containers/ContainersGroupedViews.spec.ts
@@ -2546,6 +2546,55 @@ describe('ContainersGroupedViews', () => {
     expect(wrapper.find('[data-test="actions-menu-resource-actions"]').exists()).toBe(false);
   });
 
+  it('does not duplicate hidden table Resources in the card More menu', async () => {
+    const container = makeContainer({
+      id: 'c-card-hidden-resources',
+      name: 'grafana-card',
+      sourceRepo: 'github.com/grafana/grafana',
+    });
+    const { wrapper, context, refs } = await mountCardsWithContainers([container], 800);
+    context.hiddenColumnKeys.value = ['links'];
+    refs.openActionsMenu.value = container.id;
+    await nextTick();
+
+    expect(
+      cardByName(wrapper, 'grafana-card')
+        .find('[data-test="container-card-resource-actions"]')
+        .exists(),
+    ).toBe(true);
+    expect(wrapper.find('[data-test="actions-menu-resource-actions"]').exists()).toBe(false);
+  });
+
+  it('does not duplicate hidden table Resources during forced card reflow', async () => {
+    const container = makeContainer({
+      id: 'c-forced-card-resources',
+      name: 'grafana-forced-card',
+      sourceRepo: 'github.com/grafana/grafana',
+    });
+    const { context, refs } = makeContext();
+    context.hiddenColumnKeys.value = ['links'];
+    refs.containerCardReflowForced.value = true;
+    refs.filteredContainers.value = [container];
+    refs.displayContainers.value = [container];
+    refs.renderGroups.value = [
+      {
+        key: '__flat__',
+        name: null,
+        containers: [container],
+        containerCount: 1,
+        updatesAvailable: 0,
+        updatableCount: 0,
+      },
+    ];
+    refs.openActionsMenu.value = container.id;
+    mocked.context = context;
+
+    const wrapper = mountSubject();
+    await nextTick();
+
+    expect(wrapper.find('[data-test="actions-menu-resource-actions"]').exists()).toBe(false);
+  });
+
   it('renders each table quick link independently when the other link data is absent (#295)', async () => {
     const sourceOnly = makeContainer({
       id: 'c-source-only',

--- a/ui/tests/composables/useColumnVisibility.spec.ts
+++ b/ui/tests/composables/useColumnVisibility.spec.ts
@@ -77,11 +77,11 @@ describe('useColumnVisibility', () => {
     }
   });
 
-  it('should mark identity and resource columns as required', async () => {
+  it('keeps only row identity columns required so Resources can be hidden (#498)', async () => {
     const { useColumnVisibility } = await loadColumnVisibility();
     const { allColumns } = useColumnVisibility();
     const required = allColumns.filter((c) => c.required).map((c) => c.key);
-    expect(required).toEqual(['icon', 'name', 'links']);
+    expect(required).toEqual(['icon', 'name']);
   });
 
   it('should toggle a non-required column off', async () => {
@@ -110,8 +110,22 @@ describe('useColumnVisibility', () => {
     expect(visibleColumns.value.has('icon')).toBe(true);
     toggleColumn('name');
     expect(visibleColumns.value.has('name')).toBe(true);
-    toggleColumn('links');
+  });
+
+  it('allows Resources to be hidden and persists that preference (#498)', async () => {
+    const { useColumnVisibility } = await loadColumnVisibility();
+    const { hiddenColumnKeys, visibleColumns, toggleColumn } = useColumnVisibility();
+
     expect(visibleColumns.value.has('links')).toBe(true);
+    toggleColumn('links');
+    expect(visibleColumns.value.has('links')).toBe(false);
+    expect(hiddenColumnKeys.value).toContain('links');
+
+    await nextTick();
+    const { flushPreferences } = await import('@/preferences/store');
+    flushPreferences();
+    const stored = JSON.parse(localStorage.getItem('dd-preferences') ?? '{}').containers.columns;
+    expect(stored).not.toContain('links');
   });
 
   it('should ignore unknown column keys', async () => {
@@ -152,9 +166,10 @@ describe('useColumnVisibility', () => {
     setTestPreferences({ containers: { columns: ['icon', 'name', 'status'] } });
     const { useColumnVisibility } = await loadColumnVisibility();
     const { visibleColumns } = useColumnVisibility();
-    expect(visibleColumns.value.size).toBe(4);
+    expect(visibleColumns.value.size).toBe(3);
     expect(visibleColumns.value.has('version')).toBe(false);
     expect(visibleColumns.value.has('status')).toBe(true);
+    expect(visibleColumns.value.has('links')).toBe(false);
   });
 
   it('should fall back to defaults when preferences contain invalid data', async () => {
@@ -281,7 +296,7 @@ describe('useColumnVisibility', () => {
     it('drops registry first as width tightens using column min sizes', async () => {
       const { useColumnVisibility } = await loadColumnVisibility();
       // Keep Host visible at laptop widths; the secondary software-version column
-      // yields before it when the required Resources column needs room (#498).
+      // yields before it while the default-visible Resources column uses its fixed footprint (#498).
       const width = ref(1029);
       const { hiddenColumnKeys, autoHiddenColumns } = useColumnVisibility(width);
       expect(hiddenColumnKeys.value).toContain('registry');
@@ -331,7 +346,7 @@ describe('useColumnVisibility', () => {
       ]);
     });
 
-    it('never drops icon, name, version, or links even at width=0', async () => {
+    it('does not auto-hide identity, tag, or default-visible Resources at width=0', async () => {
       const { useColumnVisibility } = await loadColumnVisibility();
       const width = ref(0);
       const { hiddenColumnKeys, autoHiddenColumns } = useColumnVisibility(width);
@@ -343,7 +358,7 @@ describe('useColumnVisibility', () => {
       expect(autoHiddenColumns.value).toHaveLength(0);
     });
 
-    it('never drops icon, name, version, or links even at very narrow positive width', async () => {
+    it('does not auto-hide identity, tag, or default-visible Resources at very narrow widths', async () => {
       const { useColumnVisibility } = await loadColumnVisibility();
       const width = ref(1);
       const { hiddenColumnKeys, autoHiddenColumns } = useColumnVisibility(width);
@@ -382,7 +397,7 @@ describe('useColumnVisibility', () => {
 
     it('autoHiddenColumns lists exactly the dropped columns when some are auto-hidden', async () => {
       const { useColumnVisibility } = await loadColumnVisibility();
-      // At 1029 the required Resources column pushes three optional columns out.
+      // At 1029 the default-visible fixed Resources column pushes three responsive columns out.
       const width = ref(1029);
       const { autoHiddenColumns } = useColumnVisibility(width);
       expect(autoHiddenColumns.value).toHaveLength(3);
@@ -403,7 +418,7 @@ describe('useColumnVisibility', () => {
       width.value = 1029;
       await nextTick();
       expect(hiddenColumnKeys.value).toContain('registry');
-      // At 1029, the required Resources column remains while optional columns reflow.
+      // At 1029, default-visible Resources remains while responsive columns reflow.
       expect(autoHiddenColumns.value.map((c) => c.key)).toEqual([
         'registry',
         'softwareVersion',
@@ -427,7 +442,7 @@ describe('useColumnVisibility', () => {
       base.value = 1029;
       await nextTick();
       expect(hiddenColumnKeys.value).toContain('registry');
-      // At 1029, the required Resources column remains while optional columns reflow.
+      // At 1029, default-visible Resources remains while responsive columns reflow.
       expect(autoHiddenColumns.value.map((c) => c.key)).toEqual([
         'registry',
         'softwareVersion',
@@ -446,9 +461,9 @@ describe('useColumnVisibility', () => {
       expect(hiddenColumnKeys.value).not.toContain('name');
       expect(hiddenColumnKeys.value).not.toContain('version');
       expect(hiddenColumnKeys.value).toContain('kind');
-      expect(hiddenColumnKeys.value).toContain('status');
-      expect(hiddenColumnKeys.value).not.toContain('links');
-      expect(autoHiddenColumns.value.map((c) => c.key)).toEqual(['kind', 'status']);
+      expect(hiddenColumnKeys.value).not.toContain('status');
+      expect(hiddenColumnKeys.value).toContain('links');
+      expect(autoHiddenColumns.value.map((c) => c.key)).toEqual(['kind']);
     });
   });
 
@@ -516,6 +531,7 @@ describe('useColumnVisibility', () => {
             'status',
             'server',
             'registry',
+            'links',
             'uptime',
           ],
         },

--- a/ui/tests/preferences/migrate.spec.ts
+++ b/ui/tests/preferences/migrate.spec.ts
@@ -903,6 +903,14 @@ describe('preferences migration', () => {
         expect(result.containers.columns).toEqual(['icon', ...columns, 'links']);
       });
 
+      it('should preserve a legacy Resources column without duplicating it', () => {
+        const columns = ['name', 'links', 'status'];
+        localStorage.setItem('dd-table-cols-v1', JSON.stringify(columns));
+        const result = migrateFromLegacyKeys();
+        expect(result.containers.columns).toEqual(['icon', 'name', 'status', 'links']);
+        expect(result.containers.columns.filter((column) => column === 'links')).toHaveLength(1);
+      });
+
       it('should drop stale columns that no longer exist in the table', () => {
         localStorage.setItem(
           'dd-table-cols-v1',


### PR DESCRIPTION
## Summary

- let people hide the Containers table’s Resources column while keeping it visible by default
- move Source, Release Notes, and Registry shortcuts into the row’s More menu whenever the column is hidden
- keep card footers as the single resource-action surface in card and forced-reflow modes
- preserve current-schema choices and keep Resources visible once for legacy column migrations
- document the behavior and add unit plus real-browser regression coverage for #498

## Verification

- 4,293 UI tests across 213 files with 100% statement, branch, function, and line coverage
- app coverage gate at 100%
- full pre-push formatter, quality, script, workflow, typecheck, coverage, app build, and UI build gates passed
- seven-test #498 Playwright spec passed against the packaged QA app
- visual QA passed at the reporter’s exact 1197px viewport and at 390×844 mobile, with all three resource shortcuts preserved and no horizontal overflow

Addresses the remaining Resources-column feedback in #498.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added deterministic Playwright regression for `#498` covering Resources-column hiding and ensuring row/card “More” menu resource shortcuts remain correct (including exact `data-test` ordering).
- ✨ Added per-container “Resources” quick-links into the row More menu when the Resources column is hidden.
- ✨ Added unit coverage for resource shortcut rendering and non-duplication across table vs Cards view (including forced card reflow).
- 🔧 Made the Containers “links/Resources” column user-hideable while keeping it visible by default.
- 🔧 Updated column visibility/composable defaults and responsive auto-hide expectations to match new “required/default-visible” semantics.
- 🔧 Updated legacy `dd-table-cols-v1` migration to preserve “links/Resources” when already present, otherwise append it once for older users.
- 🐛 Fixed duplicate resource actions in card More menus by conditionally rendering resource sections only when appropriate.
- 🔧 Documented/validated the updated Resources-column behavior via tests.

## Concerns

- Verify the More-menu shortcut ordering stays stable across grouped and responsive layouts.
- Confirm migration behavior across all legacy preference payload variants (especially when `links/Resources` is already present vs missing).
- Ensure resource shortcuts are omitted when a container has no resource data (to avoid empty/irrelevant quick-links).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->