### PR TITLE
🚀 release: v1.6.0-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0-rc.5] — 2026-07-22
+
 ### Changed
 
 - **The Containers table's Resources column is now optional** ([#498](https://github.com/CodesWhat/drydock/issues/498)). It remains visible by default, but the column picker can hide it and preserves that choice. Source, release-note, and registry shortcuts move into each row's **More** menu while hidden and remain available in card and detail views.
+
+### Security
+
+- **The documentation website now runs Next.js 16.2.11 and React 19.2.8.** The Next.js patch closes nine upstream advisories disclosed against 16.2.9, including proxy bypass, Server Actions denial of service and SSRF, rewrite SSRF, response-cache confusion, image-optimization denial of service, and Server Function endpoint disclosure (GHSA-6gpp-xcg3-4w24, GHSA-m99w-x7hq-7vfj, GHSA-89xv-2m56-2m9x, GHSA-p9j2-gv94-2wf4, GHSA-68g3-v927-f742, GHSA-4633-3j49-mh5q, GHSA-4c39-4ccg-62r3, GHSA-q8wf-6r8g-63ch, GHSA-955p-x3mx-jcvp).
 
 ## [1.6.0-rc.4] — 2026-07-22
 
@@ -2215,7 +2221,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.4...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.5...HEAD
+[1.6.0-rc.5]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.4...v1.6.0-rc.5
 [1.6.0-rc.4]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.3...v1.6.0-rc.4
 [1.6.0-rc.3]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.2...v1.6.0-rc.3
 [1.6.0-rc.2]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.1...v1.6.0-rc.2

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.4-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.5-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -178,11 +178,12 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
-<summary><strong>v1.6.0-rc.4 highlights</strong></summary>
+<summary><strong>v1.6.0-rc.5 highlights</strong></summary>
 
 - **Notifications** — Per-rule/per-provider title and body templates with live preview, plus audit-backed in-app bell categories and update severity thresholds.
 - **Dashboard** — Zero-dependency CSS Grid replacement with mouse/touch reorder, bounded resize, responsive layouts, widget visibility, reset, and optional cross-device preference sync.
 - **Update policy** — Declarative watcher/label/UI precedence, override/revert audit trail, maturity countdown/manual override, and pinned-tag informational visibility with a stacked current → newer Tag view.
+- **Container resources** — The Resources column remains visible by default but can now be hidden persistently; Source, release-note, and registry shortcuts stay available from each row's More menu and from card footers.
 - **Performance & recovery** — Per-poll tag-list deduplication, lighter aggregate projections, virtualized large log histories, immutable live-log rollover, auth-bootstrap timeout, complete preference migrations, and stale-chunk self-healing.
 - **v1.6 migrations enforced** — WUD env/label aliases, legacy auth formats, obsolete watcher switches, template aliases, Kafka `clientId`, and malformed token-only Hub/DHI public configs no longer run. The trigger-taxonomy aliases remain for one final error-level warning release.
 

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.0-rc.4',
+    version: '1.6.0-rc.5',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.0-rc.4 started',
+    details: 'Drydock v1.6.0-rc.5 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.4',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.5',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.0-rc.4',
+    tag: '1.6.0-rc.5',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.0-rc.4',
+  version: '1.6.0-rc.5',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.0-rc.4',
+      version: '1.6.0-rc.5',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.0-rc.4', mode: 'demo' },
+        server: { version: '1.6.0-rc.5', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -19,9 +19,9 @@
         "fumadocs-mdx": "^15.0.12",
         "fumadocs-ui": "^16.10.5",
         "lucide-react": "^1.14.0",
-        "next": "16.2.9",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "next": "16.2.11",
+        "react": "19.2.8",
+        "react-dom": "19.2.8",
         "remark-custom-heading-id": "^2.0.0",
         "tailwind-merge": "^3.6.0"
       },
@@ -1362,15 +1362,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.11.tgz",
+      "integrity": "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.11.tgz",
+      "integrity": "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==",
       "cpu": [
         "arm64"
       ],
@@ -1384,9 +1384,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.11.tgz",
+      "integrity": "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==",
       "cpu": [
         "x64"
       ],
@@ -1400,9 +1400,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.11.tgz",
+      "integrity": "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==",
       "cpu": [
         "arm64"
       ],
@@ -1419,9 +1419,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.11.tgz",
+      "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
       ],
@@ -1438,9 +1438,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.11.tgz",
+      "integrity": "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==",
       "cpu": [
         "x64"
       ],
@@ -1457,9 +1457,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.11.tgz",
+      "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
       ],
@@ -1476,9 +1476,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.11.tgz",
+      "integrity": "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==",
       "cpu": [
         "arm64"
       ],
@@ -1492,9 +1492,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.11.tgz",
+      "integrity": "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==",
       "cpu": [
         "x64"
       ],
@@ -5533,12 +5533,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.11.tgz",
+      "integrity": "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.9",
+        "@next/env": "16.2.11",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -5552,14 +5552,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.9",
-        "@next/swc-darwin-x64": "16.2.9",
-        "@next/swc-linux-arm64-gnu": "16.2.9",
-        "@next/swc-linux-arm64-musl": "16.2.9",
-        "@next/swc-linux-x64-gnu": "16.2.9",
-        "@next/swc-linux-x64-musl": "16.2.9",
-        "@next/swc-win32-arm64-msvc": "16.2.9",
-        "@next/swc-win32-x64-msvc": "16.2.9",
+        "@next/swc-darwin-arm64": "16.2.11",
+        "@next/swc-darwin-x64": "16.2.11",
+        "@next/swc-linux-arm64-gnu": "16.2.11",
+        "@next/swc-linux-arm64-musl": "16.2.11",
+        "@next/swc-linux-x64-gnu": "16.2.11",
+        "@next/swc-linux-x64-musl": "16.2.11",
+        "@next/swc-win32-arm64-msvc": "16.2.11",
+        "@next/swc-win32-x64-msvc": "16.2.11",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -5706,24 +5706,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-remove-scroll": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,9 +33,9 @@
     "fumadocs-mdx": "^15.0.12",
     "fumadocs-ui": "^16.10.5",
     "lucide-react": "^1.14.0",
-    "next": "16.2.9",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "next": "16.2.11",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "remark-custom-heading-id": "^2.0.0",
     "tailwind-merge": "^3.6.0"
   },
@@ -53,6 +53,8 @@
     "postcss": "8.5.10",
     "esbuild": "0.28.1",
     "js-yaml": "4.3.0",
-    "sharp": "0.35.3"
+    "sharp": "0.35.3",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3"
   }
 }

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.0-rc.4",
+  version: "1.6.0-rc.5",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.0-rc.4",
+    version: "v1.6.0-rc.5",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.0-rc.4",
+      "version": "1.6.0-rc.5",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.0-rc.4",
+    "version": "1.6.0-rc.5",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.0-rc.4"
+  "version":"1.6.0-rc.5"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -162,7 +162,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.0-rc.4",
+    "version": "1.6.0-rc.5",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -185,7 +185,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.0-rc.4",
+      "drydockVersion": "1.6.0-rc.5",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.0-rc.4` | Immutable release candidate; best for reproducible testing |
+| `1.6.0-rc.5` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.0-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -3,6 +3,10 @@ title: "Updates"
 description: "Release update notes and feature highlights, with direct links to current configuration and API docs."
 ---
 
+## v1.6.0-rc.5 Highlights — July 22, 2026
+
+- **Resources can give the table its space back** — the Resources column remains visible by default, but the column picker can now hide it and preserve that choice. Source, release-note, and registry shortcuts move into each row's **More** menu while hidden; cards keep the same shortcuts in their footer without duplicating them.
+
 ## v1.6.0-rc.4 Highlights — July 22, 2026
 
 - **Pinned freshness is honest at a glance** — an informational newer-version insight now reads Major, Minor, or Patch instead of contradicting the visible newer tag with “Current.” It remains non-actionable and cannot fire update actions or notifications.

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6 RC and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.4...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.5...HEAD`],
+    ['1.6.0-rc.5', `${repositoryUrl}/compare/v1.6.0-rc.4...v1.6.0-rc.5`],
     ['1.6.0-rc.4', `${repositoryUrl}/compare/v1.6.0-rc.3...v1.6.0-rc.4`],
     ['1.6.0-rc.3', `${repositoryUrl}/compare/v1.6.0-rc.2...v1.6.0-rc.3`],
     ['1.6.0-rc.2', `${repositoryUrl}/compare/v1.6.0-rc.1...v1.6.0-rc.2`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.0-rc.4';
+const RC_VERSION = '1.6.0-rc.5';
 const RC_DATE = '2026-07-22';
 const RC_DISPLAY_DATE = 'July 22, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
@@ -23,16 +23,16 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   const quickstart = read('content/docs/current/quickstart/index.mdx');
   const changelog = read('CHANGELOG.md');
 
-  assert.match(readme, /version-1\.6\.0--rc\.4-blue/u);
-  assert.match(readme, /v1\.6\.0-rc\.4 highlights/u);
+  assert.match(readme, /version-1\.6\.0--rc\.5-blue/u);
+  assert.match(readme, /v1\.6\.0-rc\.5 highlights/u);
   assert.match(siteConfig, new RegExp(`version: "${RC_VERSION.replaceAll('.', '\\.')}"`, 'u'));
   assert.ok(updates.includes(`## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`));
-  assert.match(appApi, /"version":"1\.6\.0-rc\.4"/u);
-  assert.match(agentApi, /"version": "1\.6\.0-rc\.4"/u);
-  assert.match(portwingApi, /"version": "1\.6\.0-rc\.4"/u);
-  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.4"/u);
-  assert.match(quickstart, /\| `1\.6\.0-rc\.4` \| Immutable release candidate/u);
-  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!4\b)\d+` \| Immutable release candidate/u);
+  assert.match(appApi, /"version":"1\.6\.0-rc\.5"/u);
+  assert.match(agentApi, /"version": "1\.6\.0-rc\.5"/u);
+  assert.match(portwingApi, /"version": "1\.6\.0-rc\.5"/u);
+  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.5"/u);
+  assert.match(quickstart, /\| `1\.6\.0-rc\.5` \| Immutable release candidate/u);
+  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!5\b)\d+` \| Immutable release candidate/u);
   assert.ok(changelog.includes(`## [${RC_VERSION}] — ${RC_DATE}`));
   assert.ok(
     changelog.includes(
@@ -41,7 +41,7 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   );
   assert.ok(
     changelog.includes(
-      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.3...v${RC_VERSION}`,
+      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.4...v${RC_VERSION}`,
     ),
   );
 });
@@ -55,7 +55,7 @@ test('v1.5.2 is archived and public release routing advances to v1.6', () => {
 
   assert.match(readme, /<summary><strong>v1\.5\.2 highlights<\/strong><\/summary>/u);
   assert.match(siteContent, /version: "v1\.5\.2",[\s\S]{0,500}?status: "released"/u);
-  assert.match(siteContent, /version: "v1\.6\.0-rc\.4",[\s\S]{0,500}?status: "next"/u);
+  assert.match(siteContent, /version: "v1\.6\.0-rc\.5",[\s\S]{0,500}?status: "next"/u);
   assert.match(
     docsVersions,
     /\{ slug: "v1\.6", source: "current", title: "v1\.6" \},\s+\{ slug: "v1\.5", source: "v1\.5", title: "v1\.5" \}/u,

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.0';
-const RC_VERSION = '1.6.0-rc.4';
+const RC_VERSION = '1.6.0-rc.5';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',
@@ -52,7 +52,7 @@ test('release-gated workspace packages and locks use the v1.6 base version', () 
   }
 });
 
-test('demo runtime fixtures identify the exact v1.6.0-rc.4 candidate', () => {
+test('demo runtime fixtures identify the exact v1.6.0-rc.5 candidate', () => {
   for (const { path, valuePattern } of DEMO_RELEASE_FIXTURES) {
     const contents = readFileSync(path, 'utf8');
     assert.deepEqual(extractVersionValues(contents, valuePattern), [RC_VERSION], path);
@@ -63,18 +63,18 @@ test('release version patterns match exact optionally v-prefixed tokens', () => 
   const rcPattern = versionPattern(RC_VERSION);
   const legacyPattern = versionPattern('1.5.0');
 
-  assert.match('version: 1.6.0-rc.4', rcPattern);
-  assert.match('version: v1.6.0-rc.4', rcPattern);
-  assert.doesNotMatch('version: 1.6.0-rc.40', rcPattern);
-  assert.doesNotMatch('version: x1.6.0-rc.4', rcPattern);
+  assert.match('version: 1.6.0-rc.5', rcPattern);
+  assert.match('version: v1.6.0-rc.5', rcPattern);
+  assert.doesNotMatch('version: 1.6.0-rc.50', rcPattern);
+  assert.doesNotMatch('version: x1.6.0-rc.5', rcPattern);
   assert.match('version: v1.5.0', legacyPattern);
   assert.doesNotMatch('version: 1.5.0-rc.1', legacyPattern);
 });
 
 test('fixture version extraction retains mixed candidate identities', () => {
-  const contents = "version: '1.6.0-rc.4', version: '1.6.0-rc.40'";
+  const contents = "version: '1.6.0-rc.5', version: '1.6.0-rc.50'";
   assert.deepEqual(extractVersionValues(contents, /version:\s*["']([^"']+)["']/gu), [
-    '1.6.0-rc.4',
-    '1.6.0-rc.40',
+    '1.6.0-rc.5',
+    '1.6.0-rc.50',
   ]);
 });

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -52,6 +52,32 @@ test('sharp is pinned to a patched release in the website', () => {
   assert.ok(compareSemver(resolvedVersion(lockfile, 'sharp'), '0.35.3') >= 0);
 });
 
+test('Next.js is pinned past the 16.2.9 security advisory batch', () => {
+  const manifest = readJson('apps/web/package.json');
+  const lockfile = readJson('apps/web/package-lock.json');
+
+  assert.equal(manifest.dependencies?.next, '16.2.11');
+  assert.ok(compareSemver(resolvedVersion(lockfile, 'next'), '16.2.11') >= 0);
+});
+
+test('the rc.5 changelog records the Next.js security refresh', () => {
+  const changelog = readFileSync(new URL('../CHANGELOG.md', import.meta.url), 'utf8');
+  const rc5Header = '## [1.6.0-rc.5]';
+  const rc4Header = '## [1.6.0-rc.4]';
+  const rc5Start = changelog.indexOf(rc5Header);
+  const rc4Start = changelog.indexOf(rc4Header, rc5Start + rc5Header.length);
+
+  assert.notEqual(rc5Start, -1, 'missing rc.5 changelog header');
+  assert.notEqual(rc4Start, -1, 'missing rc.4 changelog boundary');
+
+  const rc5 = changelog.slice(rc5Start, rc4Start);
+
+  assert.match(rc5, /Next\.js 16\.2\.11/);
+  assert.match(rc5, /GHSA-6gpp-xcg3-4w24/);
+  assert.match(rc5, /GHSA-m99w-x7hq-7vfj/);
+  assert.match(rc5, /GHSA-89xv-2m56-2m9x/);
+});
+
 test('the rc.3 changelog records the security dependency refresh', () => {
   const changelog = readFileSync(new URL('../CHANGELOG.md', import.meta.url), 'utf8');
   const rc3Header = '## [1.6.0-rc.3]';


### PR DESCRIPTION
## Summary

Prepare **v1.6.0-rc.5** from the latest `main`.

rc.5 delta over rc.4:

- **#583 issue #498 Resources follow-up** — Resources remains visible by default but is now user-hideable and persistent; Source, Release Notes, and Registry remain reachable from each table row's More menu, while cards keep the same links in their footer without duplication. Covered at the reporter's exact 1197px laptop width and at 390px mobile.
- **Website security refresh** — Next.js 16.2.9 → 16.2.11 and React/React DOM 19.2.7 → 19.2.8 after nine newly disclosed Next.js advisories blocked the local Qlty gate. Added a pinned-version regression guard and rc.5 security notes.
- **Release identity** — advanced the changelog, README, website/demo, current docs, API examples, quickstart, and release guard tests to rc.5.

## Verification

- 125/125 repository script tests
- 45/45 workflow invariant tests
- 44/44 website script tests
- `npm audit`: 0 vulnerabilities in the website workspace
- Website production build: 348 pages generated on Next.js 16.2.11
- Live development smoke: homepage and `/docs/v1.6/updates` both returned 200 with rc.5 content present
- Full pre-push gate: 100% app/UI coverage, type-check, Biome, Qlty, and app/UI builds
- Local prerelease precheck completed; its five unchecked “shipped in v1.6.0” Discussion follow-ups remain GA closeout actions and are not RC blockers

After merge: verify exact-`main` CI Verify and Playwright, then dispatch `release-cut.yml` with `release_tag=v1.6.0-rc.5`.