### PR TITLE
🐛 fix(ui): repair mobile Dashboard and Containers layouts (#498)

### DIFF
--- a/.github/tests/github-action-pins.ts
+++ b/.github/tests/github-action-pins.ts
@@ -1,5 +1,5 @@
 export const expectedActionPins = new Map([
-  ['actions/cache', 'actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5'],
+  ['actions/cache', 'actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0'],
   ['actions/checkout', 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3'],
   [
     'actions/dependency-review-action',

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -182,16 +182,16 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           category: /language:${{ matrix.language }}
 
@@ -771,7 +771,7 @@ jobs:
 
       - name: Upload ZAP SARIF
         if: always() && hashFiles('artifacts/zap/zap-baseline.sarif') != ''
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           sarif_file: artifacts/zap/zap-baseline.sarif
           category: zap-baseline
@@ -979,7 +979,7 @@ jobs:
 
       - name: Upload Nuclei SARIF to code scanning
         if: always() && steps.nuclei_sarif.outputs.upload == 'true'
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           sarif_file: artifacts/dast/nuclei-report.sarif
           category: nuclei

--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -220,7 +220,7 @@ jobs:
           command: cd ${{ matrix.package }} && npm ci
 
       - name: Restore Stryker incremental cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
         with:
           path: ${{ matrix.package }}/${{ matrix.incremental_file }}
           # Append the run number so every run writes a fresh cache entry

--- a/.github/workflows/security-grype.yml
+++ b/.github/workflows/security-grype.yml
@@ -66,7 +66,7 @@ jobs:
         # Code scanning uploads need a public repo or GHAS. Drydock is public,
         # so this runs; the guard keeps the job green on a fork/private mirror.
         if: always() && github.event.repository.visibility == 'public'
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           sarif_file: ${{ steps.grype-deps.outputs.sarif }}
           category: grype-deps
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload Grype SARIF to code scanning
         if: always() && github.event.repository.visibility == 'public'
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
           category: grype-image

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -57,6 +57,6 @@ jobs:
           publish_results: true
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
         with:
           sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **The documentation website now runs Next.js 16.2.11 and React 19.2.8.** The Next.js patch closes nine upstream advisories disclosed against 16.2.9, including proxy bypass, Server Actions denial of service and SSRF, rewrite SSRF, response-cache confusion, image-optimization denial of service, and Server Function endpoint disclosure (GHSA-6gpp-xcg3-4w24, GHSA-m99w-x7hq-7vfj, GHSA-89xv-2m56-2m9x, GHSA-p9j2-gv94-2wf4, GHSA-68g3-v927-f742, GHSA-4633-3j49-mh5q, GHSA-4c39-4ccg-62r3, GHSA-q8wf-6r8g-63ch, GHSA-955p-x3mx-jcvp).
+- **The documentation website's `postcss` build dependency is upgraded to 8.5.22**, closing CVE-2026-45623 (GHSA-6g55-p6wh-862q), an arbitrary-file-read via an attacker-controlled `sourceMappingURL` (fixed upstream in 8.5.12).
 
 ## [1.6.0-rc.4] — 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.6.0-rc.5] — 2026-07-22
+## [1.6.0-rc.5] — 2026-07-23
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The Containers table's Resources column is now optional** ([#498](https://github.com/CodesWhat/drydock/issues/498)). It remains visible by default, but the column picker can hide it and preserves that choice. Source, release-note, and registry shortcuts move into each row's **More** menu while hidden and remain available in card and detail views.
 
+### Fixed
+
+- **The Dashboard and Containers views no longer overflow horizontally on narrow phone screens** ([#498](https://github.com/CodesWhat/drydock/issues/498)). Crossing into a single-column breakpoint now re-syncs the dashboard widget layout so widgets stop spilling past the viewport, single-column card lists no longer leave an empty band below reflowed cards, and long stack names in the Containers group header truncate instead of pushing the update button off-screen.
+
 ### Security
 
 - **The documentation website now runs Next.js 16.2.11 and React 19.2.8.** The Next.js patch closes nine upstream advisories disclosed against 16.2.9, including proxy bypass, Server Actions denial of service and SSRF, rewrite SSRF, response-cache confusion, image-optimization denial of service, and Server Function endpoint disclosure (GHSA-6gpp-xcg3-4w24, GHSA-m99w-x7hq-7vfj, GHSA-89xv-2m56-2m9x, GHSA-p9j2-gv94-2wf4, GHSA-68g3-v927-f742, GHSA-4633-3j49-mh5q, GHSA-4c39-4ccg-62r3, GHSA-q8wf-6r8g-63ch, GHSA-955p-x3mx-jcvp).

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -5515,9 +5515,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -5668,9 +5668,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5687,7 +5687,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,7 +50,7 @@
     "typescript": "6.0.3"
   },
   "overrides": {
-    "postcss": "8.5.10",
+    "postcss": "8.5.22",
     "esbuild": "0.28.1",
     "js-yaml": "4.3.0",
     "sharp": "0.35.3",

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -3,9 +3,10 @@ title: "Updates"
 description: "Release update notes and feature highlights, with direct links to current configuration and API docs."
 ---
 
-## v1.6.0-rc.5 Highlights — July 22, 2026
+## v1.6.0-rc.5 Highlights — July 23, 2026
 
 - **Resources can give the table its space back** — the Resources column remains visible by default, but the column picker can now hide it and preserve that choice. Source, release-note, and registry shortcuts move into each row's **More** menu while hidden; cards keep the same shortcuts in their footer without duplicating them.
+- **Phone-width Dashboard and Containers stop overflowing** — crossing into a single-column breakpoint re-syncs the dashboard widget layout so widgets no longer spill past the viewport, single-column card lists drop the empty band below reflowed cards, and long stack names in the Containers group header truncate instead of pushing the update-all button off-screen ([#498](https://github.com/CodesWhat/drydock/issues/498)).
 
 ## v1.6.0-rc.4 Highlights — July 22, 2026
 

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -3,8 +3,8 @@ import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const RC_VERSION = '1.6.0-rc.5';
-const RC_DATE = '2026-07-22';
-const RC_DISPLAY_DATE = 'July 22, 2026';
+const RC_DATE = '2026-07-23';
+const RC_DISPLAY_DATE = 'July 23, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/ui/src/components/DataTable.vue
+++ b/ui/src/components/DataTable.vue
@@ -465,6 +465,29 @@ const cardReflowForced = computed(
 );
 watch(cardReflowForced, (value) => emit('update:cardReflowForced', value), { immediate: true });
 
+// Approximate column count of the card grid, mirroring the CSS
+// `repeat(auto-fill, minmax(cardMinWidth, 1fr))` against the measured viewport with
+// the grid's `gap-3` (12px) gutter. Only the single-column vs multi-column distinction
+// matters here (see cardGridAutoRows), so an off-by-one near an exact boundary is
+// harmless. Falls back to a single column while unmeasured (viewportWidth 0).
+const CARD_GRID_GAP_PX = 12;
+function parseCardMinWidthPx(value: string): number {
+  const match = value.trim().match(/^([0-9]+(?:\.[0-9]+)?)(px|rem|em)?$/);
+  const amount = match ? Number.parseFloat(match[1]) : Number.NaN;
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return 320;
+  }
+  return match?.[2] === 'rem' || match?.[2] === 'em' ? amount * 16 : amount;
+}
+const cardColumnCount = computed(() => {
+  const minWidth = parseCardMinWidthPx(props.cardMinWidth);
+  // Math.max(1, …) also covers the pre-measurement viewportWidth === 0 case.
+  return Math.max(
+    1,
+    Math.floor((viewportWidth.value + CARD_GRID_GAP_PX) / (minWidth + CARD_GRID_GAP_PX)),
+  );
+});
+
 function resolvedColumn(colKey: string): ResolvedDataTableColumn | undefined {
   return allResolvedColumns.value.find((column) => column.key === colKey);
 }
@@ -880,6 +903,15 @@ function isFullWidthRow(row: Record<string, unknown>): boolean {
 // natural height and span every column instead of being stretched into a tall single cell.
 const hasFullWidthRows = computed(() => props.rows.some((row) => isFullWidthRow(row)));
 
+// `1fr` auto-rows equalise every card to the tallest for a tidy multi-column gallery.
+// In a SINGLE column that instead stretches every card to the tallest card in the whole
+// list, so short cards gain a large empty band (the interior `mt-auto` footer sinks to the
+// bottom) — the broken mobile layout reported in #498. Use content-height (`auto`) rows
+// whenever the grid is one column (or already carries full-width group-header rows).
+const cardGridAutoRows = computed(() =>
+  hasFullWidthRows.value || cardColumnCount.value <= 1 ? 'auto' : '1fr',
+);
+
 // Grouped table view floats each stack on the page background (the gaps between stacks ARE the
 // app bg), so the sort header needs its own fill to still read as a distinct bar — it uses the
 // raised `--dd-bg-elevated` (matching the group title bars). Ungrouped tables keep the recessed
@@ -1059,7 +1091,7 @@ function handleCardSortChange(event: Event): void {
         <ul role="list"
             class="gap-3 pb-3"
             :class="virtualScroll ? 'flex flex-col' : 'grid'"
-            :style="virtualScroll ? undefined : { gridTemplateColumns: `repeat(auto-fill, minmax(${cardMinWidth}, 1fr))`, gridAutoRows: hasFullWidthRows ? 'auto' : '1fr' }">
+            :style="virtualScroll ? undefined : { gridTemplateColumns: `repeat(auto-fill, minmax(${cardMinWidth}, 1fr))`, gridAutoRows: cardGridAutoRows }">
           <li
             v-if="topSpacerHeight > 0"
             aria-hidden="true"

--- a/ui/src/components/DataTable.vue
+++ b/ui/src/components/DataTable.vue
@@ -471,13 +471,21 @@ watch(cardReflowForced, (value) => emit('update:cardReflowForced', value), { imm
 // matters here (see cardGridAutoRows), so an off-by-one near an exact boundary is
 // harmless. Falls back to a single column while unmeasured (viewportWidth 0).
 const CARD_GRID_GAP_PX = 12;
+// The app scales the document root via `--dd-font-size` (0.8–1.3 presets), so `rem`/`em`
+// can't assume a 16px root. Resolve them against the live computed root font size, the
+// same value the browser uses for the template's `minmax()` units, so the heuristic
+// agrees with the rendered layout at every font-size preset.
+function rootFontSizePx(): number {
+  const parsed = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 16;
+}
 function parseCardMinWidthPx(value: string): number {
   const match = value.trim().match(/^([0-9]+(?:\.[0-9]+)?)(px|rem|em)?$/);
   const amount = match ? Number.parseFloat(match[1]) : Number.NaN;
   if (!Number.isFinite(amount) || amount <= 0) {
     return 320;
   }
-  return match?.[2] === 'rem' || match?.[2] === 'em' ? amount * 16 : amount;
+  return match?.[2] === 'rem' || match?.[2] === 'em' ? amount * rootFontSizePx() : amount;
 }
 const cardColumnCount = computed(() => {
   const minWidth = parseCardMinWidthPx(props.cardMinWidth);

--- a/ui/src/components/containers/ContainersGroupHeader.vue
+++ b/ui/src/components/containers/ContainersGroupHeader.vue
@@ -45,20 +45,21 @@ const emit = defineEmits<{
       class="dd-text-muted shrink-0"
     />
     <AppIcon name="stack" :size="12" class="dd-text-muted shrink-0" />
-    <span class="text-xs font-semibold dd-text">{{ group.name ?? t('containerComponents.groupHeader.ungrouped') }}</span>
+    <span class="text-xs font-semibold dd-text truncate min-w-0">{{ group.name ?? t('containerComponents.groupHeader.ungrouped') }}</span>
     <AppBadge
       size="xs"
+      class="shrink-0"
       :custom="{ bg: 'var(--dd-bg-elevated)', text: 'var(--dd-text-muted)' }"
     >
       {{ group.containerCount }}
     </AppBadge>
-    <AppBadge v-if="showUpdateControls && group.updatesAvailable > 0" tone="success" size="xs">
+    <AppBadge v-if="showUpdateControls && group.updatesAvailable > 0" tone="success" size="xs" class="shrink-0">
       {{ group.updatesAvailable }} {{ group.updatesAvailable === 1 ? t('containerComponents.groupHeader.updateSingular') : t('containerComponents.groupHeader.updatePlural') }}
     </AppBadge>
     <div
       v-if="showUpdateControls && (group.updatesAvailable > 0 || !containerActionsEnabled)"
       data-test="group-header-update-all-sticky"
-      class="ms-auto sticky end-0 z-10 flex items-center"
+      class="ms-auto shrink-0 sticky end-0 z-10 flex items-center"
     >
       <AppButton
         size="compact"
@@ -68,7 +69,7 @@ const emit = defineEmits<{
             : 'success'
         "
         weight="semibold"
-        class="inline-flex items-center justify-center"
+        class="inline-flex items-center justify-center whitespace-nowrap"
         :class="
           !containerActionsEnabled || inProgress
             ? 'cursor-not-allowed'

--- a/ui/src/views/dashboard/useDashboardResponsiveLayouts.ts
+++ b/ui/src/views/dashboard/useDashboardResponsiveLayouts.ts
@@ -319,6 +319,11 @@ export function useDashboardResponsiveLayouts(options: {
       ...layoutsByBreakpoint.value,
       [breakpoint]: cloneLayout(normalized),
     };
+    // Re-sync the active layout to the new breakpoint's coordinates. Without
+    // this, crossing into a single-column breakpoint leaves every widget at its
+    // 12-column x/w, so the 1-column CSS grid fabricates auto-sized implicit
+    // columns and the whole dashboard overflows horizontally on phones (#498).
+    layout.value = cloneLayout(normalized);
   }
 
   return {

--- a/ui/tests/components/DataTable.spec.ts
+++ b/ui/tests/components/DataTable.spec.ts
@@ -1971,6 +1971,45 @@ describe('DataTable', () => {
         expect(w.get('ul[role="list"]').attributes('style')).toContain('grid-auto-rows: auto');
       });
 
+      it('resolves rem card minimum widths against the live computed root font size', async () => {
+        // Pins rootFontSizePx() reading getComputedStyle(documentElement) rather than
+        // assuming a fixed 16px root: at a 20px root, 20rem → 400px keeps a 700px
+        // viewport single-column (auto rows); the old fixed-16px math (20rem → 320px)
+        // would fit two columns here (1fr rows), so this width tells the two apart.
+        const originalGetComputedStyle = window.getComputedStyle;
+        const spy = vi.spyOn(window, 'getComputedStyle').mockImplementation((el, ...rest) => {
+          if (el === document.documentElement) {
+            return { fontSize: '20px' } as CSSStyleDeclaration;
+          }
+          return originalGetComputedStyle(el, ...rest);
+        });
+
+        const w = await mountAtWidth(700, { preferCards: true, cardMinWidth: '20rem' });
+
+        expect(w.get('ul[role="list"]').attributes('style')).toContain('grid-auto-rows: auto');
+
+        spy.mockRestore();
+      });
+
+      it('falls back to a 16px root font size when the computed value is unparseable', async () => {
+        // Pins the rootFontSizePx() fallback branch: an unparseable computed font size
+        // (Number.parseFloat('') is NaN) falls back to 16px, so 30rem → 480px keeps a
+        // 700px viewport single-column (auto rows).
+        const originalGetComputedStyle = window.getComputedStyle;
+        const spy = vi.spyOn(window, 'getComputedStyle').mockImplementation((el, ...rest) => {
+          if (el === document.documentElement) {
+            return { fontSize: '' } as CSSStyleDeclaration;
+          }
+          return originalGetComputedStyle(el, ...rest);
+        });
+
+        const w = await mountAtWidth(700, { preferCards: true, cardMinWidth: '30rem' });
+
+        expect(w.get('ul[role="list"]').attributes('style')).toContain('grid-auto-rows: auto');
+
+        spy.mockRestore();
+      });
+
       it('falls back to a 320px card minimum width for invalid values', async () => {
         const w = await mountAtWidth(400, { cardMinWidth: 'not-a-size' });
 

--- a/ui/tests/components/DataTable.spec.ts
+++ b/ui/tests/components/DataTable.spec.ts
@@ -1956,13 +1956,17 @@ describe('DataTable', () => {
       });
 
       it('converts rem card minimum widths when detecting a single-column grid', async () => {
-        const w = await mountAtWidth(500, { preferCards: true, cardMinWidth: '30rem' });
+        // 30rem → 480px keeps a 700px viewport single-column (auto rows); the 320px
+        // fallback would fit two columns here (1fr rows), so this width distinguishes a
+        // real rem conversion from the invalid-value fallback.
+        const w = await mountAtWidth(700, { preferCards: true, cardMinWidth: '30rem' });
 
         expect(w.get('ul[role="list"]').attributes('style')).toContain('grid-auto-rows: auto');
       });
 
       it('converts em card minimum widths when detecting a single-column grid', async () => {
-        const w = await mountAtWidth(500, { preferCards: true, cardMinWidth: '30em' });
+        // 30em → 480px, same distinguishing rationale as the rem case above.
+        const w = await mountAtWidth(700, { preferCards: true, cardMinWidth: '30em' });
 
         expect(w.get('ul[role="list"]').attributes('style')).toContain('grid-auto-rows: auto');
       });

--- a/ui/tests/components/DataTable.spec.ts
+++ b/ui/tests/components/DataTable.spec.ts
@@ -1947,6 +1947,38 @@ describe('DataTable', () => {
         expect(w.findAll('[data-test="dd-card"]')[0].classes()).toContain('h-full');
       });
 
+      it('uses content-height rows for a single-column card grid', async () => {
+        const w = await mountAtWidth(400, { cardMinWidth: '320px' });
+        const list = w.get('ul[role="list"]');
+
+        expect(list.attributes('style')).toContain('grid-auto-rows: auto');
+        expect(w.findAll('[data-test="dd-card"]')[0].classes()).toContain('h-full');
+      });
+
+      it('converts rem card minimum widths when detecting a single-column grid', async () => {
+        const w = await mountAtWidth(500, { preferCards: true, cardMinWidth: '30rem' });
+
+        expect(w.get('ul[role="list"]').attributes('style')).toContain('grid-auto-rows: auto');
+      });
+
+      it('converts em card minimum widths when detecting a single-column grid', async () => {
+        const w = await mountAtWidth(500, { preferCards: true, cardMinWidth: '30em' });
+
+        expect(w.get('ul[role="list"]').attributes('style')).toContain('grid-auto-rows: auto');
+      });
+
+      it('falls back to a 320px card minimum width for invalid values', async () => {
+        const w = await mountAtWidth(400, { cardMinWidth: 'not-a-size' });
+
+        expect(w.get('ul[role="list"]').attributes('style')).toContain('grid-auto-rows: auto');
+      });
+
+      it('falls back to a 320px card minimum width for zero values', async () => {
+        const w = await mountAtWidth(400, { cardMinWidth: '0px' });
+
+        expect(w.get('ul[role="list"]').attributes('style')).toContain('grid-auto-rows: auto');
+      });
+
       it('uses a vertical flex list and natural card height while virtualized', async () => {
         const manyRows = Array.from({ length: 20 }, (_, i) => ({
           id: `${i + 1}`,

--- a/ui/tests/components/containers/ContainersGroupHeader.spec.ts
+++ b/ui/tests/components/containers/ContainersGroupHeader.spec.ts
@@ -102,6 +102,29 @@ describe('ContainersGroupHeader', () => {
     expect(sticky.find('button').exists()).toBe(true);
   });
 
+  it('keeps a long group name from shrinking or wrapping the update controls (#498)', () => {
+    const longName = 'immich-machine-learning-openvino';
+    const wrapper = mountHeader({
+      group: {
+        key: 'stack-a',
+        name: longName,
+        containers: [],
+        containerCount: 3,
+        updatesAvailable: 3,
+        updatableCount: 3,
+      },
+    });
+    const groupName = wrapper.findAll('span').find((span) => span.text() === longName);
+    const badges = wrapper.findAllComponents({ name: 'AppBadge' });
+    const sticky = wrapper.get('[data-test="group-header-update-all-sticky"]');
+
+    expect(groupName?.classes()).toEqual(expect.arrayContaining(['truncate', 'min-w-0']));
+    expect(badges).toHaveLength(2);
+    expect(badges.every((badge) => badge.classes().includes('shrink-0'))).toBe(true);
+    expect(sticky.classes()).toContain('shrink-0');
+    expect(sticky.get('button').classes()).toContain('whitespace-nowrap');
+  });
+
   it('uses tighter spacing for the first group and looser spacing for later groups', async () => {
     const wrapper = mountHeader({ isFirst: true });
 

--- a/ui/tests/views/dashboard/useDashboardWidgetOrder.spec.ts
+++ b/ui/tests/views/dashboard/useDashboardWidgetOrder.spec.ts
@@ -208,6 +208,24 @@ describe('useDashboardWidgetOrder', () => {
     expect(state.layout.value.every((item) => item.w === 1)).toBe(true);
   });
 
+  it('re-syncs the active layout when crossing between mobile and desktop breakpoints', async () => {
+    const { state } = await mountWidgetOrderComposable();
+
+    state.onBreakpointChanged('sm');
+    await nextTick();
+
+    expect(state.currentBreakpoint.value).toBe('sm');
+    expect(state.layout.value.every((item) => item.x === 0)).toBe(true);
+    expect(state.layout.value.every((item) => item.w === 1)).toBe(true);
+
+    state.onBreakpointChanged('lg');
+    await nextTick();
+
+    expect(state.currentBreakpoint.value).toBe('lg');
+    expect(state.layout.value.some((item) => item.w > 1)).toBe(true);
+    expect(state.layout.value.some((item) => item.x > 0)).toBe(true);
+  });
+
   it('hydrates legacy single-column gridLayout into the mobile responsive breakpoint', async () => {
     preferences.dashboard.gridLayout = DASHBOARD_WIDGET_IDS.map((id, index) => ({
       i: id,


### PR DESCRIPTION
Folds today's outstanding fixes into the staged-but-uncut `v1.6.0-rc.5` tree so the 7-day soak covers them. The 2026-07-22 rc.5 cut was cancelled before publishing; this re-stages the same rc.5 identity with the fixes added, then rc.5 is re-cut from `main` after merge.

## What's here

- **fix(ui) #498 — mobile layout.** The reporter's iPhone 16 (~393px) hit a broken layout on both Dashboard and Containers.
  - Dashboard re-syncs the active widget layout when crossing into a single-column breakpoint, so widgets stop spilling past the viewport (measured scrollWidth 944→377 at 393px).
  - `DataTable` single-column card mode uses `auto` grid rows instead of `1fr`, killing the empty band below reflowed cards.
  - The Containers group header truncates long stack names and pins the update-all button (`truncate min-w-0` / `shrink-0` / `whitespace-nowrap`) so it stops getting clipped off-screen.
  - Verified in the live demo app via Playwright at 393×852; desktop is unaffected.
- **chore(ci).** Bump `github/codeql-action` v4.36.2→v4.36.3 and `actions/cache` v5.0.5→v5.1.0 (SHA-pinned), plus a sync of the `actions/cache` pin fixture in `.github/tests/github-action-pins.ts` that the workflow-pin test asserts against.
- **security(web).** Bump the `postcss` build-dependency override to 8.5.22, closing CVE-2026-45623 (GHSA-6g55-p6wh-862q) — a pre-existing repo-wide osv-scanner finding that was failing every push off `main`. Merging this unblocks the gate for everyone.
- **docs(changelog).** Entries under the existing `[1.6.0-rc.5]` heading (Fixed: mobile layout; Security: postcss).

## Testing

- 7 regression tests (single-column card `auto` rows + `parseCardMinWidthPx` px/rem/em/invalid/zero branches, dashboard breakpoint re-sync, group-header truncation classes).
- Full pre-push gate green: app + ui coverage 100%, both builds, scripts/workflow/web-scripts tests, qlty, zizmor. `apps/web` `npm audit` clean after the postcss bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- 🐛 Fixed mobile Dashboard layout synchronization to prevent widget overflow at the single-column breakpoint.
- 🐛 Fixed `DataTable` card-mode grid sizing by deriving `gridAutoRows` (`auto` vs `1fr`) to eliminate excess vertical space in responsive reflows, including `cardMinWidth` handling for `px`/`rem`/`em` and fallback behavior.
- 🐛 Fixed `Containers` group header layout so long names truncate (`min-w-0`) and update controls remain visible (including non-wrapping “update all” button styling).
- 🔧 Updated `github/codeql-action` to `v4.36.3` and `actions/cache` to `v5.1.0`, including SHA-pinned fixture updates across workflows/tests.
- 🔒 Security: Updated `postcss` override to `8.5.22` to address CVE-2026-45623.
- ✨ Added regression tests covering Dashboard breakpoint/layout re-sync, `DataTable` single-column detection via `cardMinWidth` unit conversion + fallback rules, and `ContainersGroupHeader` truncation/button layout.

## Concerns

- Confirm the `postcss` override version (`8.5.22`) and the intended CVE reference align with the project’s dependency resolution strategy.
- Verify all `github/codeql-action` / `actions/cache` SHA pins and expected fixtures remain consistent across workflows and the pin-test file.
- Ensure the new `DataTable` unit-conversion heuristics for `rem`/`em` match the intended browser baseline font assumptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->