### PR TITLE
🧪 test(ci): gate Playwright on QA fixture readiness

### DIFF
--- a/.github/tests/e2e-playwright-workflow.test.ts
+++ b/.github/tests/e2e-playwright-workflow.test.ts
@@ -13,6 +13,7 @@ const qaComposePath = fileURLToPath(new URL('../../test/qa-compose.yml', import.
 const playwrightConfigPath = fileURLToPath(
   new URL('../../e2e/playwright.config.ts', import.meta.url),
 );
+const authSetupPath = fileURLToPath(new URL('../../e2e/playwright/auth.setup.ts', import.meta.url));
 const loadWorkflow = loadWorkflowFrom.bind(undefined, workflowPath);
 const getWorkflowStep = getWorkflowStepFrom.bind(undefined, workflowPath);
 
@@ -73,6 +74,42 @@ test('Playwright QA fails closed when required remote fixtures cannot be seeded'
   expect(bootstrapCommand).toContain('docker --host "$$host_docker" pull');
   expect(bootstrapCommand).toContain('docker --host "$$host_docker" save --output "$$archive"');
   expect(bootstrapCommand).toContain('docker load --input "$$archive"');
+});
+
+test('Playwright waits for one complete QA scan before browser tests and parks background scans', () => {
+  const workflow = loadWorkflow();
+  const steps = workflow.jobs?.playwright?.steps ?? [];
+  const authSetup = readFileSync(authSetupPath, 'utf8');
+  const healthIndex = steps.findIndex((step) => step.name === 'Wait for QA health');
+  const playwrightIndex = steps.findIndex((step) => step.name === 'Run Playwright tests');
+  const loginIndex = authSetup.indexOf('await loginWithBasicAuth(page, credentials)');
+  const readinessIndex = authSetup.indexOf('.poll(');
+
+  expect(healthIndex).toBeGreaterThan(-1);
+  expect(playwrightIndex).toBeGreaterThan(healthIndex);
+  expect(getWorkflowStep('playwright', 'Wait for QA fixture readiness')).toBeUndefined();
+  expect(loginIndex).toBeGreaterThan(-1);
+  expect(readinessIndex).toBeGreaterThan(loginIndex);
+  expect(authSetup).toContain('/api/v1/containers?limit=100');
+  expect(authSetup).not.toContain('/api/v1/containers/watch');
+  expect(authSetup).toContain('page.request.get');
+  expect(authSetup).toContain('180_000');
+  expect(authSetup).toContain('setup.setTimeout(240_000)');
+  expect(authSetup).toContain('Nginx (Hooked)');
+  expect(authSetup).toContain("container.labels?.['dd.group'] === 'web-stack'");
+  expect(authSetup).toContain('container.result');
+  expect(authSetup).toContain('container.updateAvailable === true');
+
+  const qaCompose = yaml.parse(readFileSync(qaComposePath, 'utf8')) as {
+    services?: Record<string, { environment?: string[] }>;
+  };
+  const environment = qaCompose.services?.drydock?.environment ?? [];
+  expect(environment).toContain('DD_WATCHER_LOCAL_CRON=0 0 29 2 *');
+  expect(environment).toContain('DD_WATCHER_REMOTE_CRON=0 0 29 2 *');
+  expect(environment).toContain('DD_WATCHER_LOCAL_JITTER=0');
+  expect(environment).toContain('DD_WATCHER_REMOTE_JITTER=0');
+  expect(environment).toContain('DD_WATCHER_LOCAL_WATCHEVENTS=false');
+  expect(environment).toContain('DD_WATCHER_REMOTE_WATCHEVENTS=false');
 });
 
 test('Playwright health fixture waits until Docker observes the unhealthy transition', () => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **The Containers table's Resources column is now optional** ([#498](https://github.com/CodesWhat/drydock/issues/498)). It remains visible by default, but the column picker can hide it and preserves that choice. Source, release-note, and registry shortcuts move into each row's **More** menu while hidden and remain available in card and detail views.
+- **The Playwright release gate now waits for watcher-complete QA fixtures.** Browser scenarios start only after the authenticated setup sees the full local and remote fixture set from the startup scans, while later cron and Docker-event scans are parked in the browser-only compose stack. This prevents grouping, update-status, and targeted-refresh assertions from racing partially enriched container state without adding whole-suite retries or changing production watcher defaults.
 
 ### Fixed
 

--- a/docs/cucumber-reliability.md
+++ b/docs/cucumber-reliability.md
@@ -59,6 +59,10 @@ The health-transition test also waited for an asynchronous Docker event to refre
 
 The targeted scan also exposed a product bug in the endpoint: it refreshed live Docker containers, then scanned the stale store object captured before the refresh and could overwrite the new health. The endpoint now scans the refreshed object, retaining the real watcher and SSE behavior under test without depending on event-delivery timing.
 
+Exact-main verification for rc.5 then exposed a separate suite-startup race in [Playwright run 29967817350](https://github.com/CodesWhat/drydock/actions/runs/29967817350). The first attempt reached the health-transition scenario while a full watcher scan still held the shared QA process; the rerun passed that scenario but started browser assertions before the first 27-container local scan had completed, so group and update-result fixtures were only partially populated. The QA `/health` endpoint had correctly reported that Express was serving requests, but it did not promise that watcher enrichment was complete. Two-minute cron polling and Docker-event refreshes could also start another full scan during the suite.
+
+Playwright's authenticated setup now waits for a snapshot of at least 29 containers with representative local and remote groups, registry results, and update availability before any browser scenario runs. It does not trigger another scan alongside the built-in startup scan. The browser-only compose fixture parks later cron runs and disables event-driven refreshes, leaving production watcher defaults unchanged while keeping the accepted snapshot stable. A cold-stack validation produced one local and one remote startup scan, and the complete 34-scenario browser suite then passed with no retries (33 passed, one intentional skip).
+
 ## Residual risk and follow-up threshold
 
 The remaining nondeterministic boundary is live public-registry behavior. It produced two direct readiness failures plus the npm and GitLab transport failures in the 30-attempt history. Exact readiness and richer artifacts make those failures actionable, but do not make Docker Hub, Quay, npm, or other providers deterministic.

--- a/e2e/playwright/auth.setup.ts
+++ b/e2e/playwright/auth.setup.ts
@@ -8,6 +8,46 @@ import {
 
 const authFile = 'playwright/.auth/user.json';
 
+interface QaContainer {
+  displayName?: string;
+  labels?: Record<string, string>;
+  result?: unknown;
+  updateAvailable?: boolean;
+}
+
+function hasCompleteQaFixtureSnapshot(payload: unknown): boolean {
+  const containers = (payload as { data?: QaContainer[] } | undefined)?.data;
+  if (!Array.isArray(containers) || containers.length < 29) {
+    return false;
+  }
+
+  return (
+    containers.some(
+      (container) =>
+        container.displayName === 'Nginx (Hooked)' &&
+        container.labels?.['dd.group'] === 'web-stack' &&
+        container.result !== null &&
+        typeof container.result === 'object' &&
+        container.updateAvailable === true,
+    ) &&
+    containers.some(
+      (container) =>
+        container.displayName === 'Traefik Proxy' && container.labels?.['dd.group'] === 'infra',
+    ) &&
+    containers.some(
+      (container) =>
+        container.displayName === 'Node (Vulnerable)' &&
+        container.labels?.['dd.group'] === 'security-test',
+    ) &&
+    containers.some(
+      (container) =>
+        container.displayName === 'Remote Nginx' && container.labels?.['dd.group'] === 'remote',
+    )
+  );
+}
+
+setup.setTimeout(240_000);
+
 setup('authenticate', async ({ page, request, baseURL }) => {
   const availability = await checkServerAvailability(request, baseURL);
   expect(availability.healthy, getServerUnavailableMessage(baseURL)).toBeTruthy();
@@ -17,6 +57,26 @@ setup('authenticate', async ({ page, request, baseURL }) => {
   await page.goto('/login');
 
   await loginWithBasicAuth(page, credentials);
+
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await page.request.get('/api/v1/containers?limit=100', {
+            timeout: 15_000,
+          });
+          return response.ok() && hasCompleteQaFixtureSnapshot(await response.json());
+        } catch {
+          return false;
+        }
+      },
+      {
+        message: 'Drydock startup watcher scans did not produce the complete QA fixture snapshot',
+        timeout: 180_000,
+        intervals: [2_000],
+      },
+    )
+    .toBe(true);
 
   await page.context().storageState({ path: authFile });
 });

--- a/test/qa-compose.yml
+++ b/test/qa-compose.yml
@@ -19,8 +19,15 @@ services:
       - DD_ALLOW_INSECURE_ROOT=true
       - DD_LOG_FORMAT=text
       - DD_WATCHER_LOCAL_WATCHBYDEFAULT=false
-      - DD_WATCHER_LOCAL_CRON=*/2 * * * *
-      - DD_WATCHER_LOCAL_WATCHEVENTS=true
+      # Browser QA waits for the built-in startup scan after /health. Keep later
+      # scheduled scans out of the short-lived suite so they cannot race fixture
+      # assertions or targeted refreshes. February 29 is accepted by the watcher
+      # and parks the next scheduled scan well outside the normal QA window.
+      - DD_WATCHER_LOCAL_CRON=0 0 29 2 *
+      - DD_WATCHER_LOCAL_JITTER=0
+      # Event-driven refreshes are production behavior, but the browser suite
+      # needs a frozen fixture snapshot after the startup scan completes.
+      - DD_WATCHER_LOCAL_WATCHEVENTS=false
       # Docker action (manual only — auto=false prevents auto-updating test containers)
       - DD_ACTION_DOCKER_LOCAL_AUTO=false
       - DD_ACTION_DOCKER_LOCAL_PRUNE=true
@@ -94,8 +101,9 @@ services:
       - DD_WATCHER_REMOTE_HOST=docker-remote
       - DD_WATCHER_REMOTE_PORT=2375
       - DD_WATCHER_REMOTE_WATCHBYDEFAULT=true
-      - DD_WATCHER_REMOTE_CRON=*/2 * * * *
-      - DD_WATCHER_REMOTE_WATCHEVENTS=true
+      - DD_WATCHER_REMOTE_CRON=0 0 29 2 *
+      - DD_WATCHER_REMOTE_JITTER=0
+      - DD_WATCHER_REMOTE_WATCHEVENTS=false
     depends_on:
       docker-remote:
         condition: service_healthy


### PR DESCRIPTION
Rescued from the `fix/playwright-qa-readiness` worktree during the main↔dev reconciliation audit — this commit had reached neither branch and would have been lost when that worktree was cleaned up.

It's the root-cause fix for the Playwright flake that burned an rc.5 cut cycle (`apiRequestContext.post: Timeout 45000ms` on the notification-bell spec, plus the intermittent "Start drydock" Cucumber failures).

## What it does

- **`e2e/playwright/auth.setup.ts`** — auth setup now polls `/api/v1/containers` until the *complete* 29-container QA fixture snapshot is present (specific named containers with their `dd.group` labels and a populated `result`) before writing `storageState`. Previously specs could start against a half-populated store, so assertions raced the startup watcher scan. 180s poll budget at 2s intervals, setup timeout raised to 240s.
- **`test/qa-compose.yml`** — parks the local and remote watcher crons on `0 0 29 2 *` with `JITTER=0` and `WATCHEVENTS=false`, so no scheduled or event-driven rescan can mutate fixtures mid-suite. The startup scan still runs; only the later races are removed.
- **`.github/tests/e2e-playwright-workflow.test.ts`** — coverage asserting the readiness gating stays wired up.

## Verification

Full pre-push gate green: clean-tree, ts-nocheck, biome, qlty, qlty-smells, scripts-test, workflow-tests (9 files / 46 tests), typecheck-ui, coverage (app + ui both at 100%), build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added
- Playwright fixture-readiness gating for 29 expected QA containers before saving `storageState`.
- Workflow test coverage for setup sequencing and readiness configuration.
- Documentation of the startup race and cold-stack validation.

🔧 Changed
- Increased Playwright setup timeout to 240 seconds with a 180-second readiness polling budget.
- Disabled scheduled and event-driven watcher rescans during browser tests while preserving the startup scan.
- Added required container, label, result, and update-availability checks.

- Readiness validation is tightly coupled to a hardcoded set of 29 containers and labels.
- The `0 0 29 2 *` watcher schedule should remain intentional and documented as a disabled schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->