### PR TITLE
🔧 chore(ci): block release cuts when main has drifted from the dev branch

### DIFF
--- a/.github/tests/branch-drift-guard.test.ts
+++ b/.github/tests/branch-drift-guard.test.ts
@@ -42,19 +42,45 @@ test('the drift guard compares trees, not commit ancestry', () => {
 
 test('the drift guard is skipped once the dev branch is retired after GA', () => {
   const run = syncStep()?.run ?? '';
-  expect(run).toContain('git ls-remote --exit-code --heads origin "${dev_branch}"');
+  expect(run).toContain('refs="$(git ls-remote --heads origin "refs/heads/${dev_branch}")"');
   // Absent dev branch is a clean no-op, not a failed cut.
+  expect(run).toContain('if [ -z "${refs}" ]; then');
   expect(run).toContain('exit 0');
+});
+
+test('an unanswerable remote query fails the cut instead of skipping the guard', () => {
+  // --exit-code collapses "no such branch" and "could not reach origin" into the same
+  // non-zero status, so a network blip would silently take the retired-branch path and
+  // let a drifted main be tagged. Only empty output on a *successful* query may skip.
+  const run = syncStep()?.run ?? '';
+  expect(run).not.toContain('git ls-remote --exit-code');
+  expect(run).toContain('::error::Could not query origin for ${dev_branch}');
+
+  const queryIndex = run.indexOf('if ! refs="$(git ls-remote');
+  const skipIndex = run.indexOf('if [ -z "${refs}" ]; then');
+  expect(queryIndex).toBeGreaterThanOrEqual(0);
+  expect(skipIndex).toBeGreaterThan(queryIndex);
 });
 
 test('the drift guard runs before any tagging or publishing work', () => {
   const names = releaseSteps().map((step) => step.name);
-  const guardIndex = names.indexOf(SYNC_STEP_NAME);
-  const checkoutIndex = names.indexOf('Checkout');
-  const resolveIndex = names.indexOf('Resolve target SHA and lowercase repository');
+  const indexOfStep = (name: string) => {
+    const index = names.indexOf(name);
+    // A missing step would make the ordering assertions below pass vacuously against -1.
+    expect(index, `release-cut has no step named "${name}"`).toBeGreaterThanOrEqual(0);
+    return index;
+  };
 
-  expect(guardIndex).toBeGreaterThan(checkoutIndex);
-  expect(guardIndex).toBeLessThan(resolveIndex);
+  const guardIndex = indexOfStep(SYNC_STEP_NAME);
+
+  expect(guardIndex).toBeGreaterThan(indexOfStep('Checkout'));
+  expect(guardIndex).toBeLessThan(indexOfStep('Resolve target SHA and lowercase repository'));
+  // The steps that actually publish or sign something, so the guard can't be reordered
+  // past the point where a drifted cut has already left the runner.
+  expect(guardIndex).toBeLessThan(indexOfStep('Log in to GHCR'));
+  expect(guardIndex).toBeLessThan(indexOfStep('Build and push staging image'));
+  expect(guardIndex).toBeLessThan(indexOfStep('Sign container images'));
+  expect(guardIndex).toBeLessThan(indexOfStep('Verify release artifact signature'));
 });
 
 test('ci-verify gates pull requests into the integration branch, not just main', () => {

--- a/.github/tests/branch-drift-guard.test.ts
+++ b/.github/tests/branch-drift-guard.test.ts
@@ -1,0 +1,69 @@
+import { fileURLToPath } from 'node:url';
+
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
+
+const releaseCutPath = fileURLToPath(new URL('../workflows/release-cut.yml', import.meta.url));
+const ciVerifyPath = fileURLToPath(new URL('../workflows/ci-verify.yml', import.meta.url));
+
+const SYNC_STEP_NAME = 'Assert main is in sync with the active dev branch';
+
+function releaseSteps(): WorkflowStep[] {
+  return loadWorkflow(releaseCutPath).jobs?.release?.steps ?? [];
+}
+
+function syncStep(): WorkflowStep | undefined {
+  return releaseSteps().find((step) => step.name === SYNC_STEP_NAME);
+}
+
+test('release-cut refuses to tag when main has drifted from the active dev branch', () => {
+  const step = syncStep();
+  expect(step).toBeDefined();
+  expect(step?.env?.RELEASE_TAG).toBe('${{ inputs.release_tag }}');
+
+  const run = step?.run ?? '';
+  // Derives dev/vX.Y from the release tag rather than hardcoding a version.
+  expect(run).toContain('dev_branch="dev/v${minor}"');
+  expect(run).toContain('git fetch --quiet origin "${dev_branch}"');
+  // Fails the cut, rather than warning, when content differs.
+  expect(run).toContain('git diff --quiet HEAD "origin/${dev_branch}"');
+  expect(run).toContain('::error::main has drifted');
+  expect(run).toContain('exit 1');
+});
+
+test('the drift guard compares trees, not commit ancestry', () => {
+  // The repo allows squash merges only, so every dev -> main sync creates a commit
+  // dev lacks. An ancestry check would fail on every cut after the first and would
+  // have to be disabled, which defeats the guard. Tree equality is the real invariant.
+  const run = syncStep()?.run ?? '';
+  expect(run).toContain('git diff');
+  expect(run).not.toContain('--is-ancestor');
+  expect(run).not.toContain('merge-base');
+});
+
+test('the drift guard is skipped once the dev branch is retired after GA', () => {
+  const run = syncStep()?.run ?? '';
+  expect(run).toContain('git ls-remote --exit-code --heads origin "${dev_branch}"');
+  // Absent dev branch is a clean no-op, not a failed cut.
+  expect(run).toContain('exit 0');
+});
+
+test('the drift guard runs before any tagging or publishing work', () => {
+  const names = releaseSteps().map((step) => step.name);
+  const guardIndex = names.indexOf(SYNC_STEP_NAME);
+  const checkoutIndex = names.indexOf('Checkout');
+  const resolveIndex = names.indexOf('Resolve target SHA and lowercase repository');
+
+  expect(guardIndex).toBeGreaterThan(checkoutIndex);
+  expect(guardIndex).toBeLessThan(resolveIndex);
+});
+
+test('ci-verify gates pull requests into the integration branch, not just main', () => {
+  const on = loadWorkflow(ciVerifyPath).on as
+    | { pull_request?: { branches?: string[] } }
+    | undefined;
+  const branches = on?.pull_request?.branches ?? [];
+
+  expect(branches).toContain('main');
+  // v1.6 work landed on dev/v1.6 through PRs that ran no backend/frontend CI at all.
+  expect(branches).toContain('dev/**');
+});

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -21,7 +21,12 @@ on:
     branches:
       - main
   pull_request:
-    branches: [main]
+    # `dev/**` too: v1.6 work landed on dev/v1.6 via PRs that ran no backend or
+    # frontend CI at all, because this only ever fired for PRs targeting main.
+    # The integration branch is where features are supposed to land, so it needs
+    # the same gate main gets — otherwise dev is only as good as whatever the
+    # author happened to run locally.
+    branches: [main, 'dev/**']
   schedule:
     # Both schedules now run the full security sweep: CodeQL, Fuzz, DAST
     # (ZAP baseline + Nuclei), plus the lint/test/build chain DAST depends on.

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -81,6 +81,33 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      - name: Assert main is in sync with the active dev branch
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          # main is never an independent commit target: it only advances by merging from
+          # dev/vX.Y before a cut. If a fix landed straight on main, main holds work the
+          # integration branch never got and the next dev merge silently reverts it. That
+          # is exactly how v1.6 drifted (rc.3-rc.5 fixes on main, dev 112 files behind).
+          #
+          # Compare TREES, not commit ancestry: this repo allows squash merges only, so
+          # every dev -> main sync mints a commit dev lacks and an ancestry check would
+          # always fail. Identical trees is the real invariant.
+          minor="$(printf '%s' "${RELEASE_TAG}" | sed -E 's/^v?([0-9]+)\.([0-9]+)\..*/\1.\2/')"
+          dev_branch="dev/v${minor}"
+          if ! git ls-remote --exit-code --heads origin "${dev_branch}" >/dev/null 2>&1; then
+            echo "No ${dev_branch} on origin (retired after GA, or not yet created) — nothing to compare."
+            exit 0
+          fi
+          git fetch --quiet origin "${dev_branch}"
+          if ! git diff --quiet HEAD "origin/${dev_branch}"; then
+            echo "::error::main has drifted from ${dev_branch}. Cutting now would ship content ${dev_branch} never received, or miss content it has. Forward-port first, then re-dispatch."
+            git diff --stat HEAD "origin/${dev_branch}" | tail -25
+            exit 1
+          fi
+          echo "main is in sync with ${dev_branch} (identical trees)."
+
       - name: Resolve target SHA and lowercase repository
         id: target
         run: |

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -96,7 +96,15 @@ jobs:
           # always fail. Identical trees is the real invariant.
           minor="$(printf '%s' "${RELEASE_TAG}" | sed -E 's/^v?([0-9]+)\.([0-9]+)\..*/\1.\2/')"
           dev_branch="dev/v${minor}"
-          if ! git ls-remote --exit-code --heads origin "${dev_branch}" >/dev/null 2>&1; then
+          # Separate "branch is absent" from "we could not ask". --exit-code collapses
+          # both into a non-zero status, so a network blip or auth failure would take the
+          # skip path and let a drifted main be tagged. Empty output on a successful query
+          # is the only thing that means the branch is genuinely gone.
+          if ! refs="$(git ls-remote --heads origin "refs/heads/${dev_branch}")"; then
+            echo "::error::Could not query origin for ${dev_branch}. Refusing to skip the drift check on an unanswered question."
+            exit 1
+          fi
+          if [ -z "${refs}" ]; then
             echo "No ${dev_branch} on origin (retired after GA, or not yet created) — nothing to compare."
             exit 0
           fi


### PR DESCRIPTION
v1.6's rc.3–rc.5 fixes landed straight on `main` while `dev/v1.6` sat 112 files behind holding superseded UI, and nothing caught it for weeks. Two gaps made that possible; both are closed here.

## 1. `release-cut.yml` refuses to tag a drifted main

New *Assert main is in sync with the active dev branch* step derives `dev/vX.Y` from the release tag and fails the cut when main's tree differs, so a direct-to-main fix can't be tagged without being forward-ported first.

- Derives the branch from the tag rather than hardcoding a version (`v1.6.0-rc.6` → `dev/v1.6`, `v1.10.3-rc.1` → `dev/v1.10`).
- Skips cleanly when the dev branch is absent — retired after GA, or not yet created.
- Runs after `Checkout` and before any tagging or publishing work.

**It compares trees, not commit ancestry.** This repo allows squash merges only (`allow_merge_commit: false`, `allow_rebase_merge: false`), so every `dev → main` sync mints a commit `dev` lacks. A `merge-base --is-ancestor` check would fail on every cut after the first and would have to be disabled, defeating the guard. Identical trees is the invariant that actually holds.

## 2. `ci-verify.yml` now gates `dev/**` pull requests

The trigger was `pull_request: branches: [main]`, so **PRs into `dev/v1.6` ran no backend or frontend CI at all** — dev was only ever as good as whatever the author ran locally. The integration branch is where features are supposed to land, so it now gets the same gate main gets.

## Verification

Full pre-push gate green (284s): clean-tree, ts-nocheck, biome, qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, coverage (app + ui at 100%), build, zizmor.

New tests cover the failure path, the tree-not-ancestry choice, the post-GA skip, step ordering, and the widened trigger. Guard logic was also exercised against the live repo: tag→branch derivation for 5 tag shapes, `ls-remote` presence/absence, and a real `main` vs `dev/v1.6` comparison (currently in sync, so a cut today passes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

✨ Added
- Added a release guard that blocks tagging and publishing when `main`’s tree differs from the active `dev/vX.Y` branch.
- Added coverage for drift detection, retired development branches, tree comparison, ordering, and CI triggers.

🔧 Changed
- CI verification now runs for pull requests targeting `main` and `dev/**`.

- Confirm the release guard derives the expected development branch correctly from `release_tag`.
- Confirm missing development branches intentionally bypass the drift check.
- Confirm the guard executes before all tagging and publishing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->