### PR TITLE
📝 docs(readme): move the language switcher above the logo

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <strong>Deutsch</strong> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
   <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
@@ -9,8 +11,6 @@
 <h1>drydock</h1>
 
 **Container-Image-Update-Watcher – 23 Register, 20 Benachrichtigungs- und Aktionsanbieter.**
-
-<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <strong>Deutsch</strong> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
 
 </div>
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<p><a href="README.md">English</a> · <strong>Español</strong> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
   <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
@@ -9,8 +11,6 @@
 <h1>drydock</h1>
 
 **Observador de actualizaciones de imágenes de contenedores: 23 registros, 20 proveedores de notificaciones y acciones.**
-
-<p><a href="README.md">English</a> · <strong>Español</strong> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
 
 </div>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <strong>Français</strong> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
   <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
@@ -9,8 +11,6 @@
 <h1>drydock</h1>
 
 **Observateur de mise à jour d'image de conteneur : 23 registres, 20 fournisseurs de notifications et d'actions.**
-
-<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <strong>Français</strong> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<p><strong>English</strong> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
   <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
@@ -9,8 +11,6 @@
 <h1>drydock</h1>
 
 **Container image update watcher — 23 registries, 20 notification and action providers.**
-
-<p><strong>English</strong> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
 
 </div>
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <strong>Polski</strong> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
   <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
@@ -9,8 +11,6 @@
 <h1>drydock</h1>
 
 **Obserwator aktualizacji obrazów kontenerów — 23 rejestry, 20 dostawców powiadomień i działań.**
-
-<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <strong>Polski</strong> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
 
 </div>
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <strong>Português (Brasil)</strong></p>
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
   <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
@@ -9,8 +11,6 @@
 <h1>drydock</h1>
 
 **Observador de atualização de imagem de contêiner — 23 registros, 20 provedores de notificação e ação.**
-
-<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <strong>Português (Brasil)</strong></p>
 
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <strong>简体中文</strong> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/whale-logo-dark.png" />
   <source media="(prefers-color-scheme: light)" srcset="docs/assets/whale-logo.png" />
@@ -9,8 +11,6 @@
 <h1>drydock</h1>
 
 **容器镜像更新观察程序 — 23 个注册表、20 个通知和操作提供程序。**
-
-<p><a href="README.md">English</a> · <a href="README.es.md">Español</a> · <a href="README.pl.md">Polski</a> · <strong>简体中文</strong> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.pt-BR.md">Português (Brasil)</a></p>
 
 </div>
 


### PR DESCRIPTION
The switcher read as buried under the logo, title, and tagline. Since the tagline directly above it is English, a non-English reader hit a sentence they may not read before finding their own language. It is now the first thing rendered.

Kept inside `<div align="center">` rather than above it, so it stays centered instead of rendering left-aligned over a centered logo.

Applied to all seven READMEs (`README.md` + 6 translations) so the copies do not drift — the Spanish one needed a different matcher since Spanish is bold rather than a link there.

Pure move: 2 lines changed per file, no content edits. Full pre-push gate green (275s), `release-docs-identity` 11/11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changelog

- 🔧 Changed language switcher placement in all seven README files, moving it above the logo while keeping it within the centered header.
- 🗑️ Removed the previous switcher locations without changing content.
- ✅ Full pre-push gate passed, including `release-docs-identity` (11/11).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->