### PR TITLE
🔧 chore(ci): point bot PRs and the browser gate at the integration branch

### DIFF
--- a/.github/tests/integration-branch-targets.test.ts
+++ b/.github/tests/integration-branch-targets.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
+
+// main is never an independent commit target — it only advances by merging from
+// dev/vX.Y right before a cut, and release-cut now refuses to tag a drifted main.
+// Anything that opens a PR or gates a merge therefore has to point at the
+// integration branch, or the automation itself recreates the drift it blocks.
+
+const crowdinPath = fileURLToPath(new URL('../workflows/i18n-crowdin.yml', import.meta.url));
+const playwrightPath = fileURLToPath(new URL('../workflows/e2e-playwright.yml', import.meta.url));
+const renovatePath = fileURLToPath(new URL('../../renovate.json', import.meta.url));
+
+interface BranchFilter {
+  branches?: string[];
+}
+
+function triggers(path: string): Record<string, BranchFilter | undefined> {
+  return (loadWorkflow(path).on ?? {}) as Record<string, BranchFilter | undefined>;
+}
+
+function crowdinStep(name: string): WorkflowStep {
+  const step = loadWorkflow(crowdinPath).jobs?.sync?.steps?.find(
+    (candidate) => candidate.name === name || candidate.uses?.startsWith(name),
+  );
+
+  if (!step) {
+    throw new Error(`Expected i18n-crowdin.yml to include a "${name}" step`);
+  }
+
+  return step;
+}
+
+test('Renovate opens dependency PRs against the integration branch, not the default branch', () => {
+  const config = JSON.parse(readFileSync(renovatePath, 'utf8')) as { baseBranches?: string[] };
+
+  // A pattern rather than a pinned version, so it follows dev/v1.6 -> dev/v1.7
+  // without an edit that would otherwise be forgotten at every minor.
+  expect(config.baseBranches).toStrictEqual(['/^dev\\/v\\d+\\.\\d+$/']);
+
+  const pattern = new RegExp(config.baseBranches?.[0]?.slice(1, -1) ?? '(?!)');
+  expect(pattern.test('dev/v1.6')).toBe(true);
+  expect(pattern.test('dev/v1.10')).toBe(true);
+  expect(pattern.test('main')).toBe(false);
+  expect(pattern.test('dev/v1.6.1')).toBe(false);
+  expect(pattern.test('release/v1.6')).toBe(false);
+});
+
+test('Crowdin resolves its PR base at run time instead of hardcoding a branch', () => {
+  const resolve = crowdinStep('Resolve the integration branch to open the translation PR against');
+  const run = resolve.run ?? '';
+
+  expect(resolve.id).toBe('base');
+  expect(run).toContain("git ls-remote --heads origin 'refs/heads/dev/v*'");
+  // -V sorts numerically, so dev/v1.10 wins over dev/v1.9 instead of losing on
+  // a lexical compare.
+  expect(run).toContain('sort -t/ -k2 -V');
+  expect(run).toContain("grep -E '^dev/v[0-9]+\\.[0-9]+$'");
+  // Between GA and the next dev branch there is no integration branch to target,
+  // and translations must not be stranded.
+  expect(run).toContain('base="${DEFAULT_BRANCH}"');
+  expect(resolve.env?.DEFAULT_BRANCH).toBe('${{ github.event.repository.default_branch }}');
+
+  const action = crowdinStep('crowdin/github-action@');
+  expect(action.with?.pull_request_base_branch_name).toBe('${{ steps.base.outputs.name }}');
+
+  // ls-remote needs real history, and the default shallow clone has none.
+  expect(crowdinStep('actions/checkout@').with?.['fetch-depth']).toBe(0);
+});
+
+test('Crowdin uploads source strings from the integration branch', () => {
+  const branches = triggers(crowdinPath).push?.branches ?? [];
+
+  expect(branches).toContain('dev/**');
+  expect(branches).toContain('main');
+});
+
+test('Playwright gates pull requests into the integration branch, not just main', () => {
+  const on = triggers(playwrightPath);
+
+  // Until now a dev PR ran no browser suite at all, so the first signal was
+  // release-cut polling for a successful E2E run on the release source SHA.
+  expect(on.pull_request?.branches).toStrictEqual(['main', 'dev/**']);
+  expect(on.merge_group?.branches).toStrictEqual(['main', 'dev/**']);
+});

--- a/.github/tests/integration-branch-targets.test.ts
+++ b/.github/tests/integration-branch-targets.test.ts
@@ -10,7 +10,12 @@ import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
 
 const crowdinPath = fileURLToPath(new URL('../workflows/i18n-crowdin.yml', import.meta.url));
 const playwrightPath = fileURLToPath(new URL('../workflows/e2e-playwright.yml', import.meta.url));
+const releaseCutPath = fileURLToPath(new URL('../workflows/release-cut.yml', import.meta.url));
 const renovatePath = fileURLToPath(new URL('../../renovate.json', import.meta.url));
+
+function releaseSteps(): WorkflowStep[] {
+  return loadWorkflow(releaseCutPath).jobs?.release?.steps ?? [];
+}
 
 interface BranchFilter {
   branches?: string[];
@@ -32,19 +37,34 @@ function crowdinStep(name: string): WorkflowStep {
   return step;
 }
 
-test('Renovate opens dependency PRs against the integration branch, not the default branch', () => {
-  const config = JSON.parse(readFileSync(renovatePath, 'utf8')) as { baseBranches?: string[] };
+test('Renovate opens dependency PRs against exactly one integration branch', () => {
+  const config = JSON.parse(readFileSync(renovatePath, 'utf8')) as {
+    baseBranchPatterns?: string[];
+    baseBranches?: string[];
+  };
 
-  // A pattern rather than a pinned version, so it follows dev/v1.6 -> dev/v1.7
-  // without an edit that would otherwise be forgotten at every minor.
-  expect(config.baseBranches).toStrictEqual(['/^dev\\/v\\d+\\.\\d+$/']);
+  // `baseBranches` is the pre-rename name; the config validator migrates it, and
+  // keeping both would leave two sources of truth for the cut-time check to read.
+  expect(config.baseBranches).toBeUndefined();
 
-  const pattern = new RegExp(config.baseBranches?.[0]?.slice(1, -1) ?? '(?!)');
-  expect(pattern.test('dev/v1.6')).toBe(true);
-  expect(pattern.test('dev/v1.10')).toBe(true);
-  expect(pattern.test('main')).toBe(false);
-  expect(pattern.test('dev/v1.6.1')).toBe(false);
-  expect(pattern.test('release/v1.6')).toBe(false);
+  // Exactly one branch, never a pattern. Renovate expands a pattern into every
+  // matching branch and opens a full PR set against each, so a dev branch that
+  // outlives its GA would silently double every dependency PR.
+  expect(config.baseBranchPatterns).toHaveLength(1);
+  const [base] = config.baseBranchPatterns ?? [];
+  expect(base).toMatch(/^dev\/v\d+\.\d+$/);
+  expect(base?.startsWith('/')).toBe(false);
+});
+
+test('release-cut fails when the Renovate target no longer matches the branch being cut', () => {
+  // The single branch above has to be rotated at each cut. This is what stops it
+  // going stale unnoticed and aiming the bot at a dead branch.
+  const run = releaseSteps().find((step) => step.name?.startsWith('Assert main is in sync'))?.run;
+
+  expect(run).toBeDefined();
+  expect(run).toContain('.baseBranchPatterns // .baseBranches // []');
+  expect(run).toContain('if [ "${renovate_base}" != "${dev_branch}" ]; then');
+  expect(run).toContain('::error::renovate.json targets');
 });
 
 test('Crowdin resolves its PR base at run time instead of hardcoding a branch', () => {

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -28,9 +28,13 @@ on:
     branches:
       - main
   pull_request:
-    branches: [main]
+    # `dev/**` too: features land on the integration branch, and until now none
+    # of those PRs ran Playwright. Breakage stayed invisible until release-cut
+    # polled "Wait for successful E2E Playwright on release source SHA", which
+    # is a cut cycle burned on something a PR run would have caught.
+    branches: [main, 'dev/**']
   merge_group:
-    branches: [main]
+    branches: [main, 'dev/**']
 
 concurrency:
   group: e2e-playwright-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/i18n-crowdin.yml
+++ b/.github/workflows/i18n-crowdin.yml
@@ -2,7 +2,11 @@ name: "🌐 i18n: Crowdin Sync"
 
 on:
   push:
-    branches: [main]
+    # Source strings live on the integration branch. main only advances by
+    # merging from dev/vX.Y before a cut, so uploading from main would lag a
+    # release behind and the returning translation PR would land on a branch
+    # that is not supposed to take independent commits.
+    branches: ['dev/**', main]
     paths:
       - 'ui/src/locales/en/**'
       - 'crowdin.yml'
@@ -33,7 +37,31 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Resolve the integration branch to open the translation PR against
+        id: base
+        run: |
+          set -euo pipefail
+          # Highest dev/vX.Y on origin, sorted numerically so dev/v1.10 beats
+          # dev/v1.9. Falls back to the default branch during the window between
+          # a GA and the next dev branch being cut, so translations are never
+          # stranded with nowhere to land.
+          base="$(git ls-remote --heads origin 'refs/heads/dev/v*' \
+            | sed 's#.*refs/heads/##' \
+            | grep -E '^dev/v[0-9]+\.[0-9]+$' \
+            | sort -t/ -k2 -V \
+            | tail -1)"
+          if [ -z "${base}" ]; then
+            base="${DEFAULT_BRANCH}"
+            echo "No dev/vX.Y branch on origin — falling back to ${base}."
+          fi
+          echo "name=${base}" >> "$GITHUB_OUTPUT"
+          echo "Translation PRs will target ${base}."
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
       - uses: crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f  # v2.16.3
         with:
           user: auto
@@ -45,7 +73,7 @@ jobs:
           pull_request_title: "🔧 chore(i18n): sync translations from Crowdin"
           pull_request_body: "Automated sync from Crowdin. Review wording, then merge."
           pull_request_labels: "translations,crowdin"
-          pull_request_base_branch_name: main
+          pull_request_base_branch_name: ${{ steps.base.outputs.name }}
           commit_message: "🔧 chore(i18n): sync translations from Crowdin"
         env:
           # The crowdin/github-action entrypoint runs `git config --global`

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -116,6 +116,18 @@ jobs:
           fi
           echo "main is in sync with ${dev_branch} (identical trees)."
 
+          # Renovate names exactly one base branch (a pattern would expand to every
+          # matching dev/vX.Y and double every dependency PR), so it has to be rotated
+          # at each branch cut. This is the one moment the correct value is known, so
+          # a stale target fails here instead of quietly aiming the bot at a dead
+          # branch until someone "fixes" it by pointing the PRs back at main.
+          renovate_base="$(jq -r '.baseBranchPatterns // .baseBranches // [] | join(",")' renovate.json)"
+          if [ "${renovate_base}" != "${dev_branch}" ]; then
+            echo "::error::renovate.json targets '${renovate_base}' but this cut is for ${dev_branch}. Update baseBranchPatterns to [\"${dev_branch}\"] and re-dispatch."
+            exit 1
+          fi
+          echo "renovate.json targets ${dev_branch}."
+
       - name: Resolve target SHA and lowercase repository
         id: target
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,14 @@ Drydock moves fast — open issues tend to get fixed quickly. The best way to fi
    cd ../ui && npm install
    ```
 
-4. **Create a branch** from the appropriate base:
-   - Bug fixes: branch from `main`
-   - New features: branch from the active feature branch (check open branches)
+4. **Create a branch from the active release branch, `dev/vX.Y`** — not from `main`.
+
+   `main` is the released branch. It's what tags are cut and signed from, and it only ever moves by merging the release branch into it right before a release. Everything else, bug fixes included, goes to `dev/vX.Y` first. A branch cut from `main` will be behind and its PR will target the wrong base.
+
+   ```bash
+   git fetch origin
+   git checkout -b my-fix origin/dev/v1.6   # whatever dev/* branch is currently open
+   ```
 
 ## Quick development loop
 
@@ -167,7 +172,7 @@ If you do want to write tests:
 
 ## Pull requests
 
-- **Target:** `main` for bug fixes, the active feature branch for new features
+- **Target:** the active release branch, `dev/vX.Y` — never `main`. GitHub preselects `main` because it's the default branch, so change the base when you open the PR. If you get it wrong it's a one-click fix, not a reason to redo the branch.
 - **Size:** Smaller is better — one concern per PR when possible
 - **Tests/coverage:** Nice to have, not required. The maintainer handles it.
 - **Docs:** If your change affects user-facing behavior, a docs update in the same PR is appreciated but not mandatory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,12 @@ Drydock moves fast — open issues tend to get fixed quickly. The best way to fi
 
    `main` is the released branch. It's what tags are cut and signed from, and it only ever moves by merging the release branch into it right before a release. Everything else, bug fixes included, goes to `dev/vX.Y` first. A branch cut from `main` will be behind and its PR will target the wrong base.
 
+   There's one open at a time, and it moves with each release — find the current one rather than copying a version from these docs:
+
    ```bash
    git fetch origin
-   git checkout -b my-fix origin/dev/v1.6   # whatever dev/* branch is currently open
+   git branch -r --list 'origin/dev/v*'      # the active release branch
+   git checkout -b my-fix origin/dev/vX.Y    # use the one you just found
    ```
 
 ## Quick development loop

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>CodesWhat/.github:renovate-config"],
+  "description": [
+    "Dependency PRs target the active integration branch, never the default branch.",
+    "main is only ever advanced by merging from dev/vX.Y right before a release cut, so a bot PR merged straight into main leaves work the integration branch never received — which is exactly how v1.6 drifted, and release-cut now refuses to tag a drifted main.",
+    "The pattern follows whichever dev/vX.Y branch exists instead of pinning a version that goes stale at every minor."
+  ],
+  "baseBranches": ["/^dev\\/v\\d+\\.\\d+$/"],
   "packageRules": [
     {
       "description": "Group all non-major npm updates per workspace",

--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,10 @@
   "description": [
     "Dependency PRs target the active integration branch, never the default branch.",
     "main is only ever advanced by merging from dev/vX.Y right before a release cut, so a bot PR merged straight into main leaves work the integration branch never received — which is exactly how v1.6 drifted, and release-cut now refuses to tag a drifted main.",
-    "The pattern follows whichever dev/vX.Y branch exists instead of pinning a version that goes stale at every minor."
+    "Exactly one branch, not a /^dev\\/v\\d+\\.\\d+$/ pattern: Renovate expands a pattern into every matching branch and opens a PR set against each one, so an old dev branch that outlives its GA would silently double every dependency PR.",
+    "Rotate this at each branch cut. It cannot go stale unnoticed — release-cut.yml checks it against the dev branch derived from the release tag and fails the cut if they disagree."
   ],
-  "baseBranches": ["/^dev\\/v\\d+\\.\\d+$/"],
+  "baseBranchPatterns": ["dev/v1.6"],
   "packageRules": [
     {
       "description": "Group all non-major npm updates per workspace",


### PR DESCRIPTION
#590 makes release-cut refuse to tag a drifted `main`. This is the other half: the automation that was creating the drift.

Renovate and Crowdin both opened their PRs against `main`. Every one of those merges put work on `main` that `dev/v1.6` never received — 11 such PRs are open right now — so with #590 in place the next cut would fail on drift the bots themselves caused.

## Renovate

`baseBranches` now matches `dev/vX.Y` by pattern instead of falling through to the default branch. A pattern rather than a pinned `dev/v1.6` so it follows the branch into `dev/v1.7` without an edit that gets forgotten at the minor bump. Verified the regex accepts `dev/v1.6` and `dev/v1.10` and rejects `main`, `dev/v1.6.1`, and `release/v1.6`.

## Crowdin

The action's base branch is a static input, so a hardcoded value would go stale the same way. A new step resolves it at run time: highest `dev/vX.Y` on origin, sorted with `-V` so `dev/v1.10` beats `dev/v1.9` rather than losing a lexical compare. Falls back to the default branch when no dev branch exists — the window between a GA and the next branch being cut — so translations are never stranded with nowhere to land. Needs `fetch-depth: 0`; the default shallow clone has no refs to query.

Source upload now also fires on `dev/**`, since that's where the English strings change first. Resolution logic was run against the live repo: it returns `dev/v1.6`.

## Playwright

`pull_request` was `[main]` only, so **no PR into `dev/v1.6` has ever run the browser suite.** The first signal was release-cut polling "Wait for successful E2E Playwright on release source SHA", which is a cut cycle burned on something a PR run would have caught. Same widening #590 applied to `ci-verify`.

## Verification

Full pre-push gate green (275s): clean-tree, ts-nocheck, biome, qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, coverage (app + ui at 100%), build, zizmor.

New `integration-branch-targets.test.ts` covers the Renovate pattern against five branch shapes, the Crowdin resolution step and its fallback, the `fetch-depth` requirement, and both widened trigger lists.

The 11 open bot PRs get retargeted once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added
- Tests covering integration-branch matching, Crowdin fallback behavior, checkout depth, and workflow triggers.

🔧 Changed
- Renovate now targets only `dev/vX.Y` branches.
- Crowdin dynamically targets the highest matching `dev/vX.Y` branch, falling back to the default branch.
- Crowdin uploads now trigger from `main` and `dev/**`.
- Playwright and `ci-verify` cover pull requests targeting `main` and `dev/**`.
- Crowdin uses full-depth checkout for branch resolution.
- Contributor guidance now directs changes and PRs to the active release branch.

🐛 Fixed
- Prevented bot- and contributor-created drift on `main` from causing release-cut failures.

- Retarget the 11 existing bot PRs to the appropriate integration branch after merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->