### PR TITLE
📝 docs(release): prepare v1.6.0-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0-rc.6] — 2026-07-26
+
 ### Added
 
 - **Maturity-cleared notification** ([Discussion #587](https://github.com/CodesWhat/drydock/discussions/587)). When an update previously withheld by the maturity gate (`maturityMode: mature`) becomes applicable, drydock now fires a dedicated `maturity-cleared` notification instead of waiting for the next scheduled scan's generic `update-available` notification. A new background sweep (`DD_MATURITY_SWEEP_CRON`, default every 5 minutes) re-checks containers currently withheld by the gate and fires the moment each one's soak window elapses; the same check also runs at every watch-cycle scan. Delivery respects the same `THRESHOLD`, include/exclude, and `ONCE` dedup rules as `update-available`, and is deduplicated against it so the same update is never announced twice. Action triggers (Docker, Docker Compose, Command) are unaffected and keep applying updates on their normal scan cadence.
+
+### Changed
+
+- **Routine dependency maintenance across every workspace.** Minor and patch updates for the app, UI, demo, documentation website, and end-to-end suites, including `undici` 8.8.0, `helmet` 8.3.0, `express-rate-limit` 8.6.0, `node-cron` 4.6.0, `re2js` 2.8.6, and `@aws-sdk/client-ecr` 3.1091.0.
+- **Translations resynced from Crowdin** ([#545](https://github.com/CodesWhat/drydock/pull/545)), refreshing the container, dashboard, list, and shared-component catalogs across the supported locales.
+
+### Fixed
+
+- **Empty-result fallbacks in CI scripts are reachable again** ([#599](https://github.com/CodesWhat/drydock/pull/599)). Steps that run under `bash -eo pipefail` piped a `grep` or `find` straight into a variable assignment, so an empty result — no matching branch, a load-test artifact directory that a failed run never created — exited non-zero and aborted the step before the deliberate "nothing found" handler beneath it could run. The Crowdin sync hit this for real on 2026-07-24 and retargeted its translation PR at the default branch. The fallible command is now guarded on its own so a genuine failure (network, auth, bad syntax) still fails loudly, and regression tests pin every affected site.
+- **Renovate no longer opens dependency PRs that bump `package.json` without the lockfile** ([#594](https://github.com/CodesWhat/drydock/pull/594)), which previously landed manifests and lockfiles out of step. A `lockfile-sync` test now enforces the pairing.
+- **The gitignored `.planning` directory is no longer tracked** ([#593](https://github.com/CodesWhat/drydock/pull/593)), with a test guarding against re-adding files that `.gitignore` already excludes.
 
 ## [1.6.0-rc.5] — 2026-07-23
 
@@ -2231,7 +2244,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.5...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.6...HEAD
+[1.6.0-rc.6]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.5...v1.6.0-rc.6
 [1.6.0-rc.5]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.4...v1.6.0-rc.5
 [1.6.0-rc.4]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.3...v1.6.0-rc.4
 [1.6.0-rc.3]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.2...v1.6.0-rc.3

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.5-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.6-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -178,7 +178,7 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
-<summary><strong>v1.6.0-rc.5 highlights</strong></summary>
+<summary><strong>v1.6.0-rc.6 highlights</strong></summary>
 
 - **Notifications** — Per-rule/per-provider title and body templates with live preview, plus audit-backed in-app bell categories and update severity thresholds.
 - **Dashboard** — Zero-dependency CSS Grid replacement with mouse/touch reorder, bounded resize, responsive layouts, widget visibility, reset, and optional cross-device preference sync.

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.0-rc.5',
+    version: '1.6.0-rc.6',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.0-rc.5 started',
+    details: 'Drydock v1.6.0-rc.6 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.5',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.6',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.0-rc.5',
+    tag: '1.6.0-rc.6',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.0-rc.5',
+  version: '1.6.0-rc.6',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.0-rc.5',
+      version: '1.6.0-rc.6',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.0-rc.5', mode: 'demo' },
+        server: { version: '1.6.0-rc.6', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.0-rc.5",
+  version: "1.6.0-rc.6",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.0-rc.5",
+    version: "v1.6.0-rc.6",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.0-rc.5",
+      "version": "1.6.0-rc.6",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.0-rc.5",
+    "version": "1.6.0-rc.6",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.0-rc.5"
+  "version":"1.6.0-rc.6"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -162,7 +162,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.0-rc.5",
+    "version": "1.6.0-rc.6",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -185,7 +185,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.0-rc.5",
+      "drydockVersion": "1.6.0-rc.6",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.0-rc.5` | Immutable release candidate; best for reproducible testing |
+| `1.6.0-rc.6` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.0-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -3,6 +3,12 @@ title: "Updates"
 description: "Release update notes and feature highlights, with direct links to current configuration and API docs."
 ---
 
+## v1.6.0-rc.6 Highlights — July 26, 2026
+
+- **Maturity-cleared updates get their own notification** — when an update held back by the maturity gate (`maturityMode: mature`) finally clears its soak window, drydock now fires a dedicated `maturity-cleared` notification right away instead of waiting on the next scan's generic update-available message ([Discussion #587](https://github.com/CodesWhat/drydock/discussions/587)). A background sweep checks gated containers every few minutes so the notification lands close to the moment the update actually becomes applicable, and it's deduplicated against `update-available` so nothing gets announced twice.
+- **Routine dependency and translation maintenance** — minor and patch bumps across the app, UI, demo, website, and end-to-end workspaces, plus a refreshed translation sync from Crowdin covering the container, dashboard, list, and shared-component catalogs.
+- **CI scripts no longer choke on empty results** — steps that piped a `grep` or `find` straight into a variable assignment could abort before their own "nothing found" fallback ever ran, since an empty match exits non-zero under `bash -eo pipefail`. Fallible commands are now guarded individually so a real failure still fails loudly and an empty result still falls through to its handler.
+
 ## v1.6.0-rc.5 Highlights — July 23, 2026
 
 - **Resources can give the table its space back** — the Resources column remains visible by default, but the column picker can now hide it and preserve that choice. Source, release-note, and registry shortcuts move into each row's **More** menu while hidden; cards keep the same shortcuts in their footer without duplicating them.

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6 RC and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.5...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.6...HEAD`],
+    ['1.6.0-rc.6', `${repositoryUrl}/compare/v1.6.0-rc.5...v1.6.0-rc.6`],
     ['1.6.0-rc.5', `${repositoryUrl}/compare/v1.6.0-rc.4...v1.6.0-rc.5`],
     ['1.6.0-rc.4', `${repositoryUrl}/compare/v1.6.0-rc.3...v1.6.0-rc.4`],
     ['1.6.0-rc.3', `${repositoryUrl}/compare/v1.6.0-rc.2...v1.6.0-rc.3`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.0-rc.5';
-const RC_DATE = '2026-07-23';
-const RC_DISPLAY_DATE = 'July 23, 2026';
+const RC_VERSION = '1.6.0-rc.6';
+const RC_DATE = '2026-07-26';
+const RC_DISPLAY_DATE = 'July 26, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;
@@ -23,16 +23,16 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   const quickstart = read('content/docs/current/quickstart/index.mdx');
   const changelog = read('CHANGELOG.md');
 
-  assert.match(readme, /version-1\.6\.0--rc\.5-blue/u);
-  assert.match(readme, /v1\.6\.0-rc\.5 highlights/u);
+  assert.match(readme, /version-1\.6\.0--rc\.6-blue/u);
+  assert.match(readme, /v1\.6\.0-rc\.6 highlights/u);
   assert.match(siteConfig, new RegExp(`version: "${RC_VERSION.replaceAll('.', '\\.')}"`, 'u'));
   assert.ok(updates.includes(`## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`));
-  assert.match(appApi, /"version":"1\.6\.0-rc\.5"/u);
-  assert.match(agentApi, /"version": "1\.6\.0-rc\.5"/u);
-  assert.match(portwingApi, /"version": "1\.6\.0-rc\.5"/u);
-  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.5"/u);
-  assert.match(quickstart, /\| `1\.6\.0-rc\.5` \| Immutable release candidate/u);
-  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!5\b)\d+` \| Immutable release candidate/u);
+  assert.match(appApi, /"version":"1\.6\.0-rc\.6"/u);
+  assert.match(agentApi, /"version": "1\.6\.0-rc\.6"/u);
+  assert.match(portwingApi, /"version": "1\.6\.0-rc\.6"/u);
+  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.6"/u);
+  assert.match(quickstart, /\| `1\.6\.0-rc\.6` \| Immutable release candidate/u);
+  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!6\b)\d+` \| Immutable release candidate/u);
   assert.ok(changelog.includes(`## [${RC_VERSION}] — ${RC_DATE}`));
   assert.ok(
     changelog.includes(
@@ -41,7 +41,7 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   );
   assert.ok(
     changelog.includes(
-      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.4...v${RC_VERSION}`,
+      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.5...v${RC_VERSION}`,
     ),
   );
 });
@@ -55,7 +55,7 @@ test('v1.5.2 is archived and public release routing advances to v1.6', () => {
 
   assert.match(readme, /<summary><strong>v1\.5\.2 highlights<\/strong><\/summary>/u);
   assert.match(siteContent, /version: "v1\.5\.2",[\s\S]{0,500}?status: "released"/u);
-  assert.match(siteContent, /version: "v1\.6\.0-rc\.5",[\s\S]{0,500}?status: "next"/u);
+  assert.match(siteContent, /version: "v1\.6\.0-rc\.6",[\s\S]{0,500}?status: "next"/u);
   assert.match(
     docsVersions,
     /\{ slug: "v1\.6", source: "current", title: "v1\.6" \},\s+\{ slug: "v1\.5", source: "v1\.5", title: "v1\.5" \}/u,

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -3,6 +3,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const RC_VERSION = '1.6.0-rc.6';
+const PREV_RC_VERSION = '1.6.0-rc.5';
 const RC_DATE = '2026-07-26';
 const RC_DISPLAY_DATE = 'July 26, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
@@ -11,6 +12,10 @@ const BROAD_401_CLAIM =
 
 function read(path) {
   return readFileSync(path, 'utf8');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
 }
 
 test('public release surfaces identify the v1.6 release candidate', () => {
@@ -23,16 +28,35 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   const quickstart = read('content/docs/current/quickstart/index.mdx');
   const changelog = read('CHANGELOG.md');
 
-  assert.match(readme, /version-1\.6\.0--rc\.6-blue/u);
-  assert.match(readme, /v1\.6\.0-rc\.6 highlights/u);
-  assert.match(siteConfig, new RegExp(`version: "${RC_VERSION.replaceAll('.', '\\.')}"`, 'u'));
+  const escapedRcVersion = escapeRegExp(RC_VERSION);
+  const rcSuffixMatch = /^(.*-rc\.)(\d+)$/u.exec(RC_VERSION);
+  if (!rcSuffixMatch) {
+    throw new Error(`RC_VERSION must end in -rc.<number>, got: ${RC_VERSION}`);
+  }
+  const [, rcPrefix, rcNumber] = rcSuffixMatch;
+
+  assert.match(
+    readme,
+    new RegExp(`version-${escapeRegExp(RC_VERSION.replaceAll('-', '--'))}-blue`, 'u'),
+  );
+  assert.match(readme, new RegExp(`v${escapedRcVersion} highlights`, 'u'));
+  assert.match(siteConfig, new RegExp(`version: "${escapedRcVersion}"`, 'u'));
   assert.ok(updates.includes(`## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`));
-  assert.match(appApi, /"version":"1\.6\.0-rc\.6"/u);
-  assert.match(agentApi, /"version": "1\.6\.0-rc\.6"/u);
-  assert.match(portwingApi, /"version": "1\.6\.0-rc\.6"/u);
-  assert.match(portwingApi, /"drydockVersion": "1\.6\.0-rc\.6"/u);
-  assert.match(quickstart, /\| `1\.6\.0-rc\.6` \| Immutable release candidate/u);
-  assert.doesNotMatch(quickstart, /\| `1\.6\.0-rc\.(?!6\b)\d+` \| Immutable release candidate/u);
+  assert.match(appApi, new RegExp(`"version":"${escapedRcVersion}"`, 'u'));
+  assert.match(agentApi, new RegExp(`"version": "${escapedRcVersion}"`, 'u'));
+  assert.match(portwingApi, new RegExp(`"version": "${escapedRcVersion}"`, 'u'));
+  assert.match(portwingApi, new RegExp(`"drydockVersion": "${escapedRcVersion}"`, 'u'));
+  assert.match(
+    quickstart,
+    new RegExp(`\\| \`${escapedRcVersion}\` \\| Immutable release candidate`, 'u'),
+  );
+  assert.doesNotMatch(
+    quickstart,
+    new RegExp(
+      `\\| \`${escapeRegExp(rcPrefix)}(?!${rcNumber}\\b)\\d+\` \\| Immutable release candidate`,
+      'u',
+    ),
+  );
   assert.ok(changelog.includes(`## [${RC_VERSION}] — ${RC_DATE}`));
   assert.ok(
     changelog.includes(
@@ -41,7 +65,7 @@ test('public release surfaces identify the v1.6 release candidate', () => {
   );
   assert.ok(
     changelog.includes(
-      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.5...v${RC_VERSION}`,
+      `[${RC_VERSION}]: https://github.com/CodesWhat/drydock/compare/v${PREV_RC_VERSION}...v${RC_VERSION}`,
     ),
   );
 });
@@ -55,7 +79,10 @@ test('v1.5.2 is archived and public release routing advances to v1.6', () => {
 
   assert.match(readme, /<summary><strong>v1\.5\.2 highlights<\/strong><\/summary>/u);
   assert.match(siteContent, /version: "v1\.5\.2",[\s\S]{0,500}?status: "released"/u);
-  assert.match(siteContent, /version: "v1\.6\.0-rc\.6",[\s\S]{0,500}?status: "next"/u);
+  assert.match(
+    siteContent,
+    new RegExp(`version: "v${escapeRegExp(RC_VERSION)}",[\\s\\S]{0,500}?status: "next"`, 'u'),
+  );
   assert.match(
     docsVersions,
     /\{ slug: "v1\.6", source: "current", title: "v1\.6" \},\s+\{ slug: "v1\.5", source: "v1\.5", title: "v1\.5" \}/u,

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.0';
-const RC_VERSION = '1.6.0-rc.5';
+const RC_VERSION = '1.6.0-rc.6';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',
@@ -52,7 +52,7 @@ test('release-gated workspace packages and locks use the v1.6 base version', () 
   }
 });
 
-test('demo runtime fixtures identify the exact v1.6.0-rc.5 candidate', () => {
+test('demo runtime fixtures identify the exact v1.6.0-rc.6 candidate', () => {
   for (const { path, valuePattern } of DEMO_RELEASE_FIXTURES) {
     const contents = readFileSync(path, 'utf8');
     assert.deepEqual(extractVersionValues(contents, valuePattern), [RC_VERSION], path);
@@ -63,18 +63,18 @@ test('release version patterns match exact optionally v-prefixed tokens', () => 
   const rcPattern = versionPattern(RC_VERSION);
   const legacyPattern = versionPattern('1.5.0');
 
-  assert.match('version: 1.6.0-rc.5', rcPattern);
-  assert.match('version: v1.6.0-rc.5', rcPattern);
-  assert.doesNotMatch('version: 1.6.0-rc.50', rcPattern);
-  assert.doesNotMatch('version: x1.6.0-rc.5', rcPattern);
+  assert.match('version: 1.6.0-rc.6', rcPattern);
+  assert.match('version: v1.6.0-rc.6', rcPattern);
+  assert.doesNotMatch('version: 1.6.0-rc.60', rcPattern);
+  assert.doesNotMatch('version: x1.6.0-rc.6', rcPattern);
   assert.match('version: v1.5.0', legacyPattern);
   assert.doesNotMatch('version: 1.5.0-rc.1', legacyPattern);
 });
 
 test('fixture version extraction retains mixed candidate identities', () => {
-  const contents = "version: '1.6.0-rc.5', version: '1.6.0-rc.50'";
+  const contents = "version: '1.6.0-rc.6', version: '1.6.0-rc.60'";
   assert.deepEqual(extractVersionValues(contents, /version:\s*["']([^"']+)["']/gu), [
-    '1.6.0-rc.5',
-    '1.6.0-rc.50',
+    '1.6.0-rc.6',
+    '1.6.0-rc.60',
   ]);
 });

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -52,7 +52,7 @@ test('release-gated workspace packages and locks use the v1.6 base version', () 
   }
 });
 
-test('demo runtime fixtures identify the exact v1.6.0-rc.6 candidate', () => {
+test(`demo runtime fixtures identify the exact v${RC_VERSION} candidate`, () => {
   for (const { path, valuePattern } of DEMO_RELEASE_FIXTURES) {
     const contents = readFileSync(path, 'utf8');
     assert.deepEqual(extractVersionValues(contents, valuePattern), [RC_VERSION], path);
@@ -63,18 +63,18 @@ test('release version patterns match exact optionally v-prefixed tokens', () => 
   const rcPattern = versionPattern(RC_VERSION);
   const legacyPattern = versionPattern('1.5.0');
 
-  assert.match('version: 1.6.0-rc.6', rcPattern);
-  assert.match('version: v1.6.0-rc.6', rcPattern);
-  assert.doesNotMatch('version: 1.6.0-rc.60', rcPattern);
-  assert.doesNotMatch('version: x1.6.0-rc.6', rcPattern);
+  assert.match(`version: ${RC_VERSION}`, rcPattern);
+  assert.match(`version: v${RC_VERSION}`, rcPattern);
+  assert.doesNotMatch(`version: ${RC_VERSION}0`, rcPattern);
+  assert.doesNotMatch(`version: x${RC_VERSION}`, rcPattern);
   assert.match('version: v1.5.0', legacyPattern);
   assert.doesNotMatch('version: 1.5.0-rc.1', legacyPattern);
 });
 
 test('fixture version extraction retains mixed candidate identities', () => {
-  const contents = "version: '1.6.0-rc.6', version: '1.6.0-rc.60'";
+  const contents = `version: '${RC_VERSION}', version: '${RC_VERSION}0'`;
   assert.deepEqual(extractVersionValues(contents, /version:\s*["']([^"']+)["']/gu), [
-    '1.6.0-rc.6',
-    '1.6.0-rc.60',
+    RC_VERSION,
+    `${RC_VERSION}0`,
   ]);
 });


### PR DESCRIPTION
Prepares the release surfaces for cutting `v1.6.0-rc.6`. No runtime code changes.

## Why now

rc.5 was cut on 2026-07-23. Since then `dev/v1.6` picked up **#587, the maturity-cleared notification** — a new feature, not a fix, with a new `maturity-policy` model, ~170 lines in `Trigger.ts`, ~100 in `store/container.ts`, and a new background sweep on a new `DD_MATURITY_SWEEP_CRON` default. On top of that the delta carries a full dependency bump wave across all six lockfiles plus a Crowdin translation resync.

That's too much unsoaked change to take straight to GA, so it gets an RC first.

## What's here

**Changelog.** Promotes `[Unreleased]` to `[1.6.0-rc.6] — 2026-07-26` so `release-cut.yml`'s CHANGELOG validation resolves an entry for the tag, and backfills the rest of the delta since rc.5: the dependency wave, the translation resync, and the three CI/repo fixes (#599, #594, #593) that landed without changelog entries of their own.

**Release identity.** The usual 16-file bump: version badge, `site-config.ts`, the roadmap entry in `site-content.ts`, demo mock fixtures, the API doc response samples, the quickstart tag matrix, a new highlights section on the updates page, and the three pinned identity tests under `scripts/`.

All eight version files that `release-cut.yml` checks already sit at the `1.6.0` base, so no `package.json` bump is needed for this RC.

## Verification

- `node --test scripts/*.test.mjs` — 133 pass, 0 fail
- Full pre-push gate green end to end: qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, web-scripts-test, coverage (230s), build, zizmor
- `main` and `dev/v1.6` trees were in sync before this branch, so the pre-cut drift guard only needs the one sync after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

### ✨ Added
- Added `v1.6.0-rc.6` highlights (maturity-cleared notifications, dependency + translation resync, CI scripting robustness) for July 26, 2026.

### 🔧 Changed
- Promoted the `v1.6.0-rc.6` release surface by updating version identity references from `v1.6.0-rc.5` → `v1.6.0-rc.6` across README, site config/content, roadmap/demo content, API documentation samples, quickstart tags, and the updates page.
- Updated mock/demo data to report `1.6.0-rc.6` consistently (agent, audit, container, server, and API handler fixtures).
- Refactored release identity assertions in release tests to derive current RC expectations from `RC_VERSION`, added `PREV_RC_VERSION` for changelog compare-chain links, and ensured archived release references remain literal.
- Updated changelog compare link expectations for the RC series to use `v1.6.0-rc.6` as the chain head and added the `v1.6.0-rc.6` expected compare range (`v1.6.0-rc.5...v1.6.0-rc.6`).
- Tightened quickstart/version negative-match logic via dynamically constructed regexes and validation that `RC_VERSION` matches `-rc.<number>` before deriving prefix/number.

## Concerns
- Ensure changelog entry content/date (“Unreleased” → `v1.6.0-rc.6`, 2026-07-26) is correctly updated everywhere it’s generated/linked (docs + compare-link tests).
- Verify archived `1.5.0` / `1.5.2` references remain literal in identity tests (to avoid unintended tautologies).
- Confirm all release surface fixtures (including demo/portal API examples and Portwing message fields) use the same `rc.6` token with no remaining `rc.5` stragglers.
- Confirm verification remains green for the full pre-push gate (133 passing script tests, zero failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->