### PR TITLE
🔧 chore(ui): regenerate icon-bundle against the locked iconify versions

### DIFF
--- a/ui/src/boot/icon-bundle.json
+++ b/ui/src/boot/icon-bundle.json
@@ -1710,7 +1710,7 @@
     "height": 24
   },
   "tabler:server": {
-    "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M3 7a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3m0 6a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3zm4-7v.01M7 16v.01\"/>",
+    "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M3 7a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3zm0 8a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3zm4-7v.01M7 16v.01\"/>",
     "width": 24,
     "height": 24
   },


### PR DESCRIPTION
The committed `ui/src/boot/icon-bundle.json` was generated against `@iconify-json/tabler@1.2.35`, but #594 bumped the lockfile to 1.2.37 without re-running `npm run icons`. Since then every fresh `npm ci` worktree has kept resurfacing a one-icon diff (`tabler:server` path style) that had to be reverted by hand.

This regenerates the bundle against the locked versions so the checked-in asset matches the lockfile again. One line changed; output is otherwise byte-identical.

Full local pre-push gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed `tabler:server` SVG path data in `ui/src/boot/icon-bundle.json` to match `@iconify-json/tabler@1.2.37`.
- 🔧 Regenerated the bundle with all other output byte-identical.
- 🔧 Confirmed the local pre-push gate passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->