### PR TITLE
🐛 fix(i18n): fork l10n_crowdin from the resolved integration branch

### DIFF
--- a/.github/tests/crowdin-workflow.test.ts
+++ b/.github/tests/crowdin-workflow.test.ts
@@ -16,6 +16,8 @@ interface CrowdinConfig {
 const workflowPath = fileURLToPath(new URL('../workflows/i18n-crowdin.yml', import.meta.url));
 const crowdinConfigPath = fileURLToPath(new URL('../../crowdin.yml', import.meta.url));
 const crowdinActionRef = 'crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f';
+const integrationBranchCheckoutStepName =
+  'Check out the integration branch so l10n_crowdin forks from it';
 
 function loadCrowdinWorkflowStep(): WorkflowStep {
   const workflow = loadWorkflow(workflowPath);
@@ -39,6 +41,33 @@ test('Crowdin action runs as workspace owner and surfaces sync failures', () => 
 
   expect(step.with?.user).toBe('auto');
   expect(step['continue-on-error']).toBeUndefined();
+});
+
+test('Crowdin checks out the resolved integration branch before creating its branch', () => {
+  const steps = loadWorkflow(workflowPath).jobs?.sync?.steps ?? [];
+  const baseStepIndex = steps.findIndex((step) => step.id === 'base');
+  const checkoutStepIndex = steps.findIndex(
+    (step) => step.name === integrationBranchCheckoutStepName,
+  );
+  const crowdinStepIndex = steps.findIndex((step) =>
+    step.uses?.startsWith('crowdin/github-action@'),
+  );
+  const checkoutStep = steps[checkoutStepIndex];
+
+  expect(baseStepIndex).toBeGreaterThanOrEqual(0);
+  expect(checkoutStepIndex).toBeGreaterThan(baseStepIndex);
+  expect(crowdinStepIndex).toBeGreaterThan(checkoutStepIndex);
+
+  expect(checkoutStep?.env?.BASE).toBe('${{ steps.base.outputs.name }}');
+  expect(checkoutStep?.run).not.toContain('${{ steps.base.outputs.name }}');
+
+  const fetchCommand = 'git fetch origin "refs/heads/${BASE}:refs/remotes/origin/${BASE}"';
+  const checkoutCommand = 'git checkout -B "${BASE}" "refs/remotes/origin/${BASE}"';
+  expect(checkoutStep?.run).toContain(fetchCommand);
+  expect(checkoutStep?.run).toContain(checkoutCommand);
+  expect(checkoutStep?.run?.indexOf(fetchCommand)).toBeLessThan(
+    checkoutStep?.run?.indexOf(checkoutCommand) ?? -1,
+  );
 });
 
 test('Crowdin workflow lets crowdin.yml own the target language list', () => {

--- a/.github/workflows/i18n-crowdin.yml
+++ b/.github/workflows/i18n-crowdin.yml
@@ -68,6 +68,19 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
+      - name: Check out the integration branch so l10n_crowdin forks from it
+        env:
+          BASE: ${{ steps.base.outputs.name }}
+        run: |
+          set -euo pipefail
+          # The checkout above pinned HEAD to the triggering ref, which is main
+          # whenever a sync merge touches locale files. The crowdin action forks
+          # l10n_crowdin from HEAD, so without this switch the translation PR
+          # carries main's squash history and shows as permanently conflicting
+          # against the dev base (bit #601 and #618).
+          git fetch origin "refs/heads/${BASE}:refs/remotes/origin/${BASE}"
+          git checkout -B "${BASE}" "refs/remotes/origin/${BASE}"
+
       - uses: crowdin/github-action@52aa776766211d83d975df51f3b9c53c2f8ba35f  # v2.16.3
         with:
           user: auto


### PR DESCRIPTION
The Crowdin workflow checks out the triggering ref, which is `main` whenever a dev→main sync merge touches locale files. The crowdin action then forked `l10n_crowdin` from main's squash history while opening the PR against the dev base, leaving the translation PR permanently CONFLICTING (#601, #618 — closing #601 didn't cure it because the next run recreated the branch the same broken way).

Fix: after resolving the integration branch, fetch it and switch to it before the crowdin action runs, so `l10n_crowdin` forks from the branch the PR actually targets. BASE is passed via `env` (no inline template interpolation in `run:`).

Covered by a new workflow test asserting the step's position (after `base`, before the crowdin action), env wiring, and fetch-before-checkout ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed Crowdin workflow to fetch and check out the resolved integration branch before running the Crowdin action.
- 🐛 Fixed translation PRs being based on the triggering ref during `dev` → `main` syncs, preventing persistent conflicts.
- ✨ Added workflow tests covering step ordering, `BASE` configuration, and fetch-before-checkout behavior.

## Concerns

- Verify the resolved `BASE` branch always exists on `origin` before checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->