### PR TITLE
✅ test(e2e): track renovated picomatch and yaml override pins in security guards

### DIFF
--- a/e2e/tests/security/picomatch-lockfile.test.js
+++ b/e2e/tests/security/picomatch-lockfile.test.js
@@ -23,7 +23,7 @@ test('package manifest explicitly pins picomatch to the patched version', () => 
   const packageJsonPath = join(process.cwd(), 'package.json');
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 
-  assert.equal(packageJson.overrides?.picomatch, '4.0.4');
+  assert.equal(packageJson.overrides?.picomatch, '4.0.5');
 });
 
 test('package lockfile does not resolve vulnerable picomatch versions', () => {

--- a/e2e/tests/security/yaml-lockfile.test.js
+++ b/e2e/tests/security/yaml-lockfile.test.js
@@ -22,7 +22,7 @@ function compareSemver(a, b) {
 test('package manifest explicitly pins yaml to the patched version', () => {
   const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'));
 
-  assert.equal(packageJson.overrides?.yaml, '2.8.3');
+  assert.equal(packageJson.overrides?.yaml, '2.9.0');
 });
 
 test('package lockfile does not resolve vulnerable yaml versions', () => {


### PR DESCRIPTION
#563's e2e minor/patch bump moved the `picomatch` (4.0.4→4.0.5) and `yaml` (2.8.3→2.9.0) overrides past the exact-pin assertions in the e2e security guard tests, failing the (non-required) Cucumber support check on dev. The vulnerable-version floors stay at the CVE-patched releases; only the exact-pin expectations track the new overrides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

🔒 Security
- Updated security e2e expectations for `picomatch` override `4.0.5`.
- Updated security e2e expectations for `yaml` override `2.9.0`.
- Preserved vulnerable-version floor checks at CVE-patched releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->