### PR TITLE
🐛 fix(agent): stop agent reports from clearing controller-set update policy overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Controller-set update policy overrides no longer vanish from agent-managed containers** ([#565](https://github.com/CodesWhat/drydock/issues/565)). Remote agents resolve their own declarative (env/label) policy but never learn controller-side runtime overrides, so every container report they send carries an explicit empty override layer. The controller persisted that layer verbatim, and `updateContainer` (`app/store/container.ts`) treated any present `updatePolicyOverrides` key as authoritative — clearing maturity mode/min-age days, skip lists, and snoozes on every periodic agent sync or manual recheck. This was the settings-deletion mechanism behind #565, distinct from the soak-clock resets fixed in [#568](https://github.com/CodesWhat/drydock/pull/568) and rc.7. The controller now reapplies its stored overrides when ingesting agent reports, and the store itself encodes the rule the recreate path has had since [#497](https://github.com/CodesWhat/drydock/pull/497): an empty incoming override layer carries no controller intent and only clears stored overrides when the update-policy PATCH handler marks the write as authoritative, so deliberate clears from the UI still stick.
+
 ## [1.6.0-rc.7] — 2026-07-26
 
 ### Changed

--- a/app/agent/AgentClient.test.ts
+++ b/app/agent/AgentClient.test.ts
@@ -3768,6 +3768,159 @@ describe('AgentClient', () => {
       expect(result).toBe(report);
     });
 
+    test('preserves controller-owned maturity overrides when an agent recheck reports an empty override layer (#565)', async () => {
+      const controllerOverrides = {
+        maturityMode: 'mature',
+        maturityMinAgeDays: 5,
+      };
+      storeContainer.getContainer.mockReturnValue({
+        id: 'c1',
+        name: 'test',
+        updateAvailable: false,
+        updatePolicy: controllerOverrides,
+        updatePolicyDeclarative: { env: {}, label: {} },
+        updatePolicyOverrides: controllerOverrides,
+        updatePolicySources: {
+          maturityMode: 'override',
+          maturityMinAgeDays: 'override',
+        },
+      });
+      storeContainer.updateContainer.mockImplementation((container) => container);
+      const report = {
+        container: {
+          id: 'c1',
+          name: 'test',
+          updateAvailable: false,
+          updatePolicy: undefined,
+          updatePolicyDeclarative: { env: {}, label: {} },
+          updatePolicyOverrides: {},
+          updatePolicySources: {},
+        },
+      };
+      axios.post.mockResolvedValue({ data: report });
+
+      const result = await client.watchContainer('docker', 'local', {
+        id: 'c1',
+        name: 'test',
+      });
+
+      expect(storeContainer.updateContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          updatePolicy: controllerOverrides,
+          updatePolicyOverrides: controllerOverrides,
+          updatePolicySources: {
+            maturityMode: 'override',
+            maturityMinAgeDays: 'override',
+          },
+        }),
+      );
+      expect(result.container).toMatchObject({
+        updatePolicy: controllerOverrides,
+        updatePolicyOverrides: controllerOverrides,
+      });
+    });
+
+    test('preserves controller-owned skip and snooze overrides when an agent report has an empty override layer (#565)', async () => {
+      const controllerOverrides = {
+        skipTags: ['beta'],
+        skipDigests: ['sha256:abc'],
+        snoozeUntil: '2099-01-01T00:00:00.000Z',
+      };
+      storeContainer.getContainer.mockReturnValue({
+        id: 'c1',
+        name: 'test',
+        updateAvailable: false,
+        updatePolicy: controllerOverrides,
+        updatePolicyDeclarative: { env: {}, label: {} },
+        updatePolicyOverrides: controllerOverrides,
+        updatePolicySources: {
+          skipTags: 'override',
+          skipDigests: 'override',
+        },
+      });
+      storeContainer.updateContainer.mockImplementation((container) => container);
+      axios.post.mockResolvedValue({
+        data: {
+          container: {
+            id: 'c1',
+            name: 'test',
+            updateAvailable: false,
+            updatePolicy: undefined,
+            updatePolicyDeclarative: { env: {}, label: {} },
+            updatePolicyOverrides: {},
+            updatePolicySources: {},
+          },
+        },
+      });
+
+      const result = await client.watchContainer('docker', 'local', {
+        id: 'c1',
+        name: 'test',
+      });
+
+      expect(storeContainer.updateContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          updatePolicy: controllerOverrides,
+          updatePolicyOverrides: controllerOverrides,
+          updatePolicySources: {
+            skipTags: 'override',
+            skipDigests: 'override',
+          },
+        }),
+      );
+      expect(result.container).toMatchObject({
+        updatePolicy: controllerOverrides,
+        updatePolicyOverrides: controllerOverrides,
+      });
+    });
+
+    test('keeps cleared controller overrides empty when an agent report carries stale values (#565)', async () => {
+      const staleOverrides = {
+        skipTags: ['beta'],
+        snoozeUntil: '2099-01-01T00:00:00.000Z',
+      };
+      storeContainer.getContainer.mockReturnValue({
+        id: 'c1',
+        name: 'test',
+        updateAvailable: false,
+        updatePolicy: { skipTags: ['stable'] },
+        updatePolicyDeclarative: { env: { skipTags: ['stable'] }, label: {} },
+        updatePolicyOverrides: {},
+        updatePolicySources: { skipTags: 'env' },
+      });
+      storeContainer.updateContainer.mockImplementation((container) => container);
+      axios.post.mockResolvedValue({
+        data: {
+          container: {
+            id: 'c1',
+            name: 'test',
+            updateAvailable: false,
+            updatePolicy: staleOverrides,
+            updatePolicyDeclarative: { env: { skipTags: ['stable'] }, label: {} },
+            updatePolicyOverrides: staleOverrides,
+            updatePolicySources: { skipTags: 'override' },
+          },
+        },
+      });
+
+      const result = await client.watchContainer('docker', 'local', {
+        id: 'c1',
+        name: 'test',
+      });
+
+      expect(storeContainer.updateContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          updatePolicy: { skipTags: ['stable'] },
+          updatePolicyOverrides: {},
+          updatePolicySources: { skipTags: 'env' },
+        }),
+      );
+      expect(result.container).toMatchObject({
+        updatePolicy: { skipTags: ['stable'] },
+        updatePolicyOverrides: {},
+      });
+    });
+
     test('should throw on failure', async () => {
       axios.post.mockRejectedValue(new Error('watch failed'));
       await expect(

--- a/app/agent/AgentClient.ts
+++ b/app/agent/AgentClient.ts
@@ -43,6 +43,7 @@ import {
   isTerminalContainerUpdateOperationStatus,
   type TerminalContainerUpdateOperationStatus,
 } from '../model/container-update-operation.js';
+import { applyUpdatePolicyOverrides, getUpdatePolicyOverrides } from '../model/update-policy.js';
 import * as registry from '../registry/index.js';
 import { resolveConfiguredPath } from '../runtime/paths.js';
 import { createConfiguredSbomStorage } from '../security/configured-sbom-storage.js';
@@ -629,6 +630,12 @@ export class AgentClient {
 
     // Save to store logic with Change Detection
     const existing = storeContainer.getContainer(container.id);
+    if (existing && container.updatePolicyDeclarative !== undefined) {
+      // The controller owns runtime overrides. Agent watcher normalization always
+      // contributes an override layer (often `{}`), but that layer only reflects
+      // the agent's local store and must not clear controller-set policy on ingest.
+      applyUpdatePolicyOverrides(container, getUpdatePolicyOverrides(existing));
+    }
     const containerReport = {
       container: container,
       changed: false,

--- a/app/api/container.ts
+++ b/app/api/container.ts
@@ -238,7 +238,7 @@ const bulkSecurityHandlers = createBulkSecurityHandlers({
     getAllContainers: () => storeContainer.getContainers({}),
     getContainer: (id) => storeContainer.getContainer(id),
     getContainerRaw: (id) => storeContainer.getContainerRaw(id),
-    updateContainer: (c) => storeContainer.updateContainer(c),
+    updateContainer: (c, options?) => storeContainer.updateContainer(c, options),
   },
   getSecurityConfiguration,
   scanImageForVulnerabilities,

--- a/app/api/container/update-policy.test.ts
+++ b/app/api/container/update-policy.test.ts
@@ -642,6 +642,24 @@ describe('api/container/update-policy', () => {
       });
     });
 
+    test('passes authoritative empty override intent when an action clears the last override', () => {
+      const harness = createLayeredHarness({
+        updatePolicy: {
+          maturityMode: 'mature',
+          maturityMinAgeDays: 7,
+          snoozeUntil: '2030-01-01T00:00:00.000Z',
+        },
+        updatePolicyOverrides: { snoozeUntil: '2030-01-01T00:00:00.000Z' },
+      });
+
+      callPatchContainerUpdatePolicy(harness.handlers, { action: 'unsnooze' });
+
+      expect(harness.storeContainer.updateContainer).toHaveBeenCalledWith(
+        expect.objectContaining({ updatePolicyOverrides: {} }),
+        { authoritativeEmptyOverrides: true },
+      );
+    });
+
     test('supports layered clear, snooze, unsnooze, maturity-clear, and whole revert actions', () => {
       const clearSkips = createLayeredHarness();
       callPatchContainerUpdatePolicy(clearSkips.handlers, { action: 'clear-skips' });

--- a/app/api/container/update-policy.ts
+++ b/app/api/container/update-policy.ts
@@ -18,7 +18,10 @@ import { getPathParamValue } from './request-helpers.js';
 
 interface UpdatePolicyStoreContainerApi {
   getContainer: (id: string) => Container | undefined;
-  updateContainer: (container: Container) => Container;
+  updateContainer: (
+    container: Container,
+    options?: { authoritativeEmptyOverrides?: boolean },
+  ) => Container;
 }
 
 interface UpdatePolicyHandlerDependencies {
@@ -450,7 +453,9 @@ function createPatchContainerUpdatePolicy({
         container.updatePolicy =
           Object.keys(normalizedPolicy).length > 0 ? normalizedPolicy : undefined;
       }
-      const containerUpdated = storeContainer.updateContainer(container);
+      const containerUpdated = storeContainer.updateContainer(container, {
+        authoritativeEmptyOverrides: true,
+      });
       if (previousOverrides) {
         recordOverrideAuditEvents(
           recordAuditEvent,

--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -384,7 +384,60 @@ test('updateContainer should keep overrides when a declarative label is removed'
   expect(updated.updatePolicySources).toEqual({ skipTags: 'override' });
 });
 
-test('updateContainer should honor an explicit empty override layer', () => {
+test('updateContainer should preserve existing overrides for a non-authoritative empty override layer', () => {
+  const existingContainer = {
+    data: createContainerFixture({
+      updatePolicy: { maturityMode: 'all' },
+      updatePolicyDeclarative: { env: { maturityMode: 'mature' }, label: {} },
+      updatePolicyOverrides: { maturityMode: 'all' },
+      updatePolicySources: { maturityMode: 'override' },
+    }),
+  };
+  const collection = { findOne: () => existingContainer, update: vi.fn() };
+  container.createCollections({ getCollection: () => collection, addCollection: () => null });
+
+  const updated = container.updateContainer(
+    createContainerFixture({
+      updatePolicy: { maturityMode: 'mature' },
+      updatePolicyDeclarative: { env: { maturityMode: 'mature' }, label: {} },
+      updatePolicyOverrides: {},
+      updatePolicySources: { maturityMode: 'env' },
+    }),
+  );
+
+  expect(updated.updatePolicyOverrides).toEqual({ maturityMode: 'all' });
+  expect(updated.updatePolicy).toEqual({ maturityMode: 'all' });
+  expect(updated.updatePolicySources).toEqual({ maturityMode: 'override' });
+});
+
+test('updateContainer should clear overrides for an authoritative empty override layer', () => {
+  const existingContainer = {
+    data: createContainerFixture({
+      updatePolicy: { maturityMode: 'all' },
+      updatePolicyDeclarative: { env: { maturityMode: 'mature' }, label: {} },
+      updatePolicyOverrides: { maturityMode: 'all' },
+      updatePolicySources: { maturityMode: 'override' },
+    }),
+  };
+  const collection = { findOne: () => existingContainer, update: vi.fn() };
+  container.createCollections({ getCollection: () => collection, addCollection: () => null });
+
+  const updated = container.updateContainer(
+    createContainerFixture({
+      updatePolicy: { maturityMode: 'mature' },
+      updatePolicyDeclarative: { env: { maturityMode: 'mature' }, label: {} },
+      updatePolicyOverrides: {},
+      updatePolicySources: { maturityMode: 'env' },
+    }),
+    { authoritativeEmptyOverrides: true },
+  );
+
+  expect(updated.updatePolicyOverrides).toEqual({});
+  expect(updated.updatePolicy).toEqual({ maturityMode: 'mature' });
+  expect(updated.updatePolicySources).toEqual({ maturityMode: 'env' });
+});
+
+test('updateContainer should normalize an authoritative undefined override layer to empty', () => {
   const existingContainer = {
     data: createContainerFixture({
       updatePolicy: { maturityMode: 'all' },
@@ -403,10 +456,98 @@ test('updateContainer should honor an explicit empty override layer', () => {
       updatePolicyOverrides: undefined,
       updatePolicySources: { maturityMode: 'env' },
     }),
+    { authoritativeEmptyOverrides: true },
   );
 
   expect(updated.updatePolicyOverrides).toEqual({});
   expect(updated.updatePolicy).toEqual({ maturityMode: 'mature' });
+  expect(updated.updatePolicySources).toEqual({ maturityMode: 'env' });
+});
+
+test('updateContainer should honor a non-empty incoming override layer without an authority flag', () => {
+  const existingContainer = {
+    data: createContainerFixture({
+      updatePolicy: { maturityMode: 'all', maturityMinAgeDays: 7 },
+      updatePolicyDeclarative: {
+        env: { maturityMode: 'mature', maturityMinAgeDays: 7 },
+        label: {},
+      },
+      updatePolicyOverrides: { maturityMode: 'all' },
+      updatePolicySources: {
+        maturityMode: 'override',
+        maturityMinAgeDays: 'env',
+      },
+    }),
+  };
+  const collection = { findOne: () => existingContainer, update: vi.fn() };
+  container.createCollections({ getCollection: () => collection, addCollection: () => null });
+
+  const updated = container.updateContainer(
+    createContainerFixture({
+      updatePolicy: { maturityMode: 'mature', maturityMinAgeDays: 21 },
+      updatePolicyDeclarative: {
+        env: { maturityMode: 'mature', maturityMinAgeDays: 7 },
+        label: {},
+      },
+      updatePolicyOverrides: { maturityMinAgeDays: 21 },
+      updatePolicySources: {
+        maturityMode: 'env',
+        maturityMinAgeDays: 'override',
+      },
+    }),
+  );
+
+  expect(updated.updatePolicyOverrides).toEqual({ maturityMinAgeDays: 21 });
+  expect(updated.updatePolicy).toEqual({ maturityMode: 'mature', maturityMinAgeDays: 21 });
+  expect(updated.updatePolicySources).toEqual({
+    maturityMode: 'env',
+    maturityMinAgeDays: 'override',
+  });
+});
+
+test('updateContainer should preserve overrides when an empty layer omits declarative policy', () => {
+  const existingContainer = {
+    data: createContainerFixture({
+      updatePolicy: { maturityMode: 'all' },
+      updatePolicyDeclarative: { env: { maturityMode: 'mature' }, label: {} },
+      updatePolicyOverrides: { maturityMode: 'all' },
+      updatePolicySources: { maturityMode: 'override' },
+    }),
+  };
+  const collection = { findOne: () => existingContainer, update: vi.fn() };
+  container.createCollections({ getCollection: () => collection, addCollection: () => null });
+
+  const updated = container.updateContainer(
+    createContainerFixture({
+      updatePolicyOverrides: {},
+    }),
+  );
+
+  expect(updated.updatePolicyDeclarative).toEqual({
+    env: { maturityMode: 'mature' },
+    label: {},
+  });
+  expect(updated.updatePolicyOverrides).toEqual({ maturityMode: 'all' });
+  expect(updated.updatePolicy).toEqual({ maturityMode: 'all' });
+  expect(updated.updatePolicySources).toEqual({ maturityMode: 'override' });
+});
+
+test('updateContainer should keep an empty override layer on the first write', () => {
+  const collection = createFilterableCollection([]);
+  container.createCollections({ getCollection: () => collection, addCollection: () => null });
+
+  const updated = container.updateContainer(
+    createContainerFixture({
+      updatePolicy: { maturityMode: 'mature' },
+      updatePolicyDeclarative: { env: { maturityMode: 'mature' }, label: {} },
+      updatePolicyOverrides: {},
+      updatePolicySources: { maturityMode: 'env' },
+    }),
+  );
+
+  expect(updated.updatePolicyOverrides).toEqual({});
+  expect(updated.updatePolicy).toEqual({ maturityMode: 'mature' });
+  expect(updated.updatePolicySources).toEqual({ maturityMode: 'env' });
 });
 
 test('updateContainer should resolve a declarative policy without a current stored container', () => {

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -1022,6 +1022,16 @@ function stashUpdatePolicyForReplacement(containerRaw) {
 }
 
 /**
+ * #565: a present-but-empty updatePolicyOverrides layer is watcher/agent normalization, not
+ * controller intent, and must never replace stored overrides. Only a non-empty layer — or an
+ * empty one from an explicitly authoritative caller (the update-policy PATCH handler clearing
+ * the last override) — carries intent.
+ */
+function isAuthoritativeOverrideLayer(overrides, authoritativeEmptyOverrides = false) {
+  return authoritativeEmptyOverrides || Object.keys(overrides ?? {}).length > 0;
+}
+
+/**
  * #496: restore a retained updatePolicy onto a replacement container. The entry is consumed
  * either way, so a stale policy can never attach to a later, unrelated container.
  */
@@ -1038,13 +1048,9 @@ function restoreRetainedUpdatePolicy(container) {
   if (entry.expiresAt <= Date.now()) {
     return;
   }
-  // A non-empty incoming controller layer is authoritative. Watcher normalization also stamps
-  // updatePolicyOverrides={} on fresh declarative data; that empty layer carries no controller
-  // intent and must not discard the retained overrides from the container being replaced.
-  if (
-    container.updatePolicyOverrides !== undefined &&
-    Object.keys(container.updatePolicyOverrides).length > 0
-  ) {
+  // A non-empty incoming controller layer is authoritative and must not be replaced; an empty
+  // one must not discard the retained overrides from the container being replaced.
+  if (isAuthoritativeOverrideLayer(container.updatePolicyOverrides)) {
     return;
   }
   if (container.updatePolicyDeclarative !== undefined) {
@@ -1139,15 +1145,15 @@ export function updateContainer(
 ) {
   const hasUpdatePolicy = Object.hasOwn(container, 'updatePolicy');
   const hasUpdatePolicyDeclarative = Object.hasOwn(container, 'updatePolicyDeclarative');
-  // #565: a present-but-empty updatePolicyOverrides is watcher/agent normalization, not
-  // controller intent, and must not clear stored overrides — mirrors the rule in
-  // restoreRetainedUpdatePolicy above. Only an authoritative caller (the update-policy PATCH
-  // handler) may clear overrides with an empty layer, signaled via options.authoritativeEmptyOverrides.
-  const incomingOverridesPresent = Object.hasOwn(container, 'updatePolicyOverrides');
+  // #565: an incoming override layer only participates in the merge when it carries controller
+  // intent (see isAuthoritativeOverrideLayer); the PATCH handler signals a deliberate clear via
+  // options.authoritativeEmptyOverrides.
   const hasUpdatePolicyOverrides =
-    incomingOverridesPresent &&
-    (options.authoritativeEmptyOverrides === true ||
-      Object.keys(container.updatePolicyOverrides ?? {}).length > 0);
+    Object.hasOwn(container, 'updatePolicyOverrides') &&
+    isAuthoritativeOverrideLayer(
+      container.updatePolicyOverrides,
+      options.authoritativeEmptyOverrides === true,
+    );
   const hasUpdateRollback = Object.hasOwn(container, 'updateRollback');
   const hasSecurity = Object.hasOwn(container, 'security');
   const hasDetails = Object.hasOwn(container, 'details');

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -1133,10 +1133,21 @@ export function insertContainer(container) {
  * Update existing container.
  * @param container
  */
-export function updateContainer(container) {
+export function updateContainer(
+  container,
+  options: { authoritativeEmptyOverrides?: boolean } = {},
+) {
   const hasUpdatePolicy = Object.hasOwn(container, 'updatePolicy');
   const hasUpdatePolicyDeclarative = Object.hasOwn(container, 'updatePolicyDeclarative');
-  const hasUpdatePolicyOverrides = Object.hasOwn(container, 'updatePolicyOverrides');
+  // #565: a present-but-empty updatePolicyOverrides is watcher/agent normalization, not
+  // controller intent, and must not clear stored overrides — mirrors the rule in
+  // restoreRetainedUpdatePolicy above. Only an authoritative caller (the update-policy PATCH
+  // handler) may clear overrides with an empty layer, signaled via options.authoritativeEmptyOverrides.
+  const incomingOverridesPresent = Object.hasOwn(container, 'updatePolicyOverrides');
+  const hasUpdatePolicyOverrides =
+    incomingOverridesPresent &&
+    (options.authoritativeEmptyOverrides === true ||
+      Object.keys(container.updatePolicyOverrides ?? {}).length > 0);
   const hasUpdateRollback = Object.hasOwn(container, 'updateRollback');
   const hasSecurity = Object.hasOwn(container, 'security');
   const hasDetails = Object.hasOwn(container, 'details');


### PR DESCRIPTION
## Problem

Agent-managed containers lose their controller-set update policy overrides (maturity mode/min-age days, skip lists, snooze) on every agent report. The agent resolves its own declarative (env/label) policy but never learns controller-side runtime overrides, so every container report it sends carries an explicit `updatePolicyOverrides: {}` layer. The controller persisted that layer verbatim, and the store's `updateContainer` treats any *present* `updatePolicyOverrides` key as authoritative — even when empty. Any manual recheck or periodic agent sync wiped the settings.

This is the settings-deletion half of #565. The soak-clock resets in that thread were real but separate mechanisms, fixed in #566/#568 and the rc.7 identity batch (#607). The reporter runs the controller-agent architecture (confirmed in their own words in #496, reconfirmed in #623), which is why the symptom survived all four prior fixes: those fixed the clock, this deletes the actual override values — matching the original before/after screenshots.

The insert/recreate path has had exactly this protection since #496/#497 (`restoreRetainedUpdatePolicy`: "an empty layer carries no controller intent"); the same-id `updateContainer` path never got it.

## Fix (two layers)

1. **`AgentClient.buildContainerReport`** reapplies the controller's stored runtime overrides onto the incoming agent report before persistence. Covers all five agent ingestion call sites (handshake, single-container, pending watcher-cycle, bulk reports, recheck) — they all funnel through this one method.
2. **`storeContainer.updateContainer`** now encodes the invariant directly, mirroring the insert-path rule: a present-but-empty override layer carries no intent and falls back to the stored overrides, unless the caller passes `authoritativeEmptyOverrides: true`. The update-policy PATCH handler passes it, so deliberate clears from the UI still stick.

Safety was verified adversarially before landing: overrides can only be set via the controller's PATCH endpoint, there is no controller→agent policy push that could echo stale values back, expired snoozes can't be resurrected (evaluated live at read time), and the local (non-agent) watcher path already preserves overrides by construction (it mutates the live store doc).

## Tests

- Regression: mature/5-day override survives an agent report with an empty override layer (fails pre-fix)
- skipTags/skipDigests/snoozeUntil survive the same scenario
- Inverse: cleared overrides stay cleared on subsequent agent reports (no resurrection)
- Store guard: authoritative empty clears; non-empty always authoritative; declarative-absent empty preserved; first-write empty stays empty
- PATCH handler passes clear authority to the store

Full app suite: 394 files / 12,395 tests, 100% coverage. Full lefthook pre-push gate green.

Refs #565


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed agent reports clearing controller-owned update-policy overrides.
- 🔧 Reapplied stored maturity, minimum-age, skip-list, and snooze overrides during agent report normalization.
- 🔧 Treated empty override layers as non-authoritative by default during container updates.
- ✨ Added explicit `authoritativeEmptyOverrides` support for intentional clears from update-policy PATCH requests.
- ✨ Added regression coverage for override preservation, clearing, and PATCH behavior.
- 🔧 Forwarded update options through container API handlers.

## Validation

- Full suite passes: 394 files, 12,395 tests, 100% coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->