### PR TITLE
📝 docs(release): prepare v1.6.0-rc.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0-rc.8] — 2026-07-28
+
 ### Fixed
 
 - **Auto-update no longer stops when the update-available notification rule is scoped to specific channels** ([#623](https://github.com/CodesWhat/drydock/issues/623)). Action triggers (`docker`, `dockercompose`, `command`) were gated by the same trigger allow-list on the `update-available` notification rule that routes messages to notification channels — but action-trigger ids are deliberately barred from that list by the API validator, the UI picker, and the documented rule model, so the moment any notification trigger was assigned to the rule, every action trigger (local and agent-hosted alike) silently failed the membership check with `excluded-from-allow-list` and auto-update stopped fleet-wide, with only a debug log as evidence. Action-category triggers are now exempt from the allow-list membership check in `getUpdateAvailableAutoTriggerDispatchDecision` (`app/triggers/providers/Trigger.ts`), mirroring the exemption the lifecycle-notification path has always had; disabling the rule itself still acts as the global kill switch. Present since the rule allow-list landed in v1.6.0-rc.1.
@@ -2262,7 +2264,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.7...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.8...HEAD
+[1.6.0-rc.8]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.7...v1.6.0-rc.8
 [1.6.0-rc.7]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.6...v1.6.0-rc.7
 [1.6.0-rc.6]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.5...v1.6.0-rc.6
 [1.6.0-rc.5]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.4...v1.6.0-rc.5

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.7-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.8-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -178,7 +178,7 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
-<summary><strong>v1.6.0-rc.7 highlights</strong></summary>
+<summary><strong>v1.6.0-rc.8 highlights</strong></summary>
 
 - **Notifications** — Per-rule/per-provider title and body templates with live preview, plus audit-backed in-app bell categories and update severity thresholds.
 - **Dashboard** — Zero-dependency CSS Grid replacement with mouse/touch reorder, bounded resize, responsive layouts, widget visibility, reset, and optional cross-device preference sync.

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.0-rc.7',
+    version: '1.6.0-rc.8',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.0-rc.7 started',
+    details: 'Drydock v1.6.0-rc.8 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.7',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.8',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.0-rc.7',
+    tag: '1.6.0-rc.8',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.0-rc.7',
+  version: '1.6.0-rc.8',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.0-rc.7',
+      version: '1.6.0-rc.8',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.0-rc.7', mode: 'demo' },
+        server: { version: '1.6.0-rc.8', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.0-rc.7",
+  version: "1.6.0-rc.8",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.0-rc.7",
+    version: "v1.6.0-rc.8",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.0-rc.7",
+      "version": "1.6.0-rc.8",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.0-rc.7",
+    "version": "1.6.0-rc.8",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.0-rc.7"
+  "version":"1.6.0-rc.8"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -162,7 +162,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.0-rc.7",
+    "version": "1.6.0-rc.8",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -185,7 +185,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.0-rc.7",
+      "drydockVersion": "1.6.0-rc.8",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.0-rc.7` | Immutable release candidate; best for reproducible testing |
+| `1.6.0-rc.8` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.0-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -3,6 +3,11 @@ title: "Updates"
 description: "Release update notes and feature highlights, with direct links to current configuration and API docs."
 ---
 
+## v1.6.0-rc.8 Highlights — July 28, 2026
+
+- **Agent-managed containers keep their update policy** — remote agents never learn controller-side runtime overrides, so every agent report carried an empty override layer that the controller persisted verbatim, wiping maturity mode, min-age days, skip lists, and snoozes on every sync or recheck. The controller now reapplies its stored overrides when ingesting agent reports, and the store only honors an empty override layer when the update-policy API marks the clear as deliberate — so settings finally survive agent syncs while UI clears still stick ([#565](https://github.com/CodesWhat/drydock/issues/565)).
+- **Auto-update keeps running when update notifications are scoped to specific channels** — assigning any notification trigger to the update-available rule silently disabled every action trigger (Docker, Docker Compose, Command) fleet-wide, because action triggers were run through an allow-list they're structurally barred from joining. Action triggers are now exempt from the allow-list membership check; disabling the rule itself remains the kill switch ([#623](https://github.com/CodesWhat/drydock/issues/623)).
+
 ## v1.6.0-rc.7 Highlights — July 26, 2026
 
 - **Four identity-drift bugs fixed** — the maturity soak clock no longer resets when a container is recreated, notification dedup no longer double-fires a `once: true` notification on a manual recheck, a finishing security scan no longer reverts an update the watcher detected mid-scan, and containers with no available update no longer surface under maturity/age filters or sorts. All four traced back to inconsistent candidate-identity comparisons, now unified behind one shared helper.

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6 RC and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.7...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.8...HEAD`],
+    ['1.6.0-rc.8', `${repositoryUrl}/compare/v1.6.0-rc.7...v1.6.0-rc.8`],
     ['1.6.0-rc.7', `${repositoryUrl}/compare/v1.6.0-rc.6...v1.6.0-rc.7`],
     ['1.6.0-rc.6', `${repositoryUrl}/compare/v1.6.0-rc.5...v1.6.0-rc.6`],
     ['1.6.0-rc.5', `${repositoryUrl}/compare/v1.6.0-rc.4...v1.6.0-rc.5`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.0-rc.7';
-const PREV_RC_VERSION = '1.6.0-rc.6';
-const RC_DATE = '2026-07-26';
-const RC_DISPLAY_DATE = 'July 26, 2026';
+const RC_VERSION = '1.6.0-rc.8';
+const PREV_RC_VERSION = '1.6.0-rc.7';
+const RC_DATE = '2026-07-28';
+const RC_DISPLAY_DATE = 'July 28, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.0';
-const RC_VERSION = '1.6.0-rc.7';
+const RC_VERSION = '1.6.0-rc.8';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Prepares the release surfaces for cutting `v1.6.0-rc.8`. No runtime code changes.

## Why now

The #565 agent-report override wipe (#624) and the #623 action-trigger allow-list lockout (#625) are both runtime fixes, so they force a new candidate and restart the soak.

## What's here

**Changelog.** Promotes `[Unreleased]` to `[1.6.0-rc.8] — 2026-07-28` so `release-cut.yml`'s CHANGELOG validation resolves an entry for the tag. Both Fixed entries came in with #624/#625; this adds the link definitions and a fresh empty Unreleased section.

**Release identity.** The usual 17-file bump, mirroring the rc.7 prep (#609): version badge, `site-config.ts`, the roadmap entry in `site-content.ts`, demo mock fixtures, the API doc response samples, the quickstart tag matrix, a new highlights section on the updates page, and the three pinned identity tests under `scripts/`. README highlights block keeps the cumulative v1.6 feature list (badge + summary line bump only).

All eight version files already sit at the `1.6.0` base, so no `package.json` bump is needed.

## Verification

- `node --test scripts/*.test.mjs`: 133 pass, 0 fail
- Full pre-push gate green end to end: qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, web-scripts-test, coverage, build, zizmor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added `v1.6.0-rc.8` highlights and changelog links for `#624` and `#625`.
- 🔧 Promoted the changelog release entry to `1.6.0-rc.8` dated July 28, 2026 and added a new Unreleased section.
- 🔧 Updated release identity across badges, site configuration, roadmap/content, fixtures, API examples, quickstart tags, and identity tests.
- 🔧 Retained the cumulative v1.6 feature list in the README.
- 🔧 Left `package.json` unchanged.

- 133 script tests and the full pre-push gate passed.
- No substantive review findings were reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->