### PR TITLE
📝 docs(triggers): state the action-trigger exemption from notification-rule trigger lists

### DIFF
--- a/content/docs/current/configuration/triggers/index.mdx
+++ b/content/docs/current/configuration/triggers/index.mdx
@@ -181,7 +181,7 @@ Rules are managed via `GET /api/v1/notifications` and `PATCH /api/v1/notificatio
 
 Overrides are keyed by canonical trigger ID, so the same event can use different copy for Slack, SMTP, ntfy, or any other configured notification provider. They use the same sandboxed `${...}` syntax and variables documented in [Template variable reference](#template-variable-reference). The preview API is `POST /api/v1/notifications/:id/preview`; see the [Notification rules API](/docs/api#notification-rules) for its request shape.
 
-<Callout type="warn">Command, Docker, and Docker Compose triggers cannot be assigned to notification rules or template overrides. These are update-action triggers, not notification triggers. Only messaging/alerting triggers (Slack, SMTP, Discord, ntfy, etc.) can be assigned.</Callout>
+<Callout type="warn">Command, Docker, and Docker Compose triggers cannot be assigned to notification rules or template overrides. These are update-action triggers, not notification triggers. Only messaging/alerting triggers (Slack, SMTP, Discord, ntfy, etc.) can be assigned. Because of this, a rule's trigger list only scopes which notification channels receive messages. Action triggers are exempt from that list and keep executing updates no matter how it's scoped, including when the trigger runs on a remote agent. Disabling the rule itself (not narrowing its trigger list) is what stops automatic update execution via action triggers.</Callout>
 
 ## Event Types
 


### PR DESCRIPTION
Closes the documentation gap from #625: the notification-rules callout said action triggers can't be assigned to rules, but nothing explained what a scoped trigger list means for them. The callout now states the list scopes notification delivery only, action triggers are exempt and keep executing updates however the list is scoped (including agent-hosted triggers), and disabling the rule itself is the kill switch.

Docs-only; no runtime changes.

Refs #623