### PR TITLE
🐛 fix(release): make GA promotion executable and keep artifact provenance honest

### DIFF
--- a/.github/tests/release-cut-ga-promotion.test.ts
+++ b/.github/tests/release-cut-ga-promotion.test.ts
@@ -44,6 +44,11 @@ test('release-cut captures a CHANGELOG snapshot from the target SHA', () => {
 
   expect(step?.id).toBe('target_changelog');
   expect(step?.run).toContain('git show "${TARGET_SHA}:CHANGELOG.md"');
+  // The extractor must be snapshotted as the whole scripts/ tree, not a single
+  // file: it imports relative siblings (./lib/parse-args.mjs), which Node
+  // resolves against the script's own location.
+  expect(step?.run).toContain('git archive "${TARGET_SHA}" scripts | tar -x -C');
+  expect(step?.run).not.toContain('git show "${TARGET_SHA}:scripts/');
 });
 
 test('release-cut reads CHANGELOG from the target-sha snapshot, not the checked-out tree', () => {

--- a/.github/tests/release-cut-ga-promotion.test.ts
+++ b/.github/tests/release-cut-ga-promotion.test.ts
@@ -1,0 +1,139 @@
+import { fileURLToPath } from 'node:url';
+
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
+
+const workflowPath = fileURLToPath(new URL('../workflows/release-cut.yml', import.meta.url));
+
+const prereleaseOnlySignSteps = [
+  'Sign release artifact',
+  'Verify release artifact signature',
+  'Attest release artifact provenance',
+  'Export release provenance asset',
+  'Verify release artifact provenance attestation',
+];
+
+const gaPromotionSteps = [
+  'Download candidate release artifact for promotion',
+  'Verify downloaded candidate artifact checksum',
+  'Verify candidate artifact provenance attestation',
+  'Verify candidate artifact signature',
+  'Verify candidate artifact is reproducible from source SHA',
+  'Promote candidate artifact to GA release filenames',
+];
+
+const assetSuffixes = [
+  'tar.gz',
+  'tar.gz.sha256',
+  'tar.gz.bundle',
+  'tar.gz.sig',
+  'tar.gz.pem',
+  'tar.gz.intoto.jsonl',
+];
+
+function loadReleaseSteps(): WorkflowStep[] {
+  const workflow = loadWorkflow(workflowPath);
+  return workflow.jobs?.release?.steps ?? [];
+}
+
+function getStep(name: string): WorkflowStep | undefined {
+  return loadReleaseSteps().find((step) => step.name === name);
+}
+
+test('release-cut captures a CHANGELOG snapshot from the target SHA', () => {
+  const step = getStep('Capture CHANGELOG snapshot from target SHA');
+
+  expect(step?.id).toBe('target_changelog');
+  expect(step?.run).toContain('git show "${TARGET_SHA}:CHANGELOG.md"');
+});
+
+test('release-cut reads CHANGELOG from the target-sha snapshot, not the checked-out tree', () => {
+  const validateStep = getStep('Validate CHANGELOG entry for release tag');
+  const notesStep = getStep('Generate release notes from changelog');
+
+  for (const step of [validateStep, notesStep]) {
+    expect(step?.env).toMatchObject({
+      CHANGELOG_PATH: '${{ steps.target_changelog.outputs.path }}',
+    });
+    expect(step?.run).toContain('--file "${CHANGELOG_PATH}"');
+    expect(step?.run).not.toContain('--file CHANGELOG.md');
+  }
+});
+
+test('release-cut gates artifact sign/attest/verify steps to prereleases only', () => {
+  for (const stepName of prereleaseOnlySignSteps) {
+    const step = getStep(stepName);
+
+    expect(step?.if).toBe("steps.tag.outputs.is_prerelease == 'true'");
+  }
+});
+
+test('release-cut promotes the candidate artifact at GA in a fixed step order, each GA-gated', () => {
+  const steps = loadReleaseSteps();
+  const indexOf = (name: string) => steps.findIndex((step) => step.name === name);
+
+  for (const stepName of gaPromotionSteps) {
+    const step = getStep(stepName);
+
+    expect(step, `expected step "${stepName}" to exist`).toBeDefined();
+    expect(step?.if).toBe("steps.tag.outputs.is_prerelease == 'false'");
+  }
+
+  const indices = gaPromotionSteps.map(indexOf);
+  for (let i = 1; i < indices.length; i += 1) {
+    expect(indices[i]).toBeGreaterThan(indices[i - 1]);
+  }
+});
+
+test('release-cut downloads and promotes exactly the six candidate asset suffixes', () => {
+  const downloadStep = getStep('Download candidate release artifact for promotion');
+  const promoteStep = getStep('Promote candidate artifact to GA release filenames');
+
+  // The download runs under the pinned retry wrapper (transient GitHub API /
+  // asset-CDN failures must not abort a GA run), so its script lives in
+  // `with.command`, not `run`.
+  expect(downloadStep?.uses).toContain('nick-fields/retry@');
+  const downloadCommand = String(downloadStep?.with?.command ?? '');
+  for (const suffix of assetSuffixes) {
+    expect(downloadCommand).toContain(`--pattern "drydock-\${CANDIDATE_TAG}.${suffix}"`);
+  }
+
+  expect(promoteStep?.run).toContain(
+    'for ext in tar.gz tar.gz.sha256 tar.gz.bundle tar.gz.sig tar.gz.pem tar.gz.intoto.jsonl',
+  );
+});
+
+test('release-cut verifies candidate provenance against SOURCE_SHA, keeping TARGET_SHA for prereleases', () => {
+  const candidateStep = getStep('Verify candidate artifact provenance attestation');
+  const prereleaseStep = getStep('Verify release artifact provenance attestation');
+
+  expect(candidateStep?.env).toMatchObject({
+    SOURCE_SHA: '${{ steps.source.outputs.source_sha }}',
+  });
+  expect(candidateStep?.run).toContain('--source-digest "${SOURCE_SHA}"');
+  expect(candidateStep?.run).not.toContain('--source-digest "${TARGET_SHA}"');
+
+  expect(prereleaseStep?.env).toMatchObject({
+    TARGET_SHA: '${{ steps.target.outputs.sha }}',
+  });
+  expect(prereleaseStep?.run).toContain('--source-digest "${TARGET_SHA}"');
+});
+
+test('release-cut compares decompressed tar streams for reproducibility, not raw gzip bytes', () => {
+  const reproStep = getStep('Verify candidate artifact is reproducible from source SHA');
+
+  expect(reproStep?.run).toContain('gzip -dc "${rebuilt}"');
+  expect(reproStep?.run).toContain('gzip -dc "${downloaded}"');
+});
+
+test('release-cut builds the GA-day release artifact under the candidate tag prefix', () => {
+  const buildStep = getStep('Build release artifact');
+
+  expect(buildStep?.env).toMatchObject({
+    CANDIDATE_TAG: '${{ inputs.candidate_tag }}',
+    IS_PRERELEASE: '${{ steps.tag.outputs.is_prerelease }}',
+  });
+  expect(buildStep?.run).toContain('if [ "${IS_PRERELEASE}" = "true" ]; then');
+  expect(buildStep?.run).toContain('archive_tag="${RELEASE_TAG}"');
+  expect(buildStep?.run).toContain('archive_tag="${CANDIDATE_TAG}"');
+  expect(buildStep?.run).toContain('artifact="dist/drydock-${archive_tag}.tar.gz"');
+});

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -180,8 +180,16 @@ jobs:
           # would pair main's data with stale parser code. Pin both to
           # TARGET_SHA so a parser fix that lands on main during the soak is
           # the code that actually parses main's file.
-          extract_script_path="${RUNNER_TEMP}/target-sha-extract-changelog-entry.mjs"
-          git show "${TARGET_SHA}:scripts/extract-changelog-entry.mjs" > "${extract_script_path}"
+          #
+          # The whole scripts/ tree is extracted (not a single-file `git show`)
+          # because the extractor imports relative siblings — e.g.
+          # ./lib/parse-args.mjs — and Node resolves those against the script's
+          # own location, so a lone copied file dies with ERR_MODULE_NOT_FOUND.
+          scripts_snapshot_dir="${RUNNER_TEMP}/target-sha-scripts"
+          mkdir -p "${scripts_snapshot_dir}"
+          git archive "${TARGET_SHA}" scripts | tar -x -C "${scripts_snapshot_dir}"
+          extract_script_path="${scripts_snapshot_dir}/scripts/extract-changelog-entry.mjs"
+          test -f "${extract_script_path}"
           echo "extract_script=${extract_script_path}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve release tag from input

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -144,6 +144,46 @@ jobs:
           echo "Target SHA: ${sha}"
           echo "Repository (lowercase): ${repo_lower}"
 
+      - name: Capture CHANGELOG snapshot from target SHA
+        id: target_changelog
+        env:
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Defect: GA promotes a seven-day-old RC candidate whose checked-out
+          # tree (after "Checkout exact release source" below) can only ever
+          # contain "## [X.Y.Z-rc.N] - ..." headings — each RC promotes
+          # [Unreleased] to its own rc heading at prep time, and the GA heading
+          # "## [X.Y.Z] - ..." is not added to CHANGELOG.md until GA day, on
+          # main, AFTER the candidate was already tagged. Reading CHANGELOG.md
+          # out of the detached candidate checkout therefore can never find the
+          # GA entry — both changelog-reading steps below would deterministically
+          # fail on every possible GA dispatch. They must instead read
+          # CHANGELOG.md as it exists at TARGET_SHA (this run's dispatch-time
+          # main HEAD), which is where the GA heading actually lives.
+          #
+          # For prereleases SOURCE_SHA == TARGET_SHA, so this is behavior-neutral
+          # there — same file, same content, just read one commit earlier than
+          # the detached checkout that follows.
+          #
+          # `git show SHA:path` reads the blob straight out of the object
+          # database and needs no checkout of that SHA, so this is safe to run
+          # here (before "Checkout exact release source") or after — the
+          # earlier checkout step fetched full history (fetch-depth: 0), so the
+          # TARGET_SHA tree's objects are already present either way.
+          changelog_path="${RUNNER_TEMP}/target-sha-changelog.md"
+          git show "${TARGET_SHA}:CHANGELOG.md" > "${changelog_path}"
+          echo "path=${changelog_path}" >> "$GITHUB_OUTPUT"
+          # Snapshot the extractor script too, for the same reason: at GA the
+          # working tree is the candidate's seven-day-old checkout, so running
+          # its scripts/extract-changelog-entry.mjs against main's CHANGELOG
+          # would pair main's data with stale parser code. Pin both to
+          # TARGET_SHA so a parser fix that lands on main during the soak is
+          # the code that actually parses main's file.
+          extract_script_path="${RUNNER_TEMP}/target-sha-extract-changelog-entry.mjs"
+          git show "${TARGET_SHA}:scripts/extract-changelog-entry.mjs" > "${extract_script_path}"
+          echo "extract_script=${extract_script_path}" >> "$GITHUB_OUTPUT"
+
       - name: Resolve release tag from input
         id: next
         env:
@@ -311,12 +351,18 @@ jobs:
 
       - name: Validate CHANGELOG entry for release tag
         env:
+          CHANGELOG_PATH: ${{ steps.target_changelog.outputs.path }}
+          EXTRACT_SCRIPT: ${{ steps.target_changelog.outputs.extract_script }}
           RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
         run: |
           set -euo pipefail
           entry_file="$(mktemp)"
 
-          if ! node scripts/extract-changelog-entry.mjs --version "${RELEASE_TAG}" --file CHANGELOG.md > "${entry_file}" 2>/dev/null; then
+          # Read from the TARGET_SHA snapshots captured above (both the
+          # CHANGELOG and the extractor script), not the checked-out SOURCE_SHA
+          # tree — see the rationale in "Capture CHANGELOG snapshot from
+          # target SHA".
+          if ! node "${EXTRACT_SCRIPT}" --version "${RELEASE_TAG}" --file "${CHANGELOG_PATH}" > "${entry_file}" 2>/dev/null; then
             echo "::error::CHANGELOG entry for ${RELEASE_TAG} missing. Add heading '## [${RELEASE_TAG#v}] - YYYY-MM-DD' and retry."
             exit 1
           fi
@@ -687,16 +733,199 @@ jobs:
 
       - name: Build release artifact
         env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          IS_PRERELEASE: ${{ steps.tag.outputs.is_prerelease }}
           RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
           SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
         run: |
           set -euo pipefail
           mkdir -p dist
-          artifact="dist/drydock-${RELEASE_TAG}.tar.gz"
-          git archive --format=tar.gz --prefix="drydock-${RELEASE_TAG}/" --output="${artifact}" "${SOURCE_SHA}"
+          # At GA, SOURCE_SHA is the RC candidate's commit, not this run's own
+          # tag. Archive it under the prefix the RC build itself used
+          # (CANDIDATE_TAG), not RELEASE_TAG's GA-versioned prefix. git archive
+          # embeds no build-time timestamps (each entry's mtime is that blob's
+          # committer date) and the tree + prefix are its only other inputs, so
+          # identical tree + identical prefix + same git version reproduces the
+          # RC artifact byte-for-byte. That equality is what "Verify candidate
+          # artifact is reproducible from source SHA" below relies on — using
+          # RELEASE_TAG's own prefix here would make this rebuild diverge from
+          # the RC artifact by construction and always fail that check. This
+          # rebuild is never published directly at GA; see the promotion steps
+          # below for why (Defect 2: attestation provenance).
+          if [ "${IS_PRERELEASE}" = "true" ]; then
+            archive_tag="${RELEASE_TAG}"
+          else
+            archive_tag="${CANDIDATE_TAG}"
+          fi
+          artifact="dist/drydock-${archive_tag}.tar.gz"
+          git archive --format=tar.gz --prefix="drydock-${archive_tag}/" --output="${artifact}" "${SOURCE_SHA}"
           sha256sum "${artifact}" > "${artifact}.sha256"
 
+      # ────────────────────────────────────────────────────────────────────
+      # Defect 2 — artifact provenance at GA: design decision
+      #
+      # actions/attest-build-provenance always records the WORKFLOW RUN's own
+      # checkout commit (github.sha) as the attested subject's build source.
+      # At GA that is TARGET_SHA (today's main HEAD), never SOURCE_SHA (the
+      # seven-day-soaked candidate commit the tarball is actually built from).
+      # Rebuilding and re-attesting inside the GA run — option (b): keep
+      # rebuilding, keep attesting, verify with TARGET_SHA since that is what
+      # the attestation truthfully records — would produce an attestation
+      # that verifies cleanly while asserting a false claim: "this tarball
+      # was built from TARGET_SHA" when its tree is actually SOURCE_SHA's.
+      # That is silently wrong provenance, worse than a hard failure, and it
+      # also breaks the promotion model everywhere else in this workflow:
+      # the container image is never rebuilt at GA either — it reuses the
+      # exact RC digest and re-verifies the RC-time attestation against
+      # SOURCE_SHA (see "Verify container build provenance attestation" and
+      # "Verify container SBOM attestation" above, both intentionally
+      # SOURCE_SHA-keyed and correct as-is).
+      #
+      # Chosen instead — option (a), mirroring that container-image pattern:
+      # at GA, do not rebuild or re-attest the release artifact at all.
+      # Download the candidate's already-published tar.gz and its
+      # .intoto.jsonl bundle from the RC's GitHub release, re-verify that
+      # existing attestation against SOURCE_SHA (honest at RC time, since
+      # SOURCE_SHA == TARGET_SHA when the RC was cut), prove by a fresh
+      # git-archive rebuild that the downloaded bytes still match SOURCE_SHA's
+      # tree today, and republish those same soaked bytes under the GA tag.
+      # The GA artifact IS the promoted RC artifact with its original honest
+      # provenance — true promotion semantics, not a rebuild with mislabeled
+      # provenance. The signing/attestation steps below therefore only run
+      # for prereleases, where SOURCE_SHA == TARGET_SHA and rebuild-then-attest
+      # is correct exactly as it was before this fix.
+      # ────────────────────────────────────────────────────────────────────
+
+      - name: Download candidate release artifact for promotion
+        if: steps.tag.outputs.is_prerelease == 'false'
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          GH_TOKEN: ${{ github.token }}
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            set -euo pipefail
+            mkdir -p dist/candidate
+            gh release download "${CANDIDATE_TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --dir dist/candidate \
+              --clobber \
+              --pattern "drydock-${CANDIDATE_TAG}.tar.gz" \
+              --pattern "drydock-${CANDIDATE_TAG}.tar.gz.sha256" \
+              --pattern "drydock-${CANDIDATE_TAG}.tar.gz.bundle" \
+              --pattern "drydock-${CANDIDATE_TAG}.tar.gz.sig" \
+              --pattern "drydock-${CANDIDATE_TAG}.tar.gz.pem" \
+              --pattern "drydock-${CANDIDATE_TAG}.tar.gz.intoto.jsonl"
+
+      - name: Verify downloaded candidate artifact checksum
+        if: steps.tag.outputs.is_prerelease == 'false'
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+        run: |
+          set -euo pipefail
+          # Not `sha256sum -c`: the .sha256 file was written as
+          # `sha256sum dist/drydock-<tag>.tar.gz > ...` at repo-root cwd during
+          # the RC build, so it embeds the path "dist/drydock-<tag>.tar.gz".
+          # The download step above lands the file flat in dist/candidate/, so
+          # -c's embedded-path lookup would miss it regardless of directory —
+          # compare the recorded hash value directly instead.
+          artifact="dist/candidate/drydock-${CANDIDATE_TAG}.tar.gz"
+          recorded_hash="$(awk '{print $1}' "${artifact}.sha256")"
+          actual_hash="$(sha256sum "${artifact}" | awk '{print $1}')"
+          if [ "${recorded_hash}" != "${actual_hash}" ]; then
+            echo "::error::Downloaded ${artifact} (sha256=${actual_hash}) does not match its published checksum (${recorded_hash})."
+            exit 1
+          fi
+
+      - name: Verify candidate artifact provenance attestation
+        if: steps.tag.outputs.is_prerelease == 'false'
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          # This re-verifies the attestation actions/attest-build-provenance
+          # produced during the RC run, which honestly recorded SOURCE_SHA as
+          # its build source (SOURCE_SHA == TARGET_SHA at RC-cut time).
+          artifact="dist/candidate/drydock-${CANDIDATE_TAG}.tar.gz"
+          gh attestation verify "${artifact}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/release-cut.yml" \
+            --source-ref refs/heads/main \
+            --source-digest "${SOURCE_SHA}" \
+            --bundle "${artifact}.intoto.jsonl" >/dev/null
+
+      - name: Verify candidate artifact signature
+        if: steps.tag.outputs.is_prerelease == 'false'
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+        run: |
+          set -euo pipefail
+          artifact="dist/candidate/drydock-${CANDIDATE_TAG}.tar.gz"
+          identity_regex="^https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release-cut.yml@refs/heads/main$"
+          issuer="https://token.actions.githubusercontent.com"
+
+          cosign verify-blob \
+            --bundle "${artifact}.bundle" \
+            --certificate-identity-regexp "${identity_regex}" \
+            --certificate-oidc-issuer "${issuer}" \
+            "${artifact}" >/dev/null
+
+      - name: Verify candidate artifact is reproducible from source SHA
+        if: steps.tag.outputs.is_prerelease == 'false'
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+        run: |
+          set -euo pipefail
+          # "Build release artifact" above already rebuilt SOURCE_SHA's tree
+          # under CANDIDATE_TAG's own prefix for exactly this comparison. This
+          # proves the downloaded RC bytes still carry what SOURCE_SHA's tree
+          # contains today before they get promoted to the GA release below.
+          #
+          # Compare DECOMPRESSED tar streams, not gzip bytes: gzip encoding can
+          # drift between the git versions on the RC-cut and GA runners, which
+          # would fail a byte-compare on identical trees and hard-block a
+          # legitimate GA. Tamper detection is not this step's job — the
+          # signature and attestation verifies above already pin the downloaded
+          # artifact's exact original bytes. This step only asserts tree
+          # identity, which the tar stream captures fully (entry mtimes are
+          # commit dates, no build-time inputs).
+          rebuilt="dist/drydock-${CANDIDATE_TAG}.tar.gz"
+          downloaded="dist/candidate/drydock-${CANDIDATE_TAG}.tar.gz"
+          rebuilt_sha="$(gzip -dc "${rebuilt}" | sha256sum | cut -d ' ' -f 1)"
+          downloaded_sha="$(gzip -dc "${downloaded}" | sha256sum | cut -d ' ' -f 1)"
+          if [ "${rebuilt_sha}" != "${downloaded_sha}" ]; then
+            echo "::error::Candidate artifact ${downloaded} (content sha256=${downloaded_sha}) does not match a fresh git archive of ${CANDIDATE_TAG}'s source SHA (content sha256=${rebuilt_sha}). Refusing to promote a non-reproducible artifact."
+            exit 1
+          fi
+          echo "Candidate artifact is reproducible from source SHA."
+
+      - name: Promote candidate artifact to GA release filenames
+        if: steps.tag.outputs.is_prerelease == 'false'
+        env:
+          CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          # The promoted asset keeps the RC build's internal tar prefix
+          # (drydock-${CANDIDATE_TAG}/) — renaming the release-asset *filename*
+          # to the GA tag is cosmetic, not a content change, so the RC's
+          # existing cosign signature and provenance attestation (both computed
+          # over file bytes, never over the filename) stay valid without being
+          # redone.
+          for ext in tar.gz tar.gz.sha256 tar.gz.bundle tar.gz.sig tar.gz.pem tar.gz.intoto.jsonl; do
+            cp "dist/candidate/drydock-${CANDIDATE_TAG}.${ext}" "dist/drydock-${RELEASE_TAG}.${ext}"
+          done
+          # Regenerate the checksum file so its embedded filename matches the
+          # promoted name; the hash itself is unchanged since the bytes are.
+          (cd dist && sha256sum "drydock-${RELEASE_TAG}.tar.gz" > "drydock-${RELEASE_TAG}.tar.gz.sha256")
+
       - name: Sign release artifact
+        if: steps.tag.outputs.is_prerelease == 'true'
         env:
           RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
@@ -731,6 +960,7 @@ jobs:
             fi
 
       - name: Verify release artifact signature
+        if: steps.tag.outputs.is_prerelease == 'true'
         env:
           RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
         run: |
@@ -747,11 +977,13 @@ jobs:
 
       - name: Attest release artifact provenance
         id: attest_release_artifact
+        if: steps.tag.outputs.is_prerelease == 'true'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-path: dist/drydock-${{ steps.next.outputs.release_tag }}.tar.gz
 
       - name: Export release provenance asset
+        if: steps.tag.outputs.is_prerelease == 'true'
         env:
           RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
           BUNDLE_PATH: ${{ steps.attest_release_artifact.outputs.bundle-path }}
@@ -761,12 +993,16 @@ jobs:
           cp "${BUNDLE_PATH}" "${artifact}.intoto.jsonl"
 
       - name: Verify release artifact provenance attestation
+        if: steps.tag.outputs.is_prerelease == 'true'
         env:
           RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ steps.target.outputs.sha }}
         run: |
           set -euo pipefail
+          # Prerelease only: SOURCE_SHA == TARGET_SHA here, so asserting
+          # TARGET_SHA is equivalent to asserting SOURCE_SHA and matches what
+          # "Attest release artifact provenance" actually just recorded.
           artifact="dist/drydock-${RELEASE_TAG}.tar.gz"
           gh attestation verify "${artifact}" \
             --repo "${GITHUB_REPOSITORY}" \
@@ -778,6 +1014,8 @@ jobs:
       - name: Generate release notes from changelog
         id: release_notes
         env:
+          CHANGELOG_PATH: ${{ steps.target_changelog.outputs.path }}
+          EXTRACT_SCRIPT: ${{ steps.target_changelog.outputs.extract_script }}
           RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
@@ -787,7 +1025,10 @@ jobs:
 
           entry_path="$(mktemp)"
           missing_heading="## [${RELEASE_TAG#v}] - YYYY-MM-DD"
-          if ! node scripts/extract-changelog-entry.mjs --version "${RELEASE_TAG}" --file CHANGELOG.md > "${entry_path}"; then
+          # Same TARGET_SHA snapshots as the validation step above — the GA
+          # heading (and the parser that reads it) live on main, never in the
+          # detached SOURCE_SHA checkout.
+          if ! node "${EXTRACT_SCRIPT}" --version "${RELEASE_TAG}" --file "${CHANGELOG_PATH}" > "${entry_path}"; then
             rm -f "${entry_path}" "${notes_path}"
             echo "::error::Release notes generation failed: CHANGELOG entry missing for ${RELEASE_TAG}. Add heading '${missing_heading}' and retry release."
             {


### PR DESCRIPTION
## Problem

GA promotion is structurally broken in `release-cut.yml` — two ways.

**1. The GA CHANGELOG entry is unreachable.** For GA dispatches, `source_sha` resolves to the RC candidate's commit and the workflow does `git checkout --detach` onto it before "Validate CHANGELOG entry for release tag" and "Generate release notes from changelog" run. The candidate's tree contains `## [X.Y.Z-rc.N]` headings but can never contain `## [X.Y.Z]` — each RC prep promotes `[Unreleased]` to its own rc heading, and the GA heading only lands on main on GA day, after the candidate was tagged. Both steps therefore deterministically fail on every possible GA dispatch. None of rc.1–rc.7 escapes this.

**2. GA artifact provenance would be silently wrong.** "Build release artifact" archives `SOURCE_SHA` (the candidate commit), but "Attest release artifact provenance" runs unconditionally and records the *run's* checkout (`TARGET_SHA`, main's GA-day HEAD) as build source, and the verify step asserts `TARGET_SHA` — so at GA the check passes while the attestation claims the tarball came from a commit it wasn't built from. A green check asserting false provenance is worse than a failure.

## Fix

**CHANGELOG from the dispatch tree.** A new early step captures `TARGET_SHA:CHANGELOG.md` *and* `TARGET_SHA:scripts/extract-changelog-entry.mjs` via `git show` (no checkout needed; full history is fetched). Both consuming steps read those snapshots — main's data parsed by main's parser, so an extractor fix landing during the soak actually applies at GA. Prerelease cuts are unaffected in behavior: `SOURCE_SHA == TARGET_SHA` there, same file and script either way.

**Artifact promotion, not re-attestation.** Mirrors the container-image model (GA reuses the RC digest and re-verifies RC-time attestations against `SOURCE_SHA`; it never rebuilds). New GA-only steps: download the RC's published `tar.gz` + `sha256`/`bundle`/`sig`/`pem`/`intoto.jsonl` assets (retry-wrapped), verify the recorded checksum, verify the RC-time provenance attestation against `SOURCE_SHA` (honest, since `SOURCE_SHA == TARGET_SHA` when the RC was cut), verify the cosign signature, prove the downloaded artifact is still reproducible from `SOURCE_SHA`'s tree, then copy to GA filenames for upload — the RC's signature and attestation stay valid because they cover file bytes, not filenames. The five sign/attest/verify steps for freshly built artifacts are now `is_prerelease`-gated; RC cuts run exactly what they ran before.

The reproducibility check compares **decompressed tar streams** (`gzip -dc | sha256sum`), not gzip bytes: gzip encoding can drift between the RC-cut and GA runners' git versions, which would false-block a legitimate GA on identical trees. Tamper detection isn't this step's job — the signature and attestation verifies already pin the downloaded bytes; this step only asserts tree identity, which the tar stream (entry mtimes are commit dates) captures fully.

## Review

Independently reviewed (adversarial pass) before opening. Two findings fixed: the extractor-script pinning above, and the retry wrapper on the download. Two consciously not taken:
- The capture step also runs on RC cuts. Intentional — one uniform code path instead of forked prerelease/GA branches; `git show` of the just-checked-out commit's own blob has no realistic failure mode that wouldn't already kill the run.
- GA re-dispatch after a partial failure regenerates notes from the *current* main HEAD. Fail-closed and intended: recovery for an existing tag re-reads the dispatch-time CHANGELOG; if the GA entry was edited meanwhile, validation either passes with the fresh entry or fails loudly.

Known accepted gap (pre-existing, inert for v1.6): `scripts/append-upgrade-notes.mjs` still reads `UPGRADE-NOTES.md` from the candidate checkout at GA; `appliesToVersion()` excludes 1.6+, so it's a no-op this line. Tracked for a follow-up if a future line needs it.

## Tests

`.github/tests/release-cut-ga-promotion.test.ts` (8 new policy tests, 63 → 71 total): snapshot step exists and both consumers are wired to it (and no step reads `--file CHANGELOG.md` anymore), the five sign/attest/verify steps are prerelease-gated, the six GA promotion steps exist in order and are GA-gated, download/promote cover exactly the six asset suffixes, candidate verify asserts `SOURCE_SHA` while the prerelease verify keeps `TARGET_SHA`, the repro check decompresses before hashing, and the archive prefix selects `CANDIDATE_TAG` at GA.

zizmor clean, actionlint (qlty) clean, full pre-push gate green.

Closes GA blocker 3 from the 2026-07-28 release audit (tracker). Workflow files don't ship in the image, so this rides the rc.8 sync with no soak impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added
- Added policy tests for changelog snapshots, GA promotion ordering, asset handling, provenance, reproducibility, and archive naming.

🔧 Changed
- Snapshot the changelog and extractor from `TARGET_SHA` before checkout.
- Promote verified RC artifacts for GA releases instead of rebuilding and re-attesting them.
- Verify checksums, provenance against `SOURCE_SHA`, cosign signatures, and reproducibility via decompressed tar streams.
- Restrict signing, attestation, and verification steps to prerelease workflows.
- Promote exactly six release assets and regenerate GA checksum filenames.

🐛 Fixed
- Fixed GA promotion to use the GA-day source tree and parser while preserving RC artifact integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->