### PR TITLE
🐛 fix(ui): unclip the row-overlay chip and keep tags visible on registry errors

### DIFF
--- a/ui/src/components/containers/ContainersGroupedViews.vue
+++ b/ui/src/components/containers/ContainersGroupedViews.vue
@@ -231,18 +231,6 @@ function recentFailureReasonText(c: { lastUpdateFailureReason?: string }): strin
   return c.lastUpdateFailureReason ?? '';
 }
 
-function registryErrorPillLabel(c: {
-  registryErrorKind?: 'rate-limited' | 'auth' | 'not-found' | 'transient' | 'unknown';
-}): string {
-  if (c.registryErrorKind === 'rate-limited')
-    return t('containerComponents.groupedViews.registryErrorRateLimited');
-  if (c.registryErrorKind === 'auth')
-    return t('containerComponents.groupedViews.registryErrorAuth');
-  if (c.registryErrorKind === 'not-found')
-    return t('containerComponents.groupedViews.registryErrorNotFound');
-  return t('containerComponents.groupedViews.registryErrorCheckFailed');
-}
-
 function blockedUpdateTooltip(container: {
   newTag?: string | null;
   updateBouncer?: string;
@@ -754,49 +742,45 @@ onScopeDispose(() => {
             </div>
           </div>
           <div v-else class="text-center">
-            <div v-if="c.registryError" class="inline-flex items-center justify-center gap-1 px-1.5 py-0.5 dd-rounded" style="background-color: var(--dd-danger-muted);" v-tooltip.top="tt(registryErrorTooltip(c))">
-              <AppIcon name="warning" :size="10" style="color: var(--dd-danger);" class="shrink-0" />
-              <span class="text-2xs-plus font-medium" style="color: var(--dd-danger);">{{ registryErrorPillLabel(c) }}</span>
+            <!-- Registry errors are flagged in the registry column (warning glyph + tooltip);
+                 the tag cell keeps showing the container's actual tag. -->
+            <div class="inline-flex items-center justify-center gap-1">
+              <AppIcon
+                v-if="c.tagPinGated"
+                name="pin"
+                :size="12"
+                class="dd-text-muted shrink-0"
+                data-test="container-tag-pinned-glyph"
+                :aria-label="t('containerComponents.groupedViews.ariaPinnedTag')"
+                v-tooltip.top="tt(t('containerComponents.groupedViews.pinnedTagTooltip'))"
+              />
+              <span class="text-2xs-plus dd-text-secondary truncate max-w-[140px]" v-tooltip.top="c.currentTag">{{ c.currentTag }}</span>
+              <NoUpdateReasonBadge v-if="c.noUpdateReason" :reason="c.noUpdateReason" />
             </div>
-            <template v-else>
-              <div class="inline-flex items-center justify-center gap-1">
-                <AppIcon
-                  v-if="c.tagPinGated"
-                  name="pin"
-                  :size="12"
-                  class="dd-text-muted shrink-0"
-                  data-test="container-tag-pinned-glyph"
-                  :aria-label="t('containerComponents.groupedViews.ariaPinnedTag')"
-                  v-tooltip.top="tt(t('containerComponents.groupedViews.pinnedTagTooltip'))"
-                />
-                <span class="text-2xs-plus dd-text-secondary truncate max-w-[140px]" v-tooltip.top="c.currentTag">{{ c.currentTag }}</span>
-                <NoUpdateReasonBadge v-if="c.noUpdateReason" :reason="c.noUpdateReason" />
-              </div>
-              <div v-if="getContainerListPolicyState(c).snoozed || getContainerListPolicyState(c).skipped || getContainerListPolicyState(c).maturityBlocked"
-                   class="mt-1 inline-flex items-center justify-center gap-1">
-                <span v-if="getContainerListPolicyState(c).snoozed"
-                      class="inline-flex items-center justify-center"
-                      style="color: var(--dd-info);"
-                      :aria-label="t('containerComponents.groupedViews.ariaSnoozedUpdates')"
-                      v-tooltip.top="tt(containerPolicyTooltip(c, 'snoozed'))">
-                  <AppIcon name="pause" :size="14" />
-                </span>
-                <span v-if="getContainerListPolicyState(c).skipped"
-                      class="inline-flex items-center justify-center"
-                      style="color: var(--dd-warning);"
-                      :aria-label="t('containerComponents.groupedViews.ariaSkippedUpdates')"
-                      v-tooltip.top="tt(containerPolicyTooltip(c, 'skipped'))">
-                  <AppIcon name="skip-forward" :size="14" />
-                </span>
-                <span v-if="getContainerListPolicyState(c).maturityBlocked"
-                      class="inline-flex items-center justify-center"
-                      style="color: var(--dd-primary);"
-                      :aria-label="t('containerComponents.groupedViews.ariaMaturityBlocked')"
-                      v-tooltip.top="tt(containerPolicyTooltip(c, 'maturity'))">
-                  <AppIcon name="clock" :size="14" />
-                </span>
-              </div>
-            </template>
+            <div v-if="getContainerListPolicyState(c).snoozed || getContainerListPolicyState(c).skipped || getContainerListPolicyState(c).maturityBlocked"
+                 class="mt-1 inline-flex items-center justify-center gap-1">
+              <span v-if="getContainerListPolicyState(c).snoozed"
+                    class="inline-flex items-center justify-center"
+                    style="color: var(--dd-info);"
+                    :aria-label="t('containerComponents.groupedViews.ariaSnoozedUpdates')"
+                    v-tooltip.top="tt(containerPolicyTooltip(c, 'snoozed'))">
+                <AppIcon name="pause" :size="14" />
+              </span>
+              <span v-if="getContainerListPolicyState(c).skipped"
+                    class="inline-flex items-center justify-center"
+                    style="color: var(--dd-warning);"
+                    :aria-label="t('containerComponents.groupedViews.ariaSkippedUpdates')"
+                    v-tooltip.top="tt(containerPolicyTooltip(c, 'skipped'))">
+                <AppIcon name="skip-forward" :size="14" />
+              </span>
+              <span v-if="getContainerListPolicyState(c).maturityBlocked"
+                    class="inline-flex items-center justify-center"
+                    style="color: var(--dd-primary);"
+                    :aria-label="t('containerComponents.groupedViews.ariaMaturityBlocked')"
+                    v-tooltip.top="tt(containerPolicyTooltip(c, 'maturity'))">
+                <AppIcon name="clock" :size="14" />
+              </span>
+            </div>
           </div>
           </div>
         </template>
@@ -1213,11 +1197,8 @@ onScopeDispose(() => {
                 <CopyableTag :tag="c.currentTag" class="text-xs font-bold dd-text truncate max-w-[120px]" @click.stop>
                   {{ c.currentTag }}
                 </CopyableTag>
-                <span v-if="c.registryError" class="inline-flex items-center gap-1 ml-1 px-1.5 py-0.5 dd-rounded" style="background-color: var(--dd-danger-muted);" v-tooltip.top="tt(registryErrorTooltip(c))">
-                  <AppIcon name="warning" :size="10" style="color: var(--dd-danger);" class="shrink-0" />
-                  <span class="text-2xs-plus font-medium" style="color: var(--dd-danger);">{{ registryErrorPillLabel(c) }}</span>
-                </span>
-                <NoUpdateReasonBadge v-else-if="c.noUpdateReason" :reason="c.noUpdateReason" class="ml-1" />
+                <!-- Registry errors surface via the card's warning glyph, not a tag-line pill. -->
+                <NoUpdateReasonBadge v-if="c.noUpdateReason" :reason="c.noUpdateReason" class="ml-1" />
               </template>
             </div>
             <!-- Resource links live in the footer's shared icon group. Keeping release notes in

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -292,6 +292,11 @@ tr.dd-row-updating > td.dd-data-table-row-overlay-host,
 tr.dd-row-scanning > td.dd-data-table-row-overlay-host {
   position: relative;
   overflow: visible;
+  /* The pinned identity-cluster cells are `sticky z-10`; the later siblings in
+     DOM order otherwise paint over this cell's full-width overlay and clip the
+     centered chip at the cluster's edge. While an overlay is active, lift the
+     host cell above its z-10 row siblings (but below the z-20 sticky header). */
+  z-index: 11;
 }
 
 tr.dd-row-updating > td.dd-data-table-row-overlay-host > .dd-row-overlay,

--- a/ui/tests/components/containers/ContainersGroupedViews.spec.ts
+++ b/ui/tests/components/containers/ContainersGroupedViews.spec.ts
@@ -3035,7 +3035,7 @@ describe('ContainersGroupedViews', () => {
       expect(text).toContain('1.26');
     });
 
-    it('renders the rate-limited error pill in the version cell when registryError is set and newTag is null', async () => {
+    it('keeps the current tag in the version cell when registryError is set and newTag is null (error surfaces via the registry glyph, not a tag pill)', async () => {
       const container = makeContainer({
         id: 'c-ratelimited',
         name: 'alpha',
@@ -3063,7 +3063,8 @@ describe('ContainersGroupedViews', () => {
       mocked.context = context;
       const wrapper = mountSubject();
       const row = rowByName(wrapper, 'alpha');
-      expect(row.text()).toContain('Rate limited');
+      expect(row.text()).toContain('1.0.0');
+      expect(row.text()).not.toContain('Rate limited');
     });
 
     it('renders the human-readable currentTag for a hybrid both-halves-change row (fix #356, #370)', async () => {


### PR DESCRIPTION
Two dashboard/containers-table fixes from live-instance screenshots:

**1. UPDATING/QUEUED/SCANNING overlay chip clipped at the sticky-cluster edge.**
The pinned identity cluster cells are `sticky z-10` and later in DOM order than the overlay-host cell, so they painted over the full-width row overlay and cut the centered chip in half ("UPDATING" rendered as "DATING"). While an overlay is active, the host cell now gets `z-index: 11` — above its z-10 row siblings, still below the z-20 sticky header.

**2. Registry errors no longer replace the tag in the tag column.**
A rate-limit/auth/not-found registry error rendered a danger pill *instead of* the container's current tag (table mode) or appended one (card mode), duplicating the warning triangle + tooltip the registry column already shows. The tag cell now always shows the actual tag; the registry glyph stays the single error flag. `registryErrorPillLabel` removed; locale keys left in place.

Specs updated accordingly (103/103 green, UI build clean).

**HOLD: merge after v1.6.0 GA** — runtime UI delta must not enter the GA tree (rc.8 is the promotion candidate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added
- Verified tag visibility during registry errors in GroupedViews specs.

🔧 Changed
- Raised active updating/scanning overlay host cells to `z-index: 11`.
- Kept container tags visible in version cells during registry errors.
- Limited registry-error messaging to the registry column’s warning glyph and tooltip.

🗑️ Removed
- Removed duplicate registry-error pills from table and card views.

- 103 tests pass and the UI build is clean.
- Merge is held until after v1.6.0 GA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->