### PR TITLE
📝 docs(portwing): document edge exec protocol, trigger limits, and sockguard pairing

### DIFF
--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -235,6 +235,41 @@ The agent finishes with `dd:container_log_end` (`requestId`, `containerId`, opti
 
 Mixed-version fleets remain compatible. An older Portwing agent ignores `stream` and returns the legacy `dd:container_log_response`; Drydock renders that response as one stdout chunk and then ends the viewer. A newer agent still uses the legacy response for requests that omit `stream: true`.
 
+### Exec session protocol
+
+<Callout type="warn">This section is a protocol reference for agent implementers, not a usable end-user feature. drydock's controller implements the exec transport described below, but v1.6 exposes no exec UI or API for end users to actually open a session — nothing in the product calls it yet. Exec is Edge-only: it rides the same `portwing/1.0` WebSocket as everything else on this page, and there is no equivalent on the [standard inbound-agent](/docs/api/agent) HTTP protocol.</Callout>
+
+Like container-log streaming, exec sessions are multiplexed over the same authenticated connection. drydock starts a session with:
+
+```json
+{
+  "type": "exec_start",
+  "data": {
+    "execId": "0190f3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f",
+    "containerId": "8d3f…",
+    "cmd": ["/bin/sh"],
+    "user": "root",
+    "cols": 80,
+    "rows": 24,
+    "tty": true
+  }
+}
+```
+
+The agent confirms the process started with `exec_ready` (`execId`), then streams base64-encoded output chunks:
+
+```json
+{
+  "type": "exec_output",
+  "data": {
+    "execId": "0190f3c2-1a2b-7c3d-8e4f-5a6b7c8d9e0f",
+    "data": "bHMgLWxhCg=="
+  }
+}
+```
+
+drydock sends stdin the same way with `exec_input` (`execId`, base64 `data`) and terminal resizes with `exec_resize` (`execId`, `cols`, `rows`). Either side ends the session with `exec_end` (`execId`, optional `reason`); drydock's current handler tears down the local session on receipt but does not yet inspect the `reason` field. Up to `MAX_EXEC_SESSIONS` (100) concurrent exec sessions are tracked per edge connection — `startExec` rejects once that limit is reached.
+
 ### Protocol limits
 
 | Parameter | Value |

--- a/content/docs/current/configuration/agents/index.mdx
+++ b/content/docs/current/configuration/agents/index.mdx
@@ -40,6 +40,9 @@ services:
     image: ghcr.io/codeswhat/portwing:latest
     restart: unless-stopped
     volumes:
+      # NOTE: :ro only read-protects the socket *file* — the agent still gets
+      # the full Docker Engine API through it. It is not an API boundary; see
+      # the warning below for the production setup.
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       - DRYDOCK_URL=https://drydock.example.com
@@ -53,7 +56,7 @@ secrets:
     file: ./portwing_ed25519.pem
 ```
 
-<Callout type="warn">This example bind-mounts the raw Docker socket into the Portwing container for brevity. In production, front it with a socket filter instead — see the [sockguard tab](/docs/guides/security#isolate-the-docker-socket) of the Security Hardening Guide, and sockguard's [`examples/compose/tri-tool/`](https://github.com/CodesWhat/sockguard/tree/main/examples/compose/tri-tool) bundle for a runnable compose stack that fronts an Edge agent's Docker socket with sockguard instead of a raw bind mount.</Callout>
+<Callout type="warn">This example bind-mounts the raw Docker socket into the Portwing container for brevity, and `:ro` is not a security boundary — it only prevents modifying the socket file itself, while every Docker Engine API operation (create, exec, delete) remains available through it. In production, front it with a socket filter instead — see the [sockguard tab](/docs/guides/security#isolate-the-docker-socket) of the Security Hardening Guide, and sockguard's [`examples/compose/tri-tool/`](https://github.com/CodesWhat/sockguard/tree/main/examples/compose/tri-tool) bundle for a runnable compose stack that fronts an Edge agent's Docker socket with sockguard instead of a raw bind mount.</Callout>
 
 The Drydock controller needs the agent's public key registered before it connects. No Portwing-specific environment variable is required:
 

--- a/content/docs/current/configuration/agents/index.mdx
+++ b/content/docs/current/configuration/agents/index.mdx
@@ -53,6 +53,8 @@ secrets:
     file: ./portwing_ed25519.pem
 ```
 
+<Callout type="warn">This example bind-mounts the raw Docker socket into the Portwing container for brevity. In production, front it with a socket filter instead — see the [sockguard tab](/docs/guides/security#isolate-the-docker-socket) of the Security Hardening Guide, and sockguard's [`examples/compose/tri-tool/`](https://github.com/CodesWhat/sockguard/tree/main/examples/compose/tri-tool) bundle for a runnable compose stack that fronts an Edge agent's Docker socket with sockguard instead of a raw bind mount.</Callout>
+
 The Drydock controller needs the agent's public key registered before it connects. No Portwing-specific environment variable is required:
 
 ```yaml
@@ -68,6 +70,8 @@ Generate the agent's keypair with `portwing keygen -comment "edge-host-01"`, the
 <Callout type="info">Portwing's `portwing/1.0` wire protocol and key-registry API are stable under the published compatibility policy. Set `DD_EXPERIMENTAL_PORTWING=false` only when an emergency rollback requires disabling new edge connections.</Callout>
 
 <Callout type="info">**Container logs work continuously over the authenticated edge tunnel.** Live viewers receive separate stdout/stderr chunks, may request timestamps, and cancel the upstream Docker stream when the viewer closes. Both ends enforce bounded queues so a stalled viewer or controller is disconnected instead of growing memory without limit. Older Portwing agents fall back to the bounded one-shot log response, so mixed-version fleets degrade gracefully.</Callout>
+
+<Callout type="warn">**Update triggers are not yet proxied over Edge Mode.** `docker` and `dockercompose` action triggers only run on a standard (inbound HTTP) agent today — Edge Mode currently proxies discovery/watch state, continuous container logs, and container delete, but not update triggers. If you need to update containers on a NAT'd/firewalled host, configure it as a standard agent instead.</Callout>
 
 ## Quickstart
 
@@ -379,7 +383,7 @@ When the controller proxies an update to an agent, it posts to the agent-local `
 - **Watchers**: Run on the Agent to discover containers.
 - **Registries**: Configured on the Agent to check for updates.
 - **Triggers**:
-  - `docker` and `dockercompose` triggers are configured and executed **on the Agent** (allowing update of remote containers). The controller automatically proxies update requests to the correct agent.
+  - `docker` and `dockercompose` triggers are configured and executed **on the Agent** (allowing update of remote containers). The controller automatically proxies update requests to the correct agent. **Exception:** this proxying only works for standard (inbound HTTP) agents — [Edge (Portwing) agents](#edge-agent-dial-out-portwing) don't yet support update triggers.
   - Notification triggers (e.g. `smtp`, `discord`) are configured and executed **on the Controller**. Notifications automatically include a `[server-name]` prefix identifying which server each update comes from. The controller name defaults to the detected Docker or Podman daemon host name when available, then the process hostname, and can be overridden with `DD_SERVER_NAME`.
 
 ## Troubleshooting

--- a/content/docs/current/faq/index.mdx
+++ b/content/docs/current/faq/index.mdx
@@ -478,3 +478,17 @@ See the [Quick start](/docs/quickstart) for the recommended `DD_*` / `dd.*` conf
 ## Home Assistant wud-card or Homepage widget shows no data
 
 The Home Assistant [wud-card](https://github.com/angryvoegi/wud-card) and Homepage's native `whatsupdocker` widget both speak WUD's old unversioned, bare-array API shape rather than drydock's `/api/v1` envelope. Set `DD_COMPAT_WUDCARD=true` (default `false`) to reshape the handful of endpoints those integrations call back into the shape they expect — see [wud-card compatibility](/docs/configuration/server#wud-card-compatibility) for details, including the CORS setup needed if Home Assistant runs on a different origin than drydock. Homepage doesn't need CORS configuration, since it proxies the request server-side.
+
+## Why doesn't my edge agent apply updates?
+
+An Edge (Portwing) agent only proxies discovery/watch state, continuous container logs, and container delete over its WebSocket tunnel — `docker` and `dockercompose` action triggers are not yet proxied over Edge Mode. If update actions on an edge-connected host silently do nothing, or never show up as available in the UI, that's expected behavior in v1.6, not a misconfiguration.
+
+**Fix:** Configure update triggers on a standard (inbound HTTP) agent instead. See [Edge-agent dial-out (Portwing)](/docs/configuration/agents#edge-agent-dial-out-portwing) for exactly what Edge Mode does and doesn't proxy today.
+
+## How do I rotate or revoke an edge-agent key?
+
+1. Register the new key: `POST /api/v1/portwing/keys` with the new `pubkeyBase64` and a `label` (or add it to the file pointed at by `DD_PORTWING_AUTHORIZED_KEYS` and restart the controller).
+2. Point the agent at the new private key and its `keyId`, and restart it — it reconnects and authenticates under the new key.
+3. Once the agent is confirmed running on the new key, revoke the old one: `DELETE /api/v1/portwing/keys/:keyId`. This disconnects any live session still authenticated with it and frees the old key for audit-only retention.
+
+See the [Portwing Edge API](/docs/api/portwing#key-registry) for the full key-registry reference.

--- a/content/docs/current/guides/security/index.mdx
+++ b/content/docs/current/guides/security/index.mdx
@@ -93,7 +93,7 @@ services:
 
 The preset's allow-rules are the security boundary, in the same spirit as the proxy's environment flags — everything not explicitly allowed is denied.
 
-sockguard also ships a separate [`portwing-with-exec.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing-with-exec.yaml) preset for deployments that need remote exec through the Edge agent (see the [exec session protocol](/docs/api/portwing#exec-session-protocol)); exec authorization — privileged/root escalation and per-command allowlisting — is enforced by sockguard's exec policy, not by drydock.
+sockguard also ships a separate [`portwing-with-exec.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing-with-exec.yaml) preset for deployments that need remote exec through the Edge agent (see the [exec session protocol](/docs/api/portwing#exec-session-protocol)). To activate it, replace the preset file the compose example mounts (swap `sockguard.yaml` for a copy of `portwing-with-exec.yaml`, or point the sockguard service's config mount at it) and restart sockguard — merely having the file present changes nothing, and the default preset above denies all exec. Exec authorization — privileged/root escalation and per-command allowlisting — is enforced by sockguard's exec policy, not by drydock.
 
 </Tab>
 </Tabs>

--- a/content/docs/current/guides/security/index.mdx
+++ b/content/docs/current/guides/security/index.mdx
@@ -93,6 +93,8 @@ services:
 
 The preset's allow-rules are the security boundary, in the same spirit as the proxy's environment flags — everything not explicitly allowed is denied.
 
+sockguard also ships a separate [`portwing-with-exec.yaml`](https://github.com/CodesWhat/sockguard/blob/dev/v1.5/app/configs/portwing-with-exec.yaml) preset for deployments that need remote exec through the Edge agent (see the [exec session protocol](/docs/api/portwing#exec-session-protocol)); exec authorization — privileged/root escalation and per-command allowlisting — is enforced by sockguard's exec policy, not by drydock.
+
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Docs-only. Closes the drydock-side gaps from the 2026-07-28 tri-tool docs audit:

- api/portwing.mdx: new exec protocol section (exec_* frames incl. exec_end reason) — documented as an agent-implementer protocol reference; v1.6 ships no user-facing exec surface
- configuration/agents/index.mdx: explicit callout + Features-table exception that update-triggers are not supported over Edge Mode
- configuration/agents/index.mdx: Edge compose example now points at the sockguard tri-tool bundle instead of implying a raw socket bind mount is fine
- guides/security/index.mdx: mention the portwing-with-exec.yaml preset and sockguard-enforced exec policy
- faq/index.mdx: entries for the Edge update-trigger limitation and Ed25519 key rotation/revocation

Related issues found in the same audit: #635, #636, #637.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
✨ Added:
- Portwing Edge “exec session protocol” docs (WebSocket multiplexing) covering `exec_start`, `exec_ready`, `exec_output`, `exec_input`, `exec_resize`, and `exec_end` (including termination/reason handling) plus the per-edge-connections concurrency cap (`MAX_EXEC_SESSIONS=100`) and “implementers only” scope.
- FAQ entries for Edge update-trigger limitations and Ed25519 key rotation/revocation for edge agents.

🔧 Changed:
- Clarified that v1.6 exposes no user-facing Edge exec surface/API.
- Documented that Edge Mode does not proxy `docker`/`dockercompose` update triggers (and that related UI/action behavior may be missing or a no-op in v1.6), with guidance to configure update triggers on standard inbound HTTP agents instead.
- Updated Edge-agent (Portwing) Docker Compose example guidance to use Sockguard-style isolation (tri-tool bundle usage) and added explicit warnings about Docker socket mount security.
- Added/expanded documentation on exec-preset activation.

🔒 Security:
- Added security guidance for `portwing-with-exec.yaml` and emphasized that exec authorization (privilege/root escalation and per-command allowlisting) is enforced by Sockguard’s exec policy, not Drydock.
- Warned that `:ro` on the Docker socket bind-mount is **not** an API boundary.

- Verify the documented exec protocol details (frame shapes, `exec_end` reasons) and `MAX_EXEC_SESSIONS=100` match the implementation.
- Confirm exec-preset activation behavior is accurately documented and aligns with the shipped presets/config.
- Confirm the Ed25519 key rotation/revocation steps and referenced API workflow are correct.
- Ensure Edge update-trigger limitations are consistent across all affected docs and examples.
- Re-check Sockguard/tri-tool bundle compose guidance and that the `:ro` “not an API boundary” warning is unambiguous.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->