### PR TITLE
📝 docs(watchers): fix maintenance-window cron examples and document the update dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Maintenance-window documentation corrected and made findable** ([Discussion #639](https://github.com/CodesWhat/drydock/discussions/639)). Every documented example used a minute-precise cron (`0 2-6 * * *`) while describing it as an hourly range ("2am–6am daily"). `MAINTENANCE_WINDOW` is matched minute by minute, so that expression opens the window for one minute at the top of each listed hour and reports "closed" the rest of the day. Examples now use `* 2-6 * * *`, with a table of correct forms in [Watchers](https://getdrydock.com/docs/configuration/watchers#maintenance-window). The update confirm dialog's own wording ("This update is currently policy-blocked", "Outside maintenance window — auto update deferred until the window opens", "Update anyway") appeared nowhere in the docs, so searching for the on-screen message returned nothing; [Update Eligibility & Blockers](https://getdrydock.com/docs/configuration/actions/update-eligibility) now documents that dialog verbatim and states plainly that a soft blocker never gates a manual update.
+
 ## [1.6.0-rc.9] — 2026-07-28
 
 ### Added

--- a/content/docs/current/configuration/actions/update-eligibility.mdx
+++ b/content/docs/current/configuration/actions/update-eligibility.mdx
@@ -33,6 +33,32 @@ In `notify` mode the Update Status panel leads with **Notifications only — Dry
 
 If a container is eligible but an automatic update does not run, check that the global mode is `auto` and that a matching `docker` / `dockercompose` action trigger is configured to fire for that container.
 
+## What the update dialog is telling you
+
+When you click **Update** on a container that has soft blockers, the confirm dialog appends them to its message:
+
+> This update is currently policy-blocked:
+> • *(one line per active condition)*
+>
+> Click Update anyway to override.
+
+This is a heads-up, not a refusal. The button changes from **Update** to **Update anyway**, and clicking it applies the update immediately. Every reason listed there is a **soft** blocker, which by definition only defers drydock's *automatic* dispatch — your own manual update goes through. Cancel instead, and the container keeps waiting for the condition to clear on its own.
+
+A **hard** blocker never reaches this dialog: the Update button is disabled and the API rejects the request outright.
+
+### `maintenance-window-closed` in the update dialog
+
+> Outside maintenance window — auto update deferred until the window opens.
+
+Someone has set a maintenance window on this container's watcher (`DD_WATCHER_{watcher_name}_MAINTENANCE_WINDOW`), and right now the clock is outside it. Drydock is telling you it wouldn't have applied this update by itself yet. It has no bearing on the manual update you just asked for: click **Update anyway** and it runs.
+
+Two things commonly cause this line to show up more than expected:
+
+- **The window is narrower than it looks.** `MAINTENANCE_WINDOW` is matched minute by minute, so `0 2-3 * * *` is open only at 02:00 and 03:00 for one minute each, not from 2 AM to 4 AM. Use `* 2-3 * * *`. See [Watchers — Maintenance window](/docs/configuration/watchers#maintenance-window).
+- **The timezone isn't yours.** The window is evaluated in `MAINTENANCE_WINDOW_TZ`, which defaults to `UTC`.
+
+This is also independent of the maturity gate. A candidate can be past its maturity soak and still sit outside the maintenance window: maturity decides whether the build is old enough to trust, the window decides when drydock is allowed to act.
+
 ## Reasons reference
 
 | Reason code | Condition label | Severity | Why it fires | How to clear it |
@@ -52,7 +78,7 @@ If a container is eligible but an automatic update does not run, check that the 
 | `rollback-container` | **Rollback** | Hard | Container was created during a previous update as a rollback artifact and isn't itself updateable. | Not actionable — remove the rollback container manually if no longer needed. |
 | `active-operation` | **In progress** | Hard | An update is queued or already running for this container. | Wait for completion. |
 | `no-update-available` | **No actionable update** | Hard/internal | No actionable image update was detected. A pinned container may still have an informational newer-version insight; the insight does not bypass this internal short-circuit. | N/A |
-| `maintenance-window-closed` | **Maintenance window closed** | Soft | Automatic-update dispatch evaluated the container while its watcher's maintenance window was closed. Drydock defers automatic updates outside the window regardless of whether the update was found by cron, manual watch, webhook, or post-update fast resync. Container-list and SSE responses enrich this live watcher state for both local and agent-owned containers. Manual UI/API updates pass no maintenance-window state and are not gated by this blocker. | Wait for the next maintenance window or adjust `DD_WATCHER_{watcher_name}_MAINTENANCE_WINDOW` / `_TZ`. |
+| `maintenance-window-closed` | **Maintenance window closed** | Soft | Automatic-update dispatch evaluated the container while its watcher's maintenance window was closed. Drydock defers automatic updates outside the window regardless of whether the update was found by cron, manual watch, webhook, or post-update fast resync. Container-list and SSE responses enrich this live watcher state for both local and agent-owned containers. Manual UI/API updates pass no maintenance-window state and are not gated by this blocker. See [what the dialog is telling you](#maintenance-window-closed-in-the-update-dialog). | Click **Update anyway** to apply it now, wait for the next window, or adjust `DD_WATCHER_{watcher_name}_MAINTENANCE_WINDOW` / `_TZ` — remembering the expression is matched per minute, so `* 2-3 * * *` keeps the window open where `0 2-3 * * *` opens it for one minute. |
 
 <Callout type="info">The Update Status panel shows **Up to date** only when neither an actionable update nor an informational `updateInsight` exists. An insight-only pinned container instead shows an informational newer-version state with no update action. The panel also avoids duplicating `active-operation` when an in-progress operation badge already communicates the same state elsewhere.</Callout>
 

--- a/content/docs/current/configuration/watchers/index.mdx
+++ b/content/docs/current/configuration/watchers/index.mdx
@@ -25,7 +25,7 @@ The `docker` watcher lets you configure the Docker hosts you want to watch.
 | `DD_WATCHER_{watcher_name}_HOST` | ⚪ | Docker hostname or ip of the host to watch | | |
 | `DD_WATCHER_{watcher_name}_JITTER` | ⚪ | Jitter in ms applied to the CRON to better distribute the load on the registries (on the Hub at the first place) | > 0 | `60000` (1 minute) |
 | `DD_WATCHER_{watcher_name}_KEYFILE` | ⚪ | Key pem file path (only for TLS connection) | | |
-| `DD_WATCHER_{watcher_name}_MAINTENANCE_WINDOW` | ⚪ | Allowed update schedule (checks outside this window are skipped) | [Valid CRON expression](https://crontab.guru/) | |
+| `DD_WATCHER_{watcher_name}_MAINTENANCE_WINDOW` | ⚪ | Allowed automatic-update schedule (checks outside this window are skipped; manual updates are never gated). Matched per minute, so use `*` in the minute field — see [Maintenance window](#maintenance-window) | [Valid CRON expression](https://crontab.guru/) | |
 | `DD_WATCHER_{watcher_name}_MAINTENANCE_WINDOW_TZ` | ⚪ | Timezone used to evaluate `MAINTENANCE_WINDOW` | IANA timezone (e.g. `UTC`, `Europe/Paris`) | `UTC` |
 | `DD_WATCHER_{watcher_name}_MATURITY_MODE` | ⚪ | Default maturity policy for containers discovered by this watcher; a container label or UI/API override can replace it | `all`, `mature` | `all` (no gate) |
 | `DD_WATCHER_{watcher_name}_MATURITY_MIN_AGE_DAYS` | ⚪ | Default minimum image age when `MATURITY_MODE=mature`; a container label or UI/API override can replace it | integer (`1` to `365`) | `7` |
@@ -52,7 +52,7 @@ The default cron is `0 */6 * * *` (every 6 hours). With many watched containers 
 - If no watcher is configured, a default one named `local` will be automatically created (reading the Docker socket). To suppress this default watcher (e.g. when running as a controller-only node for remote agents), set `DD_LOCAL_WATCHER=false`.
 - Multiple watchers can be configured (if you have multiple Docker hosts to watch). Give them different names.
 - Socket configuration and host/port configuration are mutually exclusive.
-- When `MAINTENANCE_WINDOW` is configured and a check is skipped outside the allowed schedule, drydock queues one pending check and runs it automatically when the next maintenance window opens.
+- When `MAINTENANCE_WINDOW` is configured and a check is skipped outside the allowed schedule, drydock queues one pending check and runs it automatically when the next maintenance window opens. The window gates drydock's own automatic behavior only — manual updates from the UI or API always run. See [Maintenance window](#maintenance-window).
 - `wud.*` labels are ignored as of v1.6. To rewrite old compose files, run `node dist/index.js config migrate --dry-run` then `node dist/index.js config migrate --file <path>`.
 - If watcher logger initialization fails, drydock automatically falls back to structured stderr JSON logs and increments `dd_watcher_logger_init_failures_total{type,name}`. Alert on non-zero increases to catch degraded logging early.
 - The watcher fan-out is capped at **10 concurrent `watchContainer` invocations** per cron cycle. On inventories with 40–200 containers this prevents a burst of simultaneous registry calls that would trigger rate limits despite the token bucket.
@@ -684,7 +684,11 @@ docker run \
 
 ### Maintenance window
 
-Only allow update checks between 2 AM and 4 AM in Europe/Berlin:
+A maintenance window restricts **when drydock is allowed to act on its own**. Outside the window, scheduled checks are skipped and automatic updates are deferred until the window next opens. Detection is not lost: drydock queues one pending check and runs it as soon as the window opens.
+
+The window never applies to you. **Manual updates from the UI or API are not gated by it** — the container's Update action stays available at any hour. When you use it outside the window, the confirm dialog notes that the update is currently policy-blocked with _"Outside maintenance window — auto update deferred until the window opens"_ and the button reads **Update anyway**. That is a heads-up, not a refusal. See [Update Eligibility & Blockers](/docs/configuration/actions/update-eligibility#maintenance-window-closed-in-the-update-dialog).
+
+Only allow automatic updates between 2 AM and 4 AM in Europe/Berlin:
 
 <Tabs items={["Docker Compose (Maintenance Window)", "Docker (Maintenance Window)"]}>
 <Tab value="Docker Compose (Maintenance Window)">
@@ -696,7 +700,7 @@ services:
     ...
     environment:
       - DD_WATCHER_LOCAL_CRON=0 * * * *
-      - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW=0 2-3 * * *
+      - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW=* 2-3 * * *
       - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW_TZ=Europe/Berlin
 ```
 
@@ -705,13 +709,28 @@ services:
 ```bash
 docker run \
     -e DD_WATCHER_LOCAL_CRON="0 * * * *" \
-    -e DD_WATCHER_LOCAL_MAINTENANCE_WINDOW="0 2-3 * * *" \
+    -e DD_WATCHER_LOCAL_MAINTENANCE_WINDOW="* 2-3 * * *" \
     -e DD_WATCHER_LOCAL_MAINTENANCE_WINDOW_TZ="Europe/Berlin" \
   ...
   codeswhat/drydock
 ```
 </Tab>
 </Tabs>
+
+<Callout type="warn" title="Put a `*` in the minute field">
+`MAINTENANCE_WINDOW` is not a start/end range. Drydock evaluates the expression **once per minute** and the window is open only during the minutes the cron matches. So `0 2-3 * * *` is open for exactly two minutes a day, 02:00 and 03:00, not from 2 AM to 4 AM. Use `*` in the minute field to keep the window open for whole hours:
+
+| Expression | Window is open |
+| --- | --- |
+| `* 2-3 * * *` | every minute from 02:00 to 03:59 |
+| `*/5 2-3 * * *` | every 5th minute from 02:00 to 03:55 |
+| `* 2-3 * * 6,0` | 02:00 to 03:59 on Saturday and Sunday |
+| `0 2-3 * * *` | 02:00 and 03:00 only, one minute each |
+
+A minute-precise expression still works if your watcher `CRON` ticks on exactly those minutes, but the container list and the update dialog report the window as closed the rest of the time, which is confusing. Prefer the `*` form.
+</Callout>
+
+The evaluated timezone is `MAINTENANCE_WINDOW_TZ`, defaulting to `UTC` — not the host clock or your browser. The dashboard shows which watchers have a window and when the next one opens.
 
 ## Image Set Presets
 

--- a/content/docs/current/getting-started/index.mdx
+++ b/content/docs/current/getting-started/index.mdx
@@ -297,11 +297,13 @@ Restrict when auto-updates can run:
 
 ```yaml
 environment:
-  - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW=0 2-6 * * *   # 2am–6am daily
+  - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW=* 2-6 * * *   # 2am–6:59am daily
   - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW_TZ=America/New_York
 ```
 
-Updates detected outside the window are queued and applied when it opens.
+Updates detected outside the window are queued and applied when it opens. The window only gates what drydock does on its own — you can still update any container manually at any time, and the confirm dialog will note the window is closed and offer **Update anyway**.
+
+The expression is matched minute by minute rather than as a start/end range, so keep `*` in the minute field: `0 2-6 * * *` would open the window for one minute at the top of each of those hours. See [Watchers — Maintenance window](/docs/configuration/watchers#maintenance-window).
 
 ### Lifecycle hooks
 
@@ -385,7 +387,7 @@ services:
       - DD_WATCHER_LOCAL_HOST=socket-proxy
       - DD_WATCHER_LOCAL_PORT=2375
       - DD_WATCHER_LOCAL_CRON=0 */6 * * *
-      - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW=0 2-6 * * *
+      - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW=* 2-6 * * *
 
       # Auth
       - DD_AUTH_BASIC_ADMIN_USER=admin

--- a/test/qa-compose.yml
+++ b/test/qa-compose.yml
@@ -94,8 +94,9 @@ services:
       # - DD_SECURITY_SBOM_FORMATS=spdx-json,cyclonedx-json
       # - DD_SECURITY_VERIFY_SIGNATURES=false
       # --- Maintenance window (QA) ---
-      # Uncomment to test; adjust cron to match/not-match current time
-      # - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW=0 2-6 * * *
+      # Uncomment to test; adjust cron to match/not-match current time.
+      # Matched per minute, so keep `*` in the minute field for a real window.
+      # - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW=* 2-6 * * *
       # - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW_TZ=UTC
       # --- Remote Docker watcher (DinD) ---
       - DD_WATCHER_REMOTE_HOST=docker-remote

--- a/test/qa-compose.yml
+++ b/test/qa-compose.yml
@@ -94,7 +94,10 @@ services:
       # - DD_SECURITY_SBOM_FORMATS=spdx-json,cyclonedx-json
       # - DD_SECURITY_VERIFY_SIGNATURES=false
       # --- Maintenance window (QA) ---
-      # Uncomment to test; adjust cron to match/not-match current time.
+      # To test: also set DD_WATCHER_LOCAL_CRON above to a runnable schedule
+      # (it's parked at `0 0 29 2 *` and WATCHEVENTS=false, so nothing
+      # reevaluates the window otherwise), then pick a UTC window that
+      # matches/misses the current time.
       # Matched per minute, so keep `*` in the minute field for a real window.
       # - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW=* 2-6 * * *
       # - DD_WATCHER_LOCAL_MAINTENANCE_WINDOW_TZ=UTC


### PR DESCRIPTION
Came out of [#639](https://github.com/CodesWhat/drydock/discussions/639), where someone hit "Outside maintenance window — auto update deferred until the window opens" in the update dialog and couldn't find anything about it in the docs.

Two separate problems.

**The examples were wrong.** `MAINTENANCE_WINDOW` is matched minute by minute against the cron, not read as a start/end range, but every example we ship used a fixed minute and described it as an hour range:

```
DD_WATCHER_LOCAL_MAINTENANCE_WINDOW=0 2-6 * * *   # 2am–6am daily
```

That opens the window for one minute at 02:00, 03:00, 04:00, 05:00 and 06:00, and reports closed the other 1435 minutes of the day. Verified against `isInMaintenanceWindow` and node-cron's matcher. Anyone who copy-pasted it has a watcher that mostly looks broken. Examples now use `* 2-6 * * *`, and the watchers page has a table of correct forms plus a callout explaining the per-minute matching.

**The dialog's wording appeared nowhere in the docs.** Searching the site for `policy-blocked` returned zero results, so the exact text a user sees on screen was unfindable. The eligibility page now documents that dialog verbatim, with its own anchor for the maintenance-window case, and says plainly that a soft blocker never gates a manual update — the button says **Update anyway** and it works. The Update Status panel already deep-links to `#reasons-reference`; this gives it something useful to land on.

No behavior change, docs and one commented-out QA compose line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added a table of valid cron forms plus clearer maintenance-window evaluation guidance (minute-by-minute matching, timezone defaulting).
- 🔧 Changed documentation cron examples to use per-minute matching (e.g. `* 2-6 * * *` / `* 2-3 * * *`) and corrected prior misleading hour-range descriptions.
- 🔧 Changed the update confirmation dialog reference to document `policy-blocked`, **Outside maintenance window**, and **Update anyway** (with an anchor specifically for the maintenance-window case).
- 🔧 Changed guidance clarifying that **soft blockers do not prevent manual updates** (they’re overrideable via **Update anyway**).
- 🔧 Changed the QA compose example/comments, including noting the parked watcher must be **unparked** to test the maintenance-window toggle.

## Concerns / issues to address

- Confirm the cron examples match the exact evaluation logic used in code (minute-precision matching and allowed cron forms).
- Verify the “Update anyway” wording/behavior described in docs aligns with the actual UI/API flow for each blocker type.
- Ensure the maintenance-window documentation anchor points to the correct subsection.
- Double-check timezone behavior described in docs (default `UTC` and `MAINTENANCE_WINDOW_TZ` evaluation) against implementation.
- Validate the QA instructions (unpark requirement) are accurate for all relevant watcher configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->