### PR TITLE
✅ test(security): accept fast-uri 4.1.1 in the dependency guard + pin babel majors off

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,12 @@
       "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"],
       "groupName": "playwright test runner and container",
       "groupSlug": "playwright"
+    },
+    {
+      "description": "@babel/core is only present as an unscoped override consumed by @stryker-mutator/instrumenter, which requires ~7.29.0 with matching 7.x sibling plugins; npm overrides are global, so a core@8 bump forces an unsupported mix under the instrumenter and breaks the monthly mutation-testing workflow. Re-enable once Stryker supports Babel 8.",
+      "matchPackageNames": ["@babel/core"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "customManagers": [

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -22,6 +22,22 @@ function resolvedVersion(lockfile, packageName) {
   return lockfile.packages?.[`node_modules/${packageName}`]?.version;
 }
 
+// The CVE-2026-16221 fix was backported per-line: 3.1.4 on the 3.x line,
+// 4.1.1 on the 4.x line. A plain ">= 3.1.4" semver floor would wrongly pass
+// 4.0.0 and 4.1.0, which are newer than 3.1.4 but predate the 4.x backport
+// and are still vulnerable. Require the patched floor for whichever major
+// line the resolved version is on.
+function isFastUriPatched(version) {
+  const major = Number(version.split('.')[0]);
+  return major === 3 ? compareSemver(version, '3.1.4') >= 0 : compareSemver(version, '4.1.1') >= 0;
+}
+
+test('isFastUriPatched rejects unpatched 4.x releases newer than 3.1.4', () => {
+  assert.ok(isFastUriPatched('3.1.4'), '3.1.4 (3.x floor) should pass');
+  assert.ok(!isFastUriPatched('4.1.0'), '4.1.0 predates the 4.x backport and should fail');
+  assert.ok(isFastUriPatched('4.1.1'), '4.1.1 (4.x floor) should pass');
+});
+
 // fast-uri was pinned to 3.1.4 in app/ and ui/ for CVE-2026-16221
 // (GHSA-v2hh-gcrm-f6hx). 4.1.1 retains the fix, and Renovate's override
 // bump to 4.1.1 (#617) is accepted alongside the original pin below.
@@ -35,10 +51,7 @@ test('fast-uri is pinned to a patched release in app and ui', () => {
       ['3.1.4', '4.1.1'].includes(manifest.overrides?.['fast-uri']),
       `${workspace} override`,
     );
-    assert.ok(
-      compareSemver(resolvedVersion(lockfile, 'fast-uri'), '3.1.4') >= 0,
-      `${workspace} lockfile`,
-    );
+    assert.ok(isFastUriPatched(resolvedVersion(lockfile, 'fast-uri')), `${workspace} lockfile`);
   }
 });
 

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -22,12 +22,19 @@ function resolvedVersion(lockfile, packageName) {
   return lockfile.packages?.[`node_modules/${packageName}`]?.version;
 }
 
-test('fast-uri is pinned to the patched 3.x release in app and ui', () => {
+// fast-uri was pinned to 3.1.4 in app/ and ui/ for CVE-2026-16221
+// (GHSA-v2hh-gcrm-f6hx). 4.1.1 retains the fix, and Renovate's override
+// bump to 4.1.1 (#617) is accepted alongside the original pin below.
+// Transitional: drop the 3.1.4 branch once #617 lands.
+test('fast-uri is pinned to a patched release in app and ui', () => {
   for (const workspace of ['app', 'ui']) {
     const manifest = readJson(`${workspace}/package.json`);
     const lockfile = readJson(`${workspace}/package-lock.json`);
 
-    assert.equal(manifest.overrides?.['fast-uri'], '3.1.4', `${workspace} override`);
+    assert.ok(
+      ['3.1.4', '4.1.1'].includes(manifest.overrides?.['fast-uri']),
+      `${workspace} override`,
+    );
     assert.ok(
       compareSemver(resolvedVersion(lockfile, 'fast-uri'), '3.1.4') >= 0,
       `${workspace} lockfile`,


### PR DESCRIPTION
Two small unrelated dep-hygiene fixes bundled together since they're both one-liners against renovate/CI plumbing.

## fast-uri guard (unblocks #617)

`scripts/security-dependency-versions.test.mjs` pinned the `fast-uri` override to an exact `3.1.4` for CVE-2026-16221 (GHSA-v2hh-gcrm-f6hx), added in #579. Renovate PR #617 wants to bump that override to `4.1.1`, which still carries the CVE fix, and the guard's exact-equality check would fail it on merge.

Updated the guard to accept either `3.1.4` or `4.1.1`, transitionally, same pattern as #621 which did this for the picomatch/yaml e2e guards after their overrides moved past an exact pin. Once #617 lands the `3.1.4` branch can be dropped. Manifests and lockfiles aren't touched here, that's #617's job.

## renovate.json: stop proposing @babel/core majors

Renovate keeps proposing `@babel/core` v8 (#564, closed after breaking things). `@babel/core` only exists in `app/` and `ui/` as an unscoped override for `@stryker-mutator/instrumenter`, which needs `~7.29.0` with matching 7.x sibling plugins. Since npm overrides are global, a core@8 bump forces an unsupported Babel 7/8 mix under the instrumenter and breaks the monthly mutation-testing workflow.

Added a `packageRule` disabling major updates for `@babel/core` with a description explaining why, to be re-enabled once Stryker supports Babel 8.

## Test plan
- [x] `node --test scripts/security-dependency-versions.test.mjs` passes (6/6)
- [x] `node -e "JSON.parse(...)"` on renovate.json parses cleanly
- [x] `npx --yes --package renovate renovate-config-validator` validates renovate.json successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔒 Security: Allow `fast-uri` override versions `3.1.4` and `4.1.1`.
- 🔧 Changed: Require resolved `fast-uri` lockfile version `3.1.4` or newer.
- 🔧 Changed: Disable Renovate major updates for `@babel/core` until Babel 8 support is available.
- 🔧 Changed: Preserve compatibility with Babel 7 plugins.
- 🔧 Changed: Leave manifests and lockfiles unchanged.

## Concerns

- Remove the temporary `fast-uri` compatibility once Renovate PR `#617` completes.
- Re-enable `@babel/core` major updates after Stryker supports Babel 8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->