### PR TITLE
🚀 release: sync dev/v1.6 → main for v1.6.0-rc.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0-rc.11] — 2026-08-01
+
+### Added
+
+- **Portwing controller-owned Docker watcher, update, and lifecycle transport** ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637), [Portwing #76](https://github.com/CodesWhat/portwing/issues/76)). Drydock 1.6.0-rc.11+ recognizes Portwing 0.9.0's exact Docker watcher marker (`transport=docker-api`, `execution=controller`, `events=portwing`) and runs its native registry checks plus single/batch Docker updates controller-side. Container start, stop, restart, update preview, and backup rollback actions use that same native Docker capability surface instead of failing because Portwing intentionally advertises no remote trigger. A loopback-only bearer-authenticated bridge carries Docker API calls through Portwing over Standard HTTP or Edge correlated `request`/`response`/`stream` messages, while Portwing remains the lifecycle-event source. Later raw Portwing inventory (`updateAvailable=false`, `updateKind=unknown`) preserves rather than erases the controller-enriched update state.
+
+### Changed
+
+- **Standard Portwing Ed25519 requests now use signature version 2.** The controller sends five authentication headers, including `X-Portwing-Signature-Version: 2`, and signs the exact origin-form request target (escaped path plus the unmodified raw query) instead of a decoded path without its query.
+
 ## [1.6.0-rc.10] — 2026-07-31
 
 ### Added
@@ -2298,7 +2308,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.10...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.11...HEAD
+[1.6.0-rc.11]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.10...v1.6.0-rc.11
 [1.6.0-rc.10]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.9...v1.6.0-rc.10
 [1.6.0-rc.9]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.8...v1.6.0-rc.9
 [1.6.0-rc.8]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.7...v1.6.0-rc.8

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.10-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.11-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -178,8 +178,9 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
-<summary><strong>v1.6.0-rc.10 highlights</strong></summary>
+<summary><strong>v1.6.0-rc.11 highlights</strong></summary>
 
+- **Portwing transport** — Portwing 0.9.0's exact `transport=docker-api`, `execution=controller`, `events=portwing` marker now routes native registry checks, single/batch updates, start/stop/restart, update previews, and backup rollbacks through authenticated Standard HTTP or Edge request/response/stream transport. Portwing remains the lifecycle-event source, and raw inventory cannot erase controller-enriched update results. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637), [Portwing #76](https://github.com/CodesWhat/portwing/issues/76))
 - **Notifications** — Per-rule/per-provider title and body templates with live preview, plus audit-backed in-app bell categories and update severity thresholds.
 - **Dashboard** — Zero-dependency CSS Grid replacement with mouse/touch reorder, bounded resize, responsive layouts, widget visibility, reset, and optional cross-device preference sync.
 - **Update policy** — Declarative watcher/label/UI precedence, override/revert audit trail, maturity countdown/manual override, and pinned-tag informational visibility with a stacked current → newer Tag view.
@@ -257,7 +258,7 @@ Most tools force a tradeoff. The auto-updaters (Watchtower, Ouroboros) pull and 
 | 🪝 | **Lifecycle Hooks** | Pre and post-update shell commands via container labels, with per-hook timeouts and abort-on-failure control. |
 | 🗂️ | **Docker Compose Updates** | Pull and recreate Compose services through the Docker Engine API with YAML-preserving image patching. |
 | 🎛️ | **Per-Container Policy** | Regex tag rules and trigger routing use `dd.*` labels; maturity gates, skip/snooze/pin, and maintenance windows are stored via UI/API or watcher configuration. |
-| 🛰️ | **Distributed Agents** | Monitor remote Docker hosts over SSE. Portwing edge agents behind NAT dial out over WebSocket with Ed25519 key auth and continuous live logs, with no inbound port required. The endpoint is enabled by default; `DD_EXPERIMENTAL_PORTWING=false` is an emergency disable. |
+| 🛰️ | **Distributed Agents** | Monitor remote Docker hosts over SSE. Portwing 0.9.0+ agents work over inbound Standard HTTP or dial-out Edge WebSocket transport; Drydock 1.6.0-rc.11+ can run native registry checks and single/batch Docker updates controller-side through either authenticated path. Edge also carries continuous live logs with no inbound port required; `DD_EXPERIMENTAL_PORTWING=false` remains an emergency disable. |
 | 🖥️ | **Web Dashboard** | Vue 3 UI with a zero-dependency customizable widget grid, responsive table/card views, live SSE updates, notification-bell controls, and per-container detail, logs, and stats. |
 | 🔗 | **REST API & Webhooks** | Token-authenticated endpoints for CI/CD watch and update triggers, plus signed registry webhook ingestion for push events. |
 | 🔐 | **OIDC Authentication** | Secure the dashboard with OpenID Connect (Authelia, Auth0, Authentik). All auth flows fail closed by default. |

--- a/app/agent/AgentClient.test.ts
+++ b/app/agent/AgentClient.test.ts
@@ -14,6 +14,13 @@ const mockGetValidatedStoreConfiguration = vi.hoisted(() =>
 );
 const mockOffloadSbomDocuments = vi.hoisted(() => vi.fn());
 const mockCreateSbomStorage = vi.hoisted(() => vi.fn(() => ({ storage: 'controller' })));
+const mockRegistryState = vi.hoisted(() => ({
+  trigger: {},
+  watcher: {} as Record<string, { watchContainer?: ReturnType<typeof vi.fn> }>,
+  registry: {},
+  authentication: {},
+  agent: {},
+}));
 vi.mock('../runtime/paths.js', () => ({
   resolveConfiguredPath: mockResolveConfiguredPath,
 }));
@@ -75,6 +82,7 @@ vi.mock('../util/uuid.js', () => ({
 vi.mock('../registry/index.js', () => ({
   deregisterAgentComponents: vi.fn(),
   registerComponent: vi.fn(),
+  getState: vi.fn(() => mockRegistryState),
 }));
 
 import * as event from '../event/index.js';
@@ -94,6 +102,9 @@ describe('AgentClient', () => {
     vi.mocked(storeContainer.getContainer).mockReturnValue(undefined);
     vi.mocked(storeContainer.getContainers).mockReturnValue([]);
     vi.mocked(updateOperationStore.getOperationById).mockReturnValue(undefined);
+    for (const watcherId of Object.keys(mockRegistryState.watcher)) {
+      delete mockRegistryState.watcher[watcherId];
+    }
     vi.useFakeTimers();
     client = new AgentClient('test-agent', {
       host: 'localhost',
@@ -657,6 +668,58 @@ describe('AgentClient', () => {
   });
 
   describe('handshake', () => {
+    test('registers controller transport marker before applying the standard-mode inventory', async () => {
+      axios.get
+        .mockResolvedValueOnce({
+          data: [
+            {
+              id: 'c1',
+              name: 'web',
+              watcher: 'docker',
+              status: 'stopped',
+              updateAvailable: false,
+              updateKind: { kind: 'unknown' },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          data: [
+            {
+              type: 'docker',
+              name: 'docker',
+              configuration: {
+                transport: 'docker-api',
+                execution: 'controller',
+                events: 'portwing',
+              },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ data: [] });
+      const existing = {
+        id: 'c1',
+        watcher: 'docker',
+        result: { tag: '2.0.0' },
+        updateAvailable: true,
+        updateKind: { kind: 'tag', localValue: '1.0.0', remoteValue: '2.0.0' },
+        resultChanged: vi.fn().mockReturnValue(false),
+      };
+      vi.mocked(storeContainer.getContainer).mockReturnValue(existing as never);
+      vi.mocked(storeContainer.getContainers).mockReturnValue([]);
+      vi.mocked(storeContainer.updateContainer).mockImplementation((value) => value);
+
+      await client.handshake();
+
+      expect(storeContainer.updateContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'stopped',
+          result: existing.result,
+          updateAvailable: true,
+          updateKind: existing.updateKind,
+        }),
+      );
+    });
+
     test('should fetch containers, process them, and register components', async () => {
       const containers = [{ id: 'c1' }, { id: 'c2' }];
       axios.get
@@ -7594,6 +7657,7 @@ describe('AgentClient', () => {
       expect(headers['X-Portwing-Timestamp']).toMatch(/^[0-9]+$/);
       expect(headers['X-Portwing-Nonce']).toMatch(/^[0-9a-f]{32}$/);
       expect(headers['X-Portwing-Signature']).not.toMatch(/[+/=]/);
+      expect(headers['X-Portwing-Signature-Version']).toBe('2');
 
       const bodyHashHex = bodySha256Hex(bodyBytes);
       const canonicalMessage = buildCanonicalMessage(
@@ -7738,26 +7802,35 @@ describe('AgentClient', () => {
         );
       });
 
-      test('getContainerLogs (GET with query string) signs the bare path, not the query string', async () => {
+      test('getContainerLogs signs the exact escaped path and query string', async () => {
         const edClient = makeEd25519Client();
         axios.get.mockResolvedValue({ data: {} });
         await edClient.getContainerLogs('cid', { tail: 100, since: 0, timestamps: false });
         const url = axios.get.mock.calls[0][0];
         // The wire URL still carries the query string...
         expect(url).toContain('?tail=100');
-        // ...but the signed canonical path must be query-free.
         const headers = headersFromGetOrDeleteCall(axios.get);
-        expectHeadersVerify(headers, 'GET', '/api/containers/cid/logs', Buffer.alloc(0));
+        expectHeadersVerify(
+          headers,
+          'GET',
+          '/api/containers/cid/logs?tail=100&since=0&timestamps=false',
+          Buffer.alloc(0),
+        );
       });
 
-      test('getLogEntries (GET with query string) signs the bare path, not the query string', async () => {
+      test('getLogEntries signs the exact query string in wire order', async () => {
         const edClient = makeEd25519Client();
         axios.get.mockResolvedValue({ data: [] });
         await edClient.getLogEntries({ level: 'error', tail: 50 });
         const url = axios.get.mock.calls[0][0];
         expect(url).toContain('?level=error');
         const headers = headersFromGetOrDeleteCall(axios.get);
-        expectHeadersVerify(headers, 'GET', '/api/log/entries', Buffer.alloc(0));
+        expectHeadersVerify(
+          headers,
+          'GET',
+          '/api/log/entries?level=error&tail=50',
+          Buffer.alloc(0),
+        );
       });
 
       test('startSse (GET /api/events) signs an empty-body GET request', async () => {
@@ -7792,6 +7865,669 @@ describe('AgentClient', () => {
         expect(headers['X-Portwing-Timestamp']).toMatch(/^[0-9]+$/);
         expect(Number.isInteger(Number(headers['X-Portwing-Timestamp']))).toBe(true);
       });
+    });
+  });
+
+  describe('Portwing Docker API transport', () => {
+    test('component sync synthesizes docker/update only for a controller Docker transport watcher', async () => {
+      const watcher = {
+        type: 'docker',
+        name: 'docker',
+        configuration: {
+          transport: 'docker-api',
+          execution: 'controller',
+          events: 'portwing',
+        },
+      };
+
+      await client.handleComponentSync([watcher], []);
+
+      expect(registry.registerComponent).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ kind: 'watcher', provider: 'docker', name: 'docker' }),
+      );
+      expect(registry.registerComponent).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          kind: 'trigger',
+          provider: 'docker',
+          name: 'update',
+          agent: 'test-agent',
+          configuration: expect.objectContaining({
+            transport: 'docker-api',
+            execution: 'controller',
+          }),
+        }),
+      );
+    });
+
+    test('legacy component descriptors retain remote delegation and do not synthesize a trigger', async () => {
+      await client.handleComponentSync(
+        [{ type: 'docker', name: 'docker', configuration: { description: 'legacy agent' } }],
+        [],
+      );
+
+      expect(registry.registerComponent).toHaveBeenCalledTimes(1);
+      expect(registry.registerComponent).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'watcher', componentPath: 'agent/components' }),
+      );
+    });
+
+    test('marker-mode inventory preserves controller-owned update enrichment while refreshing runtime state', async () => {
+      const existing = {
+        id: 'c1',
+        name: 'web',
+        watcher: 'docker',
+        agent: 'test-agent',
+        status: 'running',
+        result: {
+          tag: '2.0.0',
+          digest: 'sha256:new',
+          updateInsight: { tag: '3.0.0', kind: 'major' },
+        },
+        updateAvailable: true,
+        updateKind: { kind: 'tag', localValue: '1.0.0', remoteValue: '2.0.0' },
+        updateDetectedAt: '2026-08-01T12:00:00.000Z',
+        maturityGatePendingSince: '2026-08-01T12:01:00.000Z',
+        updateAge: 86400,
+        updateMaturityLevel: 'mature',
+        updateEligibility: { eligible: false, reasons: ['maintenance-window'] },
+        resultChanged: vi.fn().mockReturnValue(false),
+      };
+      vi.mocked(storeContainer.getContainer).mockReturnValue(existing as never);
+      vi.mocked(storeContainer.getContainers).mockReturnValue([]);
+      vi.mocked(storeContainer.updateContainer).mockImplementation((value) => value);
+      await client.handleComponentSync(
+        [
+          {
+            type: 'docker',
+            name: 'docker',
+            configuration: {
+              transport: 'docker-api',
+              execution: 'controller',
+              events: 'portwing',
+            },
+          },
+        ],
+        [],
+      );
+
+      await client.handleContainerSync([
+        {
+          id: 'c1',
+          name: 'web',
+          watcher: 'docker',
+          status: 'stopped',
+          updateAvailable: false,
+          updateKind: { kind: 'unknown' },
+          image: { id: 'sha256:current' },
+        } as never,
+      ]);
+
+      expect(storeContainer.updateContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'c1',
+          status: 'stopped',
+          image: { id: 'sha256:current' },
+          result: existing.result,
+          updateAvailable: true,
+          updateKind: existing.updateKind,
+          updateDetectedAt: existing.updateDetectedAt,
+          maturityGatePendingSince: existing.maturityGatePendingSince,
+          updateAge: existing.updateAge,
+          updateMaturityLevel: existing.updateMaturityLevel,
+          updateEligibility: existing.updateEligibility,
+        }),
+      );
+    });
+
+    test('marker-mode incremental events cannot clear controller-owned update enrichment', async () => {
+      const existing = {
+        id: 'c1',
+        watcher: 'docker',
+        result: { tag: '2.0.0' },
+        updateAvailable: true,
+        updateKind: { kind: 'tag', localValue: '1.0.0', remoteValue: '2.0.0' },
+        updateDetectedAt: '2026-08-01T12:00:00.000Z',
+        resultChanged: vi.fn().mockReturnValue(false),
+      };
+      vi.mocked(storeContainer.getContainer).mockReturnValue(existing as never);
+      vi.mocked(storeContainer.updateContainer).mockImplementation((value) => value);
+      await client.handleComponentSync(
+        [
+          {
+            type: 'docker',
+            name: 'docker',
+            configuration: {
+              transport: 'docker-api',
+              execution: 'controller',
+              events: 'portwing',
+            },
+          },
+        ],
+        [],
+      );
+
+      await client.handleEvent('dd:container-updated', {
+        id: 'c1',
+        name: 'web',
+        watcher: 'docker',
+        status: 'restarting',
+        updateAvailable: false,
+        updateKind: { kind: 'unknown' },
+      });
+
+      expect(storeContainer.updateContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'restarting',
+          result: existing.result,
+          updateAvailable: true,
+          updateKind: existing.updateKind,
+          updateDetectedAt: existing.updateDetectedAt,
+        }),
+      );
+    });
+
+    test('marker-mode Portwing container events immediately invoke the controller-native watcher', async () => {
+      const refreshContainer = vi.fn().mockResolvedValue({
+        container: { id: 'c1', watcher: 'docker', updateAvailable: false },
+        changed: false,
+      });
+      await client.handleComponentSync(
+        [
+          {
+            type: 'docker',
+            name: 'docker',
+            configuration: {
+              transport: 'docker-api',
+              execution: 'controller',
+              events: 'portwing',
+            },
+          },
+        ],
+        [],
+      );
+      mockRegistryState.watcher['test-agent.docker.docker'] = {
+        watchContainer: refreshContainer,
+      };
+      vi.mocked(storeContainer.getContainer).mockReturnValue(undefined);
+      vi.mocked(storeContainer.insertContainer).mockImplementation((value) => value);
+
+      await client.handleEvent('dd:container-updated', {
+        id: 'c1',
+        name: 'web',
+        watcher: 'docker',
+        image: { id: 'sha256:changed' },
+        labels: { 'com.example.channel': 'stable' },
+      });
+
+      expect(refreshContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'c1',
+          agent: 'test-agent',
+          image: { id: 'sha256:changed' },
+          labels: { 'com.example.channel': 'stable' },
+        }),
+        { emitBatchEvent: true },
+      );
+    });
+
+    test('standard mode rolls back a registered watcher when synthetic trigger registration fails', async () => {
+      axios.get
+        .mockResolvedValueOnce({
+          data: [
+            {
+              id: 'c1',
+              name: 'web',
+              watcher: 'docker',
+              updateAvailable: false,
+              updateKind: { kind: 'unknown' },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          data: [
+            {
+              type: 'docker',
+              name: 'docker',
+              configuration: {
+                transport: 'docker-api',
+                execution: 'controller',
+                events: 'portwing',
+              },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ data: [] });
+      vi.mocked(registry.registerComponent)
+        .mockResolvedValueOnce(undefined as never)
+        .mockRejectedValueOnce(new Error('synthetic controller trigger failed to register'));
+      vi.mocked(storeContainer.getContainer).mockReturnValue({
+        id: 'c1',
+        watcher: 'docker',
+        result: { tag: '2.0.0' },
+        updateAvailable: true,
+        updateKind: { kind: 'tag' },
+        resultChanged: vi.fn().mockReturnValue(true),
+      } as never);
+      vi.mocked(storeContainer.getContainers).mockReturnValue([]);
+      vi.mocked(storeContainer.updateContainer).mockImplementation((value) => value);
+
+      await client.handshake();
+
+      expect(registry.deregisterAgentComponents).toHaveBeenCalledTimes(2);
+      expect(registry.deregisterAgentComponents).toHaveBeenNthCalledWith(2, 'test-agent');
+      expect(storeContainer.updateContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          updateAvailable: false,
+          updateKind: { kind: 'unknown' },
+        }),
+      );
+      expect(vi.mocked(storeContainer.updateContainer).mock.calls[0][0].result).toBeUndefined();
+    });
+
+    test('edge component sync rolls back a registered watcher when synthetic trigger registration fails', async () => {
+      vi.mocked(registry.registerComponent)
+        .mockResolvedValueOnce(undefined as never)
+        .mockRejectedValueOnce(new Error('synthetic controller trigger failed to register'));
+
+      await expect(
+        client.handleComponentSync(
+          [
+            {
+              type: 'docker',
+              name: 'docker',
+              configuration: {
+                transport: 'docker-api',
+                execution: 'controller',
+                events: 'portwing',
+              },
+            },
+          ],
+          [],
+        ),
+      ).rejects.toThrow('synthetic controller trigger failed to register');
+
+      expect(registry.deregisterAgentComponents).toHaveBeenCalledTimes(2);
+      expect(registry.deregisterAgentComponents).toHaveBeenNthCalledWith(2, 'test-agent');
+    });
+
+    test('watcher rollback preserves the registration error when cleanup also fails', async () => {
+      vi.mocked(registry.deregisterAgentComponents)
+        .mockResolvedValueOnce(undefined as never)
+        .mockRejectedValueOnce(new Error('component rollback failed'));
+      vi.mocked(registry.registerComponent).mockRejectedValueOnce(
+        new Error('watcher registration failed'),
+      );
+
+      await expect(
+        client.handleComponentSync(
+          [
+            {
+              type: 'docker',
+              name: 'docker',
+              configuration: {
+                transport: 'docker-api',
+                execution: 'controller',
+                events: 'portwing',
+              },
+            },
+          ],
+          [],
+        ),
+      ).rejects.toThrow('watcher registration failed');
+
+      expect(mockLogChild.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to roll back components after watcher registration error'),
+      );
+    });
+
+    test('a failed reconnect clears the previous controller transport marker before fetching', async () => {
+      const refreshContainer = vi.fn();
+      await client.handleComponentSync(
+        [
+          {
+            type: 'docker',
+            name: 'docker',
+            configuration: {
+              transport: 'docker-api',
+              execution: 'controller',
+              events: 'portwing',
+            },
+          },
+        ],
+        [],
+      );
+      mockRegistryState.watcher['test-agent.docker.docker'] = {
+        watchContainer: refreshContainer,
+      };
+      axios.get.mockRejectedValueOnce(new Error('container inventory unavailable'));
+
+      await expect(client.handshake()).rejects.toThrow('container inventory unavailable');
+      await client.handleEvent('dd:container-updated', {
+        id: 'c1',
+        name: 'web',
+        watcher: 'docker',
+      });
+
+      expect(refreshContainer).not.toHaveBeenCalled();
+    });
+
+    test('legacy agent inventory remains authoritative for update enrichment', async () => {
+      vi.mocked(storeContainer.getContainer).mockReturnValue({
+        id: 'c1',
+        watcher: 'docker',
+        result: { tag: '2.0.0' },
+        updateAvailable: true,
+        updateKind: { kind: 'tag' },
+        resultChanged: vi.fn().mockReturnValue(true),
+      } as never);
+      vi.mocked(storeContainer.getContainers).mockReturnValue([]);
+      vi.mocked(storeContainer.updateContainer).mockImplementation((value) => value);
+      await client.handleComponentSync(
+        [{ type: 'docker', name: 'docker', configuration: { description: 'legacy' } }],
+        [],
+      );
+
+      await client.handleContainerSync([
+        {
+          id: 'c1',
+          name: 'web',
+          watcher: 'docker',
+          updateAvailable: false,
+          updateKind: { kind: 'unknown' },
+        } as never,
+      ]);
+
+      const persisted = vi.mocked(storeContainer.updateContainer).mock.calls[0][0];
+      expect(persisted).toEqual(
+        expect.objectContaining({
+          updateAvailable: false,
+          updateKind: { kind: 'unknown' },
+        }),
+      );
+      expect(persisted.result).toBeUndefined();
+    });
+
+    test('standard mode forwards the exact target, Docker headers, and raw body through authenticated axios', async () => {
+      const responseBody = Buffer.from('{"Id":"new-container"}');
+      axios.mockResolvedValue({
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+        data: responseBody,
+      });
+      const body = Buffer.from('{"Image":"nginx:latest"}');
+
+      const response = await client.requestDockerApi(
+        'POST',
+        '/v1.44/containers/create?name=web%2Fblue',
+        { 'content-type': 'application/json', 'x-registry-auth': 'registry-token' },
+        body,
+      );
+
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'POST',
+          url: 'https://localhost:3001/v1.44/containers/create?name=web%2Fblue',
+          data: body,
+          responseType: 'arraybuffer',
+          timeout: 30_000,
+          headers: expect.objectContaining({
+            'X-Dd-Agent-Secret': 'test-secret',
+            'x-registry-auth': 'registry-token',
+          }),
+        }),
+      );
+      expect(response).toEqual({
+        statusCode: 201,
+        headers: { 'content-type': 'application/json' },
+        body: responseBody,
+      });
+    });
+
+    test('standard mode rejects non-origin targets and accepts every upstream status', async () => {
+      await expect(client.requestDockerApi('GET', 'v1.44/info')).rejects.toThrow(
+        'origin-form path',
+      );
+      await expect(client.requestDockerApi('GET', '//docker.example/info')).rejects.toThrow(
+        'origin-form path',
+      );
+
+      axios.mockResolvedValue({ status: 418, headers: {}, data: Buffer.alloc(0) });
+      await client.requestDockerApi('GET', '/v1.44/info');
+      const request = axios.mock.calls[0][0] as {
+        validateStatus: (status: number) => boolean;
+      };
+      expect(request.validateStatus(418)).toBe(true);
+    });
+
+    test('standard mode rejects literal backslashes before signing or dispatch', async () => {
+      await expect(
+        client.requestDockerApi('GET', '/\\attacker.example/v1.44/info'),
+      ).rejects.toThrow('origin-form path');
+      await expect(client.requestDockerApi('GET', '/v1.44/foo\\bar')).rejects.toThrow(
+        'origin-form path',
+      );
+
+      expect(axios).not.toHaveBeenCalled();
+    });
+
+    test('standard mode applies the Docker proxy inactivity timeout to streaming targets', async () => {
+      axios.mockResolvedValue({ status: 200, headers: {}, data: Buffer.alloc(0) });
+
+      await client.requestDockerApi('GET', '/v1.44/events');
+
+      expect(axios).toHaveBeenCalledWith(expect.objectContaining({ timeout: 30_000 }));
+    });
+
+    test('edge mode routes ordinary and streaming Docker targets through correlated generic requests', async () => {
+      const sendRequest = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: [{ Id: 'c1' }],
+      });
+      const sendStreamRequest = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: Buffer.from('{"status":"pulled"}\n'),
+      });
+      client.edgeAdapter = { sendRequest, sendStreamRequest } as never;
+
+      const listed = await client.requestDockerApi('GET', '/v1.44/containers/json?all=1', {});
+      const pulled = await client.requestDockerApi(
+        'POST',
+        '/v1.44/images/create?fromImage=nginx&tag=latest',
+        { 'x-registry-auth': 'registry-token' },
+      );
+
+      expect(sendRequest).toHaveBeenCalledWith(
+        'GET',
+        '/v1.44/containers/json?all=1',
+        {},
+        undefined,
+      );
+      expect(sendStreamRequest).toHaveBeenCalledWith(
+        'POST',
+        '/v1.44/images/create?fromImage=nginx&tag=latest',
+        { 'x-registry-auth': 'registry-token' },
+        undefined,
+      );
+      expect(listed.body.toString()).toBe('[{"Id":"c1"}]');
+      expect(pulled.body.toString()).toBe('{"status":"pulled"}\n');
+    });
+
+    test('edge mode parses JSON request bodies and recognizes exec start as streaming', async () => {
+      const sendRequest = vi.fn().mockResolvedValue({ statusCode: 204, headers: {}, body: null });
+      const sendStreamRequest = vi
+        .fn()
+        .mockResolvedValue({ statusCode: 200, headers: {}, body: 'started' });
+      client.edgeAdapter = { sendRequest, sendStreamRequest } as never;
+      const body = Buffer.from('{"Detach":false,"Tty":false}');
+
+      await client.requestDockerApi('POST', '/v1.44/exec/e1/start', {}, body);
+
+      expect(sendStreamRequest).toHaveBeenCalledWith(
+        'POST',
+        '/v1.44/exec/e1/start',
+        {},
+        {
+          Detach: false,
+          Tty: false,
+        },
+      );
+      await expect(
+        client.requestDockerApi('POST', '/v1.44/containers/create', {}, Buffer.from('{invalid')),
+      ).rejects.toThrow('must be valid JSON');
+    });
+
+    test('edge mode normalizes response body and header variants', async () => {
+      const sendRequest = vi
+        .fn()
+        .mockResolvedValueOnce({ statusCode: 200, headers: null, body: undefined })
+        .mockResolvedValueOnce({ statusCode: 200, headers: [], body: null })
+        .mockResolvedValueOnce({
+          statusCode: 200,
+          headers: {
+            'x-list': ['first', 2],
+            'x-number': 42,
+            'x-undefined': undefined,
+            'x-null': null,
+          },
+          body: new Uint8Array([65, 66]),
+        })
+        .mockResolvedValueOnce({ statusCode: 200, headers: false, body: 'plain-text' });
+      client.edgeAdapter = { sendRequest, sendStreamRequest: vi.fn() } as never;
+
+      const missing = await client.requestDockerApi('GET', '/v1.44/missing');
+      const nullBody = await client.requestDockerApi('GET', '/v1.44/null');
+      const typed = await client.requestDockerApi('GET', '/v1.44/typed');
+      const text = await client.requestDockerApi('GET', '/v1.44/text');
+
+      expect(missing).toEqual({ statusCode: 200, headers: {}, body: Buffer.alloc(0) });
+      expect(nullBody).toEqual({ statusCode: 200, headers: {}, body: Buffer.alloc(0) });
+      expect(typed.headers).toEqual({ 'x-list': 'first, 2', 'x-number': '42' });
+      expect(typed.body).toEqual(Buffer.from('AB'));
+      expect(text).toEqual({ statusCode: 200, headers: {}, body: Buffer.from('plain-text') });
+    });
+
+    test.each([
+      ['null response', null],
+      ['primitive response', 'invalid'],
+      ['array response', []],
+      ['non-integer status', { statusCode: 200.5 }],
+    ])('edge mode rejects a malformed %s', async (_label, response) => {
+      client.edgeAdapter = {
+        sendRequest: vi.fn().mockResolvedValue(response),
+        sendStreamRequest: vi.fn(),
+      } as never;
+
+      await expect(client.requestDockerApi('GET', '/v1.44/info')).rejects.toThrow(
+        'Malformed Docker API response',
+      );
+    });
+
+    test('Ed25519 signing normalizes string and Uint8Array bodies', () => {
+      const { privateKey } = generateKeyPairSync('ed25519');
+      const edClient = new AgentClient('proxy-body-signing', {
+        host: 'portwing.example.com',
+        port: 443,
+        secret: '',
+        authmode: 'ed25519',
+        signingkeyid: 'proxy-key',
+        signingkey: privateKey.export({ type: 'pkcs8', format: 'pem' }) as string,
+      });
+      const internal = edClient as unknown as {
+        buildRequestConfig: (
+          method: string,
+          target: string,
+          body: unknown,
+        ) => {
+          headers: Record<string, string>;
+        };
+      };
+
+      expect(internal.buildRequestConfig('POST', '/string', 'literal').headers).toHaveProperty(
+        'X-Portwing-Signature',
+      );
+      expect(
+        internal.buildRequestConfig('POST', '/bytes', new Uint8Array([1, 2])).headers,
+      ).toHaveProperty('X-Portwing-Signature');
+    });
+
+    test('Ed25519 standard proxy signs raw bytes and the exact escaped query target', async () => {
+      const { privateKeyPem, publicKeyObject: proxyPublicKey } = (() => {
+        const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+        return {
+          publicKeyObject: publicKey,
+          privateKeyPem: privateKey.export({ type: 'pkcs8', format: 'pem' }) as string,
+        };
+      })();
+      const edClient = new AgentClient('proxy-ed25519', {
+        host: 'portwing.example.com',
+        port: 443,
+        secret: '',
+        authmode: 'ed25519',
+        signingkeyid: 'proxy-key',
+        signingkey: privateKeyPem,
+      });
+      axios.mockResolvedValue({ status: 204, headers: {}, data: Buffer.alloc(0) });
+      const target = '/v1.44/containers/web%2Fblue/stop?t=30';
+      const body = Buffer.from('{"signal":"SIGTERM"}');
+
+      await edClient.requestDockerApi('POST', target, { 'content-type': 'application/json' }, body);
+
+      const config = axios.mock.calls[0][0] as {
+        headers: Record<string, string>;
+      };
+      expect(config.headers['X-Portwing-Signature-Version']).toBe('2');
+      const canonical = buildCanonicalMessage(
+        'POST',
+        target,
+        bodySha256Hex(body),
+        Number(config.headers['X-Portwing-Timestamp']),
+        config.headers['X-Portwing-Nonce'],
+      );
+      expect(
+        cryptoVerify(
+          null,
+          Buffer.from(canonical),
+          proxyPublicKey,
+          Buffer.from(config.headers['X-Portwing-Signature'], 'base64url'),
+        ),
+      ).toBe(true);
+    });
+
+    test('controller-native refresh failures remain best effort after Portwing events', async () => {
+      const refreshContainer = vi.fn().mockRejectedValue(new Error('registry unavailable'));
+      await client.handleComponentSync(
+        [
+          {
+            type: 'docker',
+            name: 'docker',
+            configuration: {
+              transport: 'docker-api',
+              execution: 'controller',
+              events: 'portwing',
+            },
+          },
+        ],
+        [],
+      );
+      mockRegistryState.watcher['test-agent.docker.docker'] = {
+        watchContainer: refreshContainer,
+      };
+
+      await expect(
+        client.handleEvent('dd:container-added', {
+          id: 'c1',
+          name: 'web',
+          watcher: 'docker',
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(mockLogChild.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Unable to refresh Portwing container c1'),
+      );
     });
   });
 });

--- a/app/agent/AgentClient.ts
+++ b/app/agent/AgentClient.ts
@@ -55,6 +55,7 @@ import { getRequestedOperationId } from '../triggers/providers/docker/update-run
 import { getErrorMessage } from '../util/error.js';
 import { uuidv7 } from '../util/uuid.js';
 import type { AgentAuthMode } from './components/Agent.js';
+import { usesControllerDockerTransport } from './controller-docker-transport.js';
 import type { EdgeAgentAdapter } from './EdgeAgentAdapter.js';
 import { loadEd25519PrivateKey, signRequest } from './ed25519-signer.js';
 
@@ -77,7 +78,7 @@ export interface AgentClientConfig {
   keyfile?: string;
   // Selects how requests to this agent are authenticated. Defaults to 'token'
   // (X-Dd-Agent-Secret header, unchanged). 'ed25519' signs each request with
-  // the four X-Portwing-* headers per Portwing's verifier instead — see
+  // the five X-Portwing-* headers per Portwing's verifier instead — see
   // app/agent/ed25519-signer.ts and app/agent/components/Agent.ts.
   authmode?: AgentAuthMode;
   // Required when authmode is 'ed25519'.
@@ -107,6 +108,58 @@ interface AgentClientRuntimeInfo {
   networkTxBytes?: number;
 }
 
+export interface DockerApiProxyResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: Buffer;
+}
+
+const MAX_DOCKER_PROXY_RESPONSE_BYTES = 100 * 1024 * 1024;
+const PORTWING_DOCKER_PROXY_INACTIVITY_TIMEOUT_MS = 30_000;
+
+function isStreamingDockerTarget(target: string): boolean {
+  const path = target.split('?', 1)[0];
+  return (
+    ['/logs', '/attach', '/events', '/build', '/images/create', '/images/push'].some((suffix) =>
+      path.endsWith(suffix),
+    ) ||
+    (path.includes('/exec/') && path.endsWith('/start'))
+  );
+}
+
+function normalizeDockerProxyBody(body: unknown): Buffer {
+  if (body === undefined || body === null) {
+    return Buffer.alloc(0);
+  }
+  if (Buffer.isBuffer(body)) {
+    return body;
+  }
+  if (body instanceof Uint8Array) {
+    return Buffer.from(body);
+  }
+  if (typeof body === 'string') {
+    return Buffer.from(body);
+  }
+  return Buffer.from(JSON.stringify(body));
+}
+
+function normalizeDockerProxyHeaders(headers: unknown): Record<string, string> {
+  if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
+    return {};
+  }
+  const normalized: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (typeof value === 'string') {
+      normalized[name] = value;
+    } else if (Array.isArray(value)) {
+      normalized[name] = value.map(String).join(', ');
+    } else if (value !== undefined && value !== null) {
+      normalized[name] = String(value);
+    }
+  }
+  return normalized;
+}
+
 interface AgentComponentDescriptor {
   id?: string;
   type: string;
@@ -114,6 +167,10 @@ interface AgentComponentDescriptor {
   configuration: Record<string, unknown>;
   agent?: string;
   metadata?: Record<string, unknown>;
+}
+
+function isControllerDockerTransportWatcher(descriptor: AgentComponentDescriptor): boolean {
+  return usesControllerDockerTransport(descriptor.type, descriptor.configuration);
 }
 
 interface AgentRuntimeAckPayload {
@@ -229,6 +286,7 @@ export class AgentClient {
   private readonly pendingFreshStateAfterRemoteUpdate: Set<string>;
   private readonly pendingWatcherCycleReports: Map<string, Map<string, ContainerReport>>;
   private readonly watcherSnapshotCache: Map<string, WatcherSnapshotCacheEntry>;
+  private readonly controllerDockerTransportWatchers: Set<string>;
   private statsChangedTimer: ReturnType<typeof setTimeout> | undefined;
   private handshakeInProgress: Promise<void> | null = null;
   /**
@@ -262,6 +320,7 @@ export class AgentClient {
     this.pendingFreshStateAfterRemoteUpdate = new Set();
     this.pendingWatcherCycleReports = new Map();
     this.watcherSnapshotCache = new Map();
+    this.controllerDockerTransportWatchers = new Set();
     this.statsChangedTimer = undefined;
   }
 
@@ -364,16 +423,20 @@ export class AgentClient {
     if (data === undefined) {
       return Buffer.alloc(0);
     }
+    if (Buffer.isBuffer(data) || data instanceof Uint8Array) {
+      return Buffer.from(data);
+    }
+    if (typeof data === 'string') {
+      return Buffer.from(data, 'utf8');
+    }
     return Buffer.from(JSON.stringify(data), 'utf8');
   }
 
   /**
    * Builds the AxiosRequestConfig for a single request to this agent.
-   * `path` must be the *unescaped* canonical request path (no query string,
-   * not percent-encoded) — it is signed as-is and must match what Portwing's
-   * router reconstructs as r.URL.Path, which is percent-decoded. Callers that
-   * embed encodeURIComponent()'d segments in the request URL must pass the
-   * corresponding plain (un-encoded) segments here instead.
+   * `path` is the exact origin-form request target placed on the wire:
+   * escaped path plus the unmodified raw query string. Portwing signature v2
+   * verifies those bytes verbatim, including query ordering and escaping.
    * In token mode this just returns the static axiosOptions, unchanged.
    */
   private buildRequestConfig(method: string, path: string, data?: unknown): AxiosRequestConfig {
@@ -422,6 +485,71 @@ export class AgentClient {
     this.log.info(`Connecting to agent ${this.name} at ${this.baseUrl}`);
     this.stopped = false;
     this.startSse();
+  }
+
+  /**
+   * Forward one Docker Engine API request through a standard or edge Portwing
+   * connection. The exact origin-form target is preserved for Docker routing
+   * and Ed25519 signature v2 verification.
+   */
+  async requestDockerApi(
+    method: string,
+    target: string,
+    headers: Record<string, string> = {},
+    body?: Buffer,
+  ): Promise<DockerApiProxyResponse> {
+    if (!target.startsWith('/') || target.startsWith('//') || target.includes('\\')) {
+      throw new Error('Docker API request target must be an origin-form path');
+    }
+
+    if (this.edgeAdapter) {
+      let edgeBody: unknown;
+      if (body && body.length > 0) {
+        try {
+          edgeBody = JSON.parse(body.toString('utf8'));
+        } catch {
+          throw new Error('Edge Docker API request body must be valid JSON');
+        }
+      }
+      const response = await (isStreamingDockerTarget(target)
+        ? this.edgeAdapter.sendStreamRequest(method, target, headers, edgeBody)
+        : this.edgeAdapter.sendRequest(method, target, headers, edgeBody));
+      if (!response || typeof response !== 'object' || Array.isArray(response)) {
+        throw new Error('Malformed Docker API response from edge agent');
+      }
+      const record = response as Record<string, unknown>;
+      if (!Number.isInteger(record.statusCode)) {
+        throw new Error('Malformed Docker API response status from edge agent');
+      }
+      return {
+        statusCode: Number(record.statusCode),
+        headers: normalizeDockerProxyHeaders(record.headers),
+        body: normalizeDockerProxyBody(record.body),
+      };
+    }
+
+    const authConfig = this.buildRequestConfig(method, target, body);
+    const response = await axios({
+      ...authConfig,
+      method,
+      url: `${this.baseUrl}${target}`,
+      data: body,
+      headers: {
+        ...headers,
+        ...(authConfig.headers as Record<string, string> | undefined),
+      },
+      responseType: 'arraybuffer',
+      timeout: PORTWING_DOCKER_PROXY_INACTIVITY_TIMEOUT_MS,
+      maxContentLength: MAX_DOCKER_PROXY_RESPONSE_BYTES,
+      maxBodyLength: MAX_DOCKER_PROXY_RESPONSE_BYTES,
+      maxRedirects: 0,
+      validateStatus: () => true,
+    });
+    return {
+      statusCode: response.status,
+      headers: normalizeDockerProxyHeaders(response.headers),
+      body: normalizeDockerProxyBody(response.data),
+    };
   }
 
   private pruneOldContainers(newContainers: Container[], watcher?: string) {
@@ -613,6 +741,7 @@ export class AgentClient {
       };
     }
     container.agent = this.name;
+    container = this.preserveControllerDockerEnrichment(container);
     // The container coming from Agent should already be normalized and have results
     // We rely on the Agent to perform Registry checks if configured
 
@@ -663,6 +792,57 @@ export class AgentClient {
     return containerReport;
   }
 
+  private preserveControllerDockerEnrichment(container: Container): Container {
+    if (!this.controllerDockerTransportWatchers.has(container.watcher)) {
+      return container;
+    }
+    const existing = storeContainer.getContainer(container.id);
+    if (!existing) {
+      return container;
+    }
+
+    const controllerOwnedFields: (keyof Container)[] = [
+      'result',
+      'error',
+      'updateAvailable',
+      'updateKind',
+      'updateDetectedAt',
+      'firstSeenAt',
+      'maturityGatePendingSince',
+      'updateAge',
+      'updateMaturityLevel',
+      'updateEligibility',
+      'updatePolicy',
+      'updatePolicyDeclarative',
+      'updatePolicyOverrides',
+      'updatePolicySources',
+      'security',
+      'updateRollback',
+      'updateOperation',
+      'sourceRepo',
+      'currentReleaseNotes',
+      'tagPinned',
+      'tagPinGated',
+    ];
+    const merged = { ...container } as unknown as Record<string, unknown>;
+    const existingRecord = existing as unknown as Record<string, unknown>;
+    for (const field of controllerOwnedFields) {
+      if (Object.hasOwn(existingRecord, field)) {
+        merged[field] = existingRecord[field];
+      }
+    }
+    return merged as unknown as Container;
+  }
+
+  private setControllerDockerTransportWatchers(descriptors: AgentComponentDescriptor[]): void {
+    this.controllerDockerTransportWatchers.clear();
+    for (const descriptor of descriptors) {
+      if (isControllerDockerTransportWatcher(descriptor)) {
+        this.controllerDockerTransportWatchers.add(descriptor.name);
+      }
+    }
+  }
+
   private async processAuthoritativeContainer(container: Container): Promise<ContainerReport> {
     this.clearPendingFreshState(container.id);
     return this.processContainer(container);
@@ -693,6 +873,42 @@ export class AgentClient {
         componentPath: 'agent/components',
         agent: this.name,
       });
+
+      if (kind === 'watcher' && isControllerDockerTransportWatcher(remoteComponent)) {
+        await registry.registerComponent({
+          kind: 'trigger',
+          provider: 'docker',
+          name: 'update',
+          configuration: {
+            transport: 'docker-api',
+            execution: 'controller',
+            events: 'portwing',
+            watcher: remoteComponent.name,
+          },
+          componentPath: 'agent/components',
+          agent: this.name,
+        });
+      }
+    }
+  }
+
+  private async registerAgentWatchersTransactional(
+    watchers: AgentComponentDescriptor[],
+  ): Promise<void> {
+    try {
+      await this.registerAgentComponents('watcher', watchers);
+    } catch (registrationError: unknown) {
+      try {
+        // A controller-transport watcher starts a cron and loopback bridge
+        // before its synthetic Docker trigger is registered. Tear down every
+        // component from this attempt if any later registration step fails.
+        await registry.deregisterAgentComponents(this.name);
+      } catch (cleanupError: unknown) {
+        this.log.warn(
+          `Failed to roll back components after watcher registration error (${getErrorMessage(cleanupError)})`,
+        );
+      }
+      throw registrationError;
     }
   }
 
@@ -707,6 +923,10 @@ export class AgentClient {
   }
 
   private async _doHandshake() {
+    // A reconnect is a fresh capability negotiation. Do not let a failed or
+    // removed watcher descriptor leave the previous connection's ownership
+    // contract active while the new inventory/components are fetched.
+    this.setControllerDockerTransportWatchers([]);
     const wasConnected = this.isConnected;
     const reconnected = this.hasConnectedOnce;
     const response = await axios.get<Container[]>(
@@ -716,6 +936,27 @@ export class AgentClient {
     const containers = response.data;
     this.log.info(`Handshake successful. Received ${containers.length} containers.`);
 
+    // Unregister existing components for this agent
+    await registry.deregisterAgentComponents(this.name);
+
+    // Fetch and register watchers
+    try {
+      const responseWatchers = await axios.get<AgentComponentDescriptor[]>(
+        `${this.baseUrl}/api/watchers`,
+        this.buildRequestConfig('GET', '/api/watchers'),
+      );
+      await this.registerAgentWatchersTransactional(responseWatchers.data);
+      // Only transfer update-enrichment ownership after every controller-side
+      // watcher/delegate has registered successfully.
+      this.setControllerDockerTransportWatchers(responseWatchers.data);
+      this.seedWatcherSnapshotCacheFromHandshake(responseWatchers.data);
+    } catch (error: unknown) {
+      this.log.warn(`Failed to fetch/register watchers: ${getErrorMessage(error)}`);
+    }
+
+    // Apply inventory only after watcher registration. Controller-transport
+    // descriptors change which fields are authoritative: Portwing owns live
+    // runtime state, while Drydock's native watcher owns update enrichment.
     await this.processAuthoritativeContainers(containers);
     // A zero-container handshake is ambiguous: it could mean the agent has
     // no running containers, or its in-memory store is fresh-empty after a
@@ -731,21 +972,6 @@ export class AgentClient {
       this.log.warn(
         'Handshake returned 0 containers; preserving last-known state until the first watch cycle completes',
       );
-    }
-
-    // Unregister existing components for this agent
-    await registry.deregisterAgentComponents(this.name);
-
-    // Fetch and register watchers
-    try {
-      const responseWatchers = await axios.get<AgentComponentDescriptor[]>(
-        `${this.baseUrl}/api/watchers`,
-        this.buildRequestConfig('GET', '/api/watchers'),
-      );
-      await this.registerAgentComponents('watcher', responseWatchers.data);
-      this.seedWatcherSnapshotCacheFromHandshake(responseWatchers.data);
-    } catch (error: unknown) {
-      this.log.warn(`Failed to fetch/register watchers: ${getErrorMessage(error)}`);
     }
 
     // Fetch and register triggers
@@ -1002,7 +1228,42 @@ export class AgentClient {
   private async handleContainerChangeEvent(data: unknown) {
     const containerReport = await this.processContainer(data as Container);
     this.rememberPendingWatcherCycleReport(containerReport);
+    if (containerReport?.container) {
+      await this.refreshControllerDockerTransportContainer(containerReport.container);
+    }
     this.scheduleStatsChanged();
+  }
+
+  private async refreshControllerDockerTransportContainer(container: Container): Promise<void> {
+    if (!this.controllerDockerTransportWatchers.has(container.watcher)) {
+      return;
+    }
+
+    const watcherId = `${this.name}.docker.${container.watcher}`;
+    const watcher = registry.getState().watcher[watcherId] as unknown as
+      | {
+          watchContainer?: (
+            target: Container,
+            options?: { emitBatchEvent?: boolean },
+          ) => Promise<ContainerReport>;
+        }
+      | undefined;
+    if (typeof watcher?.watchContainer !== 'function') {
+      this.log.warn(
+        `Unable to refresh Portwing container ${sanitizeLogParam(container.id)}: controller watcher ${sanitizeLogParam(watcherId)} is unavailable`,
+      );
+      return;
+    }
+
+    try {
+      await watcher.watchContainer(container, { emitBatchEvent: true });
+    } catch (error: unknown) {
+      // The Portwing event already refreshed runtime state. Preserve that
+      // useful update and retry enrichment on the next event/scheduled poll.
+      this.log.warn(
+        `Unable to refresh Portwing container ${sanitizeLogParam(container.id)} with controller watcher ${sanitizeLogParam(watcherId)} (${sanitizeLogParam(getErrorMessage(error))})`,
+      );
+    }
   }
 
   private handleContainerRemovedEvent(data: unknown) {
@@ -1687,10 +1948,11 @@ export class AgentClient {
       this.log.debug(
         `Running remote trigger ${sanitizeLogParam(triggerType)}.${sanitizeLogParam(triggerName)} (payload=${sanitizeLogParam(JSON.stringify(payload), 500)})`,
       );
+      const target = `/api/triggers/${encodeURIComponent(triggerType)}/${encodeURIComponent(triggerName)}`;
       await axios.post(
-        `${this.baseUrl}/api/triggers/${encodeURIComponent(triggerType)}/${encodeURIComponent(triggerName)}`,
+        `${this.baseUrl}${target}`,
         payload,
-        this.buildRequestConfig('POST', `/api/triggers/${triggerType}/${triggerName}`, payload),
+        this.buildRequestConfig('POST', target, payload),
       );
       if (REMOTE_UPDATE_TRIGGER_TYPES.has(triggerType)) {
         this.markPendingFreshState(container.id);
@@ -1721,10 +1983,11 @@ export class AgentClient {
       } else {
         body = containers;
       }
+      const target = `/api/triggers/${encodeURIComponent(triggerType)}/${encodeURIComponent(triggerName)}/batch`;
       await axios.post(
-        `${this.baseUrl}/api/triggers/${encodeURIComponent(triggerType)}/${encodeURIComponent(triggerName)}/batch`,
+        `${this.baseUrl}${target}`,
         body,
-        this.buildRequestConfig('POST', `/api/triggers/${triggerType}/${triggerName}/batch`, body),
+        this.buildRequestConfig('POST', target, body),
       );
       if (REMOTE_UPDATE_TRIGGER_TYPES.has(triggerType)) {
         containers.forEach(({ id }) => this.markPendingFreshState(id));
@@ -1751,7 +2014,7 @@ export class AgentClient {
       const requestUrl = query ? `${logEntriesUrl}?${query}` : logEntriesUrl;
       const response = await axios.get(
         requestUrl,
-        this.buildRequestConfig('GET', '/api/log/entries'),
+        this.buildRequestConfig('GET', query ? `/api/log/entries?${query}` : '/api/log/entries'),
       );
       return response.data;
     } catch (error: unknown) {
@@ -1779,9 +2042,10 @@ export class AgentClient {
       });
     }
     try {
+      const target = `/api/containers/${encodeURIComponent(containerId)}/logs?tail=${options.tail}&since=${options.since}&timestamps=${options.timestamps}`;
       const response = await axios.get(
-        `${this.baseUrl}/api/containers/${encodeURIComponent(containerId)}/logs?tail=${options.tail}&since=${options.since}&timestamps=${options.timestamps}`,
-        this.buildRequestConfig('GET', `/api/containers/${containerId}/logs`),
+        `${this.baseUrl}${target}`,
+        this.buildRequestConfig('GET', target),
       );
       return response.data;
     } catch (error: unknown) {
@@ -1796,10 +2060,8 @@ export class AgentClient {
     }
     try {
       this.log.debug(`Deleting container ${sanitizeLogParam(containerId)} on agent`);
-      await axios.delete(
-        `${this.baseUrl}/api/containers/${encodeURIComponent(containerId)}`,
-        this.buildRequestConfig('DELETE', `/api/containers/${containerId}`),
-      );
+      const target = `/api/containers/${encodeURIComponent(containerId)}`;
+      await axios.delete(`${this.baseUrl}${target}`, this.buildRequestConfig('DELETE', target));
     } catch (error: unknown) {
       this.log.error(`Error deleting container on agent: ${getErrorMessage(error)}`);
       throw error;
@@ -1808,9 +2070,10 @@ export class AgentClient {
 
   async getWatcher(watcherType: string, watcherName: string) {
     try {
+      const target = `/api/watchers/${encodeURIComponent(watcherType)}/${encodeURIComponent(watcherName)}`;
       const response = await axios.get<AgentComponentDescriptor>(
-        `${this.baseUrl}/api/watchers/${encodeURIComponent(watcherType)}/${encodeURIComponent(watcherName)}`,
-        this.buildRequestConfig('GET', `/api/watchers/${watcherType}/${watcherName}`),
+        `${this.baseUrl}${target}`,
+        this.buildRequestConfig('GET', target),
       );
       return response.data;
     } catch (error: unknown) {
@@ -1823,10 +2086,11 @@ export class AgentClient {
 
   async watch(watcherType: string, watcherName: string) {
     try {
+      const target = `/api/watchers/${encodeURIComponent(watcherType)}/${encodeURIComponent(watcherName)}`;
       const response = await axios.post<ContainerReport[]>(
-        `${this.baseUrl}/api/watchers/${encodeURIComponent(watcherType)}/${encodeURIComponent(watcherName)}`,
+        `${this.baseUrl}${target}`,
         {},
-        this.buildRequestConfig('POST', `/api/watchers/${watcherType}/${watcherName}`, {}),
+        this.buildRequestConfig('POST', target, {}),
       );
       const reports = response.data;
       await this.processAuthoritativeContainers(reports.map((report) => report.container));
@@ -1842,14 +2106,11 @@ export class AgentClient {
 
   async watchContainer(watcherType: string, watcherName: string, container: Container) {
     try {
+      const target = `/api/watchers/${encodeURIComponent(watcherType)}/${encodeURIComponent(watcherName)}/container/${encodeURIComponent(container.id)}`;
       const response = await axios.post<ContainerReport>(
-        `${this.baseUrl}/api/watchers/${encodeURIComponent(watcherType)}/${encodeURIComponent(watcherName)}/container/${encodeURIComponent(container.id)}`,
+        `${this.baseUrl}${target}`,
         {},
-        this.buildRequestConfig(
-          'POST',
-          `/api/watchers/${watcherType}/${watcherName}/container/${container.id}`,
-          {},
-        ),
+        this.buildRequestConfig('POST', target, {}),
       );
       const report = response.data;
 
@@ -1887,8 +2148,10 @@ export class AgentClient {
     watchers: AgentComponentDescriptor[],
     triggers: AgentComponentDescriptor[],
   ): Promise<void> {
+    this.setControllerDockerTransportWatchers([]);
     await registry.deregisterAgentComponents(this.name);
-    await this.registerAgentComponents('watcher', watchers);
+    await this.registerAgentWatchersTransactional(watchers);
+    this.setControllerDockerTransportWatchers(watchers);
     this.seedWatcherSnapshotCacheFromHandshake(watchers);
     await this.registerAgentComponents('trigger', triggers);
   }

--- a/app/agent/EdgeAgentAdapter.test.ts
+++ b/app/agent/EdgeAgentAdapter.test.ts
@@ -2,6 +2,7 @@
  * Tests for EdgeAgentAdapter frame dispatch.
  */
 import { emitAgentConnected, emitAgentDisconnected } from '../event/index.js';
+import * as registry from '../registry/index.js';
 import { AgentClient } from './AgentClient.js';
 import {
   buildEdgeSentinelConfig,
@@ -27,6 +28,9 @@ vi.mock('../event/index.js', () => ({
   emitContainerUpdateFailed: vi.fn().mockResolvedValue(undefined),
   emitSecurityAlert: vi.fn().mockResolvedValue(undefined),
   emitSecurityScanCycleComplete: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../registry/index.js', () => ({
+  deregisterAgentComponents: vi.fn().mockResolvedValue(undefined),
 }));
 // Stateful mock: mirrors the real manager.ts single-registry-slot-per-name
 // semantics closely enough for onDisconnect()'s instance-checked removal
@@ -209,6 +213,113 @@ describe('EdgeAgentAdapter — frame dispatch', () => {
     expect(
       (client as unknown as { handleComponentSync: ReturnType<typeof vi.fn> }).handleComponentSync,
     ).toHaveBeenCalledWith(watchers, triggers);
+  });
+
+  test('serializes component sync before the following container sync in wire order', async () => {
+    const { adapter, ws, client } = createAdapter();
+    adapter.activate();
+    let finishComponentSync!: () => void;
+    const componentSyncFinished = new Promise<void>((resolve) => {
+      finishComponentSync = resolve;
+    });
+    const callOrder: string[] = [];
+    const componentSync = (
+      client as unknown as { handleComponentSync: ReturnType<typeof vi.fn> }
+    ).handleComponentSync.mockImplementationOnce(async () => {
+      callOrder.push('component:start');
+      await componentSyncFinished;
+      callOrder.push('component:end');
+    });
+    const containerSync = (
+      client as unknown as { handleContainerSync: ReturnType<typeof vi.fn> }
+    ).handleContainerSync.mockImplementationOnce(async () => {
+      callOrder.push('container');
+    });
+
+    sendFrame(ws, 'dd:component_sync', { watchers: [], triggers: [] });
+    sendFrame(ws, 'dd:container_sync', { containers: [{ id: 'c1' }] });
+    await vi.waitFor(() => expect(componentSync).toHaveBeenCalledOnce());
+
+    expect(containerSync).not.toHaveBeenCalled();
+    expect(callOrder).toEqual(['component:start']);
+
+    finishComponentSync();
+    await vi.waitFor(() => expect(containerSync).toHaveBeenCalledOnce());
+    expect(callOrder).toEqual(['component:start', 'component:end', 'container']);
+  });
+
+  test('a slow state sync does not block correlated Docker responses', async () => {
+    const { adapter, ws, client } = createAdapter();
+    adapter.activate();
+    let finishComponentSync!: () => void;
+    (
+      client as unknown as { handleComponentSync: ReturnType<typeof vi.fn> }
+    ).handleComponentSync.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishComponentSync = resolve;
+        }),
+    );
+
+    sendFrame(ws, 'dd:component_sync', { watchers: [], triggers: [] });
+    await vi.waitFor(() => expect(finishComponentSync).toBeTypeOf('function'));
+    const requestPromise = adapter.sendRequest('GET', '/v1.44/version');
+    const request = JSON.parse(ws.sentMessages.at(-1) ?? '{}') as {
+      data: { requestId: string };
+    };
+    sendFrame(ws, 'response', {
+      requestId: request.data.requestId,
+      statusCode: 200,
+      body: { ApiVersion: '1.46' },
+    });
+
+    await expect(requestPromise).resolves.toEqual(
+      expect.objectContaining({ statusCode: 200, body: { ApiVersion: '1.46' } }),
+    );
+    finishComponentSync();
+  });
+
+  test('a failed ordered state frame does not poison the following frame or escape unhandled', async () => {
+    const { adapter, ws, client } = createAdapter();
+    adapter.activate();
+    const containerSync = (client as unknown as { handleContainerSync: ReturnType<typeof vi.fn> })
+      .handleContainerSync;
+    (
+      client as unknown as { handleComponentSync: ReturnType<typeof vi.fn> }
+    ).handleComponentSync.mockRejectedValueOnce(new Error('component registration failed'));
+
+    sendFrame(ws, 'dd:component_sync', { watchers: [], triggers: [] });
+    sendFrame(ws, 'dd:container_sync', { containers: [] });
+
+    await vi.waitFor(() => expect(containerSync).toHaveBeenCalledOnce());
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+
+  test('an ordered frame waiting behind an in-flight sync becomes inert after disconnect', async () => {
+    const { adapter, ws, client } = createAdapter();
+    adapter.activate();
+    let finishComponentSync!: () => void;
+    (
+      client as unknown as { handleComponentSync: ReturnType<typeof vi.fn> }
+    ).handleComponentSync.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishComponentSync = resolve;
+        }),
+    );
+    const handleContainerSync = (
+      client as unknown as { handleContainerSync: ReturnType<typeof vi.fn> }
+    ).handleContainerSync;
+
+    sendFrame(ws, 'dd:component_sync', { watchers: [], triggers: [] });
+    await vi.waitFor(() => expect(finishComponentSync).toBeTypeOf('function'));
+    sendFrame(ws, 'dd:container_sync', { containers: [{ id: 'late' }] });
+    await adapter.onDisconnect();
+    finishComponentSync();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(handleContainerSync).not.toHaveBeenCalled();
   });
 
   test('dd:container_added reaches handleEvent with hyphenated name', async () => {
@@ -496,6 +607,18 @@ describe('EdgeAgentAdapter — disconnect cleanup', () => {
     expect(manager.removeAgent).toHaveBeenCalled();
   });
 
+  test('onDisconnect deregisters controller transport delegates before removing the current agent', async () => {
+    const { adapter, client } = createAdapter();
+    adapter.activate();
+
+    await adapter.onDisconnect();
+
+    expect(registry.deregisterAgentComponents).toHaveBeenCalledWith(client.name);
+    expect(vi.mocked(registry.deregisterAgentComponents).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(manager.removeAgent).mock.invocationCallOrder[0],
+    );
+  });
+
   test('onDisconnect emits agentDisconnected when was connected', async () => {
     const { adapter, ws, client } = createAdapter();
     adapter.activate();
@@ -661,6 +784,40 @@ describe('EdgeAgentAdapter — sendStreamRequest / stream frames', () => {
     expect(resolved).toBe(false);
     // Clean up by disconnecting to avoid timer leaks
     await adapter.onDisconnect();
+  });
+
+  test('rejects and releases a streamed Docker response that exceeds the memory bound', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+    const streamPromise = adapter.sendStreamRequest('POST', '/v1.44/images/create');
+    const rejection = streamPromise.catch((error: Error) => error.message);
+    const sentFrame = JSON.parse(ws.sentMessages[ws.sentMessages.length - 1]) as {
+      data: { requestId: string };
+    };
+    const pendingKey = `stream:${sentFrame.data.requestId}`;
+    const pendingRequests = (
+      adapter as unknown as {
+        pendingRequests: Map<string, { streamBytes?: number }>;
+      }
+    ).pendingRequests;
+    const pending = pendingRequests.get(pendingKey);
+    expect(pending).toBeDefined();
+    if (pending) {
+      pending.streamBytes = 100 * 1024 * 1024;
+    }
+
+    sendFrame(ws, 'stream', {
+      requestId: sentFrame.data.requestId,
+      data: Buffer.from('x').toString('base64'),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const releasedBeforeCleanup = !pendingRequests.has(pendingKey);
+    if (!releasedBeforeCleanup) {
+      await adapter.onDisconnect();
+    }
+    expect(releasedBeforeCleanup).toBe(true);
+    expect(await rejection).toMatch(/response.*limit/i);
   });
 });
 
@@ -1420,6 +1577,21 @@ describe('EdgeAgentAdapter — activate error handler', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     // No crash — the error was caught and logged
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+
+  test('the WebSocket message listener contains failures from direct frame handlers', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+    (adapter as unknown as { handlePing: (data: Record<string, unknown>) => void }).handlePing =
+      vi.fn(() => {
+        throw new Error('direct frame handler failed');
+      });
+
+    expect(() => sendFrame(ws, 'ping', {})).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
     expect(ws.close).not.toHaveBeenCalled();
   });
 });
@@ -2678,6 +2850,19 @@ describe('EdgeAgentAdapter — torn-down adapter inertness regressions', () => {
     expect(emitAgentConnected).not.toHaveBeenCalled();
   });
 
+  test('component cleanup failure is contained while disconnect still removes the agent', async () => {
+    const { adapter, client } = createAdapter();
+    adapter.activate();
+    vi.mocked(registry.deregisterAgentComponents).mockRejectedValueOnce(
+      new Error('component cleanup failed'),
+    );
+
+    await expect(adapter.onDisconnect()).resolves.toBeUndefined();
+
+    expect(registry.deregisterAgentComponents).toHaveBeenCalledWith(client.name);
+    expect(manager.removeAgent).toHaveBeenCalledWith(client.name);
+  });
+
   test('forced close from checkLivenessAndPing detaches the message listener so a frame arriving in the close window is not dispatched', () => {
     vi.useFakeTimers();
     const { adapter, ws, client } = createAdapter();
@@ -2718,9 +2903,9 @@ describe('EdgeAgentAdapter — torn-down adapter inertness regressions', () => {
     handleContainerSyncMock.mockReturnValueOnce(pendingSync);
 
     sendFrame(ws, 'dd:container_sync', { containers: [] });
-    // handleContainerSync() has been called synchronously and is now awaiting
-    // pendingSync — this.connected is still false at this point.
-    expect(handleContainerSyncMock).toHaveBeenCalledTimes(1);
+    // Ordered state frames enter through a promise-chain microtask. Wait until
+    // this one reaches the queue head and is awaiting pendingSync.
+    await vi.waitFor(() => expect(handleContainerSyncMock).toHaveBeenCalledTimes(1));
 
     // Force-disconnect the adapter while the sync above is still pending.
     await adapter.onDisconnect();

--- a/app/agent/EdgeAgentAdapter.ts
+++ b/app/agent/EdgeAgentAdapter.ts
@@ -10,6 +10,7 @@
 import { emitAgentConnected, emitAgentDisconnected } from '../event/index.js';
 import logger from '../log/index.js';
 import type { Container } from '../model/container.js';
+import * as registry from '../registry/index.js';
 import { getErrorMessage } from '../util/error.js';
 import { uuidv7 } from '../util/uuid.js';
 import type { AgentClient, AgentClientConfig } from './AgentClient.js';
@@ -17,9 +18,17 @@ import { addAgent, getAgent, removeAgent } from './index.js';
 
 const MAX_EXEC_SESSIONS = 100;
 const MAX_PENDING_REQUESTS = 100;
+const MAX_STREAM_RESPONSE_BYTES = 100 * 1024 * 1024;
 const PING_INTERVAL_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 30_000;
 const CONTAINER_SYNC_WARN_MS = 30_000;
+const ORDERED_STATE_FRAME_TYPES = new Set([
+  'dd:component_sync',
+  'dd:container_sync',
+  'dd:container_added',
+  'dd:container_updated',
+  'dd:container_removed',
+]);
 // Number of consecutive server-initiated ping cycles that may pass without a
 // pong reply before the connection is considered dead. 2 cycles × 30s = 60s,
 // matching portwing's own readDeadline of max(2*heartbeat, 60s) for symmetry.
@@ -57,6 +66,7 @@ interface PendingRequest {
   statusCode?: number;
   headers?: Record<string, string>;
   chunks?: Buffer[];
+  streamBytes?: number;
 }
 
 export interface ContainerLogStreamChunk {
@@ -152,6 +162,7 @@ export class EdgeAgentAdapter {
   private readonly messageListener: (raw: unknown) => void;
   private readonly closeListener: () => void;
   private readonly errorListener: (err: unknown) => void;
+  private orderedStateFrameChain: Promise<void> = Promise.resolve();
 
   constructor(client: AgentClient, ws: WebSocketLike, options: EdgeAgentAdapterOptions = {}) {
     this.client = client;
@@ -307,6 +318,28 @@ export class EdgeAgentAdapter {
     const { type, data } = frame;
     if (typeof type !== 'string' || !data || typeof data !== 'object') {
       log.warn(`${this.agentName}: malformed frame (type=${String(type)})`);
+      return;
+    }
+
+    if (ORDERED_STATE_FRAME_TYPES.has(type)) {
+      const frameTask = this.orderedStateFrameChain.then(() => this.dispatchFrame(type, data));
+      // Contain failures so one bad component/snapshot/event frame cannot
+      // poison the FIFO. Attaching the rejection handler immediately also
+      // prevents unhandled-rejection windows in the WebSocket callback.
+      this.orderedStateFrameChain = frameTask.catch((err: unknown) => {
+        log.error(`Frame handling error on ${this.agentName}: ${getErrorMessage(err)}`);
+      });
+      await this.orderedStateFrameChain;
+      return;
+    }
+
+    await this.dispatchFrame(type, data);
+  }
+
+  private async dispatchFrame(type: string, data: Record<string, unknown>): Promise<void> {
+    // A frame may have been admitted to the ordered queue immediately before
+    // teardown. Re-check liveness when it reaches the head of the queue.
+    if (this.disconnected) {
       return;
     }
 
@@ -749,6 +782,18 @@ export class EdgeAgentAdapter {
     // O10: accumulate base64-decoded chunk on the pending entry
     if (typeof data.data === 'string') {
       const chunk = Buffer.from(data.data, 'base64');
+      const streamBytes = (pending.streamBytes ?? 0) + chunk.length;
+      if (streamBytes > MAX_STREAM_RESPONSE_BYTES) {
+        clearTimeout(pending.timer);
+        this.pendingRequests.delete(streamKey);
+        pending.reject(
+          new Error(
+            `Stream response exceeded the ${MAX_STREAM_RESPONSE_BYTES}-byte response limit`,
+          ),
+        );
+        return;
+      }
+      pending.streamBytes = streamBytes;
       if (!pending.chunks) {
         pending.chunks = [];
       }
@@ -1296,7 +1341,15 @@ export class EdgeAgentAdapter {
     // evict it too. Only remove when the registry's current entry for this
     // name is still THIS adapter's own client instance.
     if (getAgent(this.agentName) === this.client) {
+      const componentCleanup = registry
+        .deregisterAgentComponents(this.agentName)
+        .catch((error: unknown) => {
+          log.warn(
+            `Failed to clean up components for disconnected edge agent ${this.agentName}: ${getErrorMessage(error)}`,
+          );
+        });
       removeAgent(this.agentName);
+      await componentCleanup;
     }
 
     if (wasConnected) {

--- a/app/agent/PortwingDockerBridge.test.ts
+++ b/app/agent/PortwingDockerBridge.test.ts
@@ -229,6 +229,53 @@ describe('PortwingDockerBridge', () => {
     }
   });
 
+  test('contains an aborted request body without an unhandled rejection', async () => {
+    const requestDockerApi = vi.fn();
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+    const bodyReadStarted = deferred<void>();
+    const bodyReadSettled = deferred<void>();
+    const internal = bridge as unknown as {
+      readBody: (request: IncomingMessage) => Promise<Buffer | undefined>;
+    };
+    const originalReadBody = internal.readBody.bind(bridge);
+    const readBody = vi
+      .spyOn(internal, 'readBody')
+      .mockImplementation(async (request: IncomingMessage) => {
+        bodyReadStarted.resolve(undefined);
+        return originalReadBody(request).finally(() => {
+          bodyReadSettled.resolve(undefined);
+        });
+      });
+
+    try {
+      const clientClosed = new Promise<void>((resolve) => {
+        const request = http.request(`${endpoint.baseUrl}/v1.44/containers/create`, {
+          method: 'POST',
+          headers: {
+            authorization: endpoint.authorization,
+            'content-length': '10',
+          },
+        });
+        request.once('error', () => resolve());
+        request.flushHeaders();
+        void bodyReadStarted.promise.then(() => {
+          request.write('part');
+          request.destroy(new Error('intentional client abort'));
+        });
+      });
+
+      await clientClosed;
+      await bodyReadSettled.promise;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(readBody).toHaveBeenCalledOnce();
+      expect(requestDockerApi).not.toHaveBeenCalled();
+    } finally {
+      readBody.mockRestore();
+      await bridge.stop();
+    }
+  });
+
   test('keeps concurrent responses correlated when the remote requests complete out of order', async () => {
     const first = deferred<{
       statusCode: number;

--- a/app/agent/PortwingDockerBridge.test.ts
+++ b/app/agent/PortwingDockerBridge.test.ts
@@ -1,0 +1,426 @@
+import http, { type IncomingMessage, type ServerResponse } from 'node:http';
+import Dockerode from 'dockerode';
+import { describe, expect, test, vi } from 'vitest';
+import { PortwingDockerBridge } from './PortwingDockerBridge.js';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('PortwingDockerBridge', () => {
+  test('start is idempotent and stop before start is a no-op', async () => {
+    const bridge = new PortwingDockerBridge({ requestDockerApi: vi.fn() });
+
+    await expect(bridge.stop()).resolves.toBeUndefined();
+    const endpoint = await bridge.start();
+    try {
+      await expect(bridge.start()).resolves.toBe(endpoint);
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('fails closed when the listening server does not expose a TCP address', async () => {
+    const address = vi.spyOn(http.Server.prototype, 'address').mockReturnValueOnce(null);
+    const bridge = new PortwingDockerBridge({ requestDockerApi: vi.fn() });
+
+    try {
+      await expect(bridge.start()).rejects.toThrow(
+        'Unable to determine Portwing Docker bridge address',
+      );
+    } finally {
+      address.mockRestore();
+      await bridge.stop();
+    }
+  });
+
+  test('propagates a loopback listen error', async () => {
+    const listen = vi.spyOn(http.Server.prototype, 'listen').mockImplementation(function (
+      this: http.Server,
+    ) {
+      queueMicrotask(() => this.emit('error', new Error('loopback listen failed')));
+      return this;
+    });
+    const bridge = new PortwingDockerBridge({ requestDockerApi: vi.fn() });
+
+    try {
+      await expect(bridge.start()).rejects.toThrow('loopback listen failed');
+    } finally {
+      listen.mockRestore();
+      await bridge.stop();
+    }
+  });
+
+  test('round-trips a real Dockerode version request with the bridge bearer header', async () => {
+    const requestDockerApi = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: Buffer.from(
+        JSON.stringify({
+          Version: '27.1.1',
+          ApiVersion: '1.46',
+          MinAPIVersion: '1.24',
+          GitCommit: 'test',
+          GoVersion: 'go1.23',
+          Os: 'linux',
+          Arch: 'amd64',
+          KernelVersion: '6.8',
+          BuildTime: '2026-08-01T00:00:00Z',
+        }),
+      ),
+    });
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+    const dockerApi = new Dockerode({
+      host: endpoint.host,
+      port: endpoint.port,
+      protocol: 'http',
+      headers: { Authorization: endpoint.authorization },
+    });
+
+    try {
+      await expect(dockerApi.version()).resolves.toEqual(
+        expect.objectContaining({ Version: '27.1.1', ApiVersion: '1.46' }),
+      );
+      expect(requestDockerApi).toHaveBeenCalledWith(
+        'GET',
+        '/version',
+        expect.any(Object),
+        undefined,
+      );
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('round-trips real Dockerode start, stop, restart, and inspect operations', async () => {
+    const requestDockerApi = vi.fn((method: string, target: string) => {
+      if (method === 'GET' && target === '/containers/c1/json') {
+        return Promise.resolve({
+          statusCode: 200,
+          headers: { 'content-type': 'application/json' },
+          body: Buffer.from(JSON.stringify({ Id: 'c1', State: { Status: 'running' } })),
+        });
+      }
+      return Promise.resolve({ statusCode: 204, headers: {}, body: Buffer.alloc(0) });
+    });
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+    const dockerApi = new Dockerode({
+      host: endpoint.host,
+      port: endpoint.port,
+      protocol: 'http',
+      headers: { Authorization: endpoint.authorization },
+    });
+    const container = dockerApi.getContainer('c1');
+
+    try {
+      await container.start();
+      await container.stop();
+      await container.restart();
+      await expect(container.inspect()).resolves.toEqual(
+        expect.objectContaining({ Id: 'c1', State: { Status: 'running' } }),
+      );
+      expect(requestDockerApi.mock.calls.map(([method, target]) => [method, target])).toEqual([
+        ['POST', '/containers/c1/start'],
+        ['POST', '/containers/c1/stop'],
+        ['POST', '/containers/c1/restart'],
+        ['GET', '/containers/c1/json'],
+      ]);
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('authenticates the local request and forwards the exact Docker target, headers, and body', async () => {
+    const requestDockerApi = vi.fn().mockResolvedValue({
+      statusCode: 201,
+      headers: { 'content-type': 'application/json', 'x-docker-id': 'created' },
+      body: Buffer.from('{"Id":"c1"}'),
+    });
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+
+    try {
+      const response = await fetch(`${endpoint.baseUrl}/v1.44/containers/create?name=web%2Fblue`, {
+        method: 'POST',
+        headers: {
+          authorization: endpoint.authorization,
+          'content-type': 'application/json',
+          'x-registry-auth': 'registry-token',
+        },
+        body: '{"Image":"nginx:latest"}',
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.headers.get('x-docker-id')).toBe('created');
+      expect(await response.text()).toBe('{"Id":"c1"}');
+      expect(requestDockerApi).toHaveBeenCalledWith(
+        'POST',
+        '/v1.44/containers/create?name=web%2Fblue',
+        expect.objectContaining({
+          'content-type': 'application/json',
+          'x-registry-auth': 'registry-token',
+        }),
+        Buffer.from('{"Image":"nginx:latest"}'),
+      );
+      expect(requestDockerApi.mock.calls[0][2]).not.toHaveProperty('authorization');
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('rejects unauthenticated local callers before invoking the remote agent', async () => {
+    const requestDockerApi = vi.fn();
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+
+    try {
+      const response = await fetch(`${endpoint.baseUrl}/v1.44/info`);
+      expect(response.status).toBe(401);
+      expect(requestDockerApi).not.toHaveBeenCalled();
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('rejects a same-length incorrect bearer token with a constant-time comparison', async () => {
+    const requestDockerApi = vi.fn();
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+
+    try {
+      const replacement = endpoint.authorization.endsWith('a') ? 'b' : 'a';
+      const wrongAuthorization = `${endpoint.authorization.slice(0, -1)}${replacement}`;
+      const response = await fetch(`${endpoint.baseUrl}/v1.44/info`, {
+        headers: { authorization: wrongAuthorization },
+      });
+      expect(response.status).toBe(401);
+      expect(requestDockerApi).not.toHaveBeenCalled();
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('bounds request bodies and returns 413 without forwarding oversized payloads', async () => {
+    const requestDockerApi = vi.fn();
+    const bridge = new PortwingDockerBridge({ requestDockerApi }, { maxRequestBodyBytes: 4 });
+    const endpoint = await bridge.start();
+
+    try {
+      const response = await fetch(`${endpoint.baseUrl}/v1.44/containers/create`, {
+        method: 'POST',
+        headers: { authorization: endpoint.authorization },
+        body: '12345',
+      });
+      expect(response.status).toBe(413);
+      expect(requestDockerApi).not.toHaveBeenCalled();
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('keeps concurrent responses correlated when the remote requests complete out of order', async () => {
+    const first = deferred<{
+      statusCode: number;
+      headers: Record<string, never>;
+      body: Buffer;
+    }>();
+    const second = deferred<{
+      statusCode: number;
+      headers: Record<string, never>;
+      body: Buffer;
+    }>();
+    const requestDockerApi = vi.fn((_, target: string) =>
+      target.endsWith('/first') ? first.promise : second.promise,
+    );
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+
+    try {
+      const firstResponse = fetch(`${endpoint.baseUrl}/v1.44/first`, {
+        headers: { authorization: endpoint.authorization },
+      });
+      const secondResponse = fetch(`${endpoint.baseUrl}/v1.44/second`, {
+        headers: { authorization: endpoint.authorization },
+      });
+      await vi.waitFor(() => expect(requestDockerApi).toHaveBeenCalledTimes(2));
+
+      second.resolve({ statusCode: 200, headers: {}, body: Buffer.from('second') });
+      first.resolve({ statusCode: 200, headers: {}, body: Buffer.from('first') });
+
+      expect(await (await firstResponse).text()).toBe('first');
+      expect(await (await secondResponse).text()).toBe('second');
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('maps transport failures to a bounded 502 response without leaking error detail', async () => {
+    const requestDockerApi = vi.fn().mockRejectedValue(new Error('secret upstream detail'));
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+
+    try {
+      const response = await fetch(`${endpoint.baseUrl}/v1.44/info`, {
+        headers: { authorization: endpoint.authorization },
+      });
+      expect(response.status).toBe(502);
+      const body = await response.text();
+      expect(body).toContain('Portwing Docker transport failed');
+      expect(body).not.toContain('secret upstream detail');
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('rejects invalid upstream status codes and strips hop-by-hop response headers', async () => {
+    const requestDockerApi = vi
+      .fn()
+      .mockResolvedValueOnce({ statusCode: 700, headers: {}, body: Buffer.alloc(0) })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        headers: { connection: 'upgrade', 'x-forwarded-result': 'ok' },
+        body: Buffer.from('ok'),
+      });
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+
+    try {
+      const invalid = await fetch(`${endpoint.baseUrl}/v1.44/info`, {
+        headers: { authorization: endpoint.authorization },
+      });
+      expect(invalid.status).toBe(502);
+
+      const valid = await fetch(`${endpoint.baseUrl}/v1.44/info`, {
+        headers: { authorization: endpoint.authorization },
+      });
+      expect(valid.status).toBe(200);
+      expect(valid.headers.get('x-forwarded-result')).toBe('ok');
+      expect(valid.headers.get('connection')).not.toBe('upgrade');
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('normalizes array request headers and non-buffer request chunks', async () => {
+    const requestDockerApi = vi.fn().mockResolvedValue({
+      statusCode: 204,
+      headers: {},
+      body: Buffer.alloc(0),
+    });
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const request = http.request(
+          `${endpoint.baseUrl}/v1.44/info`,
+          {
+            headers: {
+              authorization: endpoint.authorization,
+              'set-cookie': ['one=1', 'two=2'],
+            },
+          },
+          (response) => {
+            response.resume();
+            response.once('end', resolve);
+          },
+        );
+        request.once('error', reject);
+        request.end();
+      });
+      expect(requestDockerApi).toHaveBeenCalledWith(
+        'GET',
+        '/v1.44/info',
+        expect.objectContaining({ 'set-cookie': 'one=1, two=2' }),
+        undefined,
+      );
+
+      const readBody = bridge as unknown as {
+        readBody: (request: AsyncIterable<string>) => Promise<Buffer | undefined>;
+      };
+      const syntheticRequest = {
+        async *[Symbol.asyncIterator]() {
+          yield 'text-chunk';
+        },
+      };
+      await expect(readBody.readBody(syntheticRequest)).resolves.toEqual(Buffer.from('text-chunk'));
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('defaults missing request method and URL in the internal request boundary', async () => {
+    const requestDockerApi = vi.fn().mockResolvedValue({
+      statusCode: 204,
+      headers: {},
+      body: Buffer.alloc(0),
+    });
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+    const request = {
+      headers: { authorization: endpoint.authorization },
+      method: undefined,
+      url: undefined,
+      async *[Symbol.asyncIterator]() {},
+    } as unknown as IncomingMessage;
+    const response = {
+      headersSent: false,
+      statusCode: 200,
+      setHeader: vi.fn(),
+      end: vi.fn(),
+      writeHead: vi.fn(),
+      destroy: vi.fn(),
+    } as unknown as ServerResponse;
+
+    try {
+      const internal = bridge as unknown as {
+        handle: (request: IncomingMessage, response: ServerResponse) => Promise<void>;
+      };
+      await internal.handle(request, response);
+      expect(requestDockerApi).toHaveBeenCalledWith('GET', '/', {}, undefined);
+    } finally {
+      await bridge.stop();
+    }
+  });
+
+  test('destroys a response when transport failure happens after headers are sent', async () => {
+    const requestDockerApi = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: Buffer.from('partial'),
+    });
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+    const originalSetHeader = http.ServerResponse.prototype.setHeader;
+    const setHeader = vi
+      .spyOn(http.ServerResponse.prototype, 'setHeader')
+      .mockImplementation(function (this: ServerResponse, name, value) {
+        if (String(name).toLowerCase() === 'content-length') {
+          this.flushHeaders();
+          throw new Error('response failed after headers');
+        }
+        return originalSetHeader.call(this, name, value);
+      });
+
+    try {
+      const response = await fetch(`${endpoint.baseUrl}/v1.44/info`, {
+        headers: { authorization: endpoint.authorization },
+      });
+      await expect(response.arrayBuffer()).rejects.toThrow();
+    } finally {
+      setHeader.mockRestore();
+      await bridge.stop();
+    }
+  });
+});

--- a/app/agent/PortwingDockerBridge.ts
+++ b/app/agent/PortwingDockerBridge.ts
@@ -84,7 +84,9 @@ export class PortwingDockerBridge {
       return this.endpoint;
     }
     const server = http.createServer((req, res) => {
-      void this.handle(req, res);
+      void this.handle(req, res).catch(() => {
+        res.destroy();
+      });
     });
     server.on('connection', (socket) => {
       this.sockets.add(socket);

--- a/app/agent/PortwingDockerBridge.ts
+++ b/app/agent/PortwingDockerBridge.ts
@@ -1,0 +1,195 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import http, { type IncomingMessage, type ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
+import type { DockerApiProxyResponse } from './AgentClient.js';
+
+const DEFAULT_MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024;
+
+const HOP_BY_HOP_HEADERS = new Set([
+  'authorization',
+  'connection',
+  'content-length',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+interface PortwingDockerRequester {
+  requestDockerApi(
+    method: string,
+    target: string,
+    headers: Record<string, string>,
+    body?: Buffer,
+  ): Promise<DockerApiProxyResponse>;
+}
+
+interface PortwingDockerBridgeOptions {
+  maxRequestBodyBytes?: number;
+}
+
+export interface PortwingDockerBridgeEndpoint {
+  baseUrl: string;
+  authorization: string;
+  host: '127.0.0.1';
+  port: number;
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left);
+  const rightBytes = Buffer.from(right);
+  return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes);
+}
+
+function requestHeaders(req: IncomingMessage): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (HOP_BY_HOP_HEADERS.has(name) || value === undefined) {
+      continue;
+    }
+    headers[name] = Array.isArray(value) ? value.join(', ') : value;
+  }
+  return headers;
+}
+
+function copyResponseHeaders(res: ServerResponse, headers: Record<string, string>): void {
+  for (const [name, value] of Object.entries(headers)) {
+    if (!HOP_BY_HOP_HEADERS.has(name.toLowerCase())) {
+      res.setHeader(name, value);
+    }
+  }
+}
+
+export class PortwingDockerBridge {
+  private readonly authorization: string;
+  private readonly maxRequestBodyBytes: number;
+  private readonly sockets = new Set<Socket>();
+  private server?: http.Server;
+  private endpoint?: PortwingDockerBridgeEndpoint;
+
+  constructor(
+    private readonly requester: PortwingDockerRequester,
+    options: PortwingDockerBridgeOptions = {},
+  ) {
+    this.authorization = `Bearer ${randomBytes(32).toString('base64url')}`;
+    this.maxRequestBodyBytes = options.maxRequestBodyBytes ?? DEFAULT_MAX_REQUEST_BODY_BYTES;
+  }
+
+  async start(): Promise<PortwingDockerBridgeEndpoint> {
+    if (this.endpoint) {
+      return this.endpoint;
+    }
+    const server = http.createServer((req, res) => {
+      void this.handle(req, res);
+    });
+    server.on('connection', (socket) => {
+      this.sockets.add(socket);
+      socket.once('close', () => this.sockets.delete(socket));
+    });
+    this.server = server;
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => reject(error);
+      server.once('error', onError);
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', onError);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      await this.stop();
+      throw new Error('Unable to determine Portwing Docker bridge address');
+    }
+    this.endpoint = {
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      authorization: this.authorization,
+      host: '127.0.0.1',
+      port: address.port,
+    };
+    return this.endpoint;
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    this.server = undefined;
+    this.endpoint = undefined;
+    if (!server) {
+      return;
+    }
+    for (const socket of this.sockets) {
+      socket.destroy();
+    }
+    this.sockets.clear();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  private async readBody(req: IncomingMessage): Promise<Buffer | undefined> {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let oversized = false;
+    for await (const rawChunk of req) {
+      const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk);
+      total += chunk.length;
+      if (total > this.maxRequestBodyBytes) {
+        oversized = true;
+        continue;
+      }
+      chunks.push(chunk);
+    }
+    if (oversized) {
+      return undefined;
+    }
+    return chunks.length === 0 ? Buffer.alloc(0) : Buffer.concat(chunks, total);
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (!safeEqual(req.headers.authorization ?? '', this.authorization)) {
+      res.writeHead(401, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('Unauthorized');
+      return;
+    }
+
+    const body = await this.readBody(req);
+    if (body === undefined) {
+      res.writeHead(413, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('Docker API request body exceeds the bridge limit');
+      return;
+    }
+
+    try {
+      const response = await this.requester.requestDockerApi(
+        req.method ?? 'GET',
+        req.url ?? '/',
+        requestHeaders(req),
+        body.length > 0 ? body : undefined,
+      );
+      if (
+        !Number.isInteger(response.statusCode) ||
+        response.statusCode < 100 ||
+        response.statusCode > 599
+      ) {
+        throw new Error('Invalid upstream status');
+      }
+      copyResponseHeaders(res, response.headers);
+      res.statusCode = response.statusCode;
+      res.setHeader('content-length', String(response.body.length));
+      res.end(response.body);
+    } catch {
+      if (res.headersSent) {
+        res.destroy();
+        return;
+      }
+      const message = 'Portwing Docker transport failed';
+      res.writeHead(502, {
+        'content-type': 'text/plain; charset=utf-8',
+        'content-length': String(Buffer.byteLength(message)),
+      });
+      res.end(message);
+    }
+  }
+}

--- a/app/agent/components/AgentTrigger.test.ts
+++ b/app/agent/components/AgentTrigger.test.ts
@@ -2,13 +2,50 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import * as manager from '../manager.js';
 import AgentTrigger from './AgentTrigger.js';
 
+const controllerMocks = vi.hoisted(() => {
+  const delegate = {
+    register: vi.fn(async function () {
+      return this;
+    }),
+    trigger: vi.fn().mockResolvedValue('controller-update'),
+    triggerBatch: vi.fn().mockResolvedValue('controller-batch-update'),
+    getWatcher: vi.fn(),
+    preview: vi.fn(),
+    pullImage: vi.fn(),
+    getCurrentContainer: vi.fn(),
+    inspectContainer: vi.fn(),
+    stopAndRemoveContainer: vi.fn(),
+    recreateContainer: vi.fn(),
+    deregister: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    delegate,
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock must remain constructable.
+    DockerTrigger: vi.fn(function () {
+      return delegate;
+    }),
+  };
+});
+
+vi.mock('../../triggers/providers/docker/Docker.js', () => ({
+  default: controllerMocks.DockerTrigger,
+}));
+
 vi.mock('../../log/index.js', () => ({
   default: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
 }));
 
 vi.mock('../../event/index.js', () => ({
-  registerContainerReport: vi.fn(),
-  registerContainerReports: vi.fn(),
+  registerContainerReport: vi.fn(() => vi.fn()),
+  registerContainerReports: vi.fn(() => vi.fn()),
+  registerMaturityGateCleared: vi.fn(() => vi.fn()),
+  registerContainerUpdateApplied: vi.fn(() => vi.fn()),
+  registerContainerUpdateFailed: vi.fn(() => vi.fn()),
+  registerSecurityAlert: vi.fn(() => vi.fn()),
+  registerSecurityScanCycleComplete: vi.fn(() => vi.fn()),
+  registerAgentConnected: vi.fn(() => vi.fn()),
+  registerAgentDisconnected: vi.fn(() => vi.fn()),
+  registerContainerHealthTransition: vi.fn(() => vi.fn()),
 }));
 
 vi.mock('../../prometheus/trigger.js', () => ({
@@ -24,6 +61,17 @@ describe('AgentTrigger', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    controllerMocks.delegate.register.mockImplementation(async function () {
+      return this;
+    });
+    controllerMocks.delegate.trigger.mockResolvedValue('controller-update');
+    controllerMocks.delegate.triggerBatch.mockResolvedValue('controller-batch-update');
+    controllerMocks.delegate.preview.mockResolvedValue({ containerName: 'web' });
+    controllerMocks.delegate.pullImage.mockResolvedValue(undefined);
+    controllerMocks.delegate.getCurrentContainer.mockResolvedValue({ id: 'runtime-c1' });
+    controllerMocks.delegate.inspectContainer.mockResolvedValue({ State: { Running: true } });
+    controllerMocks.delegate.stopAndRemoveContainer.mockResolvedValue(undefined);
+    controllerMocks.delegate.recreateContainer.mockResolvedValue({ id: 'replacement-c1' });
     trigger = new AgentTrigger();
     trigger.type = 'docker';
     trigger.name = 'update';
@@ -127,5 +175,144 @@ describe('AgentTrigger', () => {
       const result = schema.validate({ foo: 'bar', baz: 123 });
       expect(result.error).toBeUndefined();
     });
+  });
+
+  test('controller Docker transport delegates update execution locally and cleans up', async () => {
+    const client = { runRemoteTrigger: vi.fn(), runRemoteTriggerBatch: vi.fn() };
+    manager.getAgent.mockReturnValue(client);
+    const runtimeContext = { operationId: 'controller-operation' };
+    const container = { id: 'c1', name: 'web', watcher: 'docker', agent: 'remote-agent' };
+
+    await trigger.register(
+      'trigger',
+      'docker',
+      'update',
+      {
+        transport: 'docker-api',
+        execution: 'controller',
+        events: 'portwing',
+        watcher: 'docker',
+      },
+      'remote-agent',
+    );
+
+    expect(controllerMocks.delegate.register).toHaveBeenCalledWith(
+      'trigger',
+      'docker',
+      'update',
+      {},
+      'remote-agent',
+    );
+    expect(await trigger.trigger(container, runtimeContext)).toBe('controller-update');
+    expect(controllerMocks.delegate.trigger).toHaveBeenCalledWith(container, runtimeContext);
+    expect(client.runRemoteTrigger).not.toHaveBeenCalled();
+
+    await trigger.deregister();
+    expect(controllerMocks.delegate.deregister).toHaveBeenCalledOnce();
+  });
+
+  test('controller Docker transport propagates single and batch update failures', async () => {
+    manager.getAgent.mockReturnValue({});
+    await trigger.register(
+      'trigger',
+      'docker',
+      'update',
+      { transport: 'docker-api', execution: 'controller', events: 'portwing' },
+      'remote-agent',
+    );
+    controllerMocks.delegate.trigger.mockRejectedValueOnce(new Error('single update failed'));
+    controllerMocks.delegate.triggerBatch.mockRejectedValueOnce(new Error('batch update failed'));
+
+    await expect(trigger.trigger({ id: 'c1' })).rejects.toThrow('single update failed');
+    await expect(trigger.triggerBatch([{ id: 'c1' }, { id: 'c2' }])).rejects.toThrow(
+      'batch update failed',
+    );
+  });
+
+  test('controller Docker transport delegates action, preview, and rollback capabilities', async () => {
+    manager.getAgent.mockReturnValue({});
+    const dockerApi = { getContainer: vi.fn() };
+    const watcher = { dockerApi };
+    const runtimeContainer = { id: 'runtime-c1' };
+    const inspected = { State: { Running: true } };
+    const replacement = { id: 'replacement-c1' };
+    const container = { id: 'c1', name: 'web', watcher: 'docker', agent: 'remote-agent' };
+    const auth = { username: 'registry-user' };
+    const log = { info: vi.fn(), warn: vi.fn() };
+    controllerMocks.delegate.getWatcher.mockReturnValue(watcher);
+    controllerMocks.delegate.getCurrentContainer.mockResolvedValue(runtimeContainer);
+    controllerMocks.delegate.inspectContainer.mockResolvedValue(inspected);
+    controllerMocks.delegate.recreateContainer.mockResolvedValue(replacement);
+
+    await trigger.register(
+      'trigger',
+      'docker',
+      'update',
+      { transport: 'docker-api', execution: 'controller', events: 'portwing' },
+      'remote-agent',
+    );
+
+    expect(trigger.getWatcher(container)).toBe(watcher);
+    await expect(trigger.preview(container)).resolves.toEqual({ containerName: 'web' });
+    expect(controllerMocks.delegate.preview).toHaveBeenCalledWith(container);
+
+    await expect(trigger.pullImage(dockerApi, auth, 'nginx:1.26', log)).resolves.toBeUndefined();
+    expect(controllerMocks.delegate.pullImage).toHaveBeenCalledWith(
+      dockerApi,
+      auth,
+      'nginx:1.26',
+      log,
+    );
+    await expect(trigger.getCurrentContainer(dockerApi, container)).resolves.toBe(runtimeContainer);
+    expect(controllerMocks.delegate.getCurrentContainer).toHaveBeenCalledWith(dockerApi, container);
+    await expect(trigger.inspectContainer(runtimeContainer, log)).resolves.toBe(inspected);
+    expect(controllerMocks.delegate.inspectContainer).toHaveBeenCalledWith(runtimeContainer, log);
+    await expect(
+      trigger.stopAndRemoveContainer(runtimeContainer, inspected, container, log),
+    ).resolves.toBeUndefined();
+    expect(controllerMocks.delegate.stopAndRemoveContainer).toHaveBeenCalledWith(
+      runtimeContainer,
+      inspected,
+      container,
+      log,
+    );
+    await expect(
+      trigger.recreateContainer(dockerApi, inspected, 'nginx:1.26', container, log),
+    ).resolves.toBe(replacement);
+    expect(controllerMocks.delegate.recreateContainer).toHaveBeenCalledWith(
+      dockerApi,
+      inspected,
+      'nginx:1.26',
+      container,
+      log,
+    );
+  });
+
+  test('legacy remote mode keeps default preview behavior and rejects local-only Docker capabilities', async () => {
+    manager.getAgent.mockReturnValue({});
+    await trigger.register('trigger', 'docker', 'update', {}, 'remote-agent');
+    const container = { id: 'c1', name: 'web', watcher: 'docker', agent: 'remote-agent' };
+
+    await expect(trigger.preview(container)).resolves.toEqual({});
+    expect(() => trigger.getWatcher(container)).toThrow(
+      /does not advertise controller Docker transport/,
+    );
+    expect(() => trigger.pullImage({}, undefined, 'nginx:1.26', {})).toThrow(
+      /does not advertise controller Docker transport/,
+    );
+    expect(() => trigger.getCurrentContainer({}, container)).toThrow(
+      /does not advertise controller Docker transport/,
+    );
+    expect(() => trigger.inspectContainer({}, {})).toThrow(
+      /does not advertise controller Docker transport/,
+    );
+    expect(() => trigger.stopAndRemoveContainer({}, {}, container, {})).toThrow(
+      /does not advertise controller Docker transport/,
+    );
+    expect(() => trigger.recreateContainer({}, {}, 'nginx:1.26', container, {})).toThrow(
+      /does not advertise controller Docker transport/,
+    );
+
+    await trigger.deregister();
   });
 });

--- a/app/agent/components/AgentTrigger.ts
+++ b/app/agent/components/AgentTrigger.ts
@@ -1,5 +1,9 @@
 import type { Container } from '../../model/container.js';
+import DockerTrigger, {
+  type DockerTriggerConfiguration,
+} from '../../triggers/providers/docker/Docker.js';
 import Trigger from '../../triggers/providers/Trigger.js';
+import { usesControllerDockerTransport } from '../controller-docker-transport.js';
 import { getRequiredAgentClient } from './getRequiredAgentClient.js';
 
 /**
@@ -7,12 +11,42 @@ import { getRequiredAgentClient } from './getRequiredAgentClient.js';
  * Acts as a proxy for the remote trigger running on the agent.
  */
 class AgentTrigger extends Trigger {
+  private controllerTrigger?: DockerTrigger;
+
+  private requireControllerTrigger(capability: string): DockerTrigger {
+    if (!this.controllerTrigger) {
+      throw new Error(
+        `AgentTrigger ${this.getId()} cannot provide local Docker capability ${capability}; the agent does not advertise controller Docker transport`,
+      );
+    }
+    return this.controllerTrigger;
+  }
+
+  override async init(): Promise<void> {
+    if (!usesControllerDockerTransport(this.type, this.configuration)) {
+      await super.init();
+      return;
+    }
+    const delegate = new DockerTrigger();
+    await delegate.register(
+      'trigger',
+      'docker',
+      this.name,
+      {} as DockerTriggerConfiguration,
+      this.agent,
+    );
+    this.controllerTrigger = delegate;
+  }
+
   /**
    * Trigger method.
    * Delegates to the agent, threading runtimeContext so the controller's
    * operationId survives the controller→agent boundary (fixes #289).
    */
   async trigger(container: Container, runtimeContext?: unknown): Promise<unknown> {
+    if (this.controllerTrigger) {
+      return this.controllerTrigger.trigger(container, runtimeContext);
+    }
     const client = getRequiredAgentClient(this.agent, 'AgentTrigger');
     return client.runRemoteTrigger(container, this.type, this.name, runtimeContext);
   }
@@ -23,8 +57,42 @@ class AgentTrigger extends Trigger {
    * resolution on the agent side (fixes #289).
    */
   async triggerBatch(containers: Container[], runtimeContext?: unknown): Promise<unknown> {
+    if (this.controllerTrigger) {
+      return this.controllerTrigger.triggerBatch(containers, runtimeContext);
+    }
     const client = getRequiredAgentClient(this.agent, 'AgentTrigger');
     return client.runRemoteTriggerBatch(containers, this.type, this.name, runtimeContext);
+  }
+
+  getWatcher(...args: Parameters<DockerTrigger['getWatcher']>) {
+    return this.requireControllerTrigger('getWatcher').getWatcher(...args);
+  }
+
+  override async preview(container: Container): Promise<Record<string, unknown>> {
+    if (!this.controllerTrigger) {
+      return super.preview(container);
+    }
+    return this.controllerTrigger.preview(container);
+  }
+
+  pullImage(...args: Parameters<DockerTrigger['pullImage']>) {
+    return this.requireControllerTrigger('pullImage').pullImage(...args);
+  }
+
+  getCurrentContainer(...args: Parameters<DockerTrigger['getCurrentContainer']>) {
+    return this.requireControllerTrigger('getCurrentContainer').getCurrentContainer(...args);
+  }
+
+  inspectContainer(...args: Parameters<DockerTrigger['inspectContainer']>) {
+    return this.requireControllerTrigger('inspectContainer').inspectContainer(...args);
+  }
+
+  stopAndRemoveContainer(...args: Parameters<DockerTrigger['stopAndRemoveContainer']>) {
+    return this.requireControllerTrigger('stopAndRemoveContainer').stopAndRemoveContainer(...args);
+  }
+
+  recreateContainer(...args: Parameters<DockerTrigger['recreateContainer']>) {
+    return this.requireControllerTrigger('recreateContainer').recreateContainer(...args);
   }
 
   /**
@@ -33,6 +101,16 @@ class AgentTrigger extends Trigger {
    */
   getConfigurationSchema() {
     return this.joi.object().unknown();
+  }
+
+  override async deregisterComponent(): Promise<void> {
+    if (this.controllerTrigger) {
+      const delegate = this.controllerTrigger;
+      this.controllerTrigger = undefined;
+      await delegate.deregister();
+      return;
+    }
+    await super.deregisterComponent();
   }
 }
 

--- a/app/agent/components/AgentWatcher.test.ts
+++ b/app/agent/components/AgentWatcher.test.ts
@@ -2,6 +2,61 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import * as manager from '../manager.js';
 import AgentWatcher from './AgentWatcher.js';
 
+const controllerMocks = vi.hoisted(() => {
+  const dockerApi = { transport: 'loopback-dockerode' };
+  const dockerDelegate = {
+    dockerApi: undefined as unknown,
+    initWatcher: vi.fn(),
+    recreateDockerClient: vi.fn(),
+    register: vi.fn(async function (this: { initWatcher: () => Promise<void> }) {
+      await this.initWatcher();
+      return this;
+    }),
+    watch: vi.fn().mockResolvedValue([{ container: { id: 'c1' }, changed: true }]),
+    watchContainer: vi.fn().mockResolvedValue({ container: { id: 'c1' }, changed: true }),
+    deregister: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    dockerApi,
+    dockerDelegate,
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock must remain constructable.
+    Docker: vi.fn(function () {
+      return dockerDelegate;
+    }),
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock must remain constructable.
+    Dockerode: vi.fn(function () {
+      return dockerApi;
+    }),
+    bridge: {
+      start: vi.fn().mockResolvedValue({
+        baseUrl: 'http://127.0.0.1:43210',
+        host: '127.0.0.1',
+        port: 43210,
+        authorization: 'Bearer local-secret',
+      }),
+      stop: vi.fn().mockResolvedValue(undefined),
+    },
+    Bridge: vi.fn(),
+  };
+});
+
+// biome-ignore lint/complexity/useArrowFunction: constructor mock must remain constructable.
+controllerMocks.Bridge.mockImplementation(function () {
+  return controllerMocks.bridge;
+});
+
+vi.mock('../../watchers/providers/docker/Docker.js', () => ({
+  default: controllerMocks.Docker,
+}));
+
+vi.mock('dockerode', () => ({
+  default: controllerMocks.Dockerode,
+}));
+
+vi.mock('../PortwingDockerBridge.js', () => ({
+  PortwingDockerBridge: controllerMocks.Bridge,
+}));
+
 vi.mock('../../log/index.js', () => ({
   default: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
 }));
@@ -15,6 +70,26 @@ describe('AgentWatcher', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    controllerMocks.dockerDelegate.dockerApi = undefined;
+    controllerMocks.dockerDelegate.register.mockImplementation(async function (this: {
+      initWatcher: () => Promise<void>;
+    }) {
+      await this.initWatcher();
+      return this;
+    });
+    controllerMocks.dockerDelegate.watch.mockResolvedValue([
+      { container: { id: 'c1' }, changed: true },
+    ]);
+    controllerMocks.dockerDelegate.watchContainer.mockResolvedValue({
+      container: { id: 'c1' },
+      changed: true,
+    });
+    controllerMocks.bridge.start.mockResolvedValue({
+      baseUrl: 'http://127.0.0.1:43210',
+      host: '127.0.0.1',
+      port: 43210,
+      authorization: 'Bearer local-secret',
+    });
     watcher = new AgentWatcher();
     watcher.type = 'docker';
     watcher.name = 'local';
@@ -77,5 +152,101 @@ describe('AgentWatcher', () => {
       const result = schema.validate({ foo: 'bar', baz: 123 });
       expect(result.error).toBeUndefined();
     });
+  });
+
+  test.each([
+    [
+      'non-Docker provider',
+      'podman',
+      { transport: 'docker-api', execution: 'controller', events: 'portwing' },
+    ],
+    [
+      'legacy Docker transport',
+      'docker',
+      { transport: 'agent', execution: 'controller', events: 'portwing' },
+    ],
+    [
+      'agent-side Docker execution',
+      'docker',
+      { transport: 'docker-api', execution: 'agent', events: 'portwing' },
+    ],
+    [
+      'legacy Docker events',
+      'docker',
+      { transport: 'docker-api', execution: 'controller', events: 'docker' },
+    ],
+  ])('keeps %s in remote delegation mode', async (_label, type, configuration) => {
+    watcher.type = type;
+    manager.getAgent.mockReturnValue({ watch: vi.fn(), watchContainer: vi.fn() });
+
+    await watcher.register('watcher', type, 'local', configuration, 'remote-agent');
+
+    expect(controllerMocks.Bridge).not.toHaveBeenCalled();
+    await watcher.deregister();
+  });
+
+  test('stops the bridge when controller watcher registration fails', async () => {
+    manager.getAgent.mockReturnValue({ requestDockerApi: vi.fn() });
+    controllerMocks.dockerDelegate.register.mockRejectedValueOnce(
+      new Error('controller watcher registration failed'),
+    );
+
+    await expect(
+      watcher.register(
+        'watcher',
+        'docker',
+        'docker',
+        { transport: 'docker-api', execution: 'controller', events: 'portwing' },
+        'remote-agent',
+      ),
+    ).rejects.toThrow('controller watcher registration failed');
+
+    expect(controllerMocks.bridge.stop).toHaveBeenCalledOnce();
+  });
+
+  test('controller Docker transport uses the native watcher over an authenticated bridge and cleans it up', async () => {
+    const client = { requestDockerApi: vi.fn(), watch: vi.fn(), watchContainer: vi.fn() };
+    manager.getAgent.mockReturnValue(client);
+
+    await watcher.register(
+      'watcher',
+      'docker',
+      'docker',
+      { transport: 'docker-api', execution: 'controller', events: 'portwing' },
+      'remote-agent',
+    );
+
+    expect(controllerMocks.Bridge).toHaveBeenCalledWith(client);
+    expect(controllerMocks.Dockerode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: '127.0.0.1',
+        port: 43210,
+        protocol: 'http',
+        headers: { Authorization: 'Bearer local-secret' },
+      }),
+    );
+    expect(controllerMocks.dockerDelegate.register).toHaveBeenCalledWith(
+      'watcher',
+      'docker',
+      'docker',
+      expect.objectContaining({ watchevents: false }),
+      'remote-agent',
+    );
+    expect(watcher.dockerApi).toBe(controllerMocks.dockerApi);
+
+    expect(await watcher.watch()).toEqual([{ container: { id: 'c1' }, changed: true }]);
+    await expect(watcher.watchContainer({ id: 'c1' }, { emitBatchEvent: true })).resolves.toEqual({
+      container: { id: 'c1' },
+      changed: true,
+    });
+    expect(controllerMocks.dockerDelegate.watchContainer).toHaveBeenCalledWith(
+      { id: 'c1' },
+      { emitBatchEvent: true },
+    );
+    expect(client.watch).not.toHaveBeenCalled();
+
+    await watcher.deregister();
+    expect(controllerMocks.dockerDelegate.deregister).toHaveBeenCalledOnce();
+    expect(controllerMocks.bridge.stop).toHaveBeenCalledOnce();
   });
 });

--- a/app/agent/components/AgentWatcher.ts
+++ b/app/agent/components/AgentWatcher.ts
@@ -1,5 +1,11 @@
+import Dockerode from 'dockerode';
 import type { Container, ContainerReport } from '../../model/container.js';
+import DockerWatcher, {
+  type DockerWatcherConfiguration,
+} from '../../watchers/providers/docker/Docker.js';
 import Watcher from '../../watchers/Watcher.js';
+import { usesControllerDockerTransport } from '../controller-docker-transport.js';
+import { PortwingDockerBridge } from '../PortwingDockerBridge.js';
 import { getRequiredAgentClient } from './getRequiredAgentClient.js';
 
 /**
@@ -7,11 +13,54 @@ import { getRequiredAgentClient } from './getRequiredAgentClient.js';
  * Acts as a proxy for the remote watcher running on the agent.
  */
 class AgentWatcher extends Watcher {
+  private controllerWatcher?: DockerWatcher;
+  private controllerBridge?: PortwingDockerBridge;
+
+  override async init(): Promise<void> {
+    if (!usesControllerDockerTransport(this.type, this.configuration)) {
+      return;
+    }
+
+    const client = getRequiredAgentClient(this.agent, 'AgentWatcher');
+    const bridge = new PortwingDockerBridge(client);
+    this.controllerBridge = bridge;
+    try {
+      const endpoint = await bridge.start();
+      const dockerApi = new Dockerode({
+        host: endpoint.host,
+        port: endpoint.port,
+        protocol: 'http',
+        headers: { Authorization: endpoint.authorization },
+      });
+      const delegate = new DockerWatcher();
+      delegate.initWatcher = async () => {
+        delegate.dockerApi = dockerApi;
+      };
+      delegate.recreateDockerClient = delegate.initWatcher;
+      await delegate.register(
+        'watcher',
+        'docker',
+        this.name,
+        { watchevents: false } as DockerWatcherConfiguration,
+        this.agent,
+      );
+      this.controllerWatcher = delegate;
+      this.dockerApi = delegate.dockerApi;
+    } catch (error) {
+      await bridge.stop();
+      this.controllerBridge = undefined;
+      throw error;
+    }
+  }
+
   /**
    * Watch main method.
    * Delegate to the agent client.
    */
   async watch(): Promise<ContainerReport[]> {
+    if (this.controllerWatcher) {
+      return this.controllerWatcher.watch();
+    }
     const client = getRequiredAgentClient(this.agent, 'AgentWatcher');
     return client.watch(this.type, this.name);
   }
@@ -27,6 +76,9 @@ class AgentWatcher extends Watcher {
     container: Container,
     _options?: { emitBatchEvent?: boolean },
   ): Promise<ContainerReport> {
+    if (this.controllerWatcher) {
+      return this.controllerWatcher.watchContainer(container, _options);
+    }
     const client = getRequiredAgentClient(this.agent, 'AgentWatcher');
     return client.watchContainer(this.type, this.name, container);
   }
@@ -37,6 +89,17 @@ class AgentWatcher extends Watcher {
    */
   getConfigurationSchema() {
     return this.joi.object().unknown();
+  }
+
+  override async deregisterComponent(): Promise<void> {
+    try {
+      await this.controllerWatcher?.deregister();
+    } finally {
+      this.controllerWatcher = undefined;
+      this.dockerApi = undefined;
+      await this.controllerBridge?.stop();
+      this.controllerBridge = undefined;
+    }
   }
 }
 

--- a/app/agent/controller-docker-transport.test.ts
+++ b/app/agent/controller-docker-transport.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+import { usesControllerDockerTransport } from './controller-docker-transport.js';
+
+describe('usesControllerDockerTransport', () => {
+  test('accepts only the exact Portwing controller-owned Docker marker', () => {
+    expect(
+      usesControllerDockerTransport('docker', {
+        transport: 'docker-api',
+        execution: 'controller',
+        events: 'portwing',
+      }),
+    ).toBe(true);
+  });
+
+  test.each([
+    [
+      'non-Docker type',
+      'podman',
+      { transport: 'docker-api', execution: 'controller', events: 'portwing' },
+    ],
+    ['missing configuration', 'docker', undefined],
+    ['primitive configuration', 'docker', 'docker-api'],
+    ['array configuration', 'docker', []],
+    [
+      'wrong transport',
+      'docker',
+      { transport: 'agent', execution: 'controller', events: 'portwing' },
+    ],
+    [
+      'wrong execution',
+      'docker',
+      { transport: 'docker-api', execution: 'agent', events: 'portwing' },
+    ],
+    [
+      'wrong events',
+      'docker',
+      { transport: 'docker-api', execution: 'controller', events: 'docker' },
+    ],
+  ])('rejects %s', (_label, type, configuration) => {
+    expect(usesControllerDockerTransport(type, configuration)).toBe(false);
+  });
+});

--- a/app/agent/controller-docker-transport.ts
+++ b/app/agent/controller-docker-transport.ts
@@ -1,0 +1,12 @@
+export function usesControllerDockerTransport(type: unknown, configuration: unknown): boolean {
+  if (!configuration || typeof configuration !== 'object' || Array.isArray(configuration)) {
+    return false;
+  }
+  const marker = configuration as Record<string, unknown>;
+  return (
+    type === 'docker' &&
+    marker.transport === 'docker-api' &&
+    marker.execution === 'controller' &&
+    marker.events === 'portwing'
+  );
+}

--- a/app/agent/ed25519-signer.test.ts
+++ b/app/agent/ed25519-signer.test.ts
@@ -4,7 +4,7 @@
  * Includes known-answer / cross-check tests that pin the exact wire contract
  * required by Portwing's verifier (internal/auth/verify.go):
  *  - the empty-body SHA-256 constant
- *  - the exact canonical-message byte layout (METHOD\nPATH\nhash\nts\nnonce)
+ *  - the exact canonical-message byte layout (METHOD\nREQUEST-TARGET\nhash\nts\nnonce)
  *  - a real Ed25519 sign/verify round trip over that canonical message
  */
 import {
@@ -61,7 +61,7 @@ describe('EMPTY_BODY_SHA256_HEX / bodySha256Hex', () => {
 });
 
 describe('buildCanonicalMessage', () => {
-  test('produces the exact METHOD\\nPATH\\nhash\\nts\\nnonce byte layout with no trailing newline', () => {
+  test('produces the exact METHOD\\nREQUEST-TARGET\\nhash\\nts\\nnonce byte layout with no trailing newline', () => {
     const message = buildCanonicalMessage(
       'GET',
       '/api/containers',
@@ -121,6 +121,39 @@ describe('generateNonce', () => {
 });
 
 describe('signRequest', () => {
+  test('uses the exact escaped request target including query and declares signature version 2', () => {
+    const { privateKeyPem, publicKeyObject } = generateKeypairPem();
+    const privateKey = loadEd25519PrivateKey(privateKeyPem);
+    const requestTarget =
+      '/v1.44/containers/json?all=1&filters=%7B%22label%22%3A%5B%22a%2Fb%22%5D%7D';
+
+    const headers = signRequest({
+      method: 'GET',
+      path: requestTarget,
+      keyId: 'docker-proxy-key',
+      privateKey,
+      now: () => 1_700_000_000_000,
+      nonce: 'd'.repeat(32),
+    });
+
+    expect(headers['X-Portwing-Signature-Version']).toBe('2');
+    const canonicalMessage = buildCanonicalMessage(
+      'GET',
+      requestTarget,
+      EMPTY_BODY_SHA256_HEX,
+      1_700_000_000,
+      'd'.repeat(32),
+    );
+    expect(
+      cryptoVerify(
+        null,
+        Buffer.from(canonicalMessage, 'utf8'),
+        publicKeyObject,
+        Buffer.from(headers['X-Portwing-Signature'], 'base64url'),
+      ),
+    ).toBe(true);
+  });
+
   test('cross-check: signature verifies against the corresponding public key using the same canonical bytes', () => {
     const { privateKeyPem, publicKeyObject } = generateKeypairPem();
     const privateKey = loadEd25519PrivateKey(privateKeyPem);

--- a/app/agent/ed25519-signer.ts
+++ b/app/agent/ed25519-signer.ts
@@ -1,7 +1,7 @@
 /**
  * Ed25519 standard-mode request signing client.
  *
- * Produces the four `X-Portwing-*` headers Portwing's HTTP verifier
+ * Produces the five `X-Portwing-*` headers Portwing's HTTP verifier
  * (`internal/auth/verify.go`) expects on every authenticated standard-mode
  * request, as an opt-in alternative to the legacy `X-Dd-Agent-Secret` token
  * header (see AgentClient.ts / app/agent/components/Agent.ts `authMode`).
@@ -13,13 +13,11 @@
  * edge-mode hello signer in app/api/portwing-ws.ts#verifyHelloSignature.
  *
  * Canonical message (UTF-8, no trailing newline):
- *   METHOD\nPATH\nbody-sha256-hex\nunix-timestamp\nnonce
+ *   METHOD\nREQUEST-TARGET\nbody-sha256-hex\nunix-timestamp\nnonce
  *
  * - METHOD: HTTP method, uppercase, as sent.
- * - PATH: the request URL path only (no query string) — must match what the
- *   server's URL router reconstructs as the *decoded* path (Go's r.URL.Path),
- *   so callers must pass the plain, unescaped path segments here rather than
- *   a percent-encoded one.
+ * - REQUEST-TARGET: exact origin-form target, using the escaped path and
+ *   unmodified raw query string (for example `/v1.44/info?verbose=1`).
  * - body-sha256-hex: lowercase hex SHA-256 of the raw request body bytes as
  *   they will appear on the wire. An empty/zero-length body hashes to the
  *   well-known SHA-256-of-empty-string constant (EMPTY_BODY_SHA256_HEX).
@@ -38,6 +36,7 @@ export const ED25519_AUTH_HEADER_NAMES = {
   timestamp: 'X-Portwing-Timestamp',
   nonce: 'X-Portwing-Nonce',
   signature: 'X-Portwing-Signature',
+  signatureVersion: 'X-Portwing-Signature-Version',
 } as const;
 
 /** SHA-256 hex digest of the empty string — the body hash for empty-body requests. */
@@ -49,6 +48,7 @@ export interface Ed25519SignedHeaders {
   'X-Portwing-Timestamp': string;
   'X-Portwing-Nonce': string;
   'X-Portwing-Signature': string;
+  'X-Portwing-Signature-Version': '2';
 }
 
 /**
@@ -95,7 +95,7 @@ export function buildCanonicalMessage(
 export interface SignRequestOptions {
   /** HTTP method, any case — normalized to uppercase before signing. */
   method: string;
-  /** URL path only, no query string, unescaped (see module doc). */
+  /** Exact origin-form request target: escaped path plus unmodified raw query. */
   path: string;
   /** Raw request body bytes as they will be sent on the wire. Omit/empty for no body. */
   body?: Uint8Array;
@@ -115,7 +115,7 @@ export function generateNonce(): string {
 }
 
 /**
- * Sign a standard-mode request and return the four X-Portwing-* headers to
+ * Sign a standard-mode request and return the five X-Portwing-* headers to
  * attach to it. Pure aside from the injectable clock/nonce and the
  * node:crypto calls (randomBytes/sign) — no network or AgentClient coupling.
  */
@@ -140,5 +140,6 @@ export function signRequest(options: SignRequestOptions): Ed25519SignedHeaders {
     'X-Portwing-Timestamp': String(timestampSeconds),
     'X-Portwing-Nonce': nonce,
     'X-Portwing-Signature': signature.toString('base64url'),
+    'X-Portwing-Signature-Version': '2',
   };
 }

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -1781,7 +1781,7 @@ describe('name binding registry cap (memory-exhaustion regression)', () => {
   });
 });
 
-describe('startNoncePruning — also prunes idle name bindings', () => {
+describe('startNoncePruning — preserves stable name ownership', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     clearNonceCacheForTesting();
@@ -1791,7 +1791,7 @@ describe('startNoncePruning — also prunes idle name bindings', () => {
     vi.useRealTimers();
   });
 
-  test('prunes idle, non-live name bindings after 60s but leaves live ones intact', () => {
+  test('does not release an offline name binding solely because it is old', () => {
     vi.useFakeTimers();
     createGateway();
 
@@ -1807,7 +1807,7 @@ describe('startNoncePruning — also prunes idle name bindings', () => {
 
     vi.advanceTimersByTime(61_000);
 
-    expect(nameBindingsSizeForTesting()).toBe(0);
+    expect(nameBindingsSizeForTesting()).toBe(1);
   });
 });
 
@@ -3336,7 +3336,7 @@ describe('name-bindings persistence (identity binding survives a restart)', () =
     expect(welcome.type).toBe('welcome');
   });
 
-  test('a stale persisted binding is pruned on reload (load-time pruning), same as the periodic sweep', async () => {
+  test('an old persisted binding survives restart and still rejects a different key', async () => {
     const { db, docs } = createPersistentMockDb();
     nameBindingsStore.createCollections(db);
 
@@ -3352,8 +3352,8 @@ describe('name-bindings persistence (identity binding survives a restart)', () =
     expect(docs).toHaveLength(1);
 
     // "Restart": wipe in-memory state, re-init the collection from the same
-    // db, and create a fresh gateway — rehydrateNameBindings() checks each
-    // loaded record's own staleness before adding it back to the map.
+    // db, and create a fresh gateway. Age alone must not release the name from
+    // its key; only explicit revocation or cap-pressure eviction may do that.
     clearNonceCacheForTesting();
     clearLiveSessionsForTesting();
     nameBindingsStore.createCollections(db);
@@ -3379,9 +3379,12 @@ describe('name-bindings persistence (identity binding survives a restart)', () =
     );
     await new Promise((r) => setTimeout(r, 10));
 
-    // The stale binding was pruned on load, so a brand-new key can claim the
-    // name — and the persisted store no longer carries the pruned entry.
-    const welcome = JSON.parse(ws.sentMessages[0]) as { type: string };
-    expect(welcome.type).toBe('welcome');
+    const errorFrame = JSON.parse(ws.sentMessages[0]) as {
+      type: string;
+      data: { code: string };
+    };
+    expect(errorFrame.type).toBe('error');
+    expect(errorFrame.data.code).toBe('agent-name-claimed');
+    expect(docs).toHaveLength(1);
   });
 });

--- a/app/api/portwing-ws.ts
+++ b/app/api/portwing-ws.ts
@@ -126,25 +126,25 @@ const inFlightAgents = new Set<string>();
 // key could grow this map without bound by reconnecting under a fresh
 // agentId/agentName every time (nothing but the 200/60s per-key nonce-admission
 // limit throttles that, which still permits ~288k new bindings/day/key). Bound
-// memory the same way nonceCache is bounded: a hard size cap plus periodic
+// memory the same way nonceCache is bounded: a hard size cap plus admission-time
 // pruning of bindings that are both stale (idle past NAME_BINDING_STALE_MS) and
 // not currently backing a live connection (checked via getAgent so an active
-// agent's own binding is never evicted out from under it).
+// agent's own binding is never evicted out from under it). Age alone must never
+// release stable ownership.
 const nameToKeyId = new Map<string, { keyId: string; lastSeenAt: number }>();
 // Hard cap on distinct name bindings, matching nonceCache's cap in spirit.
 const MAX_NAME_BINDINGS = 10_000;
 // A binding idle longer than this (no hello seen under its name) becomes
-// eligible for eviction once the map is at/over MAX_NAME_BINDINGS, provided the
-// name isn't currently backing a live connection.
+// eligible for eviction only when a brand-new name would exceed
+// MAX_NAME_BINDINGS, provided the name isn't currently backing a live
+// connection.
 const NAME_BINDING_STALE_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Evict name bindings that are both idle past NAME_BINDING_STALE_MS and not
  * currently backing a live agent connection. Called opportunistically when a
- * new binding would push the map over MAX_NAME_BINDINGS, and periodically
- * alongside nonce pruning so long-idle bindings don't just wait for a cap hit.
- * Every eviction here is also write-through'd to the durable store so the two
- * never drift.
+ * new binding would push the map over MAX_NAME_BINDINGS. Every eviction here is
+ * also write-through'd to the durable store so the two never drift.
  */
 function pruneStaleNameBindings(nowMs: number): void {
   for (const [name, binding] of nameToKeyId.entries()) {
@@ -160,19 +160,12 @@ function pruneStaleNameBindings(nowMs: number): void {
  * createPortwingWsGateway() so a restarted server knows which key owns which
  * name before any agent reconnects — see the nameToKeyId doc comment above.
  *
- * Only evaluates staleness against the records it just loaded (not the whole
- * map — that's pruneStaleNameBindings()'s job on its own cadence) so a
- * binding that was already past NAME_BINDING_STALE_MS before the restart
- * doesn't get a fresh 24h lease purely from being reloaded, while a genuinely
- * fresh binding is admitted as-is.
+ * Rehydration preserves every durable binding regardless of age. Stable name
+ * ownership is released only by explicit key revocation, or by cap-pressure
+ * eviction while admitting a brand-new name.
  */
 function rehydrateNameBindings(): void {
-  const nowMs = Date.now();
   for (const record of nameBindingsStore.listBindings()) {
-    if (nowMs - record.lastSeenAt > NAME_BINDING_STALE_MS && !getAgent(record.agentName)) {
-      nameBindingsStore.deleteBinding(record.agentName);
-      continue;
-    }
     nameToKeyId.set(record.agentName, { keyId: record.keyId, lastSeenAt: record.lastSeenAt });
   }
 }
@@ -190,8 +183,6 @@ function startNoncePruning(): void {
     }
     // Reset per-key admission counters each pruning cycle (every 60 s).
     noncesPerKey.clear();
-    // Bound nameToKeyId growth the same cycle — see pruneStaleNameBindings.
-    pruneStaleNameBindings(Date.now());
   }, 60_000);
   /* v8 ignore next */
   if (typeof noncePruneInterval.unref === 'function') {
@@ -241,11 +232,12 @@ export function disconnectByKeyId(keyId: string): number {
   // restart. Best-effort/not awaited: disconnectByKeyId is called
   // synchronously (and un-awaited) from the DELETE /keys/:keyId route
   // (app/api/portwing.ts) and from many synchronous test call sites, so
-  // making this async would ripple across both for no matching benefit — a
-  // missed flush here only denies a name temporarily and self-heals via
-  // pruneStaleNameBindings()/rehydrateNameBindings()'s stale-lease check,
-  // unlike the NEW-BIND flush in processHello() below, which must be a hard,
-  // awaited failure because it is the only guard against a genuine squat.
+  // making this async would ripple across both for no matching benefit. A
+  // missed flush here fails closed: after a restart the old binding may deny
+  // reclaim until an operator retries revocation or cap-pressure eviction
+  // applies, but it never lets a different key squat the name. By contrast,
+  // the NEW-BIND flush in processHello() below must be a hard, awaited failure
+  // because it is the only guard against a genuine squat.
   // Wrapped defensively: Promise.resolve(...) guards against saveStore() ever
   // not returning a genuine thenable (the real store/index.ts save() always
   // does, being declared `async function`), and the outer try/catch guards

--- a/app/registry/index.test.ts
+++ b/app/registry/index.test.ts
@@ -1492,6 +1492,32 @@ test('deregisterAgentComponents should remove agent-specific watchers and trigge
   expect(registry.getState().trigger[triggerComponent.getId()]).toBeUndefined();
 });
 
+test('late cleanup of a disconnected agent does not delete a replacement component with the same id', async () => {
+  let finishCleanup!: () => void;
+  const oldComponent = new Component();
+  await oldComponent.register('watcher', 'docker', 'docker', {});
+  oldComponent.agent = 'myagent';
+  oldComponent.deregister = vi.fn(
+    () =>
+      new Promise((resolve) => {
+        finishCleanup = () => resolve(oldComponent);
+      }),
+  );
+  registry.getState().watcher[oldComponent.getId()] = oldComponent;
+
+  const cleanup = registry.deregisterAgentComponents('myagent');
+  await Promise.resolve();
+  const replacement = new Component();
+  await replacement.register('watcher', 'docker', 'docker', {});
+  replacement.agent = 'myagent';
+  registry.getState().watcher[replacement.getId()] = replacement;
+
+  finishCleanup();
+  await cleanup;
+
+  expect(registry.getState().watcher[replacement.getId()]).toBe(replacement);
+});
+
 test('registerTriggers in agent mode should filter out unsupported trigger types', async () => {
   // Clean all existing triggers first
   const state = registry.getState();

--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -696,7 +696,7 @@ async function deregisterComponent(component: Component, kind: ComponentKind) {
     );
   } finally {
     const components = getState()[kind];
-    if (components) {
+    if (components?.[component.getId()] === component) {
       delete components[component.getId()];
     }
   }

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.0-rc.10',
+    version: '1.6.0-rc.11',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.0-rc.10 started',
+    details: 'Drydock v1.6.0-rc.11 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.10',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0-rc.11',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.0-rc.10',
+    tag: '1.6.0-rc.11',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.0-rc.10',
+  version: '1.6.0-rc.11',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.0-rc.10',
+      version: '1.6.0-rc.11',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.0-rc.10', mode: 'demo' },
+        server: { version: '1.6.0-rc.11', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.0-rc.10",
+  version: "1.6.0-rc.11",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.0-rc.10",
+    version: "v1.6.0-rc.11",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.0-rc.10",
+      "version": "1.6.0-rc.11",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.0-rc.10",
+    "version": "1.6.0-rc.11",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.0-rc.10"
+  "version":"1.6.0-rc.11"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Portwing Edge API"
-description: "Ed25519 agent-key registry and the portwing/1.0 WebSocket edge endpoint for firewall-traversing agents."
+title: "Portwing API & Transport"
+description: "Standard request signing, controller-owned Docker transport, the Ed25519 key registry, and the portwing/1.0 edge endpoint."
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
@@ -10,6 +10,41 @@ import { Callout } from 'fumadocs-ui/components/callout';
 Edge mode inverts the normal drydock connection model. In the standard setup the controller dials out to each remote agent. Edge mode is for agents that sit behind NAT or a firewall and cannot accept inbound connections: the `portwing` agent dials **out** to drydock over an encrypted WebSocket (`wss://`), and drydock registers the connection as if the agent had been reached normally. No inbound port on the agent host is needed. The chain is `sockguard → portwing (edge client) → drydock (this endpoint)`.
 
 > For agents that accept inbound connections from the controller, see the [Agent API](/docs/api/agent).
+
+---
+
+## Standard Mode Ed25519 request signing
+
+Standard Mode can authenticate each controller request with a shared
+`X-Dd-Agent-Secret` token or with Portwing's per-request Ed25519 scheme. With
+`DD_AGENT_{name}_AUTHMODE=ed25519`, Drydock sends these five headers and does not
+send the shared secret:
+
+| Header | Value |
+| --- | --- |
+| `X-Portwing-Key-ID` | Registered 16-character public-key id |
+| `X-Portwing-Timestamp` | Unix timestamp in seconds |
+| `X-Portwing-Nonce` | Fresh request nonce |
+| `X-Portwing-Signature` | Base64url Ed25519 signature |
+| `X-Portwing-Signature-Version` | `2` |
+
+Signature version 2 signs the following UTF-8 bytes with no trailing newline:
+
+```text
+METHOD
+REQUEST-TARGET
+<SHA-256 hex of the exact request body bytes>
+<unix-timestamp-seconds>
+<nonce>
+```
+
+`REQUEST-TARGET` is the exact origin-form target sent on the wire: the escaped
+path followed by `?` and the unmodified raw query when present. For example,
+`/v1.44/containers/json?all=1&filters=%7B%7D` is signed exactly as shown.
+Percent escapes, query parameter order, repeated parameters, and raw query
+bytes must not be decoded, normalized, or reordered. This differs from the
+Edge hello signature below, whose canonical WebSocket path remains fixed by
+the `portwing/1.0` protocol.
 
 ---
 
@@ -151,7 +186,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
 1. The agent opens a WebSocket upgrade to `wss://drydock/api/portwing/ws` with the `portwing/1.0` subprotocol header. The upgrade is rejected before any WebSocket frame is read if the `Origin` header doesn't match the server (`403`) or the connection is rate-limited (`429`).
 2. The agent sends a **hello frame** as the first message, within 30 seconds — otherwise the connection is closed (code `1008`, no error frame). The frame carries `pubKeyId`, `timestamp`, `nonce`, and `signature` as described under [Ed25519 authentication model](#ed25519-authentication-model) above, plus `agentId`, `protocol` (must be `portwing/1.0`), and `version`.
 3. drydock verifies the hello. On success it replies with a **welcome frame** carrying poll configuration and server version information.
-4. The connection is then live: the agent multiplexes container-sync, exec, and (for the controller-initiated log/delete actions) request-response frames over the same WebSocket. The server also sends a `ping` frame every 30 seconds; an agent that misses two consecutive pongs (60 seconds of silence) is force-disconnected (close code `1001`, reason `ping timeout`).
+4. The connection is then live: the agent multiplexes container-sync, exec, logs, deletes, and controller-owned Docker watcher/update calls over correlated request-response-stream frames on the same WebSocket. The server also sends a `ping` frame every 30 seconds; an agent that misses two consecutive pongs (60 seconds of silence) is force-disconnected (close code `1001`, reason `ping timeout`).
 
 ### Hello frame
 
@@ -162,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.0-rc.10",
+    "version": "1.6.0-rc.11",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -173,7 +208,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
 
 `agentId` must match `^[a-zA-Z0-9_-]+$` (max 64 chars). `agentName`, if present, must be a string no longer than 256 raw characters — a non-string or oversized value is rejected with `invalid-agent-name` (close code `1008`) before it is ever sanitized or logged. A valid `agentName` is then sanitized to a safe slug (lowercase, `a-z0-9-`, max 63 chars) and used as the agent's display/registry name; an empty, missing, or all-invalid-chars name falls back to `portwing-edge-<agentId>`.
 
-**Identity binding (anti-squat/anti-theft).** A sanitized or fallback name has no cryptographic meaning of its own, so drydock binds each name to the `pubKeyId` that first authenticates a hello under it. A later hello that reuses the same name is admitted only if it authenticates under that *same* key; a hello for a name already bound to a *different* key is rejected with `agent-name-claimed`. The binding is not released on a plain disconnect — it persists so a reconnecting agent keeps its name — but it *is* released the moment the owning key is [revoked](#revoke-a-key), freeing the name for a legitimately re-provisioned agent to reclaim. The binding registry is capped at 10,000 distinct names; once full, drydock first tries evicting bindings that are both idle 24+ hours and not backing a live connection, and only rejects the hello with `registry-full` if that doesn't free up room.
+**Identity binding (anti-squat/anti-theft).** A sanitized or fallback name has no cryptographic meaning of its own, so drydock binds each name to the `pubKeyId` that first authenticates a hello under it. A later hello that reuses the same name is admitted only if it authenticates under that *same* key; a hello for a name already bound to a *different* key is rejected with `agent-name-claimed`. The binding is not released on a plain disconnect or by age alone — it persists across restarts so a reconnecting agent keeps its name — but it *is* released the moment the owning key is [revoked](#revoke-a-key), freeing the name for a legitimately re-provisioned agent to reclaim. The binding registry is capped at 10,000 distinct names; only when admitting a brand-new name at that cap does drydock try evicting bindings that are both idle 24+ hours and not backing a live connection. It rejects the hello with `registry-full` if that doesn't free up room.
 
 A name collision with an already-connected agent under the same key (or the in-flight reservation for a hello still being processed) is rejected with `agent-already-connected`. The frame also carries `dockerVersion`, `hostname`, and `capabilities` host-descriptor fields (and optionally `drydockCompat`, `watcherTypes`, `triggerTypes`) that aren't yet consumed on this path.
 
@@ -185,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.0-rc.10",
+      "drydockVersion": "1.6.0-rc.11",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }
@@ -194,6 +229,46 @@ A name collision with an already-connected agent under the same key (or the in-f
 ```
 
 `serverCompatLevel` is `1.4.0` — the compatibility level actually implemented by this server, not a target for a future release. If the hello's `drydockCompat` field has a different major version, the connection is still accepted; drydock only logs a warning so operators can check the compat matrix.
+
+### Controller-owned Docker watcher, updates, and lifecycle actions
+
+Drydock 1.6.0-rc.11+ activates this path only for Portwing 0.9.0+ watcher
+descriptors whose type is `docker` and whose configuration contains all three
+exact marker values:
+
+```json
+{
+  "transport": "docker-api",
+  "execution": "controller",
+  "events": "portwing"
+}
+```
+
+Drydock then runs its native Docker watcher, registry checks, and native Docker
+action controller-side. This capability surface includes single/batch updates,
+container start/stop/restart, update preview, and backup rollback. Dockerode
+connects to a loopback-only bridge on an ephemeral port using a random bearer
+credential. The bridge strips
+hop-by-hop and caller-supplied authorization headers before forwarding each
+Docker Engine request through the already-authenticated Portwing connection:
+
+- **Standard Mode:** HTTP requests use the configured agent token or the
+  [five-header Ed25519 signature-version-2 scheme](#standard-mode-ed25519-request-signing).
+- **Edge Mode:** non-streaming calls use correlated `request`/`response`
+  messages; Docker streaming targets use the correlated `stream` path.
+
+Both Docker updates and lifecycle actions use this controller-owned path over
+Standard or Edge mode. It does not advertise or invoke a Portwing remote
+trigger, and Portwing's legacy watcher/trigger POST endpoints may continue to
+return 501. Docker Compose actions are not part of this marker contract.
+
+`events: "portwing"` keeps Portwing authoritative for Docker lifecycle events.
+The delegated native watcher disables its own event subscription, preventing a
+duplicate Docker event stream through the bridge. Portwing inventory remains
+the raw runtime view, so its `updateAvailable=false` and `updateKind=unknown`
+defaults must not erase controller-owned enrichment. Drydock preserves its
+stored registry result, update state, policy, security, rollback, and operation
+fields when later inventory and lifecycle reports arrive.
 
 ### Continuous container-log streaming
 

--- a/content/docs/current/configuration/agents/index.mdx
+++ b/content/docs/current/configuration/agents/index.mdx
@@ -74,7 +74,7 @@ Generate the agent's keypair with `portwing keygen -comment "edge-host-01"`, the
 
 <Callout type="info">**Container logs work continuously over the authenticated edge tunnel.** Live viewers receive separate stdout/stderr chunks, may request timestamps, and cancel the upstream Docker stream when the viewer closes. Both ends enforce bounded queues so a stalled viewer or controller is disconnected instead of growing memory without limit. Older Portwing agents fall back to the bounded one-shot log response, so mixed-version fleets degrade gracefully.</Callout>
 
-<Callout type="warn">**Update triggers are not yet proxied over Edge Mode.** `docker` and `dockercompose` action triggers only run on a standard (inbound HTTP) agent today — Edge Mode currently proxies discovery/watch state, continuous container logs, and container delete, but not update triggers. If you need to update containers on a NAT'd/firewalled host, configure it as a standard agent instead.</Callout>
+<Callout type="info">**Portwing Docker updates and lifecycle actions work in both connection modes with Drydock 1.6.0-rc.11+ and Portwing 0.9.0+.** When Portwing advertises a `docker` watcher whose configuration is exactly `transport=docker-api`, `execution=controller`, and `events=portwing`, Drydock runs its native registry checks, single/batch Docker updates, container start/stop/restart, update preview, and backup rollback controller-side. Docker API calls traverse Portwing over authenticated Standard HTTP or correlated Edge `request`/`response`/`stream` messages. Portwing remains the lifecycle-event source, so the controller does not open a duplicate Docker event stream. This transport registers the native `docker` action; it does not add a controller-side Docker Compose action.</Callout>
 
 ## Quickstart
 
@@ -239,7 +239,15 @@ services:
 
 ### Ed25519 request signing (standard-mode)
 
-By default the controller authenticates to each agent with a shared secret token (the `X-Dd-Agent-Secret` header). Setting `DD_AGENT_{name}_AUTHMODE=ed25519` switches that agent to **per-request Ed25519 signing** instead: every request the controller sends carries four `X-Portwing-*` headers — `X-Portwing-Key-ID`, `X-Portwing-Timestamp` (unix seconds), `X-Portwing-Nonce`, and a base64url `X-Portwing-Signature` over the canonical `METHOD\nPATH\nSHA-256-hex(body)\ntimestamp\nnonce` message — matching [Portwing's verifier](/docs/api/portwing). No `X-Dd-Agent-Secret` is sent.
+By default the controller authenticates to each agent with a shared secret token (the `X-Dd-Agent-Secret` header). Setting `DD_AGENT_{name}_AUTHMODE=ed25519` switches that agent to **per-request Ed25519 signing** instead. Every request carries five headers:
+
+- `X-Portwing-Key-ID`
+- `X-Portwing-Timestamp` (Unix seconds)
+- `X-Portwing-Nonce`
+- `X-Portwing-Signature` (base64url Ed25519 signature)
+- `X-Portwing-Signature-Version: 2`
+
+Signature version 2 signs `METHOD\nREQUEST-TARGET\nSHA-256-hex(body)\ntimestamp\nnonce`, where `REQUEST-TARGET` is the exact origin-form target placed on the wire: the escaped path plus `?` and the unmodified raw query when present. Percent escaping, query ordering, repeated parameters, and the raw body bytes are signature inputs and must not be decoded, normalized, or reordered. This matches [Portwing's verifier](/docs/api/portwing#standard-mode-ed25519-request-signing). No `X-Dd-Agent-Secret` is sent.
 
 Use it when the remote agent verifies requests with a registered Ed25519 public key (Portwing's scheme) rather than a shared secret. Unlike a static token, a captured signature can't be replayed and there's no long-lived shared secret on the wire.
 
@@ -381,12 +389,17 @@ When the Docker watcher on an agent fails to enumerate containers (e.g. a brief 
 
 When the controller proxies an update to an agent, it posts to the agent-local `POST /api/triggers/{type}/{name}` route (or `…/batch` for batch updates). Agent-local routes are intentionally unversioned and authenticated with `X-Dd-Agent-Secret`; controller API clients should continue to use the canonical `/api/v1/*` routes. For single-update calls on `docker` and `dockercompose` triggers the controller sends only `{ id, name }` (plus an `operationId` when one is in flight) rather than the full container object, which prevents HTTP 413 errors where full payloads exceeded the agent's 256 KB body cap. Batch update calls (`…/batch`) still send the full container per item, so a very large fleet updated in one batch can still approach that cap.
 
+Portwing 0.9.0's controller-owned Docker transport does not use those legacy watcher/trigger POST routes. The exact `transport=docker-api`, `execution=controller`, `events=portwing` marker causes Drydock to start its native Docker watcher and update action against a loopback-only, random bearer-authenticated bridge. That bridge forwards Docker API calls through the agent client's existing authentication: Standard HTTP (token or Ed25519 signature version 2) or Edge correlated `request`/`response`/`stream` transport.
+
+Because registry enrichment is controller-owned on this path, later Portwing inventory commonly carries the raw defaults `updateAvailable=false` and `updateKind=unknown`. Drydock preserves its stored `result`, update status, policy, security, rollback, and operation fields instead of allowing those raw defaults to erase a controller-enriched result. Portwing's lifecycle events remain authoritative; the delegated native watcher runs with its own Docker event subscription disabled to avoid duplicate streams.
+
 ## Features in Agent Mode
 
-- **Watchers**: Run on the Agent to discover containers.
-- **Registries**: Configured on the Agent to check for updates.
+- **Watchers**: Traditional agents run watchers locally. A Portwing 0.9.0 watcher with the exact controller-transport marker runs Drydock's native Docker watcher on the Controller through Portwing.
+- **Registries**: Traditional agents perform their configured checks locally; marked Portwing watchers use the Controller's native registry configuration and enrichment.
 - **Triggers**:
-  - `docker` and `dockercompose` triggers are configured and executed **on the Agent** (allowing update of remote containers). The controller automatically proxies update requests to the correct agent. **Exception:** this proxying only works for standard (inbound HTTP) agents — [Edge (Portwing) agents](#edge-agent-dial-out-portwing) don't yet support update triggers.
+  - Traditional-agent `docker` and `dockercompose` triggers are configured and executed **on the Agent**, with the controller proxying update requests to it.
+  - A marked Portwing watcher automatically receives a controller-owned native `docker` action. Single/batch updates, start/stop/restart, update preview, and backup rollback work over Standard or Edge transport; Docker Compose is not part of this marker contract.
   - Notification triggers (e.g. `smtp`, `discord`) are configured and executed **on the Controller**. Notifications automatically include a `[server-name]` prefix identifying which server each update comes from. The controller name defaults to the detected Docker or Podman daemon host name when available, then the process hostname, and can be overridden with `DD_SERVER_NAME`.
 
 ## Troubleshooting

--- a/content/docs/current/faq/index.mdx
+++ b/content/docs/current/faq/index.mdx
@@ -481,9 +481,9 @@ The Home Assistant [wud-card](https://github.com/angryvoegi/wud-card) and Homepa
 
 ## Why doesn't my edge agent apply updates?
 
-An Edge (Portwing) agent only proxies discovery/watch state, continuous container logs, and container delete over its WebSocket tunnel — `docker` and `dockercompose` action triggers are not yet proxied over Edge Mode. If update actions on an edge-connected host silently do nothing, or never show up as available in the UI, that's expected behavior in v1.6, not a misconfiguration.
+A compatible Portwing agent can apply Docker updates over Edge Mode. Drydock 1.6.0-rc.11+ recognizes Portwing 0.9.0's exact `docker` watcher configuration — `transport=docker-api`, `execution=controller`, and `events=portwing` — then runs native registry checks and single/batch Docker updates controller-side. Calls cross the authenticated Edge tunnel as correlated `request`/`response`/`stream` messages; Standard Mode uses the same controller path over HTTP. Portwing remains the lifecycle-event source, avoiding a second Docker event stream, and its later raw `updateAvailable=false` / `updateKind=unknown` inventory does not erase Drydock's enriched result.
 
-**Fix:** Configure update triggers on a standard (inbound HTTP) agent instead. See [Edge-agent dial-out (Portwing)](/docs/configuration/agents#edge-agent-dial-out-portwing) for exactly what Edge Mode does and doesn't proxy today.
+If updates still do not appear, verify both minimum versions and inspect the watcher descriptor for all three exact marker values. Only traditional agents that advertise remote triggers can use the legacy path. Portwing advertises none, so older or partial Portwing markers and Docker Compose actions have no working Portwing fallback; its legacy watcher/trigger POST endpoints return 501. See [Edge-agent dial-out (Portwing)](/docs/configuration/agents#edge-agent-dial-out-portwing) and the [Portwing transport reference](/docs/api/portwing#controller-owned-docker-watcher-updates-and-lifecycle-actions).
 
 ## How do I rotate or revoke an edge-agent key?
 

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.0-rc.10` | Immutable release candidate; best for reproducible testing |
+| `1.6.0-rc.11` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.0-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -3,6 +3,13 @@ title: "Updates"
 description: "Release update notes and feature highlights, with direct links to current configuration and API docs."
 ---
 
+## Unreleased
+
+## v1.6.0-rc.11 Highlights — August 1, 2026
+
+- **Portwing 0.9 Docker watcher, updates, and lifecycle actions now run controller-side** — Drydock 1.6.0-rc.11+ recognizes the exact `transport=docker-api`, `execution=controller`, `events=portwing` watcher marker, starts its native registry checks and Docker action against a loopback-only authenticated bridge, and carries Docker calls over Standard HTTP or Edge correlated request/response/stream transport. Single/batch updates, start/stop/restart, update preview, and backup rollback use this path even though Portwing advertises no remote trigger. Portwing stays authoritative for lifecycle events, and raw false/unknown inventory no longer erases controller enrichment ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637), [Portwing #76](https://github.com/CodesWhat/portwing/issues/76)).
+- **Standard Portwing request signing matches signature version 2** — Ed25519 agents now receive five headers including `X-Portwing-Signature-Version: 2`; the signature covers the exact escaped request path plus its unmodified raw query instead of a decoded path with the query omitted.
+
 ## v1.6.0-rc.10 Highlights — July 31, 2026
 
 - **Infrastructure-mode self-updates no longer fail to spawn the helper container on Docker Hub installs** — for containers labeled `dd.update.mode=infrastructure`, the helper image reference is now resolved through the registry provider's `getImageFullName` normalization instead of a raw Hub URL, so it matches the daemon-local image name and the helper actually pulls ([#645](https://github.com/CodesWhat/drydock/pull/645), fixes [#644](https://github.com/CodesWhat/drydock/issues/644)).

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6 RC and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.10...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.0-rc.11...HEAD`],
+    ['1.6.0-rc.11', `${repositoryUrl}/compare/v1.6.0-rc.10...v1.6.0-rc.11`],
     ['1.6.0-rc.10', `${repositoryUrl}/compare/v1.6.0-rc.9...v1.6.0-rc.10`],
     ['1.6.0-rc.9', `${repositoryUrl}/compare/v1.6.0-rc.8...v1.6.0-rc.9`],
     ['1.6.0-rc.8', `${repositoryUrl}/compare/v1.6.0-rc.7...v1.6.0-rc.8`],

--- a/scripts/lib/cleanup-fleet-agents.mjs
+++ b/scripts/lib/cleanup-fleet-agents.mjs
@@ -1,0 +1,29 @@
+/**
+ * Tear down controller-side components before removing agents from the manager.
+ *
+ * Edge disconnect cleanup is identity guarded so a late close from an old socket
+ * cannot delete a reconnect replacement. Fleet cleanup removes that identity
+ * immediately, so it must explicitly stop component-owned timers and servers
+ * first.
+ */
+export async function cleanupFleetAgents({
+  agents,
+  deregisterAgentComponents,
+  removeAgent,
+  onError = () => {},
+}) {
+  for (const agent of agents) {
+    try {
+      await deregisterAgentComponents(agent.name);
+    } catch (error) {
+      onError(agent.name, error);
+    }
+
+    try {
+      agent.edgeAdapter?.ws?.close(1001, 'fleet soak complete');
+    } catch {
+      // best effort
+    }
+    removeAgent(agent.name);
+  }
+}

--- a/scripts/portwing-fleet-soak.mjs
+++ b/scripts/portwing-fleet-soak.mjs
@@ -16,6 +16,7 @@ import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { cleanupFleetAgents } from './lib/cleanup-fleet-agents.mjs';
 
 const DEFAULTS = {
   agents: 8,
@@ -234,6 +235,7 @@ let sampler;
 let controllerAddress;
 let getAgents;
 let removeAgent;
+let deregisterAgentComponents;
 let clearNonceCacheForTesting;
 let assertionFailure;
 const evidence = {
@@ -329,9 +331,11 @@ function spawnAgent(index) {
 async function run() {
   const gatewayModule = await import(pathToFileURL(join(appRoot, 'dist/api/portwing-ws.js')).href);
   const managerModule = await import(pathToFileURL(join(appRoot, 'dist/agent/manager.js')).href);
+  const registryModule = await import(pathToFileURL(join(appRoot, 'dist/registry/index.js')).href);
   const storeModule = await import(pathToFileURL(join(appRoot, 'dist/store/index.js')).href);
   const { createPortwingWsGateway, clearNonceCacheForTesting: clearNonceCache } = gatewayModule;
   ({ getAgents, removeAgent } = managerModule);
+  ({ deregisterAgentComponents } = registryModule);
   clearNonceCacheForTesting = clearNonceCache;
   await storeModule.init({ memory: true });
 
@@ -557,14 +561,15 @@ async function cleanup() {
     clearInterval(sampler);
   }
   try {
-    for (const agent of getAgents?.() ?? []) {
-      try {
-        agent.edgeAdapter?.ws?.close(1001, 'fleet soak complete');
-      } catch {
-        // best effort
-      }
-      removeAgent?.(agent.name);
-    }
+    await cleanupFleetAgents({
+      agents: [...(getAgents?.() ?? [])],
+      deregisterAgentComponents,
+      removeAgent,
+      onError: (name, error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        process.stderr.write(`fleet-soak: component cleanup failed for ${name}: ${message}\n`);
+      },
+    });
   } catch {
     // best effort
   }

--- a/scripts/portwing-fleet-soak.test.mjs
+++ b/scripts/portwing-fleet-soak.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { cleanupFleetAgents } from './lib/cleanup-fleet-agents.mjs';
+
+test('deregisters agent components before closing and removing fleet agents', async () => {
+  const calls = [];
+  const agents = [
+    {
+      name: 'fleet-agent-0',
+      edgeAdapter: {
+        ws: {
+          close: () => calls.push('close:fleet-agent-0'),
+        },
+      },
+    },
+  ];
+
+  await cleanupFleetAgents({
+    agents,
+    deregisterAgentComponents: async (name) => {
+      calls.push(`deregister:start:${name}`);
+      await Promise.resolve();
+      calls.push(`deregister:end:${name}`);
+    },
+    removeAgent: (name) => calls.push(`remove:${name}`),
+  });
+
+  assert.deepEqual(calls, [
+    'deregister:start:fleet-agent-0',
+    'deregister:end:fleet-agent-0',
+    'close:fleet-agent-0',
+    'remove:fleet-agent-0',
+  ]);
+});
+
+test('continues closing agents after one component cleanup fails', async () => {
+  const removed = [];
+  const errors = [];
+  const agents = [{ name: 'fleet-agent-0' }, { name: 'fleet-agent-1' }];
+
+  await cleanupFleetAgents({
+    agents,
+    deregisterAgentComponents: async (name) => {
+      if (name === 'fleet-agent-0') {
+        throw new Error('cleanup failed');
+      }
+    },
+    removeAgent: (name) => removed.push(name),
+    onError: (name, error) => errors.push(`${name}:${error.message}`),
+  });
+
+  assert.deepEqual(removed, ['fleet-agent-0', 'fleet-agent-1']);
+  assert.deepEqual(errors, ['fleet-agent-0:cleanup failed']);
+});

--- a/scripts/portwing-transport-docs.test.mjs
+++ b/scripts/portwing-transport-docs.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const faq = readFileSync(new URL('../content/docs/current/faq/index.mdx', import.meta.url), 'utf8');
+const portwingApi = readFileSync(
+  new URL('../content/docs/current/api/portwing.mdx', import.meta.url),
+  'utf8',
+);
+
+test('Portwing FAQ links to the current controller-owned transport heading', () => {
+  assert.match(
+    faq,
+    /\/docs\/api\/portwing#controller-owned-docker-watcher-updates-and-lifecycle-actions/u,
+  );
+  assert.doesNotMatch(faq, /#controller-owned-docker-watcher-and-updates/u);
+  assert.match(
+    portwingApi,
+    /^### Controller-owned Docker watcher, updates, and lifecycle actions$/mu,
+  );
+});
+
+test('Portwing FAQ does not claim partial markers or Compose have a working fallback', () => {
+  assert.match(
+    faq,
+    /Only traditional agents that advertise remote triggers can use the legacy path/u,
+  );
+  assert.match(
+    faq,
+    /older or partial Portwing markers and Docker Compose actions have no working Portwing fallback/u,
+  );
+});

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.0-rc.10';
-const PREV_RC_VERSION = '1.6.0-rc.9';
-const RC_DATE = '2026-07-31';
-const RC_DISPLAY_DATE = 'July 31, 2026';
+const RC_VERSION = '1.6.0-rc.11';
+const PREV_RC_VERSION = '1.6.0-rc.10';
+const RC_DATE = '2026-08-01';
+const RC_DISPLAY_DATE = 'August 1, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.0';
-const RC_VERSION = '1.6.0-rc.10';
+const RC_VERSION = '1.6.0-rc.11';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Promotes the reviewed Portwing controller-owned Docker transport from dev/v1.6 to main for v1.6.0-rc.11. The promotion commit tree is byte-identical to the current dev/v1.6 tree: 567e23a05b4d2d6545cb721da80e7db75f131518. Companion Portwing change: https://github.com/CodesWhat/portwing/pull/81

Closes #632
Closes #637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

✨ Added
- Added controller-owned Docker transport for Portwing watcher, container, update, preview, and rollback operations.
- Added `AgentClient.requestDockerApi()` and `DockerApiProxyResponse`.
- Added `PortwingDockerBridge` with authentication, request limits, header filtering, error mapping, and shutdown cleanup.
- Added controller transport marker validation.
- Added correlated Edge request handling for responses, disconnects, timeouts, authorization failures, and agent errors.
- Added ordered Edge state-frame processing and bounded streamed-response handling.
- Added Ed25519 signature version 2 with exact path and query-string canonicalization.
- Added centralized fleet-agent component cleanup.
- Added regression coverage for transport, lifecycle, signing, cleanup, ordering, and registry behavior.

🔧 Changed
- Preserve Standard HTTP behavior when controller Docker transport is unavailable.
- Preserve controller-owned container enrichment across watcher and update events.
- Preserve durable Portwing name bindings across restarts.
- Update release metadata and documentation to `1.6.0-rc.11`.

🐛 Fixed
- Prevent stale component cleanup from removing replacement registry entries.
- Prevent watcher and trigger responses from being silently discarded.
- Prevent oversized streamed responses and Docker bridge requests.
- Prevent cleanup failures from blocking remaining agent cleanup.
- Prevent signing mismatches for escaped targets, query strings, and request bodies.
- Handle aborted Portwing bridge requests.

## Concerns

- Verify unsupported controller lifecycle actions return explicit errors instead of 404 responses.
- Verify legacy and Docker Compose Portwing paths return the documented `501` response.
- Verify signature version 2 remains compatible with all Standard Mode clients.
- Verify every controller watcher and trigger registration has rollback and deregistration coverage.
- Verify response-size and request-body limits match deployment requirements.
- Verify release-version updates remain consistent across runtime data, mocks, documentation, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->