### PR TITLE
🐛 fix(portwing): contain aborted bridge requests

### DIFF
--- a/app/agent/PortwingDockerBridge.test.ts
+++ b/app/agent/PortwingDockerBridge.test.ts
@@ -234,6 +234,7 @@ describe('PortwingDockerBridge', () => {
     const bridge = new PortwingDockerBridge({ requestDockerApi });
     const endpoint = await bridge.start();
     const bodyReadStarted = deferred<void>();
+    const bodyReadSettled = deferred<void>();
     const internal = bridge as unknown as {
       readBody: (request: IncomingMessage) => Promise<Buffer | undefined>;
     };
@@ -242,7 +243,9 @@ describe('PortwingDockerBridge', () => {
       .spyOn(internal, 'readBody')
       .mockImplementation(async (request: IncomingMessage) => {
         bodyReadStarted.resolve(undefined);
-        return originalReadBody(request);
+        return originalReadBody(request).finally(() => {
+          bodyReadSettled.resolve(undefined);
+        });
       });
 
     try {
@@ -263,6 +266,7 @@ describe('PortwingDockerBridge', () => {
       });
 
       await clientClosed;
+      await bodyReadSettled.promise;
       await new Promise<void>((resolve) => setImmediate(resolve));
       expect(readBody).toHaveBeenCalledOnce();
       expect(requestDockerApi).not.toHaveBeenCalled();

--- a/app/agent/PortwingDockerBridge.test.ts
+++ b/app/agent/PortwingDockerBridge.test.ts
@@ -229,6 +229,49 @@ describe('PortwingDockerBridge', () => {
     }
   });
 
+  test('contains an aborted request body without an unhandled rejection', async () => {
+    const requestDockerApi = vi.fn();
+    const bridge = new PortwingDockerBridge({ requestDockerApi });
+    const endpoint = await bridge.start();
+    const bodyReadStarted = deferred<void>();
+    const internal = bridge as unknown as {
+      readBody: (request: IncomingMessage) => Promise<Buffer | undefined>;
+    };
+    const originalReadBody = internal.readBody.bind(bridge);
+    const readBody = vi
+      .spyOn(internal, 'readBody')
+      .mockImplementation(async (request: IncomingMessage) => {
+        bodyReadStarted.resolve(undefined);
+        return originalReadBody(request);
+      });
+
+    try {
+      const clientClosed = new Promise<void>((resolve) => {
+        const request = http.request(`${endpoint.baseUrl}/v1.44/containers/create`, {
+          method: 'POST',
+          headers: {
+            authorization: endpoint.authorization,
+            'content-length': '10',
+          },
+        });
+        request.once('error', () => resolve());
+        request.flushHeaders();
+        void bodyReadStarted.promise.then(() => {
+          request.write('part');
+          request.destroy(new Error('intentional client abort'));
+        });
+      });
+
+      await clientClosed;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(readBody).toHaveBeenCalledOnce();
+      expect(requestDockerApi).not.toHaveBeenCalled();
+    } finally {
+      readBody.mockRestore();
+      await bridge.stop();
+    }
+  });
+
   test('keeps concurrent responses correlated when the remote requests complete out of order', async () => {
     const first = deferred<{
       statusCode: number;

--- a/app/agent/PortwingDockerBridge.ts
+++ b/app/agent/PortwingDockerBridge.ts
@@ -84,7 +84,9 @@ export class PortwingDockerBridge {
       return this.endpoint;
     }
     const server = http.createServer((req, res) => {
-      void this.handle(req, res);
+      void this.handle(req, res).catch(() => {
+        res.destroy();
+      });
     });
     server.on('connection', (socket) => {
       this.sockets.add(socket);


### PR DESCRIPTION
## Summary

- contain rejected bridge handlers at the HTTP server boundary
- destroy only the affected response when a local request body aborts
- add a real partial-body abort regression test that reproduces ECONNRESET without forwarding upstream

## Review context

Addresses the valid CodeRabbit finding from release-sync PR #651. The separate component-cleanup finding was verified as already protected by synchronous snapshot ordering and identity-guarded registry deletion.

## Validation

- regression failed on the old code with an unhandled ECONNRESET rejection
- focused PortwingDockerBridge suite: 16/16
- Biome clean
- scripts: 138/138
- workflow tests: 71/71
- app and UI exact coverage: 100%
- app and UI builds pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed rejected Portwing bridge handlers at the HTTP server boundary.
- 🐛 Fixed local request-body aborts to destroy only the affected response.
- ✨ Added regression coverage for partial-body aborts and prevented Docker forwarding.
- ✅ Validated focused tests, Biome, workflow tests, coverage, and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->