### PR TITLE
🔒 security(deps): pin brace-expansion 5.0.9 + ip-address 10.3.1, advance fast-uri to 4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`brace-expansion`, `ip-address`, and `fast-uri` overrides advanced to patched releases.** `brace-expansion` moved to 5.0.9 in `app/`, `ui/`, and `e2e/` (CVE-2026-69152, [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)); `ip-address` moved to 10.3.1 in `app/` (CVE-2026-54272, CVE-2026-69192, CVE-2026-69198), pulled in transitively via `express-rate-limit` and `mqtt` → `socks`; `fast-uri` advanced from 4.1.1 to 4.1.2 in `app/` and `ui/` (host confusion via backslash authority introducer, CVE-2026-18446, [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7), superseding [#658](https://github.com/CodesWhat/drydock/pull/658)).
+
 ## [1.6.0-rc.11] — 2026-08-01
 
 ### Added

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3737,9 +3737,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4798,9 +4798,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
-      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",
@@ -5396,9 +5396,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/app/package.json
+++ b/app/package.json
@@ -74,8 +74,10 @@
   "overrides": {
     "axios": "1.18.1",
     "body-parser": "2.3.0",
-    "fast-uri": "4.1.1",
+    "brace-expansion": "5.0.9",
+    "fast-uri": "4.1.2",
     "fast-xml-parser": "5.10.1",
+    "ip-address": "10.3.1",
     "picomatch": "4.0.5",
     "postcss": "8.5.24",
     "qs": "6.15.3",

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -3658,9 +3658,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -37,7 +37,7 @@
     "lodash": "4.18.1"
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "fast-xml-parser": "5.10.1",
     "joi": "18.2.3",
     "minimatch": "10.2.5",

--- a/e2e/tests/security/brace-expansion-lockfile.test.js
+++ b/e2e/tests/security/brace-expansion-lockfile.test.js
@@ -3,7 +3,7 @@ const { readFileSync } = require('node:fs');
 const { join } = require('node:path');
 const test = require('node:test');
 
-const MINIMUM_SAFE_BRACE_EXPANSION_VERSION = '5.0.7';
+const MINIMUM_SAFE_BRACE_EXPANSION_VERSION = '5.0.9';
 
 function compareSemver(a, b) {
   const aParts = a.split('.').map(Number);

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -39,20 +39,44 @@ test('isFastUriPatched rejects unpatched 4.x releases newer than 3.1.4', () => {
 });
 
 // fast-uri was pinned to 3.1.4 in app/ and ui/ for CVE-2026-16221
-// (GHSA-v2hh-gcrm-f6hx). 4.1.1 retains the fix, and Renovate's override
-// bump to 4.1.1 (#617) is accepted alongside the original pin below.
-// Transitional: drop the 3.1.4 branch once #617 lands.
+// (GHSA-v2hh-gcrm-f6hx). The 4.x line retains the fix from 4.1.1 onward.
 test('fast-uri is pinned to a patched release in app and ui', () => {
   for (const workspace of ['app', 'ui']) {
     const manifest = readJson(`${workspace}/package.json`);
     const lockfile = readJson(`${workspace}/package-lock.json`);
 
-    assert.ok(
-      ['3.1.4', '4.1.1'].includes(manifest.overrides?.['fast-uri']),
-      `${workspace} override`,
-    );
+    assert.ok(isFastUriPatched(manifest.overrides?.['fast-uri']), `${workspace} override`);
     assert.ok(isFastUriPatched(resolvedVersion(lockfile, 'fast-uri')), `${workspace} lockfile`);
   }
+});
+
+// brace-expansion 5.0.8 was vulnerable to CVE-2026-69152 (GHSA-rgw5-rvv9-x895),
+// patched in 5.0.9.
+test('brace-expansion is pinned to a patched release in app, ui, and e2e', () => {
+  for (const workspace of ['app', 'ui', 'e2e']) {
+    const manifest = readJson(`${workspace}/package.json`);
+    const lockfile = readJson(`${workspace}/package-lock.json`);
+
+    assert.ok(
+      compareSemver(manifest.overrides?.['brace-expansion'], '5.0.9') >= 0,
+      `${workspace} override`,
+    );
+    assert.ok(
+      compareSemver(resolvedVersion(lockfile, 'brace-expansion'), '5.0.9') >= 0,
+      `${workspace} lockfile`,
+    );
+  }
+});
+
+// ip-address 10.2.0 was vulnerable to CVE-2026-54272, CVE-2026-69192, and
+// CVE-2026-69198 (pulled in via express-rate-limit and mqtt -> socks in
+// app), patched in 10.3.1.
+test('ip-address is pinned to a patched release in app', () => {
+  const manifest = readJson('app/package.json');
+  const lockfile = readJson('app/package-lock.json');
+
+  assert.ok(compareSemver(manifest.overrides?.['ip-address'], '10.3.1') >= 0, 'app override');
+  assert.ok(compareSemver(resolvedVersion(lockfile, 'ip-address'), '10.3.1') >= 0, 'app lockfile');
 });
 
 test('fast-xml-parser is pinned to the patched release in app', () => {

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -22,24 +22,27 @@ function resolvedVersion(lockfile, packageName) {
   return lockfile.packages?.[`node_modules/${packageName}`]?.version;
 }
 
-// The CVE-2026-16221 fix was backported per-line: 3.1.4 on the 3.x line,
-// 4.1.1 on the 4.x line. A plain ">= 3.1.4" semver floor would wrongly pass
-// 4.0.0 and 4.1.0, which are newer than 3.1.4 but predate the 4.x backport
-// and are still vulnerable. Require the patched floor for whichever major
-// line the resolved version is on.
+// Only the 4.x line is vetted now: 4.1.2 carries both the CVE-2026-16221 fix
+// and the backslash-authority host-confusion fix (GHSA-7p8r-x3mc-p8w7).
+// The transitional 3.1.4 branch was dropped once the override moved to 4.x,
+// and any other major (including a future 5.x) fails until explicitly vetted.
 function isFastUriPatched(version) {
   const major = Number(version.split('.')[0]);
-  return major === 3 ? compareSemver(version, '3.1.4') >= 0 : compareSemver(version, '4.1.1') >= 0;
+  return major === 4 && compareSemver(version, '4.1.2') >= 0;
 }
 
-test('isFastUriPatched rejects unpatched 4.x releases newer than 3.1.4', () => {
-  assert.ok(isFastUriPatched('3.1.4'), '3.1.4 (3.x floor) should pass');
-  assert.ok(!isFastUriPatched('4.1.0'), '4.1.0 predates the 4.x backport and should fail');
-  assert.ok(isFastUriPatched('4.1.1'), '4.1.1 (4.x floor) should pass');
+test('isFastUriPatched only accepts vetted 4.x releases at or above 4.1.2', () => {
+  assert.ok(!isFastUriPatched('3.1.4'), '3.x is no longer a supported line and should fail');
+  assert.ok(
+    !isFastUriPatched('4.1.1'),
+    '4.1.1 predates the backslash-authority fix and should fail',
+  );
+  assert.ok(isFastUriPatched('4.1.2'), '4.1.2 (current floor) should pass');
+  assert.ok(!isFastUriPatched('5.0.0'), 'an unvetted future major should fail');
 });
 
-// fast-uri was pinned to 3.1.4 in app/ and ui/ for CVE-2026-16221
-// (GHSA-v2hh-gcrm-f6hx). The 4.x line retains the fix from 4.1.1 onward.
+// fast-uri is pinned to 4.1.2 in app/ and ui/: it carries the CVE-2026-16221
+// fix (GHSA-v2hh-gcrm-f6hx) plus the backslash-authority host-confusion fix.
 test('fast-uri is pinned to a patched release in app and ui', () => {
   for (const workspace of ['app', 'ui']) {
     const manifest = readJson(`${workspace}/package.json`);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3534,9 +3534,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4078,9 +4078,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
-      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "dev": true,
       "funding": [
         {

--- a/ui/package.json
+++ b/ui/package.json
@@ -63,7 +63,8 @@
     "vitest": "4.1.10"
   },
   "overrides": {
-    "fast-uri": "4.1.1",
+    "brace-expansion": "5.0.9",
+    "fast-uri": "4.1.2",
     "js-cookie": "3.0.8",
     "minimatch": "10.2.6",
     "picomatch": "4.0.5",


### PR DESCRIPTION
Repo-wide CI has been red since the osv-scanner advisories published: every PR fails the qlty gate on `brace-expansion@5.0.8` (CVE-2026-69152 / GHSA-rgw5-rvv9-x895, app+ui+e2e) and `ip-address@10.2.0` (CVE-2026-54272, CVE-2026-69192, CVE-2026-69198, app via express-rate-limit and mqtt→socks).

This pins:
- `brace-expansion` → **5.0.9** (app, ui, e2e overrides)
- `ip-address` → **10.3.1** (app override)
- `fast-uri` → **4.1.2** (app, ui — supersedes #658, which also failed the guard's exact-version allowlist)

Guard updates:
- `scripts/security-dependency-versions.test.mjs`: manifest-override assertion now uses the existing `isFastUriPatched()` helper instead of the `['3.1.4','4.1.1']` allowlist; new pin tests for brace-expansion (all three workspaces) and ip-address (app)
- `e2e/tests/security/brace-expansion-lockfile.test.js`: minimum safe version 5.0.7 → 5.0.9

Lockfile diffs verified scoped to exactly these packages. CHANGELOG Security bullet added under Unreleased. Clears all 4 open Dependabot alerts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- 🔒 Pin `brace-expansion` to `5.0.9` in app, UI, and E2E workspaces.
- 🔒 Pin `ip-address` to `10.3.1` in the app workspace.
- 🔒 Upgrade `fast-uri` to `4.1.2` in app and UI.
- 🔧 Restrict the `fast-uri` security guard to vetted 4.x releases.
- 🔧 Add dependency guard tests for manifest overrides and lockfile resolutions.
- 🔒 Raise the E2E `brace-expansion` safe-version floor to `5.0.9`.
- 🔒 Add an Unreleased changelog security entry.
- 🔧 Verify that lockfile changes only affect the specified packages.

- Confirm the lockfile contains only the intended dependency updates.
- Confirm all four Dependabot alerts are resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->