### PR TITLE
🐛 fix(api): accept anonymous-auth sessions on WebSocket log streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **WebSocket log streams no longer reject anonymous-auth sessions** ([#636](https://github.com/CodesWhat/drydock/issues/636)). Both WS upgrade paths — the system log stream and the container log stream — gated on `isAuthenticatedSession()` requiring `session.passport.user`, which `passport-anonymous` never sets, so under `DD_ANONYMOUS_AUTH_CONFIRM=true` the log stream WebSocket always rejected the upgrade even though every REST endpoint worked. `isAuthenticatedSession` now also accepts the session when anonymous authentication is the registered mode.
+
 ### Security
 
 - **`brace-expansion`, `ip-address`, and `fast-uri` overrides advanced to patched releases.** `brace-expansion` moved to 5.0.9 in `app/`, `ui/`, and `e2e/` (CVE-2026-69152, [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)); `ip-address` moved to 10.3.1 in `app/` (CVE-2026-54272, CVE-2026-69192, CVE-2026-69198), pulled in transitively via `express-rate-limit` and `mqtt` → `socks`; `fast-uri` advanced from 4.1.1 to 4.1.2 in `app/` and `ui/` (host confusion via backslash authority introducer, CVE-2026-18446, [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7), superseding [#658](https://github.com/CodesWhat/drydock/pull/658)).
+||||||| parent of 16d6927c (🐛 fix(api): honor active anonymous auth in WS log-stream upgrades)
 
 ## [1.6.0-rc.11] — 2026-08-01
 

--- a/app/api/container/log-stream.test.ts
+++ b/app/api/container/log-stream.test.ts
@@ -4,6 +4,7 @@ import * as configuration from '../../configuration/index.js';
 import * as registry from '../../registry/index.js';
 import * as storeContainer from '../../store/container.js';
 import * as rateLimitKey from '../rate-limit-key.js';
+import { createIdentityAwareUpgradeRateLimitKeyResolver } from '../ws-upgrade-utils.js';
 import {
   attachContainerLogStreamWebSocketServer,
   createContainerLogStreamGateway,
@@ -649,6 +650,159 @@ describe('api/container/log-stream', () => {
       expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('401 Unauthorized'));
       expect(socket.destroy).toHaveBeenCalledTimes(1);
       expect(mockWebSocketServer.handleUpgrade).not.toHaveBeenCalled();
+    });
+
+    test('accepts passport-less upgrades when anonymous authentication is active', async () => {
+      const isAnonymousAuthenticationActiveSpy = vi
+        .spyOn(registry, 'isAnonymousAuthenticationActive')
+        .mockReturnValue(true);
+      const ws = new EventEmitter() as EventEmitter & {
+        send: ReturnType<typeof vi.fn>;
+        close: ReturnType<typeof vi.fn>;
+      };
+      ws.send = vi.fn();
+      ws.close = vi.fn(() => {
+        ws.emit('close');
+      });
+
+      const mockWebSocketServer = {
+        handleUpgrade: vi.fn((_req, _socket, _head, callback: (socket: unknown) => void) =>
+          callback(ws),
+        ),
+      };
+
+      const gateway = createContainerLogStreamGateway({
+        getContainer: vi.fn(() => undefined),
+        getWatchers: vi.fn(() => ({})),
+        sessionMiddleware: (_req: unknown, _res: unknown, next: (error?: unknown) => void) =>
+          next(),
+        webSocketServer: mockWebSocketServer,
+        isRateLimited: vi.fn(() => false),
+      });
+
+      const socket = createUpgradeSocket();
+      await gateway.handleUpgrade(
+        createUpgradeRequest('/api/v1/containers/c1/logs/stream') as any,
+        socket as any,
+        Buffer.alloc(0),
+      );
+
+      expect(socket.write).not.toHaveBeenCalledWith(expect.stringContaining('401 Unauthorized'));
+      expect(mockWebSocketServer.handleUpgrade).toHaveBeenCalled();
+      expect(ws.close).toHaveBeenCalledWith(4004, 'Container not found');
+
+      isAnonymousAuthenticationActiveSpy.mockRestore();
+    });
+
+    test('rejects unauthenticated upgrades when anonymous authentication is not active', async () => {
+      const isAnonymousAuthenticationActiveSpy = vi
+        .spyOn(registry, 'isAnonymousAuthenticationActive')
+        .mockReturnValue(false);
+      const mockWebSocketServer = {
+        handleUpgrade: vi.fn(),
+      };
+
+      const gateway = createContainerLogStreamGateway({
+        getContainer: vi.fn(),
+        getWatchers: vi.fn(() => ({})),
+        sessionMiddleware: (_req: unknown, _res: unknown, next: (error?: unknown) => void) =>
+          next(),
+        webSocketServer: mockWebSocketServer,
+        isRateLimited: vi.fn(() => false),
+      });
+
+      const socket = createUpgradeSocket();
+      await gateway.handleUpgrade(
+        createUpgradeRequest('/api/v1/containers/c1/logs/stream') as any,
+        socket as any,
+        Buffer.alloc(0),
+      );
+
+      expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('401 Unauthorized'));
+      expect(mockWebSocketServer.handleUpgrade).not.toHaveBeenCalled();
+
+      isAnonymousAuthenticationActiveSpy.mockRestore();
+    });
+
+    test('keys rate limiting by IP for anonymous-authenticated upgrades, not by session', async () => {
+      const isAnonymousAuthenticationActiveSpy = vi
+        .spyOn(registry, 'isAnonymousAuthenticationActive')
+        .mockReturnValue(true);
+      const capturedRateLimitKeys: string[] = [];
+      const mockWebSocketServer = {
+        handleUpgrade: vi.fn((_req, _socket, _head, callback: (socket: unknown) => void) =>
+          callback({ on: vi.fn(), off: vi.fn(), send: vi.fn(), close: vi.fn() }),
+        ),
+      };
+
+      const gateway = createContainerLogStreamGateway({
+        getContainer: vi.fn(() => undefined),
+        getWatchers: vi.fn(() => ({})),
+        sessionMiddleware: (_req: unknown, _res: unknown, next: (error?: unknown) => void) =>
+          next(),
+        webSocketServer: mockWebSocketServer,
+        isRateLimited: (key: string) => {
+          capturedRateLimitKeys.push(key);
+          return false;
+        },
+        getRateLimitKey: createIdentityAwareUpgradeRateLimitKeyResolver({
+          ratelimit: { identitykeying: true },
+        }),
+      });
+
+      const socket = createUpgradeSocket();
+      await gateway.handleUpgrade(
+        createUpgradeRequest('/api/v1/containers/c1/logs/stream') as any,
+        socket as any,
+        Buffer.alloc(0),
+      );
+
+      expect(socket.write).not.toHaveBeenCalledWith(expect.stringContaining('401 Unauthorized'));
+      expect(capturedRateLimitKeys).toEqual(['ip:127.0.0.1']);
+
+      isAnonymousAuthenticationActiveSpy.mockRestore();
+    });
+
+    test('keeps session-keyed rate limiting for passport-authenticated upgrades', async () => {
+      const authenticatingMiddleware = (
+        req: any,
+        _res: unknown,
+        next: (error?: unknown) => void,
+      ) => {
+        req.session = { passport: { user: '{"username":"alice"}' } };
+        req.sessionID = 'session-1';
+        next();
+      };
+      const capturedRateLimitKeys: string[] = [];
+      const mockWebSocketServer = {
+        handleUpgrade: vi.fn((_req, _socket, _head, callback: (socket: unknown) => void) =>
+          callback({ on: vi.fn(), off: vi.fn(), send: vi.fn(), close: vi.fn() }),
+        ),
+      };
+
+      const gateway = createContainerLogStreamGateway({
+        getContainer: vi.fn(() => undefined),
+        getWatchers: vi.fn(() => ({})),
+        sessionMiddleware: authenticatingMiddleware,
+        webSocketServer: mockWebSocketServer,
+        isRateLimited: (key: string) => {
+          capturedRateLimitKeys.push(key);
+          return false;
+        },
+        getRateLimitKey: createIdentityAwareUpgradeRateLimitKeyResolver({
+          ratelimit: { identitykeying: true },
+        }),
+      });
+
+      const socket = createUpgradeSocket();
+      await gateway.handleUpgrade(
+        createUpgradeRequest('/api/v1/containers/c1/logs/stream') as any,
+        socket as any,
+        Buffer.alloc(0),
+      );
+
+      expect(socket.write).not.toHaveBeenCalledWith(expect.stringContaining('401 Unauthorized'));
+      expect(capturedRateLimitKeys).toEqual(['session:session-1']);
     });
 
     test('closes websocket with 4004 when container is missing', async () => {

--- a/app/api/container/log-stream.ts
+++ b/app/api/container/log-stream.ts
@@ -599,13 +599,19 @@ export function createContainerLogStreamGateway(
       }
 
       const upgradeRequest = request as UpgradeRequest;
-      const authenticated = isAuthenticatedSession(upgradeRequest);
-      const rateLimitKey = getRateLimitKey(upgradeRequest, authenticated);
+      // Rate-limit keying must stay based on genuine passport authentication only —
+      // anonymous auth being active shouldn't let anonymous clients earn session-keyed
+      // (rotatable) rate limits instead of IP-keyed ones.
+      const passportAuthenticated = isAuthenticatedSession(upgradeRequest);
+      const gateAuthenticated = isAuthenticatedSession(upgradeRequest, {
+        anonymousAuthActive: registry.isAnonymousAuthenticationActive(),
+      });
+      const rateLimitKey = getRateLimitKey(upgradeRequest, passportAuthenticated);
       if (isRateLimited(rateLimitKey)) {
         writeUpgradeError(socket, 429, 'Too Many Requests');
         return;
       }
-      if (!authenticated) {
+      if (!gateAuthenticated) {
         writeUpgradeError(socket, 401, 'Unauthorized');
         return;
       }

--- a/app/api/log-stream.test.ts
+++ b/app/api/log-stream.test.ts
@@ -1,12 +1,14 @@
 import { EventEmitter } from 'node:events';
 import { WebSocketServer } from 'ws';
 import * as configuration from '../configuration/index.js';
+import * as registry from '../registry/index.js';
 import {
   attachSystemLogStreamWebSocketServer,
   createSystemLogStreamGateway,
   parseSystemLogStreamQuery,
 } from './log-stream.js';
 import * as rateLimitKey from './rate-limit-key.js';
+import { createIdentityAwareUpgradeRateLimitKeyResolver } from './ws-upgrade-utils.js';
 
 function createUpgradeSocket() {
   return {
@@ -401,6 +403,148 @@ describe('api/log-stream', () => {
       );
 
       expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('401 Unauthorized'));
+    });
+
+    test('accepts passport-less upgrades when anonymous authentication is active', async () => {
+      const isAnonymousAuthenticationActiveSpy = vi
+        .spyOn(registry, 'isAnonymousAuthenticationActive')
+        .mockReturnValue(true);
+      const mockHandleUpgrade = vi.fn(
+        (_req: unknown, _socket: unknown, _head: unknown, callback: (ws: unknown) => void) => {
+          const ws = {
+            on: vi.fn((event: string, listener: () => void) => {
+              if (event === 'close') listener();
+            }),
+            off: vi.fn(),
+            send: vi.fn(),
+            close: vi.fn(),
+          };
+          callback(ws);
+        },
+      );
+      const gateway = createSystemLogStreamGateway({
+        sessionMiddleware: (_req: unknown, _res: unknown, next: (error?: unknown) => void) =>
+          next(),
+        webSocketServer: { handleUpgrade: mockHandleUpgrade },
+        isRateLimited: vi.fn(() => false),
+      });
+      const socket = createUpgradeSocket();
+
+      await gateway.handleUpgrade(
+        createUpgradeRequest('/api/v1/log/stream') as any,
+        socket as any,
+        Buffer.alloc(0),
+      );
+
+      expect(socket.write).not.toHaveBeenCalledWith(expect.stringContaining('401 Unauthorized'));
+      expect(mockHandleUpgrade).toHaveBeenCalledTimes(1);
+
+      isAnonymousAuthenticationActiveSpy.mockRestore();
+    });
+
+    test('rejects unauthenticated upgrades when anonymous authentication is not active', async () => {
+      const isAnonymousAuthenticationActiveSpy = vi
+        .spyOn(registry, 'isAnonymousAuthenticationActive')
+        .mockReturnValue(false);
+      const gateway = createSystemLogStreamGateway({
+        sessionMiddleware: (_req: unknown, _res: unknown, next: (error?: unknown) => void) =>
+          next(),
+        webSocketServer: { handleUpgrade: vi.fn() },
+        isRateLimited: vi.fn(() => false),
+      });
+      const socket = createUpgradeSocket();
+
+      await gateway.handleUpgrade(
+        createUpgradeRequest('/api/v1/log/stream') as any,
+        socket as any,
+        Buffer.alloc(0),
+      );
+
+      expect(socket.write).toHaveBeenCalledWith(expect.stringContaining('401 Unauthorized'));
+
+      isAnonymousAuthenticationActiveSpy.mockRestore();
+    });
+
+    test('keys rate limiting by IP for anonymous-authenticated upgrades, not by session', async () => {
+      const isAnonymousAuthenticationActiveSpy = vi
+        .spyOn(registry, 'isAnonymousAuthenticationActive')
+        .mockReturnValue(true);
+      const capturedRateLimitKeys: string[] = [];
+      const mockHandleUpgrade = vi.fn(
+        (_req: unknown, _socket: unknown, _head: unknown, callback: (ws: unknown) => void) => {
+          const ws = {
+            on: vi.fn((event: string, listener: () => void) => {
+              if (event === 'close') listener();
+            }),
+            off: vi.fn(),
+            send: vi.fn(),
+            close: vi.fn(),
+          };
+          callback(ws);
+        },
+      );
+      const gateway = createSystemLogStreamGateway({
+        sessionMiddleware: (_req: unknown, _res: unknown, next: (error?: unknown) => void) =>
+          next(),
+        webSocketServer: { handleUpgrade: mockHandleUpgrade },
+        isRateLimited: (key: string) => {
+          capturedRateLimitKeys.push(key);
+          return false;
+        },
+        getRateLimitKey: createIdentityAwareUpgradeRateLimitKeyResolver({
+          ratelimit: { identitykeying: true },
+        }),
+      });
+      const socket = createUpgradeSocket();
+
+      await gateway.handleUpgrade(
+        createUpgradeRequest('/api/v1/log/stream') as any,
+        socket as any,
+        Buffer.alloc(0),
+      );
+
+      expect(socket.write).not.toHaveBeenCalledWith(expect.stringContaining('401 Unauthorized'));
+      expect(capturedRateLimitKeys).toEqual(['ip:127.0.0.1']);
+
+      isAnonymousAuthenticationActiveSpy.mockRestore();
+    });
+
+    test('keeps session-keyed rate limiting for passport-authenticated upgrades', async () => {
+      const capturedRateLimitKeys: string[] = [];
+      const mockHandleUpgrade = vi.fn(
+        (_req: unknown, _socket: unknown, _head: unknown, callback: (ws: unknown) => void) => {
+          const ws = {
+            on: vi.fn((event: string, listener: () => void) => {
+              if (event === 'close') listener();
+            }),
+            off: vi.fn(),
+            send: vi.fn(),
+            close: vi.fn(),
+          };
+          callback(ws);
+        },
+      );
+      const gateway = createSystemLogStreamGateway({
+        sessionMiddleware: authenticatingSessionMiddleware,
+        webSocketServer: { handleUpgrade: mockHandleUpgrade },
+        isRateLimited: (key: string) => {
+          capturedRateLimitKeys.push(key);
+          return false;
+        },
+        getRateLimitKey: createIdentityAwareUpgradeRateLimitKeyResolver({
+          ratelimit: { identitykeying: true },
+        }),
+      });
+      const socket = createUpgradeSocket();
+
+      await gateway.handleUpgrade(
+        createUpgradeRequest('/api/v1/log/stream') as any,
+        socket as any,
+        Buffer.alloc(0),
+      );
+
+      expect(socket.write).not.toHaveBeenCalledWith(expect.stringContaining('401 Unauthorized'));
+      expect(capturedRateLimitKeys).toEqual(['session:session-1']);
     });
 
     test('does not write error when socket is already destroyed', async () => {

--- a/app/api/log-stream.ts
+++ b/app/api/log-stream.ts
@@ -11,6 +11,7 @@ import {
   onEntry,
 } from '../log/buffer.js';
 import { toDisplayLogEntry } from '../log/display-timestamp.js';
+import * as registry from '../registry/index.js';
 import {
   applySessionMiddleware,
   createFixedWindowRateLimiter,
@@ -255,13 +256,19 @@ export function createSystemLogStreamGateway(dependencies: SystemLogStreamGatewa
       }
 
       const upgradeRequest = request as UpgradeRequest;
-      const authenticated = isAuthenticatedSession(upgradeRequest);
-      const rateLimitKey = getRateLimitKey(upgradeRequest, authenticated);
+      // Rate-limit keying must stay based on genuine passport authentication only —
+      // anonymous auth being active shouldn't let anonymous clients earn session-keyed
+      // (rotatable) rate limits instead of IP-keyed ones.
+      const passportAuthenticated = isAuthenticatedSession(upgradeRequest);
+      const gateAuthenticated = isAuthenticatedSession(upgradeRequest, {
+        anonymousAuthActive: registry.isAnonymousAuthenticationActive(),
+      });
+      const rateLimitKey = getRateLimitKey(upgradeRequest, passportAuthenticated);
       if (isRateLimited(rateLimitKey)) {
         writeUpgradeError(socket, 429, 'Too Many Requests');
         return;
       }
-      if (!authenticated) {
+      if (!gateAuthenticated) {
         writeUpgradeError(socket, 401, 'Unauthorized');
         return;
       }

--- a/app/api/ws-upgrade-utils.test.ts
+++ b/app/api/ws-upgrade-utils.test.ts
@@ -336,6 +336,16 @@ describe('ws-upgrade-utils', () => {
       const request = {} as any;
       expect(isAuthenticatedSession(request)).toBe(false);
     });
+
+    test('returns true when anonymousAuthActive is true even without a passport user', () => {
+      const request = { session: { passport: {} } } as any;
+      expect(isAuthenticatedSession(request, { anonymousAuthActive: true })).toBe(true);
+    });
+
+    test('returns false when anonymousAuthActive is false and passport user is missing', () => {
+      const request = { session: { passport: {} } } as any;
+      expect(isAuthenticatedSession(request, { anonymousAuthActive: false })).toBe(false);
+    });
   });
 
   describe('getDefaultRateLimitKey', () => {

--- a/app/api/ws-upgrade-utils.ts
+++ b/app/api/ws-upgrade-utils.ts
@@ -152,9 +152,17 @@ export async function applySessionMiddleware(
   });
 }
 
-export function isAuthenticatedSession(request: UpgradeRequest): boolean {
+export interface IsAuthenticatedSessionOptions {
+  anonymousAuthActive?: boolean;
+}
+
+export function isAuthenticatedSession(
+  request: UpgradeRequest,
+  options: IsAuthenticatedSessionOptions = {},
+): boolean {
+  const { anonymousAuthActive = false } = options;
   const passportSession = request.session?.passport;
-  return passportSession?.user !== undefined;
+  return passportSession?.user !== undefined || anonymousAuthActive;
 }
 
 export function getDefaultRateLimitKey(request: UpgradeRequest): string {

--- a/app/registry/index.test.ts
+++ b/app/registry/index.test.ts
@@ -765,6 +765,7 @@ test('registerAuthentications should register anonymous auth when confirmation i
     mockIsUpgrade.mockReturnValue(false);
     await registry.testable_registerAuthentications();
     expect(Object.keys(registry.getState().authentication)).toEqual(['anonymous.anonymous']);
+    expect(registry.isAnonymousAuthenticationActive()).toBe(true);
   } finally {
     if (previousAnonymousConfirmation === undefined) {
       delete process.env.DD_ANONYMOUS_AUTH_CONFIRM;
@@ -772,6 +773,19 @@ test('registerAuthentications should register anonymous auth when confirmation i
       process.env.DD_ANONYMOUS_AUTH_CONFIRM = previousAnonymousConfirmation;
     }
   }
+});
+
+test('isAnonymousAuthenticationActive should return false when no anonymous strategy is registered', async () => {
+  authentications = {
+    basic: {
+      john: {
+        user: 'john',
+        hash: TEST_BASIC_HASH,
+      },
+    },
+  };
+  await registry.testable_registerAuthentications();
+  expect(registry.isAnonymousAuthenticationActive()).toBe(false);
 });
 
 test('registerAuthentications should fallback to anonymous when all configured providers fail and confirmation is enabled', async () => {

--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -112,6 +112,17 @@ export function getAuthenticationRegistrationErrors(): AuthenticationRegistratio
   return [...authenticationRegistrationErrors];
 }
 
+/**
+ * Returns true when the registered authentication state contains a strategy
+ * whose description type is 'anonymous', i.e. anonymous authentication is
+ * the configured (and confirmed) auth mode.
+ */
+export function isAnonymousAuthenticationActive(): boolean {
+  return Object.values(state.authentication).some(
+    (authentication) => authentication.getStrategyDescription().type === 'anonymous',
+  );
+}
+
 function addComponentToState(kind: ComponentKind, component: Component) {
   const components = state[kind] as Record<string, Component>;
   components[component.getId()] = component;


### PR DESCRIPTION
Fixes #636.

Pre-existing since v1.5.0: `isAuthenticatedSession` only checked `session.passport.user`, which passport-anonymous never sets, so WS log streams always 401'd under `DD_ANONYMOUS_AUTH_CONFIRM=true`.

- `registry.isAnonymousAuthenticationActive()`: true iff the registered strategy is type `anonymous` (startup-gated by the explicit confirm).
- `isAuthenticatedSession(req, { anonymousAuthActive })` — default false, byte-identical for every existing caller; both WS upgrade sites pass the registry state for the 401 gate.
- **Rate-limit keying deliberately stays on the passport-only boolean** — anonymous clients remain IP-keyed (the adversarial round caught that reusing the gate boolean would let anonymous clients rotate session IDs past identity-keyed limits).

Fail-closed behavior for basic/OIDC/etc. is untouched. Review provenance: adversarial verify round (1 finding, repaired), independent Codex review: clean. Full app suite green.