### PR TITLE
🔧 chore(ui): regenerate icon-bundle against tabler 1.2.38

### DIFF
--- a/ui/src/boot/icon-bundle.json
+++ b/ui/src/boot/icon-bundle.json
@@ -1710,7 +1710,7 @@
     "height": 24
   },
   "tabler:server": {
-    "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M3 7a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3zm0 8a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3zm4-7v.01M7 16v.01\"/>",
+    "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M3 7a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3m0 6a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v2a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3zm4-7v.01M7 16v.01\"/>",
     "width": 24,
     "height": 24
   },


### PR DESCRIPTION
One-line regen of `ui/src/boot/icon-bundle.json` via `ui/scripts/extract-icons.mjs`. The #655 ui deps bump moved `@iconify-json/tabler` to 1.2.38, which changed the `tabler:server` SVG path, so the committed bundle no longer matched the locked packages. Same class of change as #608. Deterministic: re-running the extract script reproduces exactly this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed `ui/src/boot/icon-bundle.json` with regenerated `tabler:server` SVG path data.
- 🔧 Changed the bundle to match `@iconify-json/tabler` version `1.2.38`.
- 🔧 Preserved icon dimensions and entry structure.

## Concerns

- Verify that `@iconify-json/tabler` is locked to version `1.2.38`.
- Verify the bundle is reproducible with `ui/scripts/extract-icons.mjs`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->