### PR TITLE
🐛 fix(watcher): anchor digest comparison to repo-matched RepoDigests candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Pinned `js-yaml` to 3.15.1 in the e2e workspace (override; transitive dependency) for [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (CVE-2026-59870 backport gap: quadratic CPU consumption in `!!omap` resolution).
+
 ### Fixed
 
 - **Digest-update comparison no longer anchors on an arbitrary `RepoDigests[0]` entry** ([#669](https://github.com/CodesWhat/drydock/issues/669)). A local Docker image can carry multiple `repo@digest` entries for one Image ID (pull/retag accumulation, no ordering guarantee); `getRepoDigest` blindly took index 0, so a stale or foreign-repo entry landing first anchored the whole digest-update pipeline to the wrong manifest and produced a persistent digest-update false positive that survived applying the update. `getOrderedRepoDigests` (`app/watchers/providers/docker/docker-helpers.ts`) now returns every RepoDigests entry whose repo component matches the container's own image reference, ordered, falling back to the full list only when nothing matches; the container model gained an optional `image.digest.repoDigests` field carrying that ordered list, re-derived from the live Docker image inspect on every discovery/refresh cycle. `handleDigestWatch` (`app/watchers/providers/docker/image-comparison.ts`) now walks that candidate list — a cheap raw-value check first, then a normalize-and-compare registry call per remaining candidate, skipping anchors whose manifest lookup fails — and re-anchors `digest.repo` to whichever candidate actually matched, so a store already poisoned with a stale `digest.repo` self-heals on its own. A genuine same-tag republish (no candidate matches) still flags an update exactly as before; if every candidate fails to normalize, the failure now propagates instead of being silently coerced into a false "no update".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Digest-update comparison no longer anchors on an arbitrary `RepoDigests[0]` entry** ([#669](https://github.com/CodesWhat/drydock/issues/669)). A local Docker image can carry multiple `repo@digest` entries for one Image ID (pull/retag accumulation, no ordering guarantee); `getRepoDigest` blindly took index 0, so a stale or foreign-repo entry landing first anchored the whole digest-update pipeline to the wrong manifest and produced a persistent digest-update false positive that survived applying the update. `getOrderedRepoDigests` (`app/watchers/providers/docker/docker-helpers.ts`) now returns every RepoDigests entry whose repo component matches the container's own image reference, ordered, falling back to the full list only when nothing matches; the container model gained an optional `image.digest.repoDigests` field carrying that ordered list, re-derived from the live Docker image inspect on every discovery/refresh cycle. `handleDigestWatch` (`app/watchers/providers/docker/image-comparison.ts`) now walks that candidate list — a cheap raw-value check first, then a normalize-and-compare registry call per remaining candidate, skipping anchors whose manifest lookup fails — and re-anchors `digest.repo` to whichever candidate actually matched, so a store already poisoned with a stale `digest.repo` self-heals on its own. A genuine same-tag republish (no candidate matches) still flags an update exactly as before; if every candidate fails to normalize, the failure now propagates instead of being silently coerced into a false "no update".
+
 ## [1.6.0-rc.12] — 2026-08-04
 
 ### Changed

--- a/app/model/container.ts
+++ b/app/model/container.ts
@@ -66,6 +66,13 @@ export interface ContainerImage {
     watch: boolean;
     value?: string;
     repo?: string;
+    // Ordered candidate digests whose repo component matches this container's
+    // own image reference, re-derived from the live Docker image inspect on
+    // every discovery/refresh cycle (#669). Optional/additive — old stored
+    // containers lack it and fall back to single-anchor comparison using
+    // `repo` alone. See `getOrderedRepoDigests` in docker-helpers.ts and
+    // `handleDigestWatch` in image-comparison.ts.
+    repoDigests?: string[];
   };
   // True when the live Docker image inspect had no RepoDigests (built locally
   // or `docker load`ed) — derived once at discovery/refresh time, independent
@@ -437,6 +444,7 @@ const schema = joi.object({
           watch: joi.boolean().default(false),
           value: joi.string(),
           repo: joi.string(),
+          repoDigests: joi.array().items(joi.string()),
         })
         .required(),
       isLocalImage: joi.boolean(),

--- a/app/watchers/providers/docker/docker-helpers.test.ts
+++ b/app/watchers/providers/docker/docker-helpers.test.ts
@@ -360,6 +360,17 @@ describe('docker helper extraction module', () => {
     test('ignores malformed RepoDigests entries lacking an "@" separator', () => {
       expect(getOrderedRepoDigests({ RepoDigests: ['malformed-entry'] })).toBeUndefined();
     });
+
+    test('ignores entries with an empty repo or digest component', () => {
+      expect(getOrderedRepoDigests({ RepoDigests: ['acme/service@'] })).toBeUndefined();
+      expect(getOrderedRepoDigests({ RepoDigests: ['@sha256:orphan'] })).toBeUndefined();
+      // A well-formed entry still wins over malformed siblings.
+      expect(
+        getOrderedRepoDigests({
+          RepoDigests: ['acme/service@', '@sha256:orphan', 'acme/service@sha256:good'],
+        }),
+      ).toEqual(['sha256:good']);
+    });
   });
 
   test('digest watch defaults require a meaningful current tag', () => {

--- a/app/watchers/providers/docker/docker-helpers.test.ts
+++ b/app/watchers/providers/docker/docker-helpers.test.ts
@@ -12,10 +12,12 @@ import {
   getFirstConfigNumber,
   getFirstConfigString,
   getImageForRegistryLookup,
+  getImageReferenceCandidates,
   getImageReferenceCandidatesFromPattern,
   getImgsetSpecificity,
   getInspectValueByPath,
   getOldContainers,
+  getOrderedRepoDigests,
   getRawContainerName,
   getRepoDigest,
   getResolvedImgsetConfiguration,
@@ -296,6 +298,68 @@ describe('docker helper extraction module', () => {
     expect(getRepoDigest({ RepoDigests: ['repo@sha256:abc123'] })).toBe('sha256:abc123');
     expect(isContainerToWatch('true', false)).toBe(true);
     expect(isContainerToWatch('', true)).toBe(true);
+  });
+
+  describe('getOrderedRepoDigests (#669)', () => {
+    test('returns undefined when RepoDigests is empty or undefined', () => {
+      expect(getOrderedRepoDigests({ RepoDigests: [] })).toBeUndefined();
+      expect(getOrderedRepoDigests({} as any)).toBeUndefined();
+    });
+
+    test('returns the full list, in order, when no reference candidates are supplied', () => {
+      expect(
+        getOrderedRepoDigests({
+          RepoDigests: ['acme/service@sha256:one', 'other/service@sha256:two'],
+        }),
+      ).toEqual(['sha256:one', 'sha256:two']);
+    });
+
+    test('prefers the entry matching the container repo when a foreign-repo entry comes first (#669)', () => {
+      const referenceCandidates = getImageReferenceCandidates('acme/service', 'ghcr.io');
+
+      const result = getOrderedRepoDigests(
+        {
+          RepoDigests: ['unrelated/other-image@sha256:foreign', 'ghcr.io/acme/service@sha256:mine'],
+        },
+        referenceCandidates,
+      );
+
+      expect(result).toEqual(['sha256:mine']);
+    });
+
+    test('returns every matching entry in original order when several entries match', () => {
+      const referenceCandidates = getImageReferenceCandidates('acme/service', 'ghcr.io');
+
+      const result = getOrderedRepoDigests(
+        {
+          RepoDigests: [
+            'ghcr.io/acme/service@sha256:first',
+            'unrelated/other-image@sha256:foreign',
+            'ghcr.io/acme/service@sha256:second',
+          ],
+        },
+        referenceCandidates,
+      );
+
+      expect(result).toEqual(['sha256:first', 'sha256:second']);
+    });
+
+    test('falls back to the full list, in original order, when no entry matches any candidate', () => {
+      const referenceCandidates = getImageReferenceCandidates('acme/service', 'ghcr.io');
+
+      const result = getOrderedRepoDigests(
+        {
+          RepoDigests: ['unrelated/other-image@sha256:foreign', 'another/one@sha256:also-foreign'],
+        },
+        referenceCandidates,
+      );
+
+      expect(result).toEqual(['sha256:foreign', 'sha256:also-foreign']);
+    });
+
+    test('ignores malformed RepoDigests entries lacking an "@" separator', () => {
+      expect(getOrderedRepoDigests({ RepoDigests: ['malformed-entry'] })).toBeUndefined();
+    });
   });
 
   test('digest watch defaults require a meaningful current tag', () => {

--- a/app/watchers/providers/docker/docker-helpers.ts
+++ b/app/watchers/providers/docker/docker-helpers.ts
@@ -429,7 +429,10 @@ export function getOrderedRepoDigests(
   const entries = repoDigests
     .map((fullDigest) => {
       const separatorIndex = fullDigest.indexOf('@');
-      if (separatorIndex === -1) {
+      // Reject malformed entries with a missing separator or an empty
+      // repo/digest component: an empty digest would pass the model's
+      // `!== undefined` guards and compare as a phantom "change".
+      if (separatorIndex <= 0 || separatorIndex === fullDigest.length - 1) {
         return undefined;
       }
       return {

--- a/app/watchers/providers/docker/docker-helpers.ts
+++ b/app/watchers/providers/docker/docker-helpers.ts
@@ -245,7 +245,7 @@ export function getContainerConfigBooleanValue(...values: unknown[]) {
   return undefined;
 }
 
-function getImageReferenceCandidates(path?: string, domain?: string) {
+export function getImageReferenceCandidates(path?: string, domain?: string) {
   const pathNormalized = normalizeConfigStringValue(path)?.toLowerCase();
   if (!pathNormalized) {
     return [];
@@ -286,7 +286,7 @@ export function getImageReferenceCandidatesFromPattern(pattern: string) {
   }
 }
 
-function getImageReferenceCandidatesFromParsedImage(parsedImage: ParsedImageLike) {
+export function getImageReferenceCandidatesFromParsedImage(parsedImage: ParsedImageLike) {
   return getImageReferenceCandidates(parsedImage?.path, parsedImage?.domain);
 }
 
@@ -396,17 +396,74 @@ export function getFirstConfigNumber(value: unknown, paths: string[]) {
 }
 
 /**
- * Get image repo digest.
+ * Return the ordered list of digest values from a Docker image's RepoDigests,
+ * preferring entries whose repo component matches the container's own image
+ * reference over entries pulled/retagged from a foreign repo (#669).
+ *
+ * A local Docker image object can carry multiple `repo@digest` entries for a
+ * single Image ID with no ordering guarantee (pull/retag accumulation), so
+ * blindly trusting index 0 can anchor digest-update detection to the wrong
+ * manifest. `referenceCandidates` should be built via
+ * `getImageReferenceCandidates`/`getImageReferenceCandidatesFromParsedImage`
+ * so Docker Hub aliasing (`docker.io`/`registry-1.docker.io`/`library/`
+ * prefix) is handled the same way as imgset matching.
+ *
+ * When one or more entries match a candidate, only the matching entries are
+ * returned (in their original RepoDigests order). When none match — or no
+ * candidates were supplied — every entry is returned, in original order, so
+ * callers never regress to `undefined` just because identity was unknown or
+ * unmatched. Only an empty/undefined RepoDigests list returns `undefined`.
+ * @param containerImage
+ * @param referenceCandidates
+ * @returns {string[]|undefined} ordered digest values
+ */
+export function getOrderedRepoDigests(
+  containerImage: ImageWithRepoDigests,
+  referenceCandidates: string[] = [],
+): string[] | undefined {
+  const repoDigests = containerImage.RepoDigests;
+  if (!repoDigests || repoDigests.length === 0) {
+    return undefined;
+  }
+
+  const entries = repoDigests
+    .map((fullDigest) => {
+      const separatorIndex = fullDigest.indexOf('@');
+      if (separatorIndex === -1) {
+        return undefined;
+      }
+      return {
+        repo: fullDigest.substring(0, separatorIndex).toLowerCase(),
+        digest: fullDigest.substring(separatorIndex + 1),
+      };
+    })
+    .filter((entry): entry is { repo: string; digest: string } => entry !== undefined);
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  if (referenceCandidates.length > 0) {
+    const candidateSet = new Set(referenceCandidates);
+    const matchingDigests = entries
+      .filter((entry) => candidateSet.has(entry.repo))
+      .map((entry) => entry.digest);
+    if (matchingDigests.length > 0) {
+      return matchingDigests;
+    }
+  }
+
+  return entries.map((entry) => entry.digest);
+}
+
+/**
+ * Get image repo digest (first candidate from `getOrderedRepoDigests`).
+ * Kept for callers with no container identity to match against.
  * @param containerImage
  * @returns {*} digest
  */
 export function getRepoDigest(containerImage: ImageWithRepoDigests) {
-  if (!containerImage.RepoDigests || containerImage.RepoDigests.length === 0) {
-    return undefined;
-  }
-  const fullDigest = containerImage.RepoDigests[0];
-  const digestSplit = fullDigest.split('@');
-  return digestSplit[1];
+  return getOrderedRepoDigests(containerImage)?.[0];
 }
 
 /**

--- a/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
@@ -613,6 +613,7 @@ describe('docker image details orchestration module', () => {
     expect(containerInStore.image.id).toBe('image-new');
     expect(containerInStore.image.digest).toEqual({
       repo: 'sha256:new',
+      repoDigests: ['sha256:new'],
       value: 'sha256:new',
     });
     expect(containerInStore.image.created).toBe('2026-03-01T00:00:00.000Z');
@@ -797,6 +798,7 @@ describe('docker image details orchestration module', () => {
     expect(containerInStore.image.tag.value).toBe('latest');
     expect(containerInStore.image.digest).toEqual({
       repo: 'sha256:new',
+      repoDigests: ['sha256:new'],
       value: 'sha256:new',
       watch: true,
     });
@@ -1119,6 +1121,7 @@ describe('docker image details orchestration module', () => {
     expect(containerInStore.image.tag.value).toBe('latest');
     expect(containerInStore.image.digest).toEqual({
       repo: 'sha256:new',
+      repoDigests: ['sha256:new'],
       value: 'sha256:new',
       watch: true,
     });
@@ -1185,6 +1188,7 @@ describe('docker image details orchestration module', () => {
     expect(containerInStore.image.id).toBe('image-new');
     expect(containerInStore.image.digest).toEqual({
       repo: 'sha256:new',
+      repoDigests: ['sha256:new'],
       value: 'sha256:new',
       watch: false,
     });
@@ -1514,6 +1518,202 @@ describe('docker image details orchestration module', () => {
       image: {
         isLocalImage: false,
       },
+    });
+  });
+
+  describe('repo-aware digest anchor selection (#669)', () => {
+    test('discovery: selects the matching-repo entry as digest anchor and populates repoDigests when a foreign-repo entry comes first', async () => {
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(undefined);
+
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['unrelated/other-image@sha256:foreign', 'ghcr.io/acme/service@sha256:mine'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      const result = await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      expect(result?.image.digest).toMatchObject({
+        repo: 'sha256:mine',
+        repoDigests: ['sha256:mine'],
+        value: 'sha256:mine',
+      });
+    });
+
+    test('refresh (no-repair path): re-anchors digest.repo away from a foreign entry and refreshes repoDigests every cycle even when unchanged', async () => {
+      const containerInStore = {
+        id: 'container-1',
+        name: 'service',
+        error: undefined,
+        details: { ports: [], volumes: [], env: [] },
+        image: {
+          id: 'image-old',
+          name: 'acme/service',
+          registry: { name: 'ghcr', url: 'https://ghcr.io/v2' },
+          tag: { value: '1.0.0', semver: true },
+          digest: { repo: 'sha256:stale-foreign', value: 'sha256:stale-foreign', watch: true },
+          created: '2025-01-01T00:00:00.000Z',
+        },
+      };
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(containerInStore as any);
+
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-old',
+        RepoDigests: ['unrelated/other-image@sha256:foreign', 'ghcr.io/acme/service@sha256:mine'],
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      // Image id is unchanged, but the ordered candidate list is still
+      // re-derived (and the stale repo pointer corrected) every cycle rather
+      // than only when the digest.repo/image id merge check fires.
+      expect(containerInStore.image.digest.repoDigests).toEqual(['sha256:mine']);
+      expect(containerInStore.image.digest.repo).toBe('sha256:mine');
+    });
+
+    test('refresh: keeps a stored anchor that is not first but still among the fresh candidates (no ping-pong with handleDigestWatch re-anchoring)', async () => {
+      const containerInStore = {
+        id: 'container-1',
+        name: 'service',
+        error: undefined,
+        details: { ports: [], volumes: [], env: [] },
+        image: {
+          id: 'image-old',
+          name: 'acme/service',
+          registry: { name: 'ghcr', url: 'https://ghcr.io/v2' },
+          tag: { value: '1.0.0', semver: true },
+          // handleDigestWatch re-anchored to the second candidate last cycle.
+          digest: { repo: 'sha256:second', value: 'sha256:remote', watch: true },
+          created: '2025-01-01T00:00:00.000Z',
+        },
+      };
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(containerInStore as any);
+
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-old',
+        RepoDigests: ['ghcr.io/acme/service@sha256:first', 'ghcr.io/acme/service@sha256:second'],
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      // digest.repo must NOT snap back to index 0: the stored anchor is still
+      // a valid candidate, and re-deriving it here would undo the
+      // registry-verified re-anchor every cycle.
+      expect(containerInStore.image.digest.repo).toBe('sha256:second');
+      expect(containerInStore.image.digest.value).toBe('sha256:remote');
+      expect(containerInStore.image.digest.repoDigests).toEqual(['sha256:first', 'sha256:second']);
+    });
+
+    test('refresh: a malformed http(s) registry.url degrades to unmatched candidates instead of throwing', async () => {
+      const containerInStore = {
+        id: 'container-1',
+        name: 'service',
+        error: undefined,
+        details: { ports: [], volumes: [], env: [] },
+        image: {
+          id: 'image-old',
+          name: 'acme/service',
+          // No hostname — new URL() throws, exercising the catch fallback in
+          // extractRegistryDomainForMatching.
+          registry: { name: 'ghcr', url: 'https://' },
+          tag: { value: '1.0.0', semver: true },
+          digest: { repo: 'sha256:old', value: 'sha256:old', watch: true },
+          created: '2025-01-01T00:00:00.000Z',
+        },
+      };
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(containerInStore as any);
+
+      const { watcher, inspectImage } = createWatcher();
+      inspectImage.mockResolvedValue({
+        Id: 'image-old',
+        RepoDigests: ['unrelated/other-image@sha256:foreign', 'ghcr.io/acme/service@sha256:mine'],
+        Created: '2026-02-01T00:00:00.000Z',
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        createHelpers() as any,
+      );
+
+      // No candidate matched (domain extraction failed), so the fallback is
+      // the full RepoDigests list in original order — index 0 wins, same as
+      // pre-#669 behavior when identity can't be determined.
+      expect(containerInStore.image.digest.repoDigests).toEqual(['sha256:foreign', 'sha256:mine']);
+      expect(containerInStore.image.digest.repo).toBe('sha256:foreign');
+    });
+
+    test('refresh (repair path): the reparsed reference selects the matching-repo entry, not index 0', async () => {
+      const containerInStore = {
+        id: 'container-1',
+        name: 'service',
+        displayName: 'service',
+        status: 'running',
+        error: undefined,
+        details: { ports: [], volumes: [], env: [] },
+        image: {
+          id: 'image-old',
+          name: 'acme/service',
+          registry: { name: 'unknown', url: '' },
+          tag: { value: 'unknown', semver: false },
+          digest: { repo: 'sha256:old', value: 'sha256:old', watch: false },
+          architecture: 'amd64',
+          os: 'linux',
+          created: '2025-01-01T00:00:00.000Z',
+        },
+      };
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(containerInStore as any);
+
+      const { watcher, inspectContainer, inspectImage } = createWatcher();
+      inspectContainer.mockResolvedValue({
+        Config: { Image: 'ghcr.io/acme/service:latest' },
+      });
+      inspectImage.mockResolvedValue({
+        Id: 'image-new',
+        RepoDigests: ['unrelated/other-image@sha256:foreign', 'ghcr.io/acme/service@sha256:mine'],
+        Architecture: 'amd64',
+        Os: 'linux',
+        Created: '2026-03-01T00:00:00.000Z',
+      });
+      const helpers = createHelpers({
+        resolveImageName: vi.fn().mockReturnValue({ domain: 'ghcr.io', path: 'acme/service' }),
+        resolveTagName: vi.fn().mockReturnValue('latest'),
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer(),
+        {},
+        helpers as any,
+      );
+
+      expect(containerInStore.image.digest).toMatchObject({
+        repo: 'sha256:mine',
+        repoDigests: ['sha256:mine'],
+      });
     });
   });
 

--- a/app/watchers/providers/docker/docker-image-details-orchestration.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.ts
@@ -19,8 +19,10 @@ import {
   canonicalizeContainerName,
   getContainerDisplayName,
   getContainerName,
+  getImageReferenceCandidates,
+  getImageReferenceCandidatesFromParsedImage,
   getInspectValueByPath,
-  getRepoDigest,
+  getOrderedRepoDigests,
   getSemverTagFromInspectPath,
   isDigestToWatch,
   type ResolvedImgset,
@@ -150,6 +152,7 @@ interface ResolvedContainerImageState {
   tagPrecision: TagPrecision;
   watchDigest: boolean;
   repoDigest: string | undefined;
+  repoDigests: string[] | undefined;
 }
 
 interface DockerImageDetailsWatcher {
@@ -322,12 +325,23 @@ async function refreshStoredContainerImageFields(
 
   try {
     const currentImage = await watcher.dockerApi.getImage(container.Image).inspect();
-    const freshDigestRepo = getRepoDigest(currentImage);
+    const referenceCandidates = getImageReferenceCandidates(
+      containerInStore.image?.name,
+      extractRegistryDomainForMatching(containerInStore.image?.registry?.url),
+    );
+    const freshOrderedRepoDigests = getOrderedRepoDigests(currentImage, referenceCandidates);
+    const freshDigestRepo = freshOrderedRepoDigests?.[0];
     const freshImageId = currentImage.Id;
     // Keep isLocalImage in sync with the live Docker image inspect every
     // cycle — independent of shouldRepairStoredImageReference below, and
     // spread forward by the repair branch's `...containerInStore.image`.
     containerInStore.image.isLocalImage = freshDigestRepo === undefined;
+    // Re-derive the full ordered candidate list every cycle (not just when
+    // digest.repo/image id changed) so a store poisoned with a stale/wrong
+    // digest.repo self-heals: handleDigestWatch (image-comparison.ts) anchors
+    // on repoDigests when present, so a fresh list here lets it re-anchor even
+    // when the old digest.repo isn't among the freshly derived entries (#669).
+    containerInStore.image.digest.repoDigests = freshOrderedRepoDigests;
 
     if (shouldRepairStoredImageReference(containerInStore)) {
       const resolvedImageState = resolveContainerImageState({
@@ -364,6 +378,7 @@ async function refreshStoredContainerImageFields(
               ...containerInStore.image.digest,
               watch: resolvedImageState.watchDigest,
               repo: resolvedImageState.repoDigest,
+              repoDigests: resolvedImageState.repoDigests,
               value:
                 resolvedImageState.repoDigest !== undefined &&
                 resolvedImageState.repoDigest !== containerInStore.image.digest.repo
@@ -394,8 +409,16 @@ async function refreshStoredContainerImageFields(
     if (freshDigestRepo !== undefined && containerInStore.image.digest.value === undefined) {
       containerInStore.image.digest.value = freshDigestRepo;
     }
+    // A stored anchor that is still among the fresh candidates stays put even
+    // when it isn't first: handleDigestWatch re-anchors digest.repo to the
+    // candidate that actually matches the registry, and re-deriving it from
+    // index 0 here every cycle would undo that and ping-pong the anchor (#669).
+    const storedRepoStillValid =
+      containerInStore.image.digest.repo !== undefined &&
+      freshOrderedRepoDigests !== undefined &&
+      freshOrderedRepoDigests.includes(containerInStore.image.digest.repo);
     if (
-      freshDigestRepo !== containerInStore.image.digest.repo ||
+      (freshDigestRepo !== containerInStore.image.digest.repo && !storedRepoStillValid) ||
       freshImageId !== containerInStore.image.id
     ) {
       containerInStore.image.digest.repo = freshDigestRepo;
@@ -595,6 +618,10 @@ function resolveContainerImageState(
   const parsedTag = parseSemver(transformedTag);
   const isSemver = parsedTag != null;
   const tagPrecision = classifyTagPrecision(tagName, resolvedConfig.transformTags, parsedTag);
+  const repoDigests = getOrderedRepoDigests(
+    image,
+    getImageReferenceCandidatesFromParsedImage(parsedImage),
+  );
 
   return {
     parsedImage,
@@ -610,8 +637,29 @@ function resolveContainerImageState(
       tagName,
       container.Image,
     ),
-    repoDigest: getRepoDigest(image),
+    repoDigest: repoDigests?.[0],
+    repoDigests,
   };
+}
+
+/**
+ * Extract a bare domain from a stored `registry.url`, which may already be a
+ * canonicalized URL (e.g. `https://registry-1.docker.io/v2`, produced by
+ * `normalizeContainer`/`BaseRegistry.normalizeImageUrl`) rather than a plain
+ * domain. Falls back to treating the value as an already-bare domain.
+ */
+function extractRegistryDomainForMatching(url: string | undefined): string | undefined {
+  if (typeof url !== 'string' || url.trim() === '') {
+    return undefined;
+  }
+  if (/^https?:\/\//i.test(url)) {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return undefined;
+    }
+  }
+  return url;
 }
 
 function shouldRepairStoredImageReference(containerInStore: Container) {
@@ -774,8 +822,16 @@ export async function addImageDetailsToContainerOrchestration(
     return undefined;
   }
 
-  const { parsedImage, resolvedConfig, tagName, isSemver, tagPrecision, watchDigest, repoDigest } =
-    resolvedImageState;
+  const {
+    parsedImage,
+    resolvedConfig,
+    tagName,
+    isSemver,
+    tagPrecision,
+    watchDigest,
+    repoDigest,
+    repoDigests,
+  } = resolvedImageState;
   const runtimeDetails = await resolveRuntimeDetailsForDiscoveredContainer(
     runtimeDetailsFromSummary,
     containerInspect,
@@ -827,6 +883,7 @@ export async function addImageDetailsToContainerOrchestration(
       digest: {
         watch: watchDigest,
         repo: repoDigest,
+        repoDigests,
         value: repoDigest,
       },
       // True when the live image inspect had no RepoDigests (built locally or

--- a/app/watchers/providers/docker/image-comparison.test.ts
+++ b/app/watchers/providers/docker/image-comparison.test.ts
@@ -532,6 +532,212 @@ describe('image-comparison', () => {
     expect(result.digest).toBe('sha256:def456');
   });
 
+  describe('multi-anchor digest comparison (#669)', () => {
+    function createMultiAnchorContainer(overrides: Record<string, unknown> = {}) {
+      return {
+        image: {
+          id: 'image-1',
+          registry: { name: 'hub' },
+          name: 'library/postgres',
+          tag: { value: '16-alpine', semver: true, tagPrecision: 'floating' },
+          digest: {
+            watch: true,
+            repo: 'sha256:anchor-a',
+            repoDigests: ['sha256:anchor-a', 'sha256:anchor-b'],
+          },
+        },
+        tagFamily: 'strict',
+        ...overrides,
+      };
+    }
+
+    function mockRegistry(getImageManifestDigest: ReturnType<typeof vi.fn>) {
+      mockGetState.mockReturnValue({
+        registry: {
+          hub: {
+            getTags: vi.fn().mockResolvedValue(['16-alpine']),
+            getImageManifestDigest,
+            normalizeImage: identityNormalizeImage,
+          },
+        },
+      });
+    }
+
+    const log = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+
+    test('(b) raw match on a non-first anchor short-circuits with no normalization call and re-anchors digest.repo', async () => {
+      const getImageManifestDigest = vi.fn().mockResolvedValueOnce({
+        digest: 'sha256:anchor-b',
+        created: '2026-04-01T00:00:00.000Z',
+        version: 2,
+      });
+      mockRegistry(getImageManifestDigest);
+      const container = createMultiAnchorContainer();
+
+      await findNewVersion(container as never, log);
+
+      // Only the initial remote-digest lookup happened — the raw match at
+      // step 2 skips the normalize-and-compare registry call entirely.
+      expect(getImageManifestDigest).toHaveBeenCalledTimes(1);
+      expect(container.image.digest.value).toBe('sha256:anchor-b');
+      expect(container.image.digest.repo).toBe('sha256:anchor-b');
+    });
+
+    test('(c) match only after normalizing a non-first anchor (e.g. manifest-list digest) re-anchors digest.repo', async () => {
+      const getImageManifestDigest = vi
+        .fn()
+        .mockResolvedValueOnce({
+          digest: 'sha256:platform-digest',
+          created: '2026-04-01T00:00:00.000Z',
+          version: 2,
+        })
+        .mockResolvedValueOnce({ digest: 'sha256:normalized-a' })
+        .mockResolvedValueOnce({ digest: 'sha256:platform-digest' });
+      mockRegistry(getImageManifestDigest);
+      const container = createMultiAnchorContainer();
+
+      await findNewVersion(container as never, log);
+
+      expect(getImageManifestDigest).toHaveBeenCalledTimes(3);
+      expect(getImageManifestDigest.mock.calls[1][1]).toBe('sha256:anchor-a');
+      expect(getImageManifestDigest.mock.calls[2][1]).toBe('sha256:anchor-b');
+      expect(container.image.digest.value).toBe('sha256:platform-digest');
+      expect(container.image.digest.repo).toBe('sha256:anchor-b');
+    });
+
+    test('(d) genuine republish: no anchor matches, update still flagged using the first anchor normalized value', async () => {
+      const getImageManifestDigest = vi
+        .fn()
+        .mockResolvedValueOnce({
+          digest: 'sha256:new-republish',
+          created: '2026-04-01T00:00:00.000Z',
+          version: 2,
+        })
+        .mockResolvedValueOnce({ digest: 'sha256:normalized-a' })
+        .mockResolvedValueOnce({ digest: 'sha256:normalized-b' });
+      mockRegistry(getImageManifestDigest);
+      const container = createMultiAnchorContainer();
+
+      await findNewVersion(container as never, log);
+
+      expect(getImageManifestDigest).toHaveBeenCalledTimes(3);
+      expect(container.image.digest.value).toBe('sha256:normalized-a');
+      // digest.repo is left untouched — no anchor matched, so no re-anchoring.
+      expect(container.image.digest.repo).toBe('sha256:anchor-a');
+    });
+
+    test('(e) one anchor fails to normalize, a later anchor matches — comparison still succeeds', async () => {
+      const getImageManifestDigest = vi
+        .fn()
+        .mockResolvedValueOnce({
+          digest: 'sha256:target',
+          created: '2026-04-01T00:00:00.000Z',
+          version: 2,
+        })
+        .mockRejectedValueOnce(new Error('manifest unknown (404)'))
+        .mockResolvedValueOnce({ digest: 'sha256:target' });
+      mockRegistry(getImageManifestDigest);
+      const container = createMultiAnchorContainer();
+
+      const result = await findNewVersion(container as never, log);
+
+      expect(getImageManifestDigest).toHaveBeenCalledTimes(3);
+      expect(result.digest).toBe('sha256:target');
+      expect(container.image.digest.value).toBe('sha256:target');
+      expect(container.image.digest.repo).toBe('sha256:anchor-b');
+    });
+
+    test('(f) every anchor fails to normalize — findNewVersion rejects instead of reporting no update', async () => {
+      const getImageManifestDigest = vi
+        .fn()
+        .mockResolvedValueOnce({
+          digest: 'sha256:target',
+          created: '2026-04-01T00:00:00.000Z',
+          version: 2,
+        })
+        .mockRejectedValueOnce(new Error('anchor-a manifest unknown'))
+        .mockRejectedValueOnce(new Error('anchor-b manifest unknown'));
+      mockRegistry(getImageManifestDigest);
+      const container = createMultiAnchorContainer();
+
+      await expect(findNewVersion(container as never, log)).rejects.toThrow(
+        'anchor-b manifest unknown',
+      );
+    });
+
+    test('(g) legacy container with no repoDigests field falls back to single-anchor comparison unchanged', async () => {
+      const getImageManifestDigest = vi
+        .fn()
+        .mockResolvedValueOnce({
+          digest: 'sha256:new-manifest',
+          created: '2026-04-01T00:00:00.000Z',
+          version: 2,
+        })
+        .mockResolvedValueOnce({ digest: 'sha256:normalized-legacy' });
+      mockRegistry(getImageManifestDigest);
+      const container = createMultiAnchorContainer({
+        image: {
+          id: 'image-1',
+          registry: { name: 'hub' },
+          name: 'library/postgres',
+          tag: { value: '16-alpine', semver: true, tagPrecision: 'floating' },
+          digest: { watch: true, repo: 'sha256:legacy-anchor' },
+        },
+      });
+
+      await findNewVersion(container as never, log);
+
+      expect(getImageManifestDigest).toHaveBeenCalledTimes(2);
+      expect(getImageManifestDigest.mock.calls[1][1]).toBe('sha256:legacy-anchor');
+      expect(container.image.digest.value).toBe('sha256:normalized-legacy');
+      expect(container.image.digest.repo).toBe('sha256:legacy-anchor');
+    });
+
+    test('(i) self-heal: a stale digest.repo absent from the fresh repoDigests list is replaced by the matching entry', async () => {
+      const getImageManifestDigest = vi.fn().mockResolvedValueOnce({
+        digest: 'sha256:anchor-b',
+        created: '2026-04-01T00:00:00.000Z',
+        version: 2,
+      });
+      mockRegistry(getImageManifestDigest);
+      const container = createMultiAnchorContainer({
+        image: {
+          id: 'image-1',
+          registry: { name: 'hub' },
+          name: 'library/postgres',
+          tag: { value: '16-alpine', semver: true, tagPrecision: 'floating' },
+          digest: {
+            watch: true,
+            // Poisoned: not present anywhere in the freshly derived list below.
+            repo: 'sha256:very-stale-and-foreign',
+            repoDigests: ['sha256:anchor-a', 'sha256:anchor-b'],
+          },
+        },
+      });
+
+      await findNewVersion(container as never, log);
+
+      expect(container.image.digest.repo).toBe('sha256:anchor-b');
+      expect(container.image.digest.value).toBe('sha256:anchor-b');
+    });
+
+    test('(j) version !== 2 fallback is unchanged: digest.value takes digest.repo verbatim, repoDigests is not consulted', async () => {
+      const getImageManifestDigest = vi.fn().mockResolvedValueOnce({
+        digest: 'sha256:anchor-b',
+        created: '2026-04-01T00:00:00.000Z',
+        version: 1,
+      });
+      mockRegistry(getImageManifestDigest);
+      const container = createMultiAnchorContainer();
+
+      await findNewVersion(container as never, log);
+
+      expect(getImageManifestDigest).toHaveBeenCalledTimes(1);
+      expect(container.image.digest.value).toBe('sha256:anchor-a');
+      expect(container.image.digest.repo).toBe('sha256:anchor-a');
+    });
+  });
+
   test('sets noUpdateReason from getTagCandidates when tag is pinned-specific and digest watch is off', async () => {
     mockGetState.mockReturnValue({
       registry: {

--- a/app/watchers/providers/docker/image-comparison.ts
+++ b/app/watchers/providers/docker/image-comparison.ts
@@ -238,6 +238,18 @@ function getRegistry(registryName: string): Registry {
 /**
  * Resolve remote digest information when digest watching is enabled.
  * Updates `container.image.digest.value` and populates digest/created on `result`.
+ *
+ * When the remote manifest is a v2 (manifest-list-capable) reference, a
+ * single local anchor (`container.image.digest.repo`) is not always the
+ * right one to normalize against: a local Docker image can carry several
+ * `repo@digest` RepoDigests entries for one Image ID (pull/retag
+ * accumulation), and `container.image.digest.repoDigests` — populated in
+ * `docker-image-details-orchestration.ts` via `getOrderedRepoDigests` — holds
+ * the full ordered candidate list (#669). This compares every candidate in
+ * order (cheap raw match first, then a normalize-and-compare registry call
+ * per remaining candidate) instead of trusting a single anchor, and
+ * re-anchors `container.image.digest.repo` to whichever candidate actually
+ * matched so a store poisoned with a stale/wrong anchor self-heals.
  */
 async function handleDigestWatch(
   container: Container,
@@ -264,16 +276,68 @@ async function handleDigestWatch(
   result.digest = remoteDigest.digest;
   result.created = remoteDigest.created;
 
-  if (remoteDigest.version === 2) {
-    const digestV2 = await registryProvider.getImageManifestDigest(
-      queryImage,
-      container.image.digest.repo,
-      lookupOptions,
-    );
-    container.image.digest.value = digestV2.digest;
-  } else {
+  if (remoteDigest.version !== 2) {
     container.image.digest.value = container.image.digest.repo;
+    return;
   }
+
+  const { repoDigests } = container.image.digest;
+  const anchors: string[] =
+    repoDigests && repoDigests.length > 0
+      ? repoDigests
+      : // findNewVersion only calls handleDigestWatch when digest.repo is
+        // truthy (`container.image.digest.watch && container.image.digest.repo`),
+        // so this legacy fallback always has exactly one entry.
+        [container.image.digest.repo as string];
+
+  // Cheap path: a raw anchor already equal to the remote digest needs no
+  // registry call at all — this also covers today's single-anchor case with
+  // no behavior change beyond skipping one now-redundant lookup.
+  const rawMatch = anchors.find((anchor) => anchor === result.digest);
+  if (rawMatch !== undefined) {
+    container.image.digest.value = result.digest;
+    container.image.digest.repo = rawMatch;
+    return;
+  }
+
+  let firstNormalizedValue: string | undefined;
+  let hasNormalizedValue = false;
+  let lastError: unknown;
+
+  for (const anchor of anchors) {
+    try {
+      const normalized = await registryProvider.getImageManifestDigest(
+        queryImage,
+        anchor,
+        lookupOptions,
+      );
+      if (!hasNormalizedValue) {
+        firstNormalizedValue = normalized.digest;
+        hasNormalizedValue = true;
+      }
+      if (normalized.digest === result.digest) {
+        container.image.digest.value = result.digest;
+        container.image.digest.repo = anchor;
+        return;
+      }
+    } catch (error: unknown) {
+      // A GC'd/unreachable manifest for this anchor is itself evidence the
+      // anchor is stale — skip it and keep trying the remaining candidates.
+      lastError = error;
+    }
+  }
+
+  if (!hasNormalizedValue) {
+    // Every candidate failed to normalize — propagate the failure so
+    // findNewVersion rejects and watchContainer keeps the previous cycle's
+    // verdict, rather than silently coercing a total failure into "no update".
+    throw lastError;
+  }
+
+  // No anchor matched: preserve today's semantics for a genuine same-tag
+  // republish by flagging an update against the first anchor's normalized
+  // value.
+  container.image.digest.value = firstNormalizedValue;
 }
 
 export interface FindNewVersionOptions {

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -5679,9 +5679,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -38,6 +38,7 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
+    "js-yaml": "3.15.1",
     "fast-xml-parser": "5.10.1",
     "joi": "18.2.3",
     "minimatch": "10.2.5",


### PR DESCRIPTION
Fixes #669 — found by the adversarially-verified digest-pipeline audit behind discussion #657.

## The bug

`getRepoDigest()` blindly took `RepoDigests[0]`. A local Docker image can carry multiple `repo@digest` entries for one Image ID (pull/retag accumulation, no ordering guarantee), so a stale or foreign-repo entry at index 0 anchored `digest.repo` → `digest.value` to the wrong manifest and produced a **persistent** digest-update false positive that survived applying the update — the refresh path re-derived from the same index every cycle, so it never self-healed.

## The fix

- **`getOrderedRepoDigests`** (docker-helpers): returns RepoDigests entries whose repo component matches the container's own image reference (reusing the imgset `docker.io`/`library/`/`registry-1` aliasing normalization), in original order; falls back to the full list when nothing matches so behavior never regresses to `undefined`.
- **`image.digest.repoDigests`** (optional, additive model field): carries the ordered candidate list, re-derived from the live inspect at discovery and on every refresh cycle. Old stored containers lack it and keep single-anchor behavior.
- **`handleDigestWatch`** walks the candidates: cheap raw-equality check first (no registry call), then a poll-cycle-cached normalize-and-compare per anchor, skipping anchors whose manifest fetch fails (a GC'd manifest is itself evidence the anchor is stale). It re-anchors `digest.repo` to the candidate that matched, so an already-poisoned store self-heals. A genuine same-tag republish (no candidate matches) still flags an update exactly as before; if every candidate fails to normalize, the failure propagates (findNewVersion rejects, watchContainer keeps the previous verdict) instead of coercing into a false "no update" — deliberately avoiding the #606 anti-pattern.
- **Refresh keeps a stored anchor that is still among the fresh candidates**, so the watch-cycle re-anchor doesn't ping-pong with the refresh path.

Deliberately untouched: `getRawDigestUpdate`/`getRawUpdateKind`/`hasRawUpdate`, the watch-decision logic, registry providers, UI.

## Also in this PR

🔒 Pinned `js-yaml` 3.15.1 in e2e (override) for GHSA-5p4m-2wfm-xmqj, published mid-soak and turning the qlty medium+ gate red repo-wide — same handling as the rc.12 brace-expansion/ip-address pins. e2e is the only workspace carrying js-yaml.

## Verification

- Full app suite: 12,564 tests green, 100% statements/branches/functions/lines.
- New coverage: foreign-repo-first selection, same-repo stale-first (raw and normalized match), genuine republish still flags, per-anchor failure skip, all-anchors-fail rejection, legacy no-`repoDigests` container unchanged, self-heal of a poisoned store, refresh anchor stickiness, `version !== 2` fallback unchanged.
- Full pre-push gate green (qlty, sharded coverage, builds, e2e, playwright, zizmor).

Not GA-gating: 1.5.x-era bug, ships in v1.6.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- 🐛 Fixed Docker digest selection for stale and foreign `RepoDigests` entries.
- ✨ Added ordered repository-digest candidates and persisted them across discovery and refresh cycles.
- 🔧 Added digest-anchor re-anchoring for valid candidates and poisoned stored state.
- 🔧 Filtered malformed repository-digest entries with empty repository or digest components.
- 🔧 Preserved fallback behavior, legacy-container behavior, and non-v2 manifest handling.
- 🔧 Preserved digest-fetch error propagation when all candidates fail.
- ✨ Added coverage for candidate selection, refresh, republishing, failures, and anchor repair.
- 🔒 Pinned `js-yaml` to `3.15.1` in the e2e workspace for GHSA-5p4m-2wfm-xmqj.

## Concerns

- Verify that `getImageReferenceCandidates` uses the same normalization rules as image-set matching.
- Verify that refresh cycles preserve the selected valid anchor when candidate ordering changes.
- Verify that all-candidate manifest failures remain errors and do not become false “no update” results.
- Verify that the `repoDigests` schema remains compatible with legacy containers that lack the field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->