### PR TITLE
🔒 security(docker): bump node and trivy base-image digests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pinned `js-yaml` to 3.15.1 in the e2e workspace (override; transitive dependency) for [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (CVE-2026-59870 backport gap: quadratic CPU consumption in `!!omap` resolution).
 - Pinned `nanoid` to 3.3.18 (override; transitive dependency of `postcss` in the root, app, apps/demo, apps/web, and ui workspaces, and of `artillery` in the e2e workspace) for [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (CVE-2026-67213) and, in the e2e workspace which was still on 3.3.12, also [GHSA-28wg-ghj8-5hjv](https://github.com/advisories/GHSA-28wg-ghj8-5hjv) (CVE-2026-67214).
+- **`node:24-alpine` base image bumped to Node 24.19.0 for v1.6.0 GA**, replacing the Node 24.18.0 image shipped in rc.12. Picks up Node's July 29 2026 security release, fixing 3 HIGH (CVE-2026-56846, CVE-2026-56848, CVE-2026-58043) + 5 MEDIUM CVEs that landed in 24.18.1.
+- **Vendored `aquasec/trivy` build-stage pin bumped from 0.72.0 to 0.73.0**, resolving 4 HIGH / 6 MEDIUM CVEs in its vendored Go dependencies: go-git ([CVE-2026-71556](https://github.com/advisories/CVE-2026-71556)), `x/text` ([CVE-2026-56852](https://github.com/advisories/CVE-2026-56852)), grpc ([GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf)), oras-go ([CVE-2026-50151](https://github.com/advisories/CVE-2026-50151), [CVE-2026-50163](https://github.com/advisories/CVE-2026-50163)), and the Go stdlib ([CVE-2026-39822](https://github.com/advisories/CVE-2026-39822)).
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # checkov:skip=CKV_DOCKER_3: entrypoint uses su-exec for runtime privilege drop
 # Trivy publishes a multi-arch image and installs its binary at this path.
 # Pin the image index so every target architecture resolves reproducibly.
-FROM aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f AS trivy-bin
+FROM aquasec/trivy@sha256:7cced7cae583819fc7806d4cbc0dbbc7cad18b99f7d3e235192e6da8c091045c AS trivy-bin
 
 # Common Stage
-FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS base
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS base
 WORKDIR /home/node/app
 
 LABEL maintainer="CodesWhat"

--- a/app/configuration/dockerfile-defaults.test.ts
+++ b/app/configuration/dockerfile-defaults.test.ts
@@ -11,7 +11,7 @@ describe('Dockerfile release defaults', () => {
     const dockerfile = fs.readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
 
     expect(dockerfile).toContain(
-      'FROM aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f AS trivy-bin',
+      'FROM aquasec/trivy@sha256:7cced7cae583819fc7806d4cbc0dbbc7cad18b99f7d3e235192e6da8c091045c AS trivy-bin',
     );
     expect(dockerfile).toContain('COPY --from=trivy-bin /usr/local/bin/trivy /usr/local/bin/trivy');
     expect(dockerfile).not.toContain('alpine/edge/testing');

--- a/app/configuration/dockerfile-defaults.test.ts
+++ b/app/configuration/dockerfile-defaults.test.ts
@@ -7,6 +7,14 @@ describe('Dockerfile release defaults', () => {
     expect(dockerfile).toMatch(/FROM base AS release\s+ENV DD_LOG_FORMAT=text/u);
   });
 
+  test('release image builds from the digest-pinned Node base image', () => {
+    const dockerfile = fs.readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
+
+    expect(dockerfile).toContain(
+      'FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS base',
+    );
+  });
+
   test('release image copies Trivy from the digest-pinned multi-arch image', () => {
     const dockerfile = fs.readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
 


### PR DESCRIPTION
## Summary

Bumps the pinned node and trivy base-image digests in the Dockerfile to the current upstream releases, clearing the open base-image CVEs ahead of the v1.6.0-rc.13 cut. Held since 2026-08-04 for the GA window; promoted to rc.13 content now that the release plan cuts a final candidate instead of promoting rc.12.

Digest assertions in `app/configuration/dockerfile-defaults.test.ts` updated to match the pins.

## Testing
- Full pre-push gate green at push time (coverage 100% app+ui, builds, e2e, playwright)
- Trivy scan against the rebuilt image: no HIGH/CRITICAL findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔒 Security: Updated pinned Node 24 Alpine and Trivy image digests.
- 🔧 Changed: Updated Node from `24.18.0` to `24.19.0`.
- 🔧 Changed: Updated Trivy from `0.72.0` to `0.73.0`.
- 🔧 Changed: Updated digest assertions in `app/configuration/dockerfile-defaults.test.ts`.
- 🔒 Security: Rebuilt image scan reported no HIGH or CRITICAL findings.

## Concerns

- Confirm the full pre-push gate remains passed.
- Confirm the release-stage Docker build validates `node --version` and `trivy --version`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->