### PR TITLE
chore(commits): retire gitmoji for plain Conventional Commits

### DIFF
--- a/.github/workflows/i18n-crowdin.yml
+++ b/.github/workflows/i18n-crowdin.yml
@@ -89,11 +89,11 @@ jobs:
           download_translations: true
           localization_branch_name: l10n_crowdin
           create_pull_request: true
-          pull_request_title: "🔧 chore(i18n): sync translations from Crowdin"
+          pull_request_title: "chore(i18n): sync translations from Crowdin"
           pull_request_body: "Automated sync from Crowdin. Review wording, then merge."
           pull_request_labels: "translations,crowdin"
           pull_request_base_branch_name: ${{ steps.base.outputs.name }}
-          commit_message: "🔧 chore(i18n): sync translations from Crowdin"
+          commit_message: "chore(i18n): sync translations from Crowdin"
         env:
           # The crowdin/github-action entrypoint runs `git config --global`
           # (safe.directory, then the commit user) but the container inherits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,34 +126,36 @@ Each component type extends a base class with `init()`, `deregister()`, and type
 
 ## Commit convention
 
-We use **Gitmoji + Conventional Commits**:
+We use **Conventional Commits**. No emoji — plain format:
 
 ```text
-<emoji> <type>(<scope>): <description>
+<type>(<scope>): <description>
 ```
 
-| Emoji | Type | Use |
-|---|---|---|
-| ✨ | `feat` | New feature |
-| 🐛 | `fix` | Bug fix |
-| 📝 | `docs` | Documentation |
-| 💄 | `style` | UI/cosmetic changes |
-| ♻️ | `refactor` | Code refactor (no feature/fix) |
-| ⚡ | `perf` | Performance improvement |
-| ✅ | `test` | Adding/updating tests |
-| 🔧 | `chore` | Build, config, tooling |
-| 🔒 | `security` | Security fix |
-| ⬆️ | `deps` | Dependency upgrade |
-| 🗑️ | `revert` | Intentional revert |
+| Type | Use |
+|---|---|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation |
+| `style` | UI/cosmetic changes |
+| `refactor` | Code refactor (no feature/fix), including code removal |
+| `perf` | Performance improvement |
+| `test` | Adding/updating tests |
+| `build` | Build system or dependency changes |
+| `ci` | CI/CD configuration changes |
+| `chore` | Tooling, config, misc |
+| `revert` | Intentional revert |
 
 Scope is optional. Subject line: imperative, lowercase, no trailing period.
 
+Breaking changes: add `!` before the colon (`feat(api)!: drop v1 tokens`), or a `BREAKING CHANGE:` footer.
+
 ```text
-✨ feat(docker): add health check endpoint
-🐛 fix: resolve socket EACCES (#38)
+feat(docker): add health check endpoint
+fix: resolve socket EACCES (#38)
 ```
 
-Don't stress about getting the emoji/format perfect — the commit-msg hook will tell you if something's off, and the maintainer can fix it during merge.
+Don't stress about getting the format perfect — the commit-msg hook will tell you if something's off, and the maintainer can fix it during merge.
 
 ## Testing (optional for contributors)
 

--- a/docs/ci-flow.html
+++ b/docs/ci-flow.html
@@ -140,7 +140,7 @@ header p{font-size:14px;color:#666;margin-top:4px}
 <div class="swimlane lane-commit">
   <div class="swimlane-label">Commit</div>
   <div class="swimlane-content">
-    <div class="node n-block"><span class="emoji">💬</span> Commit message format<span class="node-sub">gitmoji + conventional</span></div>
+    <div class="node n-block"><span class="emoji">💬</span> Commit message format<span class="node-sub">conventional commits</span></div>
     <div class="arrow"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14m-4-4 4 4-4 4"/></svg></div>
     <div class="node n-block"><span class="emoji">🔧</span> Biome fix + format<span class="node-sub">auto-fix, re-stage</span></div>
     <div class="arrow"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14m-4-4 4 4-4 4"/></svg></div>

--- a/scripts/commit-message.mjs
+++ b/scripts/commit-message.mjs
@@ -1,28 +1,28 @@
 const COMMIT_TYPES = {
-  feat: { emoji: '✨', aliases: [], purpose: 'new feature' },
-  fix: { emoji: '🐛', aliases: [], purpose: 'bug fix' },
-  docs: { emoji: '📝', aliases: [], purpose: 'documentation change' },
-  style: { emoji: '🎨', aliases: ['💄'], purpose: 'style/cosmetic change' },
-  refactor: { emoji: '🔄', aliases: ['♻️'], purpose: 'refactor without behavior change' },
-  perf: { emoji: '⚡', aliases: [], purpose: 'performance improvement' },
-  test: { emoji: '🧪', aliases: ['✅'], purpose: 'test change' },
-  chore: { emoji: '🔧', aliases: [], purpose: 'tooling/config change' },
-  security: { emoji: '🔒', aliases: [], purpose: 'security fix' },
-  deps: { emoji: '📦', aliases: ['⬆️'], purpose: 'dependency change' },
-  remove: { emoji: '🗑️', aliases: [], purpose: 'code removal' },
-  revert: { emoji: '🗑️', aliases: [], purpose: 'intentional revert' },
+  feat: { purpose: 'new feature' },
+  fix: { purpose: 'bug fix' },
+  docs: { purpose: 'documentation change' },
+  style: { purpose: 'style/cosmetic change' },
+  refactor: { purpose: 'refactor without behavior change' },
+  perf: { purpose: 'performance improvement' },
+  test: { purpose: 'test change' },
+  build: { purpose: 'build system or dependency change' },
+  ci: { purpose: 'CI/CD configuration change' },
+  chore: { purpose: 'tooling/misc change' },
+  revert: { purpose: 'intentional revert' },
 };
 
-function getAcceptedEmojis(type) {
-  const meta = COMMIT_TYPES[type];
-  if (!meta) {
-    return [];
-  }
-  return [meta.emoji, ...meta.aliases];
-}
+const typeAlternation = Object.keys(COMMIT_TYPES).join('|');
 
-const subjectRegex =
-  /^(?<emoji>✨|🐛|📝|🎨|💄|🔄|♻️|⚡|🧪|✅|🔧|🔒|📦|⬆️|🗑️)\s(?<type>feat|fix|docs|style|refactor|perf|test|chore|security|deps|remove|revert)(?:\((?<scope>[a-z0-9][a-z0-9._/-]*)\))?:\s(?<description>.+)$/u;
+const subjectRegex = new RegExp(
+  `^(?<type>${typeAlternation})(?:\\((?<scope>[a-z0-9][a-z0-9._/-]*)\\))?(?<breaking>!)?:\\s(?<description>.+)$`,
+  'u',
+);
+
+// Fixup/squash autosquash commits are meant to be folded away by `git rebase
+// --autosquash` before they ever reach history, so they're exempt from
+// format checks the same way merge/revert commits are.
+const autosquashRegex = /^(fixup|squash)!\s/u;
 
 export function validateCommitMessage(rawMessage) {
   const message = (rawMessage ?? '').trim();
@@ -35,19 +35,19 @@ export function validateCommitMessage(rawMessage) {
   if (subject.startsWith('Revert "')) {
     return { valid: true, errors: [] };
   }
+  if (autosquashRegex.test(subject)) {
+    return { valid: true, errors: [] };
+  }
 
   const errors = [];
   const match = subject.match(subjectRegex);
 
+  if (/^\p{Emoji}/u.test(subject)) {
+    errors.push('No emoji prefix — this repo uses plain Conventional Commits, not gitmoji.');
+  }
+
   if (!match?.groups) {
-    if (!/^\p{Emoji}/u.test(subject)) {
-      errors.push('Missing required emoji (gitmoji) prefix.');
-    }
-    if (
-      !/\s(feat|fix|docs|style|refactor|perf|test|chore|security|deps|remove|revert)(\(|:)/u.test(
-        subject,
-      )
-    ) {
+    if (!new RegExp(`^(${typeAlternation})(\\(|!|:)`, 'u').test(subject)) {
       errors.push('Missing or unsupported commit type.');
     }
     errors.push('Subject does not match required format.');
@@ -55,12 +55,7 @@ export function validateCommitMessage(rawMessage) {
     return { valid: false, errors };
   }
 
-  const { emoji, type, description } = match.groups;
-  const acceptedEmojis = getAcceptedEmojis(type);
-  if (acceptedEmojis.length > 0 && !acceptedEmojis.includes(emoji)) {
-    const expected = acceptedEmojis.map((value) => `"${value} ${type}"`).join(' or ');
-    errors.push(`Invalid emoji/type pair. Expected ${expected} but got "${emoji} ${type}".`);
-  }
+  const { description } = match.groups;
 
   if (/^[A-Z]/u.test(description)) {
     errors.push('Description must be imperative and lowercase at the start.');
@@ -81,14 +76,8 @@ export function formatValidationFailure(rawMessage, errors) {
   const message = (rawMessage ?? '').trim();
   const subject = message.split(/\r?\n/u, 1)[0] ?? '';
 
-  const allowedPairs = Object.entries(COMMIT_TYPES)
-    .map(([type, meta]) => {
-      const alternates =
-        meta.aliases.length > 0
-          ? ` (or ${meta.aliases.map((a) => `${a} ${type}`).join(', ')})`
-          : '';
-      return `  ${meta.emoji} ${type}: ${meta.purpose}${alternates}`;
-    })
+  const allowedTypes = Object.entries(COMMIT_TYPES)
+    .map(([type, meta]) => `  ${type}: ${meta.purpose}`)
     .join('\n');
 
   const formattedErrors = errors.map((error) => `  - ${error}`).join('\n');
@@ -99,22 +88,25 @@ export function formatValidationFailure(rawMessage, errors) {
     `Current subject: ${subject || '<empty>'}`,
     '',
     'Required subject format:',
-    '  <emoji> <type>(<scope>): <description>',
+    '  <type>(<scope>): <description>',
+    '',
+    'Use "!" before the colon for a breaking change, e.g. feat(api)!: drop v1 tokens',
+    '(or add a "BREAKING CHANGE:" footer). No emoji — plain Conventional Commits only.',
     '',
     'Valid examples:',
-    '  ✨ feat(docker): add health check endpoint',
-    '  🐛 fix: resolve socket EACCES (#38)',
-    '  ♻️ refactor(store): simplify collection init',
+    '  feat(docker): add health check endpoint',
+    '  fix: resolve socket EACCES (#38)',
+    '  refactor(store): simplify collection init',
     '',
-    'Allowed emoji/type pairs:',
-    allowedPairs,
+    'Allowed types:',
+    allowedTypes,
     '',
     'Validation errors:',
     formattedErrors,
     '',
     'AI_ACTION_REQUIRED: rewrite the commit subject to match the required format exactly.',
     'Fix command:',
-    '  git commit --amend -m "✨ feat(scope): concise imperative description"',
+    '  git commit --amend -m "feat(scope): concise imperative description"',
     '',
   ].join('\n');
 }

--- a/scripts/commit-message.mjs
+++ b/scripts/commit-message.mjs
@@ -14,8 +14,11 @@ const COMMIT_TYPES = {
 
 const typeAlternation = Object.keys(COMMIT_TYPES).join('|');
 
+// Exactly one literal space after the colon, and the description must start
+// with a non-space character — otherwise `feat:  Add x` slips a leading space
+// into the description and dodges the lowercase-start check.
 const subjectRegex = new RegExp(
-  `^(?<type>${typeAlternation})(?:\\((?<scope>[a-z0-9][a-z0-9._/-]*)\\))?(?<breaking>!)?:\\s(?<description>.+)$`,
+  `^(?<type>${typeAlternation})(?:\\((?<scope>[a-z0-9][a-z0-9._/-]*)\\))?(?<breaking>!)?: (?<description>\\S.*)$`,
   'u',
 );
 
@@ -47,8 +50,14 @@ export function validateCommitMessage(rawMessage) {
   }
 
   if (!match?.groups) {
+    const strictPrefix = `^(?:${typeAlternation})(?:\\([a-z0-9][a-z0-9._/-]*\\))?!?:`;
     if (!new RegExp(`^(${typeAlternation})(\\(|!|:)`, 'u').test(subject)) {
       errors.push('Missing or unsupported commit type.');
+    } else if (
+      new RegExp(`${strictPrefix}\\s`, 'u').test(subject) &&
+      !new RegExp(`${strictPrefix} \\S`, 'u').test(subject)
+    ) {
+      errors.push('Exactly one space after the colon.');
     }
     errors.push('Subject does not match required format.');
 

--- a/scripts/commit-message.test.mjs
+++ b/scripts/commit-message.test.mjs
@@ -140,3 +140,21 @@ test('failure formatter lists the allowed type list with no emoji', () => {
   assert.match(formatted, /ci: CI\/CD configuration change/);
   assert.doesNotMatch(formatted, /✨|🐛|📝|🎨|💄|🔄|♻️|⚡|🧪|✅|🔧|🔒|📦|⬆️|🗑️/u);
 });
+
+test('rejects a double space after the colon (leading space would dodge the lowercase check)', () => {
+  const result = validateCommitMessage('feat:  Add endpoint');
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join(' '), /exactly one space after the colon/i);
+});
+
+test('rejects a tab after the colon', () => {
+  const result = validateCommitMessage('feat:\tadd endpoint');
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join(' '), /exactly one space after the colon/i);
+});
+
+test('does not blame spacing when the scope is what is invalid', () => {
+  const result = validateCommitMessage('feat(BadScope): add endpoint');
+  assert.equal(result.valid, false);
+  assert.doesNotMatch(result.errors.join(' '), /exactly one space/i);
+});

--- a/scripts/commit-message.test.mjs
+++ b/scripts/commit-message.test.mjs
@@ -3,105 +3,110 @@ import test from 'node:test';
 import { formatValidationFailure, validateCommitMessage } from './commit-message.mjs';
 
 test('accepts a valid feat message with scope', () => {
-  const result = validateCommitMessage('✨ feat(docker): add health check endpoint');
+  const result = validateCommitMessage('feat(docker): add health check endpoint');
   assert.equal(result.valid, true);
 });
 
 test('accepts a valid fix message without scope', () => {
-  const result = validateCommitMessage('🐛 fix: resolve socket EACCES (#38)');
+  const result = validateCommitMessage('fix: resolve socket EACCES (#38)');
   assert.equal(result.valid, true);
 });
 
-test('accepts primary style emoji 🎨', () => {
-  const result = validateCommitMessage('🎨 style(ui): align button padding');
+test('accepts style type', () => {
+  const result = validateCommitMessage('style(ui): align button padding');
   assert.equal(result.valid, true);
 });
 
-test('accepts legacy style emoji 💄 as alias', () => {
-  const result = validateCommitMessage('💄 style(ui): align button padding');
+test('accepts refactor type', () => {
+  const result = validateCommitMessage('refactor(api): split handlers module');
   assert.equal(result.valid, true);
 });
 
-test('accepts primary refactor emoji 🔄', () => {
-  const result = validateCommitMessage('🔄 refactor(api): split handlers module');
+test('accepts test type', () => {
+  const result = validateCommitMessage('test(store): cover migration branch');
   assert.equal(result.valid, true);
 });
 
-test('accepts legacy refactor emoji ♻️ as alias', () => {
-  const result = validateCommitMessage('♻️ refactor(api): split handlers module');
+test('accepts build type (retired "deps" type now lives here)', () => {
+  const result = validateCommitMessage('build(deps): update axios 1.13 → 1.15');
   assert.equal(result.valid, true);
 });
 
-test('accepts primary test emoji 🧪', () => {
-  const result = validateCommitMessage('🧪 test(store): cover migration branch');
+test('accepts ci type (retired "deploy" type now lives here)', () => {
+  const result = validateCommitMessage('ci(deploy): retry flaky release job');
   assert.equal(result.valid, true);
 });
 
-test('accepts legacy test emoji ✅ as alias', () => {
-  const result = validateCommitMessage('✅ test(store): cover migration branch');
+test('accepts chore type (retired "config" type now lives here)', () => {
+  const result = validateCommitMessage('chore(config): tighten lint rules');
   assert.equal(result.valid, true);
 });
 
-test('accepts primary deps emoji 📦', () => {
-  const result = validateCommitMessage('📦 deps(app): update axios 1.13 → 1.15');
+test('accepts refactor type for code removal (retired "remove" type now lives here)', () => {
+  const result = validateCommitMessage('refactor(api): drop unused v0 endpoints');
   assert.equal(result.valid, true);
 });
 
-test('accepts legacy deps emoji ⬆️ as alias', () => {
-  const result = validateCommitMessage('⬆️ deps(app): update axios 1.13 → 1.15');
+test('accepts revert type', () => {
+  const result = validateCommitMessage('revert(ui): back out flaky dashboard widget');
   assert.equal(result.valid, true);
 });
 
-test('accepts remove type with 🗑️ emoji', () => {
-  const result = validateCommitMessage('🗑️ remove(api): drop unused v0 endpoints');
+test('accepts breaking change marker with "!" before the colon', () => {
+  const result = validateCommitMessage('feat(api)!: drop v1 tokens');
   assert.equal(result.valid, true);
 });
 
-test('accepts revert type with 🗑️ emoji', () => {
-  const result = validateCommitMessage('🗑️ revert(ui): back out flaky dashboard widget');
+test('accepts breaking change marker with no scope', () => {
+  const result = validateCommitMessage('feat!: drop v1 tokens');
   assert.equal(result.valid, true);
 });
 
-test('rejects message without emoji prefix', () => {
-  const result = validateCommitMessage('feat(docker): add health check endpoint');
+test('rejects a leading emoji even with an otherwise valid subject', () => {
+  const result = validateCommitMessage('✨ feat(docker): add health check endpoint');
   assert.equal(result.valid, false);
-  assert.match(result.errors.join(' '), /emoji/i);
+  assert.match(result.errors.join(' '), /no emoji prefix/i);
 });
 
 test('rejects unknown commit type', () => {
-  const result = validateCommitMessage('✨ feature(api): add endpoint');
+  const result = validateCommitMessage('feature(api): add endpoint');
   assert.equal(result.valid, false);
   assert.match(result.errors.join(' '), /type/i);
 });
 
-test('rejects mismatched emoji/type pairs', () => {
-  const result = validateCommitMessage('✨ fix(api): resolve edge case');
+test('rejects retired "security" type', () => {
+  const result = validateCommitMessage('security(api): patch injection vector');
   assert.equal(result.valid, false);
-  assert.match(result.errors.join(' '), /emoji\/type pair/i);
+  assert.match(result.errors.join(' '), /type/i);
 });
 
-test('rejects foreign emoji for a type that has an alias set', () => {
-  // 🎨 is a valid known emoji (style), but deps only accepts 📦 and ⬆️
-  const result = validateCommitMessage('🎨 deps(app): bump some-dep');
+test('rejects retired "deps" type', () => {
+  const result = validateCommitMessage('deps(app): bump some-dep');
   assert.equal(result.valid, false);
-  assert.match(result.errors.join(' '), /emoji\/type pair/i);
+  assert.match(result.errors.join(' '), /type/i);
+});
+
+test('rejects retired "remove" type', () => {
+  const result = validateCommitMessage('remove(api): drop unused v0 endpoints');
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join(' '), /type/i);
 });
 
 test('rejects trailing period', () => {
-  const result = validateCommitMessage('✨ feat(api): add endpoint.');
+  const result = validateCommitMessage('feat(api): add endpoint.');
   assert.equal(result.valid, false);
   assert.match(result.errors.join(' '), /trailing period/i);
 });
 
 test('rejects subject longer than 100 characters', () => {
   const longDescription = 'a'.repeat(90);
-  const result = validateCommitMessage(`✨ feat(api): ${longDescription}`);
+  const result = validateCommitMessage(`feat(api): ${longDescription}`);
   assert.equal(result.valid, false);
   assert.match(result.errors.join(' '), /100 characters/i);
 });
 
 test('rejects uppercase-initial description', () => {
-  const result = validateCommitMessage('✨ feat(api): Add endpoint');
+  const result = validateCommitMessage('feat(api): Add endpoint');
   assert.equal(result.valid, false);
   assert.match(result.errors.join(' '), /imperative/i);
 });
@@ -112,15 +117,26 @@ test('allows auto-generated merge commits', () => {
 });
 
 test('allows default git revert commits', () => {
-  const result = validateCommitMessage('Revert "✨ feat(api): add endpoint"');
+  const result = validateCommitMessage('Revert "feat(api): add endpoint"');
   assert.equal(result.valid, true);
 });
 
-test('failure formatter lists alias emojis in the allowed pairs list', () => {
-  const result = validateCommitMessage('feat(api): add endpoint');
-  const formatted = formatValidationFailure('feat(api): add endpoint', result.errors);
-  assert.match(formatted, /🎨 style.*💄 style/u);
-  assert.match(formatted, /🔄 refactor.*♻️ refactor/u);
-  assert.match(formatted, /🧪 test.*✅ test/u);
-  assert.match(formatted, /📦 deps.*⬆️ deps/u);
+test('allows fixup! autosquash commits', () => {
+  const result = validateCommitMessage('fixup! feat(api): add endpoint');
+  assert.equal(result.valid, true);
+});
+
+test('allows squash! autosquash commits', () => {
+  const result = validateCommitMessage('squash! feat(api): add endpoint');
+  assert.equal(result.valid, true);
+});
+
+test('failure formatter lists the allowed type list with no emoji', () => {
+  const result = validateCommitMessage('feature(api): add endpoint');
+  const formatted = formatValidationFailure('feature(api): add endpoint', result.errors);
+  assert.match(formatted, /Allowed types:/);
+  assert.match(formatted, /feat: new feature/);
+  assert.match(formatted, /build: build system or dependency change/);
+  assert.match(formatted, /ci: CI\/CD configuration change/);
+  assert.doesNotMatch(formatted, /✨|🐛|📝|🎨|💄|🔄|♻️|⚡|🧪|✅|🔧|🔒|📦|⬆️|🗑️/u);
 });

--- a/scripts/validate-commit-range.test.mjs
+++ b/scripts/validate-commit-range.test.mjs
@@ -13,8 +13,8 @@ test('main returns non-zero when commit range contains invalid messages', () => 
 
   const exitCode = main(['--base', 'abc123', '--head', 'def456'], {
     getCommits: () => [
-      { sha: '1111111', message: '✨ feat(api): add health endpoint' },
-      { sha: '2222222', message: 'fix(api): missing emoji prefix' },
+      { sha: '1111111', message: 'feat(api): add health endpoint' },
+      { sha: '2222222', message: 'Feat(api): capitalized type is invalid' },
     ],
     stdout: (message) => stdout.push(message),
     stderr: (message) => stderr.push(message),
@@ -32,8 +32,8 @@ test('main succeeds when all commit messages in range are valid', () => {
 
   const exitCode = main(['--base', 'abc123', '--head', 'def456'], {
     getCommits: () => [
-      { sha: '1111111', message: '✨ feat(api): add health endpoint' },
-      { sha: '2222222', message: '🐛 fix(ci): handle missing env var' },
+      { sha: '1111111', message: 'feat(api): add health endpoint' },
+      { sha: '2222222', message: 'fix(ci): handle missing env var' },
     ],
     stdout: (message) => stdout.push(message),
     stderr: (message) => stderr.push(message),


### PR DESCRIPTION
Retires the gitmoji commit format for plain Conventional Commits, matching the convention now standard across the CodesWhat repos.

## What changed

- `CONTRIBUTING.md` — documents the 11-type format (`feat fix docs style refactor perf test build ci chore revert`) and the `!` breaking-change syntax
- `scripts/commit-message.mjs` — shared type table and failure formatter, no emoji prefix
- `.github/workflows/i18n-crowdin.yml` — strips the emoji from Crowdin's generated commit message and PR title
- `docs/ci-flow.html` — the commit gate now reads "conventional commits" rather than "gitmoji + conventional"

The Crowdin action authors its own commits, so its message template had to change too or the bot's translation syncs would start failing the new validator.

## Verification

28/28 tests pass on this branch across `commit-message.test.mjs` and `validate-commit-range.test.mjs`, including a case asserting the failure output lists the allowed types with no emoji.

Retired types map as `config → chore(config)`, `deps → build(deps)`, `deploy → ci(deploy)`, `remove → refactor(<scope>)`.

Existing history is left alone and never rewritten.

## Note

This branches from `dev/v1.7` rather than `dev/v1.6`, to keep an RC-13 branch quiet ahead of GA. The six touched files are byte-identical across both dev branches, so it forward-ports cleanly if you'd rather it also land on `dev/v1.6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

### ✨ Added
- Documented 11 supported Conventional Commit types.
- Added `!` breaking-change syntax.
- Added exact single-space validation after the colon.
- Added tests for spacing rejection and invalid-scope hint precedence.

### 🔧 Changed
- Replaced gitmoji validation with plain Conventional Commits.
- Updated contributor and CI documentation.
- Updated Crowdin-generated commit messages and PR titles.
- Mapped retired types to supported equivalents.
- Updated commit fixtures and validation tests.
- Confirmed 28/28 tests pass.

### 🗑️ Removed
- Removed emoji prefixes, aliases, emoji/type pairing, and retired commit types.
- Left existing commit history unchanged.

### ⚠️ Breaking
- New commits must use plain Conventional Commit syntax.
- Double spaces and tabs after the colon are invalid.
- Existing gitmoji-based commits remain unchanged.

## Concerns

- Check external commit hooks and automation for gitmoji assumptions.
- Confirm all repository documentation uses the 11 supported commit types.
- Handle issue `#39` separately; this PR does not add the Prometheus `agent` label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->