### PR TITLE
docs: publish OpenSSF assurance evidence

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,59 @@
+# Drydock Governance
+
+## Model
+
+Drydock uses a lead-maintainer model. Work is proposed and reviewed in public
+issues, discussions, and pull requests. The lead maintainer owns project scope,
+release readiness, and final decisions when consensus cannot be reached.
+
+The current project roles are:
+
+| Role | Current assignment | Responsibilities |
+| --- | --- | --- |
+| Lead maintainer | [`@scttbnsn`](https://github.com/scttbnsn) | Product direction, issue triage, security response, release approval, and final technical decisions |
+| Continuity maintainer | [`@biggest-littlest`](https://github.com/biggest-littlest) | CodesWhat organization administration, access recovery, and release continuity when the lead maintainer is unavailable |
+| Code owners | Accounts listed in [`.github/CODEOWNERS`](.github/CODEOWNERS) | Review changes in owned areas and identify risk, compatibility, and test requirements |
+| Contributors | Anyone participating through issues, discussions, or pull requests | Propose, implement, test, document, and review changes |
+
+Roles are based on sustained project work and trust. The lead maintainer may add
+or remove code owners and maintainers through a public pull request that updates
+the relevant repository records. Organization-owner changes are recorded by
+GitHub's organization audit log.
+
+## Decisions and disputes
+
+Routine changes are decided through pull-request review. Larger changes should
+start with a GitHub issue or discussion that records the problem, alternatives,
+security and compatibility effects, and the intended outcome. The project seeks
+rough consensus, but the lead maintainer makes the final decision when a timely
+decision is required. The reason should be recorded in the issue or pull request.
+
+Security reports follow [`SECURITY.md`](SECURITY.md) and stay private until a fix
+and coordinated disclosure are ready. Conduct reports follow
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Change and release control
+
+Changes are made on branches and merged through pull requests. Development
+targets the active `dev/vX.Y` branch. `main` advances through a reviewed release
+sync and is the source for signed release tags and artifacts. Required CI checks
+must pass before merge, and the release workflow independently verifies the
+selected source revision before publication.
+
+## Access continuity
+
+The repository is owned by the CodesWhat GitHub organization, which has two
+owner accounts: `@scttbnsn` and `@biggest-littlest`. Either owner can administer
+the repository, close issues, restore maintainer access, manage Actions and
+release environments, and continue the pull-request and release process.
+Repository code owners provide an additional public record of review coverage.
+
+Canonical source, issues, CI, release workflows, container images, and release
+artifacts are kept in GitHub and GHCR. Releases use GitHub Actions OIDC for
+keyless signing and attestations, so continuity does not depend on a private
+signing key held on one maintainer's workstation. If one maintainer becomes
+unavailable, the remaining organization owner can revoke stale access, update
+role assignments, merge approved work, and publish a release within one week.
+
+Project forking is always available under the AGPL-3.0 license, but it is not the
+primary continuity plan.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   <br>
   <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
+  <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <br>
@@ -381,7 +382,8 @@ Drydock v1.6 no longer loads `WUD_*` environment variables or `wud.*` labels at 
 <details>
 <summary><strong>Version themes & highlights</strong></summary>
 
-High-level themes only — see [CHANGELOG.md](CHANGELOG.md) for per-release detail.
+This direction covers at least the next twelve months, through August 2027.
+High-level themes only; see [CHANGELOG.md](CHANGELOG.md) for per-release detail.
 
 | Version | Theme | Highlights |
 | --- | --- | --- |
@@ -412,6 +414,10 @@ High-level themes only — see [CHANGELOG.md](CHANGELOG.md) for per-release deta
 | Deprecations | [`DEPRECATIONS.md`](DEPRECATIONS.md) |
 | Roadmap | See [Roadmap](#roadmap) section above |
 | Contributing | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Code of Conduct | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) |
+| Governance | [`GOVERNANCE.md`](GOVERNANCE.md) |
+| Security Assurance | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md) |
+| Security Policy | [`SECURITY.md`](SECURITY.md) |
 | Issues | [GitHub Issues](https://github.com/CodesWhat/drydock/issues) |
 | Discussions | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) — feature requests & ideas welcome |
 

--- a/SECURITY-ASSURANCE.md
+++ b/SECURITY-ASSURANCE.md
@@ -1,0 +1,128 @@
+# Drydock Security Assurance Case
+
+Last reviewed: 2026-08-11
+
+This document states Drydock's security requirements, threat boundaries, and
+the public evidence supporting its security claims. It is a living assurance
+case, not a claim that Drydock can make a Docker daemon safe after an attacker
+has gained authorized Docker API access.
+
+## Security requirements and limits
+
+Drydock is intended to:
+
+- deny protected API access unless authentication succeeds, with anonymous
+  operation requiring an explicit acknowledgement;
+- validate untrusted network, registry, webhook, configuration, and update
+  inputs before using them;
+- keep credentials out of logs, debug bundles, release artifacts, and browser
+  responses;
+- limit outbound requests so registry and notification features cannot be used
+  as an unrestricted SSRF or redirect path;
+- ship changes only after automated tests, static analysis, dependency checks,
+  and release verification pass; and
+- produce signed, attributable release artifacts with provenance and SBOMs.
+
+An authenticated Drydock deployment may inspect and update containers through
+the Docker API. Docker socket access is effectively host-root access. Drydock
+does not turn an unrestricted socket into a least-privilege interface. Operators
+should place [Sockguard](https://github.com/CodesWhat/sockguard) or another
+allowlisting proxy between Drydock and the daemon, restrict network access, and
+protect every configured credential. The supported-version and disclosure
+commitments are defined in [`SECURITY.md`](SECURITY.md).
+
+## Threat model and trust boundaries
+
+The relevant threat actors are unauthenticated network clients, authenticated
+but malicious users, hostile registry or webhook responses, compromised remote
+services, malicious container metadata, and a contributor or dependency that
+attempts to alter the build or release process.
+
+The principal trust boundaries are:
+
+1. **Client to HTTP API and UI.** Network data becomes application input. Auth,
+   rate limiting, schema validation, output encoding, and security headers are
+   enforced here.
+2. **Drydock to Docker or Portwing.** Crossing this boundary can change host
+   workloads. Authentication and update policy are enforced by Drydock, while
+   endpoint-level least privilege belongs at a socket proxy.
+3. **Drydock to registries and notification providers.** Remote URLs, redirects,
+   DNS answers, response sizes, and credentials are treated as untrusted.
+4. **Process to persistent state and secrets.** Secret-file permissions,
+   redaction, bounded debug exports, and integrity checks protect this boundary.
+5. **Source to release artifact.** Reviewed source crosses CI, build, signing,
+   provenance, and publication controls before users receive an artifact.
+
+## Claims and evidence
+
+### Fail-safe defaults and complete mediation
+
+Authentication configuration fails closed. Anonymous mode must be explicitly
+confirmed, and protected routes share the authentication middleware rather than
+opting in route by route. Docker updates flow through the same policy and
+operation tracking used by the API and UI. Regression tests cover authentication
+failure, authorization, rate limiting, update admission, and agent boundaries.
+
+Evidence: [`app/authentications/`](app/authentications),
+[`app/api/`](app/api), [`app/updates/`](app/updates), and the tests adjacent to
+those modules.
+
+### Least privilege and secret handling
+
+The published container is designed for a read-only root filesystem and minimal
+runtime privileges. Configuration supports mounted secret files. Debug output
+and structured logs redact credential-bearing fields. CI release signing uses
+short-lived GitHub OIDC identities instead of a maintainer-held signing key.
+
+Evidence: [`Dockerfile`](Dockerfile), [`app/debug/`](app/debug),
+[`app/log/`](app/log), the hardened deployment in [`README.md`](README.md), and
+[`.github/workflows/release-cut.yml`](.github/workflows/release-cut.yml).
+
+### Untrusted input, injection, and outbound-request controls
+
+Inputs are parsed into typed configuration and request models. Registry auth,
+release-note, icon, webhook, and notification HTTP paths constrain protocols,
+redirects, DNS targets, and response sizes where credentials or server-side
+network access are involved. Shell-like update and hook surfaces use explicit
+argument handling and validation. Tests include malformed input, redirect,
+metadata-address, traversal, injection, and resource-limit cases.
+
+Evidence: [`app/configuration/`](app/configuration),
+[`app/registries/`](app/registries), [`app/release-notes/`](app/release-notes),
+[`app/api/icons/`](app/api/icons), and [`app/triggers/`](app/triggers).
+
+### Common weakness and dependency controls
+
+CI applies TypeScript compilation, Biome, CodeQL, dependency review, secret
+scanning, Grype, workflow security checks, unit and integration tests, browser
+tests, and 100% line, branch, function, and statement coverage gates for the
+backend and UI. Monthly mutation testing provides a separate signal about
+assertion quality. Lockfiles and SHA-pinned Actions make dependency changes
+reviewable and repeatable.
+
+Evidence: [`.github/workflows/ci-verify.yml`](.github/workflows/ci-verify.yml),
+[`.github/workflows/security-grype.yml`](.github/workflows/security-grype.yml),
+[`.github/workflows/quality-mutation-monthly.yml`](.github/workflows/quality-mutation-monthly.yml),
+[`CONTRIBUTING.md`](CONTRIBUTING.md), and the public CI, coverage, and Scorecard
+badges in [`README.md`](README.md).
+
+### Release integrity
+
+The release workflow waits for the required CI and browser-test results, builds
+the selected revision, creates an SBOM, signs images and archives with Sigstore,
+attests provenance through GitHub, verifies those records, and only then
+publishes tags and release assets. General-availability releases promote the
+previously tested release-candidate digest instead of rebuilding it.
+
+Evidence: [`.github/workflows/release-cut.yml`](.github/workflows/release-cut.yml)
+and the public [release history](https://github.com/CodesWhat/drydock/releases).
+
+## Residual risk
+
+No assurance case eliminates risk. The largest residual risk is the authority
+of the Docker API itself. A stolen deployment credential, an overly broad socket
+policy, a compromised host, or a malicious authenticated administrator can still
+cause host-level impact. External registries and notification providers can be
+unavailable or return hostile data. Operators remain responsible for network
+segmentation, backups, credential rotation, host patching, and reviewing the
+security implications of enabled update and notification features.


### PR DESCRIPTION
## Summary

- add the dynamic OpenSSF Best Practices badge alongside the numeric Scorecard badge
- publish governance, maintainer-role, access-continuity, and security-assurance evidence
- make the twelve-month roadmap horizon explicit

## Verification

- app lint, build, and 12,566-test suite passed at 100% coverage
- UI lint, typecheck, build, and 4,306-test suite passed at 100% coverage
- full pre-push scripts, workflow tests, Qlty, coverage, and build gates passed
- clean app and UI builds were reproduced bit-for-bit in two runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changelog

- ✨ Added `GOVERNANCE.md` with maintainer roles, decision processes, security reporting, access recovery, signing continuity, and release controls.
- 🔒 Added `SECURITY-ASSURANCE.md` with security requirements, threat model, trust boundaries, assurance evidence, release-integrity controls, and residual risks.
- ✨ Added the dynamic OpenSSF Best Practices badge.
- 🔧 Updated `README.md` with governance and security links.
- 🔧 Clarified the roadmap through August 2027.
- 🔧 Verified linting, builds, type checks, tests, coverage, workflow checks, Qlty, pre-push scripts, and build gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->