### PR TITLE
🐛 fix(web): read star history through GraphQL so the chart renders

### DIFF
--- a/apps/web/scripts/marketing-performance.test.mjs
+++ b/apps/web/scripts/marketing-performance.test.mjs
@@ -71,7 +71,9 @@ test("star history route never renders partial stargazer data and bounds its fet
 test("star history route reads stars through GraphQL, not the REST stargazers endpoint", () => {
   // REST /stargazers now 401s anonymously and demands contents=write from a
   // fine-grained token; the GraphQL connection needs only metadata=read.
-  assert.match(starHistoryRouteSource, /https:\/\/api\.github\.com\/graphql/u);
+  // A substring check, not a regex: an unanchored URL pattern reads as host
+  // matching to CodeQL, and this only asserts the endpoint appears in source.
+  assert.ok(starHistoryRouteSource.includes('"https://api.github.com/graphql"'));
   assert.equal(starHistoryRouteSource.indexOf("/stargazers?per_page="), -1);
   assert.match(starHistoryRouteSource, /orderBy:\{field:STARRED_AT,direction:ASC\}/u);
   // No token means no data at all, so the route must fall back rather than

--- a/apps/web/scripts/marketing-performance.test.mjs
+++ b/apps/web/scripts/marketing-performance.test.mjs
@@ -61,8 +61,12 @@ test("star history route never renders partial stargazer data and bounds its fet
   assert.equal((starHistoryRouteSource.match(/return starredAt;/gu) ?? []).length, 1);
   assert.match(
     starHistoryRouteSource,
-    /pageInfo\?\.hasNextPage !== true\) \{\n[^}]*return starredAt;/u,
+    /pageInfo\.hasNextPage === false\) \{\n[^}]*return starredAt;/u,
   );
+  // Malformed pagination metadata must not read as "no more pages".
+  assert.match(starHistoryRouteSource, /typeof pageInfo\?\.hasNextPage !== "boolean"/u);
+  // An unparseable timestamp would undercount the series, so it fails the run.
+  assert.match(starHistoryRouteSource, /!Number\.isFinite\(Date\.parse\(value\)\)/u);
   // One shared deadline across the whole pagination run.
   assert.match(starHistoryRouteSource, /AbortSignal\.timeout\(FETCH_DEADLINE_MS\)/u);
   assert.match(starHistoryRouteSource, /\n\s+signal,\n\s+next: \{ revalidate:/u);

--- a/apps/web/scripts/marketing-performance.test.mjs
+++ b/apps/web/scripts/marketing-performance.test.mjs
@@ -51,15 +51,30 @@ test("star history chart is self-hosted, with no third-party chart service left"
 });
 
 test("star history route never renders partial stargazer data and bounds its fetches", () => {
-  // Every incomplete outcome (failed page, non-array body, MAX_PAGES exhausted)
-  // must fall back, not render a truncated series as the repo total.
+  // Every incomplete outcome (missing token, failed page, non-array edges,
+  // MAX_PAGES exhausted) must fall back, not render a truncated series as the
+  // repo total.
   assert.doesNotMatch(starHistoryRouteSource, /page === 1 \? undefined : starredAt/u);
   const undefinedReturns = starHistoryRouteSource.match(/return undefined;/gu) ?? [];
   assert.ok(undefinedReturns.length >= 4, "expected each incomplete outcome to return undefined");
-  // The series is only returned from the short-page branch — the one complete outcome.
+  // The series is only returned from the last-page branch — the one complete outcome.
   assert.equal((starHistoryRouteSource.match(/return starredAt;/gu) ?? []).length, 1);
-  assert.match(starHistoryRouteSource, /batch\.length < PER_PAGE\) \{\n[^}]*return starredAt;/u);
+  assert.match(
+    starHistoryRouteSource,
+    /pageInfo\?\.hasNextPage !== true\) \{\n[^}]*return starredAt;/u,
+  );
   // One shared deadline across the whole pagination run.
   assert.match(starHistoryRouteSource, /AbortSignal\.timeout\(FETCH_DEADLINE_MS\)/u);
-  assert.match(starHistoryRouteSource, /\{ headers, signal, next:/u);
+  assert.match(starHistoryRouteSource, /\n\s+signal,\n\s+next: \{ revalidate:/u);
+});
+
+test("star history route reads stars through GraphQL, not the REST stargazers endpoint", () => {
+  // REST /stargazers now 401s anonymously and demands contents=write from a
+  // fine-grained token; the GraphQL connection needs only metadata=read.
+  assert.match(starHistoryRouteSource, /https:\/\/api\.github\.com\/graphql/u);
+  assert.equal(starHistoryRouteSource.indexOf("/stargazers?per_page="), -1);
+  assert.match(starHistoryRouteSource, /orderBy:\{field:STARRED_AT,direction:ASC\}/u);
+  // No token means no data at all, so the route must fall back rather than
+  // render an empty chart.
+  assert.match(starHistoryRouteSource, /if \(!token\) \{\n[^}]*return undefined;/u);
 });

--- a/apps/web/src/app/api/star-history/route.ts
+++ b/apps/web/src/app/api/star-history/route.ts
@@ -88,25 +88,29 @@ async function fetchStarredTimestamps(): Promise<string[] | undefined> {
     const body = payload as { data?: { repository?: { stargazers?: StargazerPage } } };
     const stargazers = body?.data?.repository?.stargazers;
     const edges = stargazers?.edges;
-    if (!Array.isArray(edges)) {
-      // Missing data means an error payload or a shape change; either way the
-      // series would be incomplete.
+    const pageInfo = stargazers?.pageInfo;
+    // An error payload or a shape change would otherwise read as "no more
+    // pages" and cache a truncated chart as the repo total for six hours.
+    if (!Array.isArray(edges) || typeof pageInfo?.hasNextPage !== "boolean") {
       return undefined;
     }
 
     for (const edge of edges) {
       const value = (edge as { starredAt?: unknown })?.starredAt;
-      if (typeof value === "string") {
-        starredAt.push(value);
+      if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
+        // Dropping an unparseable timestamp would undercount the series, so
+        // the whole run is incomplete.
+        return undefined;
       }
+      starredAt.push(value);
     }
 
-    if (stargazers?.pageInfo?.hasNextPage !== true) {
+    if (pageInfo.hasNextPage === false) {
       // The last page is the only complete outcome.
       return starredAt;
     }
 
-    const cursor = stargazers.pageInfo.endCursor;
+    const cursor = pageInfo.endCursor;
     if (typeof cursor !== "string") {
       return undefined;
     }

--- a/apps/web/src/app/api/star-history/route.ts
+++ b/apps/web/src/app/api/star-history/route.ts
@@ -22,48 +22,98 @@ const FETCH_DEADLINE_MS = 10_000;
 const SUCCESS_CACHE = "public, s-maxage=21600, stale-while-revalidate=604800";
 const FAILURE_CACHE = "public, s-maxage=300";
 
-async function fetchStarredTimestamps(): Promise<string[] | undefined> {
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github.star+json",
-    "User-Agent": "drydock-website-star-history",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
-  const token = process.env.GITHUB_TOKEN;
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
+// GraphQL rather than REST /stargazers: that endpoint now 401s without a token
+// and, for a fine-grained token, demands `contents=write` — far more than a
+// public star chart should hold. The GraphQL connection needs only
+// `metadata=read`, and returns starredAt directly.
+const STARGAZERS_QUERY = `query($owner:String!,$name:String!,$first:Int!,$after:String){
+  repository(owner:$owner,name:$name){
+    stargazers(first:$first,after:$after,orderBy:{field:STARRED_AT,direction:ASC}){
+      pageInfo{hasNextPage endCursor}
+      edges{starredAt}
+    }
   }
+}`;
+
+type StargazerPage = {
+  pageInfo?: { hasNextPage?: unknown; endCursor?: unknown };
+  edges?: unknown;
+};
+
+async function fetchStarredTimestamps(): Promise<string[] | undefined> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    // The GraphQL API has no anonymous mode, so an unconfigured deployment
+    // falls back rather than silently rendering an empty chart.
+    return undefined;
+  }
+
+  const [owner, name] = REPO_SLUG.split("/");
+  if (!owner || !name) {
+    return undefined;
+  }
+
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "User-Agent": "drydock-website-star-history",
+  };
 
   const signal = AbortSignal.timeout(FETCH_DEADLINE_MS);
   const starredAt: string[] = [];
+  let after: string | null = null;
+
   for (let page = 1; page <= MAX_PAGES; page += 1) {
-    let batch: unknown;
+    let payload: unknown;
     try {
-      const response = await fetch(
-        `https://api.github.com/repos/${REPO_SLUG}/stargazers?per_page=${PER_PAGE}&page=${page}`,
-        { headers, signal, next: { revalidate: 21600 } },
-      );
+      const response = await fetch("https://api.github.com/graphql", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          query: STARGAZERS_QUERY,
+          variables: { owner, name, first: PER_PAGE, after },
+        }),
+        signal,
+        next: { revalidate: 21600 },
+      });
       if (!response.ok) {
         return undefined;
       }
-      batch = await response.json();
+      payload = await response.json();
     } catch {
       return undefined;
     }
-    if (!Array.isArray(batch)) {
+
+    const body = payload as { data?: { repository?: { stargazers?: StargazerPage } } };
+    const stargazers = body?.data?.repository?.stargazers;
+    const edges = stargazers?.edges;
+    if (!Array.isArray(edges)) {
+      // Missing data means an error payload or a shape change; either way the
+      // series would be incomplete.
       return undefined;
     }
-    for (const entry of batch) {
-      const value = (entry as { starred_at?: unknown })?.starred_at;
+
+    for (const edge of edges) {
+      const value = (edge as { starredAt?: unknown })?.starredAt;
       if (typeof value === "string") {
         starredAt.push(value);
       }
     }
-    if (batch.length < PER_PAGE) {
-      // A short page is the end of the history — the only complete outcome.
+
+    if (stargazers?.pageInfo?.hasNextPage !== true) {
+      // The last page is the only complete outcome.
       return starredAt;
     }
+
+    const cursor = stargazers.pageInfo.endCursor;
+    if (typeof cursor !== "string") {
+      return undefined;
+    }
+    after = cursor;
   }
-  // MAX_PAGES exhausted with a full final page: history may continue, so the
+
+  // MAX_PAGES exhausted with hasNextPage still true: history continues, so the
   // series is incomplete. Fall back instead of caching a truncated total.
   return undefined;
 }


### PR DESCRIPTION
## What

The README star-history chart has been stuck on the placeholder ("loading") SVG. Root cause: GitHub's REST `/stargazers` endpoint now returns **401 anonymously**, and the route treated `GITHUB_TOKEN` as optional — so `fetchStarredTimestamps()` always returned `undefined` and the route permanently served `renderStarHistoryFallbackSvg`.

Handing it a token doesn't fix it either: for a fine-grained token the endpoint reports `x-accepted-github-permissions: metadata=read; contents=write`, and it 403s with `metadata=read` alone. Granting `contents=write` to a public star chart is not a trade worth making.

## Fix

Read the stargazers through GraphQL instead. That connection needs only `metadata=read`, returns `starredAt` directly, and pages with a cursor. Verified live against `CodesWhat/drydock`:

```
{"data":{"repository":{"stargazerCount":216,"stargazers":{"edges":[{"starredAt":"2026-02-10T16:53:13Z"},...]}}}}
```

Behaviour that did not change: every incomplete outcome still returns `undefined` and falls back rather than rendering a truncated total, the whole pagination run shares one `FETCH_DEADLINE_MS` deadline, and the success/failure cache headers are untouched. New: no token means fall back, since GraphQL has no anonymous mode.

## Verification

- `npx tsc --noEmit` clean.
- `npm run test:scripts --prefix apps/web` — 57/57. Two assertions pinned the REST pagination shape, so they're repointed at the GraphQL shape; added a case covering the endpoint swap and the no-token fallback.
- Ran the route against a real token on a local dev server: `200`, 7,578 bytes, real 216-star curve rendered — not the fallback.

`GITHUB_TOKEN` is set on the `drydock-website` Vercel project (production + preview) from a new `drydock-star-history` fine-grained token scoped to `CodesWhat/drydock` with Metadata: Read-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added GraphQL stargazer queries with `starredAt` ordering and cursor pagination.
- 🔧 Changed the star-history route from REST `/stargazers` to GraphQL.
- 🔧 Changed authentication to require `GITHUB_TOKEN` with `metadata: read`.
- 🐛 Fixed fallback handling for missing tokens, invalid responses, incomplete pagination, and pagination limits.
- 🔒 Removed dependence on the REST endpoint, which requires `contents: write`.
- ✨ Added tests for GraphQL requests, pagination, REST endpoint exclusion, and no-token fallback.

## Concerns

- Confirm the pagination limit matches the maximum expected repository star count.
- Complete the `coderabbitai` review after rate limiting ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->