### PR TITLE
chore: forward-port the v1.6.0 GA work to v1.7

### DIFF
--- a/.github/tests/release-cut-retry-workflow.test.ts
+++ b/.github/tests/release-cut-retry-workflow.test.ts
@@ -207,6 +207,11 @@ test('release-cut requires an exact, seven-day-old RC candidate for GA promotion
       required: false,
       type: 'string',
     },
+    soak_override_reason: {
+      required: false,
+      type: 'string',
+      default: '',
+    },
   });
   expect(sourceStep?.id).toBe('source');
   expect(sourceStep?.run).toContain('publishedAt');
@@ -216,6 +221,23 @@ test('release-cut requires an exact, seven-day-old RC candidate for GA promotion
   expect(sourceStep?.run).toContain('^sha256:[0-9a-f]{64}$');
   expect(sourceStep?.run).toContain('source_sha=');
   expect(sourceStep?.run).toContain('image_digest=');
+  expect(sourceStep?.run).toContain('soak_override_used=');
+});
+
+test('release-cut never interpolates soak_override_reason directly into a run: script body', () => {
+  const releaseSteps = loadReleaseSteps();
+  const stepsReferencingReason = releaseSteps.filter((step) =>
+    JSON.stringify(step).includes('soak_override_reason'),
+  );
+
+  expect(stepsReferencingReason.length).toBeGreaterThan(0);
+  for (const step of stepsReferencingReason) {
+    // The raw input must only ever appear on the right-hand side of an `env:`
+    // mapping (e.g. `SOAK_OVERRIDE_REASON: ${{ inputs.soak_override_reason }}`),
+    // never templated straight into `run:`, which is how a candidate_tag-style
+    // template-injection finding would happen.
+    expect(step.run ?? '').not.toContain('inputs.soak_override_reason');
+  }
 });
 
 test('release-cut validates the promoted digest in every registry', () => {

--- a/.github/tests/release-cut-soak-override.test.ts
+++ b/.github/tests/release-cut-soak-override.test.ts
@@ -1,0 +1,311 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadWorkflow } from './workflow-test-utils';
+
+// This test extracts and EXECUTES the real `run:` block of the "Resolve
+// release source and validate GA candidate" step (id: source) so the
+// soak_override_reason behavior can't drift from what actually ships.
+const workflowPath = fileURLToPath(new URL('../workflows/release-cut.yml', import.meta.url));
+
+const CANDIDATE_TAG = 'v1.6.0-rc.13';
+const RELEASE_TAG = 'v1.6.0';
+const CANDIDATE_DIGEST = `sha256:${'0'.repeat(64)}`;
+const SEVEN_DAYS = 604800;
+const THREE_DAYS = 3 * 86400;
+
+// Stub 'gh' for the step under test. Only implements the one subcommand it
+// calls: `release view <tag> --repo ... --json isPrerelease,publishedAt,tagName`.
+const stubGhScript = `#!/usr/bin/env bash
+if [ "\${1:-}" = "release" ] && [ "\${2:-}" = "view" ]; then
+  printf '%s' "\${FAKE_GH_RELEASE_JSON:?FAKE_GH_RELEASE_JSON not set}"
+  exit 0
+fi
+echo "stub gh: unsupported invocation: $*" >&2
+exit 127
+`;
+
+// Stub 'date' for deterministic epoch math. The real script only ever calls
+// `date -u -d "<published_at>" +%s` and `date -u +%s`; special-casing exactly
+// those two invocations (rather than parsing arbitrary date strings) also
+// sidesteps GNU-vs-BSD `date -d` incompatibility on developer machines.
+const stubDateScript = `#!/usr/bin/env bash
+if [ "\${1:-}" = "-u" ] && [ "\${2:-}" = "-d" ]; then
+  printf '%s\\n' "\${FAKE_PUBLISHED_EPOCH:?FAKE_PUBLISHED_EPOCH not set}"
+  exit 0
+fi
+if [ "\${1:-}" = "-u" ] && [ "\${2:-}" = "+%s" ]; then
+  printf '%s\\n' "\${FAKE_NOW_EPOCH:?FAKE_NOW_EPOCH not set}"
+  exit 0
+fi
+echo "stub date: unsupported invocation: $*" >&2
+exit 127
+`;
+
+// Git hooks (this repo's own pre-commit/pre-push included) invoke their
+// commands with GIT_DIR/GIT_WORK_TREE/etc. set so the hook script's git
+// commands land on the real repo regardless of its own cwd tricks. Those
+// vars are inherited by any child process that doesn't override them — so
+// when this test's setup runs *under* a git hook (e.g. this very test suite
+// running inside the pre-push gate), an unguarded `git init` in a temp
+// directory would silently operate on the real repository instead. Strip
+// them so every git command below is genuinely confined to `workdir`.
+function isolatedGitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of [
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_INDEX_FILE',
+    'GIT_COMMON_DIR',
+    'GIT_OBJECT_DIRECTORY',
+    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+    'GIT_CEILING_DIRECTORIES',
+    'GIT_PREFIX',
+  ]) {
+    delete env[key];
+  }
+  return env;
+}
+
+function loadSourceStepRunBlock(): string {
+  const workflow = loadWorkflow(workflowPath);
+  const step = workflow.jobs?.release?.steps?.find((candidate) => candidate.id === 'source');
+
+  if (!step?.run) {
+    throw new Error(
+      "Expected release-cut.yml's release job to include a step with id 'source' and a run block",
+    );
+  }
+
+  return step.run;
+}
+
+interface SourceResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+  output: Record<string, string>;
+  summary: string;
+  reasonFileContent: string | undefined;
+}
+
+function runSourceStep(options: {
+  isPrerelease: boolean;
+  ageSeconds: number;
+  soakOverrideReason?: string;
+  candidateTag?: string;
+  candidateDigest?: string;
+  createCandidateTag?: boolean;
+}): SourceResult {
+  const workdir = mkdtempSync(join(tmpdir(), 'release-cut-soak-override-'));
+  try {
+    // A real git repo so `git rev-parse --verify refs/tags/...^{commit}`
+    // behaves exactly as it does against the real checkout. `env` is
+    // explicit and GIT_DIR-stripped (see isolatedGitEnv) so this can never
+    // touch the actual repository this test itself lives in.
+    const run = (cmd: string, args: string[]) =>
+      execFileSync(cmd, args, { cwd: workdir, encoding: 'utf8', env: isolatedGitEnv() });
+    run('git', ['init', '--quiet']);
+    run('git', ['config', 'user.email', 'test@example.com']);
+    run('git', ['config', 'user.name', 'Test']);
+    writeFileSync(join(workdir, 'README.md'), 'placeholder\n');
+    run('git', ['add', 'README.md']);
+    run('git', ['commit', '--quiet', '-m', 'init']);
+
+    const candidateTag = options.candidateTag ?? CANDIDATE_TAG;
+    if (options.createCandidateTag !== false) {
+      run('git', ['tag', candidateTag]);
+    }
+
+    const stubDir = join(workdir, 'bin');
+    mkdirSync(stubDir);
+    writeFileSync(join(stubDir, 'gh'), stubGhScript, { mode: 0o755 });
+    chmodSync(join(stubDir, 'gh'), 0o755);
+    writeFileSync(join(stubDir, 'date'), stubDateScript, { mode: 0o755 });
+    chmodSync(join(stubDir, 'date'), 0o755);
+
+    const scriptPath = join(workdir, 'source-step.sh');
+    writeFileSync(scriptPath, loadSourceStepRunBlock());
+
+    const outputPath = join(workdir, 'github_output');
+    writeFileSync(outputPath, '');
+    const summaryPath = join(workdir, 'github_step_summary');
+    writeFileSync(summaryPath, '');
+    const runnerTemp = join(workdir, 'runner_temp');
+    mkdirSync(runnerTemp);
+
+    const nowEpoch = 2_000_000_000;
+    const publishedEpoch = nowEpoch - options.ageSeconds;
+
+    // Deliberately NOT `...process.env`: the source-step script under test
+    // also runs `git` (rev-parse, etc.), and this object is passed as-is to
+    // execFileSync below, which replaces rather than merges the child's
+    // environment when `env` is set explicitly. Keep it that way — spreading
+    // process.env here would reintroduce the same GIT_DIR leak isolatedGitEnv
+    // exists to prevent.
+    const env: NodeJS.ProcessEnv = {
+      PATH: `${stubDir}:${process.env.PATH ?? ''}`,
+      CANDIDATE_DIGEST: options.candidateDigest ?? CANDIDATE_DIGEST,
+      CANDIDATE_TAG: candidateTag,
+      GH_TOKEN: 'test-token',
+      GITHUB_REPOSITORY: 'CodesWhat/drydock',
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_STEP_SUMMARY: summaryPath,
+      IS_PRERELEASE: options.isPrerelease ? 'true' : 'false',
+      RELEASE_TAG,
+      RUNNER_TEMP: runnerTemp,
+      SOAK_OVERRIDE_REASON: options.soakOverrideReason ?? '',
+      TARGET_SHA: '0'.repeat(40),
+      FAKE_GH_RELEASE_JSON: JSON.stringify({
+        isPrerelease: true,
+        publishedAt: '2020-01-01T00:00:00Z',
+        tagName: candidateTag,
+      }),
+      FAKE_NOW_EPOCH: String(nowEpoch),
+      FAKE_PUBLISHED_EPOCH: String(publishedEpoch),
+    };
+
+    let status = 0;
+    let stdout = '';
+    let stderr = '';
+    try {
+      stdout = execFileSync('bash', [scriptPath], { cwd: workdir, env, encoding: 'utf8' });
+    } catch (error) {
+      const execError = error as { status?: number; stdout?: string; stderr?: string };
+      status = execError.status ?? 1;
+      stdout = execError.stdout ?? '';
+      stderr = execError.stderr ?? '';
+    }
+
+    const output: Record<string, string> = {};
+    for (const line of readFileSync(outputPath, 'utf8').split('\n')) {
+      const eq = line.indexOf('=');
+      if (eq === -1) continue;
+      output[line.slice(0, eq)] = line.slice(eq + 1);
+    }
+
+    const summary = readFileSync(summaryPath, 'utf8');
+    // Read the reason file (if the step wrote one) before the workdir under
+    // `finally` gets torn down, so callers can assert on it after return.
+    const reasonFileContent = output.soak_override_reason_path
+      ? readFileSync(output.soak_override_reason_path, 'utf8')
+      : undefined;
+
+    return { status, stdout, stderr, output, summary, reasonFileContent };
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+}
+
+test('a blank soak_override_reason still hard-fails with the unchanged error message', () => {
+  const result = runSourceStep({
+    isPrerelease: false,
+    ageSeconds: THREE_DAYS,
+    soakOverrideReason: '',
+  });
+
+  expect(result.status).not.toBe(0);
+  expect(result.stdout).toContain(
+    `::error::Candidate ${CANDIDATE_TAG} is only ${THREE_DAYS}s old; GA promotion requires seven full days (${SEVEN_DAYS}s).`,
+  );
+  expect(result.output.soak_override_used).toBeUndefined();
+});
+
+test('a whitespace-only soak_override_reason does not open the gate', () => {
+  const result = runSourceStep({
+    isPrerelease: false,
+    ageSeconds: THREE_DAYS,
+    soakOverrideReason: '   \t  ',
+  });
+
+  expect(result.status).not.toBe(0);
+  expect(result.stdout).toContain('GA promotion requires seven full days');
+  expect(result.stdout).not.toContain('must be at least 20 characters');
+});
+
+test('a too-short soak_override_reason hard-fails with a clear error', () => {
+  const result = runSourceStep({
+    isPrerelease: false,
+    ageSeconds: THREE_DAYS,
+    soakOverrideReason: 'x',
+  });
+
+  expect(result.status).not.toBe(0);
+  expect(result.stdout).toContain('soak_override_reason must be at least 20 characters');
+});
+
+test('a real soak_override_reason bypasses the age gate with an auditable warning and summary', () => {
+  const reason = 'rc.13 fleet soak passed on 2026-08-09; owner approved early GA ship.';
+  const ageSeconds = THREE_DAYS + 3600;
+  const result = runSourceStep({ isPrerelease: false, ageSeconds, soakOverrideReason: reason });
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('::warning::');
+  expect(result.stdout).toContain(CANDIDATE_TAG);
+  expect(result.stdout).toContain(`${ageSeconds}s`);
+  // The reason stays out of the workflow command; the summary and the release
+  // notes are where it is recorded.
+  expect(result.stdout).not.toContain(reason);
+
+  expect(result.output.soak_override_used).toBe('true');
+  expect(result.output.soak_override_age_seconds).toBe(String(ageSeconds));
+  expect(result.output.soak_override_reason_path).toBeTruthy();
+  expect(result.reasonFileContent).toBe(reason);
+
+  expect(result.summary).toContain('Seven-day soak overridden');
+  expect(result.summary).toContain(CANDIDATE_TAG);
+  expect(result.summary).toContain(reason);
+});
+
+test('a multiline soak_override_reason cannot smuggle a second workflow command', () => {
+  // The runner treats any stdout line starting with :: as a workflow command,
+  // so a reason echoed into ::warning:: would let the caller run one of their
+  // own. The reason must never reach stdout.
+  const reason = [
+    'rc.13 fleet soak passed; owner approved early GA ship.',
+    '::add-mask::v1.6.0',
+    '::error::injected failure',
+  ].join('\n');
+  const result = runSourceStep({
+    isPrerelease: false,
+    ageSeconds: THREE_DAYS + 3600,
+    soakOverrideReason: reason,
+  });
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('::warning::');
+  expect(result.stdout).not.toContain('::add-mask::');
+  expect(result.stdout).not.toContain('::error::');
+  // Still recorded in full where it is inert.
+  expect(result.reasonFileContent).toBe(reason);
+  expect(result.summary).toContain('::add-mask::v1.6.0');
+});
+
+test('a candidate that already cleared seven days needs no reason at all', () => {
+  const result = runSourceStep({
+    isPrerelease: false,
+    ageSeconds: SEVEN_DAYS + 3600,
+    soakOverrideReason: '',
+  });
+
+  expect(result.status).toBe(0);
+  expect(result.output.soak_override_used).toBe('false');
+  expect(result.summary).not.toContain('Seven-day soak overridden');
+});
+
+test('soak_override_reason is rejected outright for a prerelease cut, matching candidate_tag/candidate_digest', () => {
+  const result = runSourceStep({
+    isPrerelease: true,
+    ageSeconds: 0,
+    soakOverrideReason: 'this justification is long enough to pass the length gate',
+    candidateTag: '',
+    candidateDigest: '',
+    createCandidateTag: false,
+  });
+
+  expect(result.status).not.toBe(0);
+  expect(result.stdout).toContain('::error::soak_override_reason is a GA-only input');
+});

--- a/.github/tests/release-cut-soak-override.test.ts
+++ b/.github/tests/release-cut-soak-override.test.ts
@@ -237,6 +237,32 @@ test('a too-short soak_override_reason hard-fails with a clear error', () => {
   expect(result.stdout).toContain('soak_override_reason must be at least 20 characters');
 });
 
+// The two cases above jump from 1 character straight to a 68-character reason,
+// so an off-by-one flip of `-lt 20` to `-le 20` would keep every one of them
+// green. These pin both sides of the boundary, after trimming.
+test('a soak_override_reason of exactly 20 characters after trimming opens the gate', () => {
+  const reason = 'x'.repeat(20);
+  const result = runSourceStep({
+    isPrerelease: false,
+    ageSeconds: THREE_DAYS,
+    soakOverrideReason: `  ${reason}  `,
+  });
+
+  expect(result.status).toBe(0);
+  expect(result.reasonFileContent).toBe(reason);
+});
+
+test('a soak_override_reason of 19 characters after trimming does not', () => {
+  const result = runSourceStep({
+    isPrerelease: false,
+    ageSeconds: THREE_DAYS,
+    soakOverrideReason: `  ${'x'.repeat(19)}  `,
+  });
+
+  expect(result.status).not.toBe(0);
+  expect(result.stdout).toContain('soak_override_reason must be at least 20 characters');
+});
+
 test('a real soak_override_reason bypasses the age gate with an auditable warning and summary', () => {
   const reason = 'rc.13 fleet soak passed on 2026-08-09; owner approved early GA ship.';
   const ageSeconds = THREE_DAYS + 3600;

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -31,6 +31,11 @@ on:
         description: "GA only: exact sha256 digest published by candidate_tag in GHCR, Docker Hub, and Quay."
         required: false
         type: string
+      soak_override_reason:
+        description: "GA only: reason for shortening the seven-day soak on candidate_tag. Leave blank to enforce the full seven-day soak — this is the default and expected path. A non-empty value is permanently recorded in the run summary and in the published release notes."
+        required: false
+        type: string
+        default: ""
 
 permissions: {}
 
@@ -239,16 +244,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           IS_PRERELEASE: ${{ steps.tag.outputs.is_prerelease }}
           RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
+          SOAK_OVERRIDE_REASON: ${{ inputs.soak_override_reason }}
           TARGET_SHA: ${{ steps.target.outputs.sha }}
         run: |
           set -euo pipefail
 
           source_sha="${TARGET_SHA}"
           image_digest=""
+          soak_override_used="false"
+          soak_override_age_seconds=""
+          soak_override_age_days=""
+          soak_override_reason_path=""
 
           if [ "${IS_PRERELEASE}" = "true" ]; then
             if [ -n "${CANDIDATE_TAG}" ] || [ -n "${CANDIDATE_DIGEST}" ]; then
               echo "::error::candidate_tag and candidate_digest are GA-only inputs. Leave both empty for ${RELEASE_TAG}."
+              exit 1
+            fi
+            if [ -n "${SOAK_OVERRIDE_REASON}" ]; then
+              echo "::error::soak_override_reason is a GA-only input. Leave it empty for ${RELEASE_TAG}."
               exit 1
             fi
           else
@@ -278,8 +292,42 @@ jobs:
             published_epoch="$(date -u -d "${published_at}" +%s)"
             age_seconds="$(( $(date -u +%s) - published_epoch ))"
             if [ "${age_seconds}" -lt 604800 ]; then
-              echo "::error::Candidate ${CANDIDATE_TAG} is only ${age_seconds}s old; GA promotion requires seven full days (604800s)."
-              exit 1
+              # Trim leading/trailing whitespace so a lone space (or a string
+              # that is only whitespace) cannot pass as a reason.
+              trimmed_reason="$(printf '%s' "${SOAK_OVERRIDE_REASON}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+              if [ -z "${trimmed_reason}" ]; then
+                echo "::error::Candidate ${CANDIDATE_TAG} is only ${age_seconds}s old; GA promotion requires seven full days (604800s)."
+                exit 1
+              fi
+              if [ "${#trimmed_reason}" -lt 20 ]; then
+                echo "::error::soak_override_reason must be at least 20 characters of real justification to bypass the seven-day soak; got ${#trimmed_reason} after trimming whitespace."
+                exit 1
+              fi
+
+              age_days="$(awk -v s="${age_seconds}" 'BEGIN { printf "%.1f", s / 86400 }')"
+              # The reason is free text and may be multiline, so it never goes
+              # into a workflow command: a line starting with :: would be parsed
+              # as a second command. The job summary and release notes carry it.
+              echo "::warning::Candidate ${CANDIDATE_TAG} is only ${age_seconds}s (${age_days} days) old, short of the seven-day (604800s) soak requirement. Soak overridden; the justification is in the job summary and release notes."
+
+              {
+                echo "### :warning: Seven-day soak overridden for GA promotion"
+                echo "- Candidate: \`${CANDIDATE_TAG}\`"
+                echo "- Age at promotion: ${age_seconds}s (~${age_days} days) — short of the 604800s (7-day) requirement"
+                echo "- Reason: ${trimmed_reason}"
+              } >> "${GITHUB_STEP_SUMMARY}"
+
+              # The reason is free text from a workflow_dispatch input (any repo
+              # collaborator can supply it), so it is carried to later steps as
+              # a file path rather than inlined into GITHUB_OUTPUT: appending
+              # arbitrary multi-line content directly as `key=value` risks
+              # output injection if it ever contains its own newlines or an
+              # `EOF`-style delimiter.
+              soak_override_used="true"
+              soak_override_age_seconds="${age_seconds}"
+              soak_override_age_days="${age_days}"
+              soak_override_reason_path="${RUNNER_TEMP}/soak-override-reason.txt"
+              printf '%s' "${trimmed_reason}" > "${soak_override_reason_path}"
             fi
 
             source_sha="$(git rev-parse "${CANDIDATE_TAG}^{commit}")"
@@ -297,6 +345,10 @@ jobs:
           {
             echo "source_sha=${source_sha}"
             echo "image_digest=${image_digest}"
+            echo "soak_override_used=${soak_override_used}"
+            echo "soak_override_age_seconds=${soak_override_age_seconds}"
+            echo "soak_override_age_days=${soak_override_age_days}"
+            echo "soak_override_reason_path=${soak_override_reason_path}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout exact release source
@@ -1027,6 +1079,10 @@ jobs:
           RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
+          SOAK_OVERRIDE_USED: ${{ steps.source.outputs.soak_override_used }}
+          SOAK_OVERRIDE_AGE_SECONDS: ${{ steps.source.outputs.soak_override_age_seconds }}
+          SOAK_OVERRIDE_AGE_DAYS: ${{ steps.source.outputs.soak_override_age_days }}
+          SOAK_OVERRIDE_REASON_PATH: ${{ steps.source.outputs.soak_override_reason_path }}
         run: |
           set -euo pipefail
           notes_path="dist/release-notes-${RELEASE_TAG}.md"
@@ -1076,6 +1132,22 @@ jobs:
             --notes "${notes_path}" \
             --version "${RELEASE_TAG}" \
             --file UPGRADE-NOTES.md
+
+          # GA-only: the seven-day soak was shortened via soak_override_reason
+          # on the "Resolve release source" step. Record it in the published
+          # release body too, not just the run summary, so anyone reading the
+          # release later can see the soak was cut short and why.
+          if [ "${SOAK_OVERRIDE_USED:-false}" = "true" ]; then
+            override_reason="$(cat "${SOAK_OVERRIDE_REASON_PATH}")"
+            {
+              echo ""
+              echo "---"
+              echo ""
+              echo "**Note:** the standard seven-day release-candidate soak was shortened for this release."
+              echo "- Candidate age at promotion: ${SOAK_OVERRIDE_AGE_SECONDS}s (~${SOAK_OVERRIDE_AGE_DAYS} days), short of the usual 7 days (604800s)."
+              echo "- Reason: ${override_reason}"
+            } >> "${notes_path}"
+          fi
 
           echo "path=${notes_path}" >> "$GITHUB_OUTPUT"
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,59 @@
+# Drydock Governance
+
+## Model
+
+Drydock uses a lead-maintainer model. Work is proposed and reviewed in public
+issues, discussions, and pull requests. The lead maintainer owns project scope,
+release readiness, and final decisions when consensus cannot be reached.
+
+The current project roles are:
+
+| Role | Current assignment | Responsibilities |
+| --- | --- | --- |
+| Lead maintainer | [`@scttbnsn`](https://github.com/scttbnsn) | Product direction, issue triage, security response, release approval, and final technical decisions |
+| Continuity maintainer | [`@biggest-littlest`](https://github.com/biggest-littlest) | CodesWhat organization administration, access recovery, and release continuity when the lead maintainer is unavailable |
+| Code owners | Accounts listed in [`.github/CODEOWNERS`](.github/CODEOWNERS) | Review changes in owned areas and identify risk, compatibility, and test requirements |
+| Contributors | Anyone participating through issues, discussions, or pull requests | Propose, implement, test, document, and review changes |
+
+Roles are based on sustained project work and trust. The lead maintainer may add
+or remove code owners and maintainers through a public pull request that updates
+the relevant repository records. Organization-owner changes are recorded by
+GitHub's organization audit log.
+
+## Decisions and disputes
+
+Routine changes are decided through pull-request review. Larger changes should
+start with a GitHub issue or discussion that records the problem, alternatives,
+security and compatibility effects, and the intended outcome. The project seeks
+rough consensus, but the lead maintainer makes the final decision when a timely
+decision is required. The reason should be recorded in the issue or pull request.
+
+Security reports follow [`SECURITY.md`](SECURITY.md) and stay private until a fix
+and coordinated disclosure are ready. Conduct reports follow
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Change and release control
+
+Changes are made on branches and merged through pull requests. Development
+targets the active `dev/vX.Y` branch. `main` advances through a reviewed release
+sync and is the source for signed release tags and artifacts. Required CI checks
+must pass before merge, and the release workflow independently verifies the
+selected source revision before publication.
+
+## Access continuity
+
+The repository is owned by the CodesWhat GitHub organization, which has two
+owner accounts: `@scttbnsn` and `@biggest-littlest`. Either owner can administer
+the repository, close issues, restore maintainer access, manage Actions and
+release environments, and continue the pull-request and release process.
+Repository code owners provide an additional public record of review coverage.
+
+Canonical source, issues, CI, release workflows, container images, and release
+artifacts are kept in GitHub and GHCR. Releases use GitHub Actions OIDC for
+keyless signing and attestations, so continuity does not depend on a private
+signing key held on one maintainer's workstation. If one maintainer becomes
+unavailable, the remaining organization owner can revoke stale access, update
+role assignments, merge approved work, and publish a release within one week.
+
+Project forking is always available under the AGPL-3.0 license, but it is not the
+primary continuity plan.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   <br>
   <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
+  <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <br>
@@ -370,7 +371,8 @@ Drydock v1.6 no longer loads `WUD_*` environment variables or `wud.*` labels at 
 <details>
 <summary><strong>Version themes & highlights</strong></summary>
 
-High-level themes only — see [CHANGELOG.md](CHANGELOG.md) for per-release detail.
+This direction covers at least the next twelve months, through August 2027.
+High-level themes only; see [CHANGELOG.md](CHANGELOG.md) for per-release detail.
 
 | Version | Theme | Highlights |
 | --- | --- | --- |
@@ -401,6 +403,10 @@ High-level themes only — see [CHANGELOG.md](CHANGELOG.md) for per-release deta
 | Deprecations | [`DEPRECATIONS.md`](DEPRECATIONS.md) |
 | Roadmap | See [Roadmap](#roadmap) section above |
 | Contributing | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Code of Conduct | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) |
+| Governance | [`GOVERNANCE.md`](GOVERNANCE.md) |
+| Security Assurance | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md) |
+| Security Policy | [`SECURITY.md`](SECURITY.md) |
 | Issues | [GitHub Issues](https://github.com/CodesWhat/drydock/issues) |
 | Discussions | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) — feature requests & ideas welcome |
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.12-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0--rc.12-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>

--- a/SECURITY-ASSURANCE.md
+++ b/SECURITY-ASSURANCE.md
@@ -57,11 +57,16 @@ The principal trust boundaries are:
 
 ### Fail-safe defaults and complete mediation
 
-Authentication configuration fails closed. Anonymous mode must be explicitly
-confirmed, and protected routes share the authentication middleware rather than
-opting in route by route. Docker updates flow through the same policy and
-operation tracking used by the API and UI. Regression tests cover authentication
-failure, authorization, rate limiting, update admission, and agent boundaries.
+Authentication configuration fails closed at the request boundary rather than by
+terminating the process. With no authentication configured and anonymous access
+not confirmed, no Passport strategy is registered: protected requests are
+rejected and `/health` reports `503 auth strategies not yet registered` instead
+of serving traffic unauthenticated. Anonymous mode must be explicitly confirmed
+via `DD_ANONYMOUS_AUTH_CONFIRM`, and protected routes share the authentication
+middleware rather than opting in route by route. Docker updates flow through the
+same policy and operation tracking used by the API and UI. Regression tests cover
+authentication failure, authorization, rate limiting, update admission, and agent
+boundaries.
 
 Evidence: [`app/authentications/`](app/authentications),
 [`app/api/`](app/api), [`app/updates/`](app/updates), and the tests adjacent to
@@ -80,12 +85,26 @@ Evidence: [`Dockerfile`](Dockerfile), [`app/debug/`](app/debug),
 
 ### Untrusted input, injection, and outbound-request controls
 
-Inputs are parsed into typed configuration and request models. Registry auth,
-release-note, icon, webhook, and notification HTTP paths constrain protocols,
-redirects, DNS targets, and response sizes where credentials or server-side
-network access are involved. Shell-like update and hook surfaces use explicit
-argument handling and validation. Tests include malformed input, redirect,
-metadata-address, traversal, injection, and resource-limit cases.
+Inputs are parsed into typed configuration and request models. Outbound HTTP
+controls are applied per path rather than uniformly, so this section states them
+individually rather than claiming a blanket policy:
+
+| Path | Timeout | Redirects refused | Response size capped | Metadata/link-local address refused |
+| --- | --- | --- | --- | --- |
+| Registry auth and manifests (`app/registries/`) | yes | yes | no | no |
+| HTTP trigger (`app/triggers/providers/http/`) | yes | yes | no | yes |
+| Agent Docker proxy (`app/agent/`) | yes | yes | yes | no |
+| Icon fetch (`app/api/icons/`) | yes | no | yes | no |
+| Release notes (`app/release-notes/`) | yes | no | no | no |
+
+Shell-like update and hook surfaces use explicit argument handling and
+validation. Tests include malformed input, redirect, metadata-address,
+traversal, injection, and resource-limit cases.
+
+The gaps in that table are real and deliberate to state: only the HTTP trigger,
+which takes an operator-supplied URL, resolves and refuses cloud metadata and
+link-local addresses. Release notes and icons follow redirects, and release notes
+applies no response-size cap.
 
 Evidence: [`app/configuration/`](app/configuration),
 [`app/registries/`](app/registries), [`app/release-notes/`](app/release-notes),

--- a/SECURITY-ASSURANCE.md
+++ b/SECURITY-ASSURANCE.md
@@ -96,19 +96,29 @@ individually rather than claiming a blanket policy:
 | Agent Docker proxy (`app/agent/`) | yes | yes | yes | no |
 | Icon fetch (`app/api/icons/`) | yes | no | yes | no |
 | Release notes (`app/release-notes/`) | yes | no | no | no |
+| Notification providers calling axios directly (Apprise, Discord, Google Chat, Matrix, Mattermost, ntfy, Rocket.Chat, Teams, Telegram) | yes | no | no | no |
+| IFTTT notification provider (`app/triggers/providers/ifttt/`) | no | no | no | no |
+| Notification providers wrapping a vendor SDK (Gotify, Kafka, Pushover, Slack, SMTP) | vendor default | vendor default | vendor default | vendor default |
 
 Shell-like update and hook surfaces use explicit argument handling and
 validation. Tests include malformed input, redirect, metadata-address,
 traversal, injection, and resource-limit cases.
 
-The gaps in that table are real and deliberate to state: only the HTTP trigger,
+The gaps in that table are real and deliberate to state. Only the HTTP trigger,
 which takes an operator-supplied URL, resolves and refuses cloud metadata and
-link-local addresses. Release notes and icons follow redirects, and release notes
-applies no response-size cap.
+link-local addresses; several notification providers are self-hostable and so
+also take an operator-supplied host, without that check. Release notes and icons
+follow redirects, and release notes applies no response-size cap. IFTTT is the
+one path with no timeout at all: it calls axios without the shared
+`getOutboundHttpTimeoutMs()` value its nine sibling providers pass, tracked as
+[#704](https://github.com/CodesWhat/drydock/issues/704). Providers built on a
+vendor SDK inherit whatever controls that dependency applies; Drydock does not
+establish them and does not claim them here.
 
 Evidence: [`app/configuration/`](app/configuration),
 [`app/registries/`](app/registries), [`app/release-notes/`](app/release-notes),
-[`app/api/icons/`](app/api/icons), and [`app/triggers/`](app/triggers).
+[`app/api/icons/`](app/api/icons), and
+[`app/triggers/providers/`](app/triggers/providers).
 
 ### Common weakness and dependency controls
 

--- a/SECURITY-ASSURANCE.md
+++ b/SECURITY-ASSURANCE.md
@@ -1,0 +1,128 @@
+# Drydock Security Assurance Case
+
+Last reviewed: 2026-08-11
+
+This document states Drydock's security requirements, threat boundaries, and
+the public evidence supporting its security claims. It is a living assurance
+case, not a claim that Drydock can make a Docker daemon safe after an attacker
+has gained authorized Docker API access.
+
+## Security requirements and limits
+
+Drydock is intended to:
+
+- deny protected API access unless authentication succeeds, with anonymous
+  operation requiring an explicit acknowledgement;
+- validate untrusted network, registry, webhook, configuration, and update
+  inputs before using them;
+- keep credentials out of logs, debug bundles, release artifacts, and browser
+  responses;
+- limit outbound requests so registry and notification features cannot be used
+  as an unrestricted SSRF or redirect path;
+- ship changes only after automated tests, static analysis, dependency checks,
+  and release verification pass; and
+- produce signed, attributable release artifacts with provenance and SBOMs.
+
+An authenticated Drydock deployment may inspect and update containers through
+the Docker API. Docker socket access is effectively host-root access. Drydock
+does not turn an unrestricted socket into a least-privilege interface. Operators
+should place [Sockguard](https://github.com/CodesWhat/sockguard) or another
+allowlisting proxy between Drydock and the daemon, restrict network access, and
+protect every configured credential. The supported-version and disclosure
+commitments are defined in [`SECURITY.md`](SECURITY.md).
+
+## Threat model and trust boundaries
+
+The relevant threat actors are unauthenticated network clients, authenticated
+but malicious users, hostile registry or webhook responses, compromised remote
+services, malicious container metadata, and a contributor or dependency that
+attempts to alter the build or release process.
+
+The principal trust boundaries are:
+
+1. **Client to HTTP API and UI.** Network data becomes application input. Auth,
+   rate limiting, schema validation, output encoding, and security headers are
+   enforced here.
+2. **Drydock to Docker or Portwing.** Crossing this boundary can change host
+   workloads. Authentication and update policy are enforced by Drydock, while
+   endpoint-level least privilege belongs at a socket proxy.
+3. **Drydock to registries and notification providers.** Remote URLs, redirects,
+   DNS answers, response sizes, and credentials are treated as untrusted.
+4. **Process to persistent state and secrets.** Secret-file permissions,
+   redaction, bounded debug exports, and integrity checks protect this boundary.
+5. **Source to release artifact.** Reviewed source crosses CI, build, signing,
+   provenance, and publication controls before users receive an artifact.
+
+## Claims and evidence
+
+### Fail-safe defaults and complete mediation
+
+Authentication configuration fails closed. Anonymous mode must be explicitly
+confirmed, and protected routes share the authentication middleware rather than
+opting in route by route. Docker updates flow through the same policy and
+operation tracking used by the API and UI. Regression tests cover authentication
+failure, authorization, rate limiting, update admission, and agent boundaries.
+
+Evidence: [`app/authentications/`](app/authentications),
+[`app/api/`](app/api), [`app/updates/`](app/updates), and the tests adjacent to
+those modules.
+
+### Least privilege and secret handling
+
+The published container is designed for a read-only root filesystem and minimal
+runtime privileges. Configuration supports mounted secret files. Debug output
+and structured logs redact credential-bearing fields. CI release signing uses
+short-lived GitHub OIDC identities instead of a maintainer-held signing key.
+
+Evidence: [`Dockerfile`](Dockerfile), [`app/debug/`](app/debug),
+[`app/log/`](app/log), the hardened deployment in [`README.md`](README.md), and
+[`.github/workflows/release-cut.yml`](.github/workflows/release-cut.yml).
+
+### Untrusted input, injection, and outbound-request controls
+
+Inputs are parsed into typed configuration and request models. Registry auth,
+release-note, icon, webhook, and notification HTTP paths constrain protocols,
+redirects, DNS targets, and response sizes where credentials or server-side
+network access are involved. Shell-like update and hook surfaces use explicit
+argument handling and validation. Tests include malformed input, redirect,
+metadata-address, traversal, injection, and resource-limit cases.
+
+Evidence: [`app/configuration/`](app/configuration),
+[`app/registries/`](app/registries), [`app/release-notes/`](app/release-notes),
+[`app/api/icons/`](app/api/icons), and [`app/triggers/`](app/triggers).
+
+### Common weakness and dependency controls
+
+CI applies TypeScript compilation, Biome, CodeQL, dependency review, secret
+scanning, Grype, workflow security checks, unit and integration tests, browser
+tests, and 100% line, branch, function, and statement coverage gates for the
+backend and UI. Monthly mutation testing provides a separate signal about
+assertion quality. Lockfiles and SHA-pinned Actions make dependency changes
+reviewable and repeatable.
+
+Evidence: [`.github/workflows/ci-verify.yml`](.github/workflows/ci-verify.yml),
+[`.github/workflows/security-grype.yml`](.github/workflows/security-grype.yml),
+[`.github/workflows/quality-mutation-monthly.yml`](.github/workflows/quality-mutation-monthly.yml),
+[`CONTRIBUTING.md`](CONTRIBUTING.md), and the public CI, coverage, and Scorecard
+badges in [`README.md`](README.md).
+
+### Release integrity
+
+The release workflow waits for the required CI and browser-test results, builds
+the selected revision, creates an SBOM, signs images and archives with Sigstore,
+attests provenance through GitHub, verifies those records, and only then
+publishes tags and release assets. General-availability releases promote the
+previously tested release-candidate digest instead of rebuilding it.
+
+Evidence: [`.github/workflows/release-cut.yml`](.github/workflows/release-cut.yml)
+and the public [release history](https://github.com/CodesWhat/drydock/releases).
+
+## Residual risk
+
+No assurance case eliminates risk. The largest residual risk is the authority
+of the Docker API itself. A stolen deployment credential, an overly broad socket
+policy, a compromised host, or a malicious authenticated administrator can still
+cause host-level impact. External registries and notification providers can be
+unavailable or return hostile data. Operators remain responsible for network
+segmentation, backups, credential rotation, host patching, and reviewing the
+security implications of enabled update and notification features.

--- a/SECURITY-ASSURANCE.md
+++ b/SECURITY-ASSURANCE.md
@@ -1,6 +1,6 @@
 # Drydock Security Assurance Case
 
-Last reviewed: 2026-08-11
+Last reviewed: 2026-08-12
 
 This document states Drydock's security requirements, threat boundaries, and
 the public evidence supporting its security claims. It is a living assurance
@@ -132,6 +132,13 @@ the selected revision, creates an SBOM, signs images and archives with Sigstore,
 attests provenance through GitHub, verifies those records, and only then
 publishes tags and release assets. General-availability releases promote the
 previously tested release-candidate digest instead of rebuilding it.
+
+A GA promotion normally requires the candidate to have soaked for seven days,
+measured from its release publication time. That floor can be overridden by
+dispatch, and the override is deliberately noisy rather than silent: it requires
+a justification of at least 20 characters, emits a workflow warning naming the
+actual candidate age, and records the justification in both the run summary and
+the published release notes. v1.6.0 was promoted this way, at three days.
 
 Evidence: [`.github/workflows/release-cut.yml`](.github/workflows/release-cut.yml)
 and the public [release history](https://github.com/CodesWhat/drydock/releases).

--- a/apps/web/scripts/marketing-performance.test.mjs
+++ b/apps/web/scripts/marketing-performance.test.mjs
@@ -51,15 +51,36 @@ test("star history chart is self-hosted, with no third-party chart service left"
 });
 
 test("star history route never renders partial stargazer data and bounds its fetches", () => {
-  // Every incomplete outcome (failed page, non-array body, MAX_PAGES exhausted)
-  // must fall back, not render a truncated series as the repo total.
+  // Every incomplete outcome (missing token, failed page, non-array edges,
+  // MAX_PAGES exhausted) must fall back, not render a truncated series as the
+  // repo total.
   assert.doesNotMatch(starHistoryRouteSource, /page === 1 \? undefined : starredAt/u);
   const undefinedReturns = starHistoryRouteSource.match(/return undefined;/gu) ?? [];
   assert.ok(undefinedReturns.length >= 4, "expected each incomplete outcome to return undefined");
-  // The series is only returned from the short-page branch — the one complete outcome.
+  // The series is only returned from the last-page branch — the one complete outcome.
   assert.equal((starHistoryRouteSource.match(/return starredAt;/gu) ?? []).length, 1);
-  assert.match(starHistoryRouteSource, /batch\.length < PER_PAGE\) \{\n[^}]*return starredAt;/u);
+  assert.match(
+    starHistoryRouteSource,
+    /pageInfo\.hasNextPage === false\) \{\n[^}]*return starredAt;/u,
+  );
+  // Malformed pagination metadata must not read as "no more pages".
+  assert.match(starHistoryRouteSource, /typeof pageInfo\?\.hasNextPage !== "boolean"/u);
+  // An unparseable timestamp would undercount the series, so it fails the run.
+  assert.match(starHistoryRouteSource, /!Number\.isFinite\(Date\.parse\(value\)\)/u);
   // One shared deadline across the whole pagination run.
   assert.match(starHistoryRouteSource, /AbortSignal\.timeout\(FETCH_DEADLINE_MS\)/u);
-  assert.match(starHistoryRouteSource, /\{ headers, signal, next:/u);
+  assert.match(starHistoryRouteSource, /\n\s+signal,\n\s+next: \{ revalidate:/u);
+});
+
+test("star history route reads stars through GraphQL, not the REST stargazers endpoint", () => {
+  // REST /stargazers now 401s anonymously and demands contents=write from a
+  // fine-grained token; the GraphQL connection needs only metadata=read.
+  // A substring check, not a regex: an unanchored URL pattern reads as host
+  // matching to CodeQL, and this only asserts the endpoint appears in source.
+  assert.ok(starHistoryRouteSource.includes('"https://api.github.com/graphql"'));
+  assert.equal(starHistoryRouteSource.indexOf("/stargazers?per_page="), -1);
+  assert.match(starHistoryRouteSource, /orderBy:\{field:STARRED_AT,direction:ASC\}/u);
+  // No token means no data at all, so the route must fall back rather than
+  // render an empty chart.
+  assert.match(starHistoryRouteSource, /if \(!token\) \{\n[^}]*return undefined;/u);
 });

--- a/apps/web/src/app/api/star-history/route.ts
+++ b/apps/web/src/app/api/star-history/route.ts
@@ -22,48 +22,102 @@ const FETCH_DEADLINE_MS = 10_000;
 const SUCCESS_CACHE = "public, s-maxage=21600, stale-while-revalidate=604800";
 const FAILURE_CACHE = "public, s-maxage=300";
 
-async function fetchStarredTimestamps(): Promise<string[] | undefined> {
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github.star+json",
-    "User-Agent": "drydock-website-star-history",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
-  const token = process.env.GITHUB_TOKEN;
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
+// GraphQL rather than REST /stargazers: that endpoint now 401s without a token
+// and, for a fine-grained token, demands `contents=write` — far more than a
+// public star chart should hold. The GraphQL connection needs only
+// `metadata=read`, and returns starredAt directly.
+const STARGAZERS_QUERY = `query($owner:String!,$name:String!,$first:Int!,$after:String){
+  repository(owner:$owner,name:$name){
+    stargazers(first:$first,after:$after,orderBy:{field:STARRED_AT,direction:ASC}){
+      pageInfo{hasNextPage endCursor}
+      edges{starredAt}
+    }
   }
+}`;
+
+type StargazerPage = {
+  pageInfo?: { hasNextPage?: unknown; endCursor?: unknown };
+  edges?: unknown;
+};
+
+async function fetchStarredTimestamps(): Promise<string[] | undefined> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    // The GraphQL API has no anonymous mode, so an unconfigured deployment
+    // falls back rather than silently rendering an empty chart.
+    return undefined;
+  }
+
+  const [owner, name] = REPO_SLUG.split("/");
+  if (!owner || !name) {
+    return undefined;
+  }
+
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "User-Agent": "drydock-website-star-history",
+  };
 
   const signal = AbortSignal.timeout(FETCH_DEADLINE_MS);
   const starredAt: string[] = [];
+  let after: string | null = null;
+
   for (let page = 1; page <= MAX_PAGES; page += 1) {
-    let batch: unknown;
+    let payload: unknown;
     try {
-      const response = await fetch(
-        `https://api.github.com/repos/${REPO_SLUG}/stargazers?per_page=${PER_PAGE}&page=${page}`,
-        { headers, signal, next: { revalidate: 21600 } },
-      );
+      const response = await fetch("https://api.github.com/graphql", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          query: STARGAZERS_QUERY,
+          variables: { owner, name, first: PER_PAGE, after },
+        }),
+        signal,
+        next: { revalidate: 21600 },
+      });
       if (!response.ok) {
         return undefined;
       }
-      batch = await response.json();
+      payload = await response.json();
     } catch {
       return undefined;
     }
-    if (!Array.isArray(batch)) {
+
+    const body = payload as { data?: { repository?: { stargazers?: StargazerPage } } };
+    const stargazers = body?.data?.repository?.stargazers;
+    const edges = stargazers?.edges;
+    const pageInfo = stargazers?.pageInfo;
+    // An error payload or a shape change would otherwise read as "no more
+    // pages" and cache a truncated chart as the repo total for six hours.
+    if (!Array.isArray(edges) || typeof pageInfo?.hasNextPage !== "boolean") {
       return undefined;
     }
-    for (const entry of batch) {
-      const value = (entry as { starred_at?: unknown })?.starred_at;
-      if (typeof value === "string") {
-        starredAt.push(value);
+
+    for (const edge of edges) {
+      const value = (edge as { starredAt?: unknown })?.starredAt;
+      if (typeof value !== "string" || !Number.isFinite(Date.parse(value))) {
+        // Dropping an unparseable timestamp would undercount the series, so
+        // the whole run is incomplete.
+        return undefined;
       }
+      starredAt.push(value);
     }
-    if (batch.length < PER_PAGE) {
-      // A short page is the end of the history — the only complete outcome.
+
+    if (pageInfo.hasNextPage === false) {
+      // The last page is the only complete outcome.
       return starredAt;
     }
+
+    const cursor = pageInfo.endCursor;
+    if (typeof cursor !== "string") {
+      return undefined;
+    }
+    after = cursor;
   }
-  // MAX_PAGES exhausted with a full final page: history may continue, so the
+
+  // MAX_PAGES exhausted with hasNextPage still true: history continues, so the
   // series is incomplete. Fall back instead of caching a truncated total.
   return undefined;
 }


### PR DESCRIPTION
Three things landed on `dev/v1.6` during the GA push and never reached `dev/v1.7`. Found by diffing the two branches after the GA sync made `dev/v1.6` and `main` tree-identical.

### 1. OpenSSF assurance evidence (`a8b33673`, #699)

`GOVERNANCE.md`, `SECURITY-ASSURANCE.md`, and the Best Practices badge in the README. This is the one that actually bites: drydock earned the [Silver badge](https://www.bestpractices.dev/en/projects/11915) on 2026-08-12 specifically because the GA sync put that badge on `main`'s front page. The first v1.7 sync to `main` would have deleted it again and dropped `documentation_achievements` back to Unmet, losing Silver.

### 2. Star history through GraphQL (`38819656`)

v1.7 still had the REST `/stargazers` path. That endpoint 401s anonymously and, for a fine-grained token, demands `contents=write` — far more than a public star chart should hold — so the route fell back on every request and getdrydock.com just said "loading". The GraphQL stargazers connection needs only `metadata=read`.

### 3. Auditable soak override (`2b55ff4b`)

The `soak_override_reason` dispatch input, its validation, and the 311-line test. The 604800s floor is untouched. Used once, for the v1.6.0 GA cut at 3.0 days; v1.7 should have the same escape hatch and the same audit trail.

### Deliberately not carried over

- `daf12292` — v1.6.0 GA release identity and CHANGELOG. v1.7 produces its own.
- `b98808e7` — rc.13 release identity.
- `bd6f598d` — base-image digest bumps. The Dockerfile is already byte-identical; `cee3a686` covered it on this branch.
- `#689` and `#683` show up in the commit gap but were already forward-ported as `#690` and `#686`.

### Verification

- `apps/web/src/app/api/star-history/route.ts` and `.github/workflows/release-cut.yml` are byte-identical to `dev/v1.6`.
- `npm run test:workflows` — 80/80.
- `node --test apps/web/scripts/marketing-performance.test.mjs` — 6/6.
- Full pre-push gate green, including coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added OpenSSF governance, security-assurance documentation, and Best Practices Silver badge.
- ✨ Added authenticated GitHub GraphQL pagination for star history.
- ✨ Added GA-only `soak_override_reason` support with validation, audit output, and release-note disclosure.
- ✨ Added tests for GraphQL pagination, malformed responses, token handling, and soak override boundaries.
- 🔧 Replaced REST `/stargazers` requests with GitHub GraphQL requests.
- 🔒 Documented per-path outbound-request controls, fail-closed authentication, release integrity, and residual risks.

## Concerns

- Verify `GITHUB_TOKEN` exists in every runtime that serves the star-history route.
- Verify malformed or incomplete GraphQL pagination returns fallback data and no partial results.
- Verify prerelease workflows reject `soak_override_reason` before release actions run.
- Verify shortened, multiline, and sanitized override reasons remain safe in workflow outputs and release notes.
- Review the documented IFTTT outbound path and its missing shared timeout control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->