### PR TITLE
chore(deps): rotate the Renovate integration branch to dev/v1.7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "Rotate this at each branch cut. It cannot go stale unnoticed — release-cut.yml checks it against the dev branch derived from the release tag and fails the cut if they disagree.",
     "skipInstalls is off because the default fast path silently produced package.json bumps with an untouched lockfile. In July 2026 it left ui/ and apps/web/ that way while app/, e2e/ and apps/demo/ came out fine, and npm ci then rejected those branches with EUSAGE before a single test ran — one broken lockfile surfacing as four unrelated CI failures. A full install is slower per run and correct every run. scripts/lockfile-sync.test.mjs is the backstop that does not depend on this being right."
   ],
-  "baseBranchPatterns": ["dev/v1.6"],
+  "baseBranchPatterns": ["dev/v1.7"],
   "skipInstalls": false,
   "packageRules": [
     {


### PR DESCRIPTION
One line, but it's a release blocker.

`renovate.json` still reads `"baseBranchPatterns": ["dev/v1.6"]` on every branch including `main`. v1.6 GA'd on 2026-08-12. The config's own description says to rotate this at each branch cut, and `release-cut.yml:129` enforces it:

```
renovate.json targets 'dev/v1.6' but this cut is for dev/v1.7.
Update baseBranchPatterns to ["dev/v1.7"] and re-dispatch.
```

So a v1.7 cut fails at the "Assert main is in sync" step until this lands.

The quieter cost is happening right now: every dependency PR keeps targeting the retired line. #692–#695 are open against `dev/v1.6`, which has nothing left to ship, and `dev/v1.7` is receiving no dependency updates at all.

`i18n-crowdin.yml` needs no equivalent change — it resolves the highest `dev/vX.Y` on origin at run time and already targets v1.7.

`.github/tests/integration-branch-targets.test.ts` asserts shape rather than a specific branch (exactly one entry, matching `^dev/v\d+\.\d+$`, and that `baseBranches` stays undefined), so it stays green: 6/6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed `renovate.json` to target `dev/v1.7` instead of retired `dev/v1.6`.
- ✨ Added compatibility with the v1.7 release synchronization check.

## Concerns

- Verify that dependency PRs target `dev/v1.7`.
- Keep `i18n-crowdin.yml` unchanged.
- Confirm integration branch target tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->