### PR TITLE
docs: add AGENTS.md and RELEASING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,158 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## What is Drydock?
+
+Drydock is a Docker container update manager. It watches running containers, checks registries for newer image versions, and triggers notifications/actions when updates are available. It supports 23 registry providers, 20 trigger types, and a distributed controller-agent architecture (including native integration with [Portwing](https://github.com/CodesWhat/portwing) agents).
+
+## Repository structure
+
+This is a multi-workspace repo; each JS/TS workspace manages its own `package.json`:
+
+- **`app/`** — Backend (TypeScript, Express, LokiJS). Compiles with `tsc` directly, no bundler.
+- **`ui/`** — Frontend (Vue 3, Tailwind CSS 4, Vite SPA).
+- **`e2e/`** — Cucumber API/stream contracts + Playwright browser tests.
+- **`content/docs/`** — Versioned MDX documentation, the source of truth for published docs.
+- **`apps/web/`** — Next.js marketing/docs site (`drydock-website`); consumes a generated copy of `content/docs/`.
+- **`apps/demo/`** — Public demo instance (`drydock-demo`).
+- **`scripts/`** — Repository maintenance scripts (release tooling, quality gates, workflow tests), each covered by `node:test`.
+- **`.github/workflows/`** — CI, release, and security workflows.
+
+## Build, test, and lint
+
+```bash
+# Backend — run from app/
+npm run build           # tsc compilation + copy static assets
+npm test                # vitest --coverage (100% threshold enforced; requires Node >=24)
+npx vitest run path/to/file.test.ts   # single test file, no coverage
+npm run lint             # biome check .
+npm run lint:fix         # biome check --fix .
+
+# Frontend — run from ui/
+npm run build            # icons + fonts extraction, then vite build
+npm run serve             # dev server on port 8080
+npm run typecheck         # tsc --noEmit
+npm run test:unit         # vitest run --coverage (100% threshold enforced)
+npx vitest run tests/path/to/file.spec.ts   # single test file
+npm run lint / lint:fix
+
+# Full quality gate from repo root (what pre-push runs)
+./scripts/qlty-check-gate.sh all
+node scripts/qlty-smells-gate.mjs --scope=all
+
+# E2E — run from e2e/
+npm run test:local        # Cucumber tests against a running instance
+
+# Docker
+docker build -t drydock:dev .
+docker compose -f test/qa-compose.yml up -d   # QA environment on port 3333
+```
+
+Node.js **24+** is required (`engines` in root `package.json`, enforced again inside `app/`'s own `npm test` script).
+
+## Architecture
+
+### Component registry
+
+The core pattern (`app/registry/`) loads providers dynamically from environment variables at startup:
+
+```text
+DD_REGISTRY_GHCR_PRIVATE_TOKEN=xxx       →  loads registries/providers/ghcr/Ghcr.ts
+DD_NOTIFICATION_SLACK_MYSLACK_TOKEN=xxx  →  loads triggers/providers/slack/Slack.ts
+DD_WATCHER_LOCAL_SOCKET=xxx              →  loads watchers/providers/docker/Docker.ts
+```
+
+Each component type (watcher, registry, trigger, authentication) extends a base `Component` class with `init()`, `deregister()`, and type-specific methods.
+
+### Subsystems
+
+- **Watchers** (`app/watchers/`) — monitor containers via the Docker socket, reading `dd.watch`/`dd.tag.*` labels.
+- **Registries** (`app/registries/`) — query image registries for available tags; 23 providers share auth patterns via `BaseRegistry`.
+- **Triggers** (`app/triggers/`) — send notifications or execute actions on update; category-scoped `DD_ACTION_*`/`DD_NOTIFICATION_*`. The legacy `DD_TRIGGER_*` env vars and `dd.trigger.*` labels are removed as of v1.7.0 — a leftover `DD_TRIGGER_*` variable now fails startup; see `DEPRECATIONS.md`.
+- **Store** (`app/store/`) — LokiJS in-memory database, persisted to `/store/dd.json`.
+- **Agents** (`app/agent/`) — controller-agent distributed architecture; agents run remote watchers/triggers, including Portwing edge/standard agents.
+- **API** (`app/api/`) — Express REST API with SSE for real-time updates.
+
+Configuration is env-var only, `DD_` prefix, nested via underscores (e.g. `DD_REGISTRY_HUB_PUBLIC_AUTH`); secret-file support via `DD_PASSWORD__FILE`.
+
+## Testing patterns
+
+- Vitest with globals enabled — no need to import `describe`, `test`, `expect`, `vi`.
+- `vi.mock()` factories are hoisted above imports; use `vi.hoisted()` for values a mock factory needs.
+- Backend tests typically mock the logger:
+
+  ```ts
+  vi.mock('../../log/index.js', () => ({
+    default: { child: () => ({ info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() }) },
+  }));
+  ```
+
+## Coverage policy
+
+**100% line/branch/function/statement coverage is enforced for both `app/` and `ui/`.** This is a hard gate, not a target — the pre-push `coverage` step and CI both fail under it. External contributors aren't expected to hit this bar; per `CONTRIBUTING.md`, the maintainer brings PRs up to 100% during merge.
+
+When coverage fails, read `.coverage-gaps.json` (gitignored, written by `scripts/coverage-gaps.mjs`) for the exact files, uncovered lines, and branch ids, parsed from `lcov.info`.
+
+## Commit convention
+
+Plain Conventional Commits, no emoji: `<type>(<scope>): <description>`
+
+| Type | Use |
+|---|---|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation |
+| `style` | UI/cosmetic changes |
+| `refactor` | Refactor (also covers code removal) |
+| `perf` | Performance improvement |
+| `test` | Adding/updating tests |
+| `build` | Build system or dependency changes |
+| `ci` | CI/CD configuration changes |
+| `chore` | Tooling, config, misc |
+| `revert` | Intentional revert |
+
+Add `!` before the colon (`feat(api)!: drop v1 tokens`), or a `BREAKING CHANGE:` footer, for a breaking change. Enforced by the `commit-msg` hook (`scripts/validate-commit-msg.mjs`); on failure it prints an explicit amend command.
+
+## Pre-push checks (Lefthook)
+
+`git push` runs a piped (sequential, fail-fast) pipeline that takes about **4 minutes end to end**. In order:
+
+1. `clean-tree` — rejects uncommitted changes (CI only ever sees committed state)
+2. `ts-nocheck` — checks for `@ts-nocheck` directives against the allowlist
+3. `biome check .` — lint/format
+4. `qlty` — static analysis via `./scripts/qlty-check-gate.sh all` (medium+ severity gate, budgeted at **4 minutes**)
+5. `qlty-smells` — code-smell advisory scan (non-blocking)
+6. `scripts-test` — `node --test scripts/*.test.mjs`
+7. `workflow-tests` — `npm run test:workflows` (CI/workflow invariants, outside the app suite)
+8. `typecheck-ui` — `npm run typecheck --prefix ui`
+9. `web-scripts-test` — `npm run test:scripts --prefix apps/web`, only when a push touches `apps/web/**`
+10. `coverage` — sharded `app`+`ui` parallel vitest with the 100% threshold above (takes roughly **210 seconds**); on failure writes `.coverage-gaps.json`
+11. `build` — sharded `app`+`ui` parallel `tsc`/`vite`, no tests (they already ran in step 10)
+12. `docker-build` — optional, only when `DD_LOCAL_DOCKER=1`
+13. `zizmor` — GitHub Actions workflow security scan, only when `.github/workflows/*.yml` changed and `zizmor` is installed
+
+Coverage runs before build so tests execute exactly once per push, and a coverage failure surfaces before a slower build failure would bury it.
+
+**E2E (Cucumber) and Playwright are intentionally not in pre-push.** They run in `ci-verify.yml`/`e2e-playwright.yml` on the same commit a few minutes later, and are too slow and Docker-stateful for every local push. Run them directly first if you want the signal locally: `scripts/run-e2e-tests.sh` and `scripts/run-playwright-qa.sh` (referenced from `lefthook.yml`).
+
+Never use `--no-verify`. If a hook fails, fix the root cause — that's what it's there to catch before CI does.
+
+## Merging
+
+Pull requests are **squash-only** — the repo has merge commits and rebase merges disabled. Don't rely on `git merge-base --is-ancestor` for anything branch-related in this repo; every merge to `main` mints a new commit that `dev/vX.Y` never had, so ancestry checks fail even on a fully in-sync branch. Compare trees instead (`git diff --quiet <a> <b>`) — see `RELEASING.md` for where this matters.
+
+## Release & branch model
+
+Feature work and fixes land on `dev/vX.Y` via PR — never target `main` directly (see `CONTRIBUTING.md`). Cutting an actual release (`main` sync, RC/GA tagging, the soak requirement) is a maintainer operation documented in `RELEASING.md`.
+
+## Local planning archive
+
+Longer-form working notes and the roadmap tracker live under `.planning/` at the **bare repo root** (`~/code/codeswhat/drydock/.planning/`, not inside any worktree) and are gitignored — never reference their contents in committed files. The committed roadmap summary lives in `README.md`.
+
+## Key constraints
+
+- Biome is a direct devDependency in the root workspace; qlty handles all other linters (actionlint, checkov, dockerfmt, hadolint, markdownlint, osv-scanner, shellcheck, shfmt, trivy, trufflehog, yamllint) but not biome — qlty's biome integration doesn't reliably apply fixes.
+- `content/docs/` is the source of truth for published docs; the generated copy under `apps/web/content/docs/` is gitignored.
+- `CHANGELOG.md` at the repo root is the single source of truth for the changelog.
+- Regex from user config (tag include/exclude/transform) is compiled via `re2js` for linear-time execution — never introduce a raw `RegExp` on user-supplied patterns.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,118 @@
+# Releasing drydock
+
+`CONTRIBUTING.md` covers the contributor PR flow. This is the maintainer flow: how a release actually gets cut, from RC through GA. Everything here is driven by one workflow, `.github/workflows/release-cut.yml`, dispatched manually from `main`.
+
+## Overview
+
+`release-cut.yml` builds a recoverable, idempotent pipeline: images are first pushed under run-scoped staging tags, signed, attested, and attached to a **draft** GitHub release before anything user-facing is touched. Image tags, the git tag, and the public release are only finalized at the end, in that order — a failed run can safely be re-dispatched and it resumes from verified state instead of redoing work.
+
+The workflow only runs from `refs/heads/main` (the cosign OIDC identity is pinned to that ref) and only via `workflow_dispatch` — **Actions → 🏷️ Release: Cut → Run workflow**, run on `main`.
+
+Two shapes of release come out of the same workflow:
+
+- **RC (prerelease)** — builds fresh, multi-arch, from `main` HEAD.
+- **GA** — never rebuilds. It promotes an exact, already-soaked RC digest and tags the exact RC source commit.
+
+## Before dispatching
+
+1. **Sync `main` with the active dev branch first if it's drifted.** `main` is never an independent commit target — it only advances by merging from `dev/vX.Y` immediately before a cut, for every RC, not just GA. The workflow itself asserts this (see [Branch flow](#branch-flow-and-drift-check) below) and fails the whole run if it's out of sync, so do the merge before dispatching, not after.
+
+2. **Run the local precheck** — this cannot run in CI because it reads a gitignored file:
+
+   ```bash
+   npm run release:precheck v1.6.0
+   ```
+
+   Surfaces open GitHub Discussions still owed a "shipped in `<version>`" reply, read from `.planning/roadmap/current-tracker.md` (gitignored, lives at the bare repo root — invisible to the GitHub-hosted runner). Exits non-zero on a GA tag with pending replies; pass `--force` to bypass. Post the replies and tick the boxes, then dispatch.
+
+3. **CHANGELOG.md needs the entry before you dispatch.** The workflow reads `CHANGELOG.md` as it exists at the dispatch-time `main` HEAD and fails the run if the heading is missing or empty:
+
+   ```text
+   ## [1.6.0] - 2026-08-11
+   ```
+
+   No leading `v` in the heading, unlike the tag itself. (For a GA promoted from an RC, this heading is added to `main` on GA day — it's never present in the RC's own commit.)
+
+4. **Green CI on the target SHA.** The workflow polls for a successful `ci-verify.yml` run, then separately for a successful `e2e-playwright.yml` run, both on the SHA it's about to release — each poll allows up to 18 attempts, 300s apart (up to 90 minutes per workflow) before failing the run. Don't dispatch against a commit that hasn't finished CI; you'll just be waiting out the polling budget for something that was never going to turn green.
+
+## Cutting an RC
+
+Dispatch with just `release_tag` set, e.g. `v1.6.0-rc.14`. Leave `candidate_tag`, `candidate_digest`, and `soak_override_reason` empty — they're GA-only and the workflow hard-fails if any of them are set on a prerelease.
+
+`release_tag` must match `^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` — i.e. `vX.Y.Z` or `vX.Y.Z-<prerelease>` (`v1.6.0` or `v1.6.0-rc.14`). The tag's base version must match every workspace `package.json`/`package-lock.json` (`package.json`, `app/`, `ui/`, `e2e/` — checked explicitly), and the tag must not already exist pointing anywhere else.
+
+The workflow builds the multi-arch image (`linux/amd64,linux/arm64`) fresh from `main`, pushes it under a run-scoped staging tag, signs it with cosign (keyless, GitHub OIDC), attests SLSA build provenance and a Trivy SPDX SBOM, generates a `git archive` tarball with matching signature/attestation, and publishes it all as a GitHub prerelease. **Registry tags never carry the `v` prefix** — the workflow strips it itself (`${RELEASE_TAG#v}`), so `v1.6.0-rc.13` publishes as `ghcr.io/codeswhat/drydock:1.6.0-rc.13`, `docker.io/codeswhat/drydock:1.6.0-rc.13`, and the Quay equivalent.
+
+## Promoting to GA
+
+GA promotion requires three additional inputs:
+
+| Input | Format | Notes |
+|---|---|---|
+| `release_tag` | `vX.Y.Z` (no prerelease suffix) | e.g. `v1.6.0` |
+| `candidate_tag` | exact `vX.Y.Z-rc.N` | e.g. `v1.6.0-rc.13` — must belong to the same `X.Y.Z` as `release_tag`, and must already exist as a published GitHub prerelease |
+| `candidate_digest` | exact `sha256:<64 lowercase hex>` | the digest that `candidate_tag` publishes in GHCR, Docker Hub, **and** Quay — the workflow re-resolves all three and fails if any don't match |
+
+### The seven-day soak floor
+
+GA promotion requires the candidate to be **at least seven full days old (604800 seconds)**, measured from **the RC's GitHub release publication time (`publishedAt`)** — not the git tag's creation date, and not when the RC's build finished. Those can differ by minutes to hours depending on when the draft release was finalized.
+
+If the candidate is younger than that, the run fails outright *unless* `soak_override_reason` is supplied.
+
+### `soak_override_reason` — the escape hatch
+
+GA-only. Leave it blank to enforce the full seven-day soak — that's the default and expected path. If the candidate is under 604800 seconds old:
+
+- **Blank or whitespace-only** → hard fail, workflow stops. No implicit override.
+- **Under 20 characters after trimming** → hard fail: `soak_override_reason must be at least 20 characters of real justification to bypass the seven-day soak`. This is a floor on substance, not just presence — a placeholder like `"skip"` doesn't clear it.
+- **20+ characters** → the soak requirement is bypassed, and the workflow:
+  - Emits an `::warning::` annotation naming the real candidate age (both seconds and days), visible on the run's Actions summary
+  - Writes a `:warning: Seven-day soak overridden for GA promotion` block into the job's `$GITHUB_STEP_SUMMARY`, with the candidate tag, exact age, and the reason text
+  - Appends the same age + reason as a trailing note in the **published release notes**, so anyone reading the GA release later — not just the person watching the Actions run — can see the soak was cut short and why
+
+The reason is carried between steps as a temp file, not inlined into a `GITHUB_OUTPUT` key=value pair, specifically because it's free text from a `workflow_dispatch` input and could otherwise be used for output injection (a line starting with `::` or an embedded delimiter).
+
+**Real case:** v1.6.0 GA was promoted with this override on 2026-08-12, at roughly three days of soak (candidate age 260253s, ~3.0 days) against the 604800s requirement. The published release notes carry the reason: rc.13's fleet soak had passed clean three days earlier, the candidate digest was byte-identical across all three registries, and there were no open regressions against the milestone — the owner made the call to ship early rather than wait out the remaining four days.
+
+### What promotion actually does
+
+GA never rebuilds the image or the release artifact. It:
+
+1. Downloads the candidate's already-published `.tar.gz`, `.sha256`, `.bundle`, `.sig`, `.pem`, and `.intoto.jsonl` from the RC's GitHub release
+2. Verifies the checksum, the cosign signature, and the SLSA provenance attestation against the RC's original `SOURCE_SHA` (honest at RC-cut time, since source and target SHA were identical then)
+3. Rebuilds a fresh `git archive` of the candidate tag's commit today and compares decompressed tar bytes against the downloaded artifact, proving the soaked bytes are still exactly what that source SHA's tree contains
+4. Republishes those same verified bytes under the GA tag/filenames, re-tags the exact RC image digest under the GA image tags (`{major}.{minor}.{patch}`, `{major}.{minor}`, `{major}`, and `latest`) without rebuilding, and re-verifies the exact digest was published in every registry
+5. Pushes the GA git tag pointing at the RC's original commit (not at today's `main` HEAD) and publishes the GitHub release
+
+This is a deliberate design choice, not an oversight: `actions/attest-build-provenance` always records the workflow run's own checkout commit as the attested build source, and at GA that's today's `main` HEAD, never the seven-day-soaked candidate commit the tarball actually came from. Rebuilding and re-attesting at GA would produce an attestation that verifies cleanly while asserting something false. Promoting the RC's existing, honestly-attested bytes avoids that.
+
+## After the cut
+
+Both RC and GA runs finish with, in order: exact-digest image tags published to GHCR/Docker Hub/Quay, the git tag pushed, and the GitHub release flipped from draft to public. The job's `$GITHUB_STEP_SUMMARY` records the source SHA, bump level, version, tag, and image digest for every run.
+
+**Verify:**
+
+- The `release-cut.yml` run is green
+- `docker pull ghcr.io/codeswhat/drydock:<version>` (also `docker.io/codeswhat/drydock` and `quay.io/codeswhat/drydock`)
+- The GitHub release has the tarball, checksum, signature bundle, `.intoto.jsonl`, and image SPDX SBOM attached
+- `gh attestation verify oci://ghcr.io/codeswhat/drydock@<digest> --repo CodesWhat/drydock` for the container; the same pattern for the tarball via `cosign verify-blob`
+
+## Branch flow and drift check
+
+Feature and fix branches PR into `dev/vX.Y`, never `main`, per `CONTRIBUTING.md`. `main` only ever moves by merging `dev/vX.Y` into it, immediately before a cut. The workflow enforces this itself, before doing anything else:
+
+```bash
+git diff --quiet origin/main origin/dev/vX.Y
+```
+
+**This compares trees, not commit ancestry — deliberately.** drydock's branch protection allows squash merges only (`allow_squash_merge: true`, `allow_merge_commit: false`, `allow_rebase_merge: false`). Every `dev` → `main` sync therefore mints a brand-new commit that `dev` itself never has, which means `git merge-base --is-ancestor origin/dev/vX.Y origin/main` would fail on *every* cut after the first, sync or no sync. Tree equality is the invariant that actually holds.
+
+If the two have drifted, the run fails with a diffstat and refuses to tag — forward-port the missing content into `dev/vX.Y` (or reconcile whichever side is ahead) and re-dispatch. If `dev/vX.Y` doesn't exist on origin at all (retired post-GA, or not yet cut), the check is a no-op.
+
+The same step also asserts `renovate.json`'s `baseBranchPatterns` names exactly the `dev/vX.Y` branch this cut targets. Renovate has to name one concrete branch (a pattern would double every dependency PR against every matching `dev/vX.Y`), so it has to be rotated at every branch cut — this is the one moment in the pipeline where the correct target is unambiguous, so a stale value fails the cut with the exact value to set rather than silently leaving the bot aimed at a dead branch.
+
+## If something goes wrong
+
+The pipeline is designed to be resumed, not restarted: re-dispatching the same `release_tag` after a partial failure picks up from whatever was already published (existing tags, existing draft release) and continues. It refuses to touch a release that's already public (`Release ${RELEASE_TAG} is already public; refusing to alter it`) or a tag that already points somewhere else.
+
+If a bad release already went out, don't delete the tag or the release — that breaks pinned image digests and anything that already resolved them. Cut a patch release through the normal flow instead, and edit the bad release's notes to point at the fix.


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` — drydock has no committed agent-instructions file (`.gitignore` excludes `CLAUDE.md`/`.claude/`). Covers repo structure, build/test/lint commands, the component registry pattern, the 100% coverage gate on both `app/` and `ui/`, and the full pre-push lefthook pipeline (~4 min, qlty budgeted at 4 min, coverage ~210s), squash-only merges, and where the `.planning/` archive lives.
- Adds `RELEASING.md` — `CONTRIBUTING.md` only covers the contributor PR flow; nothing documented how a release is actually cut. Walks through `release-cut.yml` end to end: RC vs GA dispatch inputs and their exact formats, the seven-day soak floor measured from the RC's release publication time, the `soak_override_reason` escape hatch (20-char minimum, `::warning::` annotation, stamped into the run summary and published release notes), and the tree-equality drift check between `main` and the active dev branch (not commit ancestry, since this repo is squash-only).

Both files are new and were verified against the actual repo config (`lefthook.yml`, `.qlty/qlty.toml`, `package.json`, `.github/workflows/release-cut.yml`, `CONTRIBUTING.md`) rather than copied from sockguard/portwing's versions — drydock's gates and release mechanics differ.

## Test plan

- [x] `qlty check AGENTS.md RELEASING.md` — no issues
- [x] Full pre-push lefthook pipeline ran clean on push (biome, qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, web-scripts-test, coverage, build, zizmor)
- [x] Soak-override and v1.6.0 GA details cross-checked against the actual published `v1.6.0` GitHub release