### PR TITLE
fix(ifttt): apply the shared outbound HTTP timeout

### DIFF
--- a/SECURITY-ASSURANCE.md
+++ b/SECURITY-ASSURANCE.md
@@ -97,7 +97,7 @@ individually rather than claiming a blanket policy:
 | Icon fetch (`app/api/icons/`) | yes | no | yes | no |
 | Release notes (`app/release-notes/`) | yes | no | no | no |
 | Notification providers calling axios directly (Apprise, Discord, Google Chat, Matrix, Mattermost, ntfy, Rocket.Chat, Teams, Telegram) | yes | no | no | no |
-| IFTTT notification provider (`app/triggers/providers/ifttt/`) | no | no | no | no |
+| IFTTT notification provider (`app/triggers/providers/ifttt/`) | yes | no | no | no |
 | Notification providers wrapping a vendor SDK (Gotify, Kafka, Pushover, Slack, SMTP) | vendor default | vendor default | vendor default | vendor default |
 
 Shell-like update and hook surfaces use explicit argument handling and
@@ -108,12 +108,9 @@ The gaps in that table are real and deliberate to state. Only the HTTP trigger,
 which takes an operator-supplied URL, resolves and refuses cloud metadata and
 link-local addresses; several notification providers are self-hostable and so
 also take an operator-supplied host, without that check. Release notes and icons
-follow redirects, and release notes applies no response-size cap. IFTTT is the
-one path with no timeout at all: it calls axios without the shared
-`getOutboundHttpTimeoutMs()` value its nine sibling providers pass, tracked as
-[#704](https://github.com/CodesWhat/drydock/issues/704). Providers built on a
-vendor SDK inherit whatever controls that dependency applies; Drydock does not
-establish them and does not claim them here.
+follow redirects, and release notes applies no response-size cap. Providers
+built on a vendor SDK inherit whatever controls that dependency applies;
+Drydock does not establish them and does not claim them here.
 
 Evidence: [`app/configuration/`](app/configuration),
 [`app/registries/`](app/registries), [`app/release-notes/`](app/release-notes),

--- a/app/triggers/providers/ifttt/Ifttt.test.ts
+++ b/app/triggers/providers/ifttt/Ifttt.test.ts
@@ -86,6 +86,7 @@ test('trigger should send http request to IFTTT', async () => {
     },
     method: 'POST',
 
+    timeout: 30000,
     url: 'https://maker.ifttt.com/trigger/event/with/key/key',
   });
 });
@@ -112,6 +113,7 @@ test('trigger should not throw when container result is missing', async () => {
       'Content-Type': 'application/json',
     },
     method: 'POST',
+    timeout: 30000,
     url: 'https://maker.ifttt.com/trigger/event/with/key/key',
   });
 });
@@ -132,6 +134,7 @@ test('triggerBatch should send http request with containers json', async () => {
       'Content-Type': 'application/json',
     },
     method: 'POST',
+    timeout: 30000,
     url: 'https://maker.ifttt.com/trigger/event/with/key/key',
   });
 });
@@ -157,6 +160,7 @@ test('triggerBatch should use runtimeContext.title as value1 and empty value2 wh
       'Content-Type': 'application/json',
     },
     method: 'POST',
+    timeout: 30000,
     url: 'https://maker.ifttt.com/trigger/event/with/key/key',
   });
 });
@@ -179,6 +183,7 @@ test('triggerBatch should use runtimeContext.body as value2 and empty value1 whe
       'Content-Type': 'application/json',
     },
     method: 'POST',
+    timeout: 30000,
     url: 'https://maker.ifttt.com/trigger/event/with/key/key',
   });
 });
@@ -205,6 +210,7 @@ test('triggerBatch should use both runtimeContext title and body when both are s
       'Content-Type': 'application/json',
     },
     method: 'POST',
+    timeout: 30000,
     url: 'https://maker.ifttt.com/trigger/event/with/key/key',
   });
 });

--- a/app/triggers/providers/ifttt/Ifttt.ts
+++ b/app/triggers/providers/ifttt/Ifttt.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 
+import { getOutboundHttpTimeoutMs } from '../../../configuration/runtime-defaults.js';
 import Trigger, { type BatchRuntimeContext, type TriggerConfiguration } from '../Trigger.js';
 
 interface IftttConfiguration extends TriggerConfiguration {
@@ -80,6 +81,7 @@ class Ifttt extends Trigger<IftttConfiguration> {
         'Content-Type': 'application/json',
       },
       data: body,
+      timeout: getOutboundHttpTimeoutMs(),
     };
     const response = await axios(options);
     return response.data;


### PR DESCRIPTION
IFTTT was the one outbound path in the codebase with no timeout at all. It called `axios(options)` bare while its nine sibling providers all pass `getOutboundHttpTimeoutMs()`, so a hung IFTTT endpoint hung the notification indefinitely.

Three parts:

- `Ifttt.ts` now passes the shared timeout the same way its siblings do.
- The six `toHaveBeenCalledWith({...})` assertions in `Ifttt.test.ts` carry the new key. Left exact rather than loosened to `objectContaining` — the exactness is what makes them worth having.
- `SECURITY-ASSURANCE.md`: the IFTTT row's timeout column reads `yes`, and the sentence naming IFTTT as the untimed path is gone, since it stops being true when this lands.

Fixes: #704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added `timeout: getOutboundHttpTimeoutMs()` to IFTTT webhook requests.
- 🔧 Changed six `Ifttt.test.ts` Axios option assertions to expect a `30000` ms timeout.
- 🔒 Updated `SECURITY-ASSURANCE.md` to mark IFTTT timeout support as enabled.
- 🗑️ Removed the outdated statement that IFTTT lacks a timeout and the related issue reference.

## Concerns

- Verify all IFTTT Axios calls use the shared outbound timeout.
- Verify the test expectation remains aligned with the configured default timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->