### PR TITLE
ci(checks): remove emoji from required job names

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -29,7 +29,6 @@ const secretScanScriptPath = fileURLToPath(
 );
 const gitleaksConfigPath = fileURLToPath(new URL('../../.gitleaks.toml', import.meta.url));
 const gitleaksIgnorePath = fileURLToPath(new URL('../../.gitleaksignore', import.meta.url));
-const emojiPrefix = /^\p{Extended_Pictographic}/u;
 const workflowTestsCommand = 'npm run test:workflows';
 const loadWorkflow = loadWorkflowFrom.bind(undefined, workflowPath);
 const getWorkflowStep = getWorkflowStepFrom.bind(undefined, workflowPath);
@@ -43,17 +42,14 @@ function getTestJobStep(name: string): WorkflowStep | undefined {
   return workflow.jobs?.test?.steps?.find((step) => step.name === name);
 }
 
-test('ci-verify job names are emoji-prefixed for GitHub checks readability', () => {
+test('required ci-verify jobs publish stable plain-text check names', () => {
   const workflow = loadWorkflow();
 
-  const jobsWithoutEmoji = Object.entries(workflow.jobs ?? {})
-    .map(([jobId, job]) => ({
-      jobId,
-      name: job.name ?? '',
-    }))
-    .filter(({ name }) => !emojiPrefix.test(name));
-
-  expect(jobsWithoutEmoji).toStrictEqual([]);
+  expect(workflow.jobs?.zizmor?.name).toBe('Security: Actions');
+  expect(workflow.jobs?.lint?.name).toBe('Quality: Lint');
+  expect(workflow.jobs?.test?.name).toBe('Quality: Test & Coverage');
+  expect(workflow.jobs?.build?.name).toBe('Build');
+  expect(workflow.jobs?.e2e?.name).toBe('E2E: Cucumber');
 });
 
 test('script node tests are wired into local and CI gates', () => {

--- a/.github/tests/e2e-playwright-workflow.test.ts
+++ b/.github/tests/e2e-playwright-workflow.test.ts
@@ -17,6 +17,10 @@ const authSetupPath = fileURLToPath(new URL('../../e2e/playwright/auth.setup.ts'
 const loadWorkflow = loadWorkflowFrom.bind(undefined, workflowPath);
 const getWorkflowStep = getWorkflowStepFrom.bind(undefined, workflowPath);
 
+test('required Playwright job publishes a stable plain-text check name', () => {
+  expect(loadWorkflow().jobs?.playwright?.name).toBe('E2E: Playwright');
+});
+
 test('Playwright workflow disables browser downloads for host-side npm installs', () => {
   const workflow = loadWorkflow();
 

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -52,7 +52,7 @@ permissions: {}
 
 jobs:
   zizmor:
-    name: "🔐 Security: Actions"
+    name: "Security: Actions"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -359,7 +359,7 @@ jobs:
           head-ref: ${{ github.event_name == 'push' && github.sha || '' }}
 
   lint:
-    name: "🧹 Quality: Lint"
+    name: "Quality: Lint"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -415,7 +415,7 @@ jobs:
           retention-days: 14
 
   test:
-    name: "🧪 Quality: Test & Coverage"
+    name: "Quality: Test & Coverage"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -564,7 +564,7 @@ jobs:
         working-directory: apps/web
 
   build:
-    name: "🏗️ Build"
+    name: "Build"
     needs: [lint, test]
     runs-on: ubuntu-latest
     timeout-minutes: 35  # Includes UI build + single-arch QA image + multi-arch smoke build
@@ -1061,7 +1061,7 @@ jobs:
         run: docker compose -p drydock-zap -f test/qa-compose.yml down -v --remove-orphans
 
   e2e:
-    name: "🥒 E2E: Cucumber"
+    name: "E2E: Cucumber"
     if: github.event_name == 'workflow_dispatch' || (github.event_name != 'schedule' && needs.changes.outputs.runtime == 'true')
     runs-on: ubuntu-latest
     # Covers the bounded npm/setup retry budgets, readiness waits, scenario

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -80,7 +80,7 @@ jobs:
           filters: .github/filters/runtime.yml
 
   playwright:
-    name: "🎭 E2E: Playwright"
+    name: "E2E: Playwright"
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.runtime == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 35  # UI build + Docker build + QA stack startup + Playwright pull + UI flow tests


### PR DESCRIPTION
## Summary

- rename the six required check jobs to stable plain-text contexts
- replace the old emoji-prefix invariant with exact required-context tests
- leave non-required advisory job names unchanged

## Verification

- `npx vitest run .github/tests/ci-verify-workflow.test.ts .github/tests/e2e-playwright-workflow.test.ts --config .github/tests/vitest.config.mjs --maxWorkers=1 --fileParallelism=false`
- `npm run test:workflows`
- full Lefthook pre-push gate, including 100% app/UI coverage, builds, qlty, and zizmor

The main ruleset still requires the old six contexts. It will be patched with `gh api` only after this PR is reviewed, green, and merged into `dev/v1.7`, while Drydock has no other open PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed six required CI check names to stable plain-text contexts.
- 🔧 Changed required-context tests to assert exact job names.
- 🗑️ Removed the unused emoji-name invariant.
- ✨ Added coverage for `E2E: Playwright`.
- 🔒 Preserved the `zizmor` job name change without changing advisory job names.
- ✨ Verified with targeted Vitest tests, `npm run test:workflows`, and Lefthook pre-push checks.

## Concerns

- Update the repository ruleset to use the new required contexts after merge into `dev/v1.7`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->