### PR TITLE
fix(mqtt): resync home assistant discovery

### DIFF
--- a/app/triggers/providers/mqtt/Hass.test.ts
+++ b/app/triggers/providers/mqtt/Hass.test.ts
@@ -738,6 +738,19 @@ test('updateContainerSensors serializes retained aggregate snapshots across cont
   expect(retainedTotalCounts).toEqual([1, 2]);
 });
 
+test('updateContainerSensors continues after a preceding aggregate update fails', async () => {
+  mqttClientMock.publish
+    .mockRejectedValueOnce(new Error('aggregate publish failed'))
+    .mockResolvedValue(undefined);
+
+  await expect(hass.updateContainerSensors({ name: 'first', watcher: 'local' })).rejects.toThrow(
+    'aggregate publish failed',
+  );
+  await expect(
+    hass.updateContainerSensors({ name: 'second', watcher: 'local' }),
+  ).resolves.toBeUndefined();
+});
+
 test.each(containerData)(
   'removeContainerSensor must publish all sensor removal messages expected by HA',
   async ({ containerName, data }) => {

--- a/app/triggers/providers/mqtt/Hass.test.ts
+++ b/app/triggers/providers/mqtt/Hass.test.ts
@@ -3166,6 +3166,68 @@ describe('hass install commands (#210)', () => {
       );
     });
 
+    test('deregister retires and drains all registered container and watcher work', async () => {
+      let releaseWatcherPublish!: () => void;
+      let markWatcherPublishStarted!: () => void;
+      const watcherPublishStarted = new Promise<void>((resolve) => {
+        markWatcherPublishStarted = resolve;
+      });
+      const watcherPublishGate = new Promise<void>((resolve) => {
+        releaseWatcherPublish = resolve;
+      });
+      const clientMock = {
+        publish: vi.fn((topic: string) => {
+          if (topic === 'topic/local/running') {
+            markWatcherPublishStarted();
+            return watcherPublishGate;
+          }
+          return undefined;
+        }),
+      };
+      const h = new Hass({
+        client: clientMock,
+        configuration: {
+          topic: 'topic',
+          hass: { discovery: false, prefix: 'homeassistant', commands: false },
+        },
+        log,
+        isContainerAllowed: () => true,
+      });
+      const containerAddedCb = registerContainerAdded.mock.calls.at(-1)[0];
+      const containerUpdatedCb = registerContainerUpdated.mock.calls.at(-1)[0];
+      const containerRemovedCb = registerContainerRemoved.mock.calls.at(-1)[0];
+      const watcherStartCb = registerWatcherStart.mock.calls.at(-1)[0];
+      const watcherStopCb = registerWatcherStop.mock.calls.at(-1)[0];
+      const activeWatcherSync = watcherStartCb({ name: 'local' });
+      await watcherPublishStarted;
+
+      let deregisterResolved = false;
+      const deregisterPromise = h.deregister().then(() => {
+        deregisterResolved = true;
+      });
+      const retiredContainer = {
+        id: 'retired-container',
+        name: 'retired-container',
+        watcher: 'local',
+      };
+      const retiredWork = [
+        containerAddedCb(retiredContainer),
+        containerUpdatedCb(retiredContainer),
+        containerRemovedCb(retiredContainer),
+        watcherStartCb({ name: 'retired-watcher' }),
+        watcherStopCb({ name: 'retired-watcher' }),
+      ];
+      await flushMicrotasks();
+
+      expect(deregisterResolved).toBe(false);
+      expect(clientMock.publish).toHaveBeenCalledTimes(1);
+
+      releaseWatcherPublish();
+      await Promise.all([activeWatcherSync, ...retiredWork, deregisterPromise]);
+      expect(deregisterResolved).toBe(true);
+      expect(clientMock.publish).toHaveBeenCalledTimes(1);
+    });
+
     test('deregister drains active discovery sync and drops stale queued work', async () => {
       let releasePublish!: () => void;
       let markPublishStarted!: () => void;

--- a/app/triggers/providers/mqtt/Hass.test.ts
+++ b/app/triggers/providers/mqtt/Hass.test.ts
@@ -1493,6 +1493,145 @@ describe('hass sensor sync gating by isContainerAllowed (#491)', () => {
   });
 });
 
+describe('hass discovery startup resync (#708)', () => {
+  function getResyncDiscovery(hassInstance: Hass): () => Promise<void> {
+    const resyncDiscovery = (hassInstance as unknown as { resyncDiscovery?: () => Promise<void> })
+      .resyncDiscovery;
+    expect(resyncDiscovery).toEqual(expect.any(Function));
+    return resyncDiscovery!.bind(hassInstance);
+  }
+
+  test('republishes stored container discovery after the command subscription is active', async () => {
+    const capableClient = makeCapableClientMock();
+    const commandsHass = new Hass({
+      client: capableClient,
+      configuration: {
+        topic: 'topic',
+        hass: { discovery: true, prefix: 'homeassistant', commands: true },
+      },
+      log,
+      isContainerAllowed: () => true,
+    });
+    const container = {
+      id: 'ctr-existing',
+      name: 'nginx',
+      watcher: 'local',
+      displayIcon: 'mdi:docker',
+    };
+    vi.spyOn(containerStore, 'getContainers').mockReturnValue([container] as any);
+    vi.spyOn(commandsHass, 'updateContainerSensors').mockResolvedValue(undefined);
+
+    await commandsHass.initCommandSubscription();
+    await getResyncDiscovery(commandsHass)();
+
+    expect(containerStore.getContainers).toHaveBeenCalledWith({});
+    const discoveryCall = capableClient.publish.mock.calls.find(
+      ([topic]) => topic === 'homeassistant/update/topic_local_nginx/config',
+    );
+    expect(discoveryCall).toBeDefined();
+    expect(JSON.parse(discoveryCall![1])).toMatchObject({
+      command_topic: 'topic/local/nginx/cmd',
+      payload_install: 'install',
+    });
+  });
+
+  test('cleans retained discovery for stored containers excluded by this trigger', async () => {
+    const container = { id: 'ctr-excluded', name: 'redis', watcher: 'local' };
+    vi.spyOn(containerStore, 'getContainers').mockReturnValue([container] as any);
+    const excludedHass = new Hass({
+      client: mqttClientMock,
+      configuration: {
+        topic: 'topic',
+        hass: { discovery: true, prefix: 'homeassistant' },
+      },
+      log,
+      isContainerAllowed: () => false,
+    });
+
+    await getResyncDiscovery(excludedHass)();
+
+    expect(mqttClientMock.publish).toHaveBeenCalledWith(
+      'homeassistant/update/topic_local_redis/config',
+      '',
+      { retain: true },
+    );
+  });
+
+  test('omits command topics when broker subscription fails before resync', async () => {
+    const capableClient = makeCapableClientMock();
+    capableClient.subscribeAsync.mockRejectedValue(new Error('ACL denied'));
+    const commandsHass = new Hass({
+      client: capableClient,
+      configuration: {
+        topic: 'topic',
+        hass: { discovery: true, prefix: 'homeassistant', commands: true },
+      },
+      log,
+      isContainerAllowed: () => true,
+    });
+    const container = { id: 'ctr-existing', name: 'nginx', watcher: 'local' };
+    vi.spyOn(containerStore, 'getContainers').mockReturnValue([container] as any);
+    vi.spyOn(commandsHass, 'updateContainerSensors').mockResolvedValue(undefined);
+
+    await commandsHass.initCommandSubscription();
+    await getResyncDiscovery(commandsHass)();
+
+    const discoveryCall = capableClient.publish.mock.calls.find(
+      ([topic]) => topic === 'homeassistant/update/topic_local_nginx/config',
+    );
+    expect(discoveryCall).toBeDefined();
+    const discoveryPayload = JSON.parse(discoveryCall![1]);
+    expect(discoveryPayload).not.toHaveProperty('command_topic');
+    expect(discoveryPayload).not.toHaveProperty('payload_install');
+  });
+
+  test('logs a failed container publish and continues resyncing the remaining store', async () => {
+    const capableClient = makeCapableClientMock();
+    capableClient.publish
+      .mockRejectedValueOnce(new Error('broker publish failed'))
+      .mockResolvedValue(undefined);
+    const resilientHass = new Hass({
+      client: capableClient,
+      configuration: {
+        topic: 'topic',
+        hass: { discovery: true, prefix: 'homeassistant' },
+      },
+      log,
+      isContainerAllowed: () => true,
+    });
+    const first = { id: 'ctr-first', name: 'first', watcher: 'local' };
+    const second = { id: 'ctr-second', name: 'second', watcher: 'local' };
+    vi.spyOn(containerStore, 'getContainers').mockReturnValue([first, second] as any);
+    vi.spyOn(resilientHass, 'updateContainerSensors').mockResolvedValue(undefined);
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+
+    await expect(getResyncDiscovery(resilientHass)()).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to resync hass discovery for container [first] (broker publish failed)',
+    );
+    expect(capableClient.publish).toHaveBeenCalledWith(
+      'homeassistant/update/topic_local_second/config',
+      expect.any(String),
+      { retain: true },
+    );
+  });
+
+  test('logs a store read failure and leaves startup resync successful', async () => {
+    vi.spyOn(containerStore, 'getContainers').mockImplementation(() => {
+      throw new Error('store unavailable');
+    });
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+
+    await expect(getResyncDiscovery(hass)()).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to load containers for hass discovery resync (store unavailable)',
+    );
+    expect(mqttClientMock.publish).not.toHaveBeenCalled();
+  });
+});
+
 // ── #386: agenttopicsegment flag ─────────────────────────────────────────────
 
 describe('agenttopicsegment flag', () => {

--- a/app/triggers/providers/mqtt/Hass.test.ts
+++ b/app/triggers/providers/mqtt/Hass.test.ts
@@ -1353,10 +1353,14 @@ describe('hass sensor sync gating by isContainerAllowed (#491)', () => {
     const container = { id: 'ctr-removal-retry', name: 'nginx', watcher: 'local' };
     const internalSet = (gatedHass as unknown as { cleanedExcludedContainerKeys: Set<string> })
       .cleanedExcludedContainerKeys;
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
 
     // First excluded event: the removal publish rejects.
     mqttClientGatedMock.publish.mockRejectedValueOnce(new Error('mqtt publish failed'));
-    await expect(containerAddedCb(container)).rejects.toThrow('mqtt publish failed');
+    await expect(containerAddedCb(container)).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to sync hass discovery for container [nginx] (mqtt publish failed)',
+    );
     // A failed removal must not be marked cleaned — the key must not stick.
     expect(internalSet.size).toBe(0);
 
@@ -1608,18 +1612,21 @@ describe('hass discovery startup resync (#708)', () => {
     const firstPublish = new Promise<void>((_resolve, reject) => {
       rejectFirstPublish = reject;
     });
-    let publishCount = 0;
+    let queuedDiscoveryPublishCount = 0;
     const resilientClient = {
-      publish: vi.fn(() => {
-        publishCount += 1;
-        if (publishCount === 1) {
+      publish: vi.fn((topic: string) => {
+        if (
+          topic === 'homeassistant/update/topic_local_queued/config' &&
+          queuedDiscoveryPublishCount === 0
+        ) {
+          queuedDiscoveryPublishCount += 1;
           markFirstPublishStarted();
           return firstPublish;
         }
         return undefined;
       }),
     };
-    new Hass({
+    const resilientHass = new Hass({
       client: resilientClient,
       configuration: {
         topic: 'topic',
@@ -1628,6 +1635,8 @@ describe('hass discovery startup resync (#708)', () => {
       log,
       isContainerAllowed: () => true,
     });
+    vi.spyOn(resilientHass, 'updateContainerSensors').mockResolvedValue(undefined);
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
     const containerUpdatedCb = registerContainerUpdated.mock.calls.at(-1)[0];
     const container = { id: 'ctr-queued', name: 'queued', watcher: 'local' };
 
@@ -1636,8 +1645,11 @@ describe('hass discovery startup resync (#708)', () => {
     const laterUpdate = containerUpdatedCb({ ...container, displayName: 'Later update' });
     rejectFirstPublish(new Error('broker publish failed'));
 
-    await expect(failedUpdate).rejects.toThrow('broker publish failed');
+    await expect(failedUpdate).resolves.toBeUndefined();
     await expect(laterUpdate).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to sync hass discovery for container [queued] (broker publish failed)',
+    );
     const discoveryCalls = resilientClient.publish.mock.calls.filter(
       ([topic]) => topic === 'homeassistant/update/topic_local_queued/config',
     );

--- a/app/triggers/providers/mqtt/Hass.test.ts
+++ b/app/triggers/providers/mqtt/Hass.test.ts
@@ -3095,6 +3095,62 @@ describe('hass install commands (#210)', () => {
   });
 
   describe('deregister / lifecycle', () => {
+    test('deregister drains active discovery sync and drops stale queued work', async () => {
+      let releasePublish!: () => void;
+      let markPublishStarted!: () => void;
+      const publishStarted = new Promise<void>((resolve) => {
+        markPublishStarted = resolve;
+      });
+      const publishGate = new Promise<void>((resolve) => {
+        releasePublish = resolve;
+      });
+      const clientMock = {
+        publish: vi.fn((topic: string) => {
+          if (topic === 'homeassistant/update/topic_local_queued/config') {
+            markPublishStarted();
+            return publishGate;
+          }
+          return undefined;
+        }),
+      };
+      const h = new Hass({
+        client: clientMock,
+        configuration: {
+          topic: 'topic',
+          hass: { discovery: true, prefix: 'homeassistant', commands: false },
+        },
+        log,
+        isContainerAllowed: () => true,
+      });
+      vi.spyOn(h, 'updateContainerSensors').mockResolvedValue(undefined);
+      const containerUpdatedCb = registerContainerUpdated.mock.calls.at(-1)[0];
+      const queuedSync = containerUpdatedCb({ id: 'ctr-queued', name: 'queued', watcher: 'local' });
+      await publishStarted;
+      const staleQueuedSync = containerUpdatedCb({
+        id: 'ctr-queued',
+        name: 'queued',
+        watcher: 'local',
+        displayName: 'Stale queued update',
+      });
+
+      let deregisterResolved = false;
+      const deregisterPromise = h.deregister().then(() => {
+        deregisterResolved = true;
+      });
+      await flushMicrotasks();
+
+      expect(deregisterResolved).toBe(false);
+
+      releasePublish();
+      await Promise.all([queuedSync, staleQueuedSync, deregisterPromise]);
+      expect(deregisterResolved).toBe(true);
+      expect(
+        clientMock.publish.mock.calls.filter(
+          ([topic]) => topic === 'homeassistant/update/topic_local_queued/config',
+        ),
+      ).toHaveLength(1);
+    });
+
     test('deregister unsubscribes exact filters, removes the exact listener, and clears the rate limiter', async () => {
       const clientMock = makeCapableClientMock();
       const h = new Hass({

--- a/app/triggers/providers/mqtt/Hass.test.ts
+++ b/app/triggers/providers/mqtt/Hass.test.ts
@@ -702,6 +702,42 @@ test('updateContainerSensors should use container count queries instead of full 
   expect(getContainersSpy).not.toHaveBeenCalled();
 });
 
+test('updateContainerSensors serializes retained aggregate snapshots across containers', async () => {
+  let releaseFirstPublish!: () => void;
+  let markFirstPublishStarted!: () => void;
+  const firstPublishStarted = new Promise<void>((resolve) => {
+    markFirstPublishStarted = resolve;
+  });
+  const firstPublishGate = new Promise<void>((resolve) => {
+    releaseFirstPublish = resolve;
+  });
+  const retainedTotalCounts: number[] = [];
+  let firstTotalCountPublish = true;
+  mqttClientMock.publish.mockImplementation(async (topic: string, value: string) => {
+    if (topic !== 'topic/total_count') {
+      return;
+    }
+    if (firstTotalCountPublish) {
+      firstTotalCountPublish = false;
+      markFirstPublishStarted();
+      await firstPublishGate;
+    }
+    retainedTotalCounts.push(Number(value));
+  });
+  let containerCount = 1;
+  vi.spyOn(containerStore, 'getContainerCount').mockImplementation(() => containerCount);
+
+  const firstUpdate = hass.updateContainerSensors({ name: 'first', watcher: 'local' });
+  await firstPublishStarted;
+  containerCount = 2;
+  const secondUpdate = hass.updateContainerSensors({ name: 'second', watcher: 'local' });
+  await flushMicrotasks();
+  releaseFirstPublish();
+  await Promise.all([firstUpdate, secondUpdate]);
+
+  expect(retainedTotalCounts).toEqual([1, 2]);
+});
+
 test.each(containerData)(
   'removeContainerSensor must publish all sensor removal messages expected by HA',
   async ({ containerName, data }) => {
@@ -3095,6 +3131,28 @@ describe('hass install commands (#210)', () => {
   });
 
   describe('deregister / lifecycle', () => {
+    test('watcher lifecycle callbacks isolate publish failures', async () => {
+      const clientMock = {
+        publish: vi.fn().mockRejectedValue(new Error('watcher publish failed')),
+      };
+      new Hass({
+        client: clientMock,
+        configuration: {
+          topic: 'topic',
+          hass: { discovery: true, prefix: 'homeassistant', commands: false },
+        },
+        log,
+        isContainerAllowed: () => true,
+      });
+      const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+      const watcherStartCb = registerWatcherStart.mock.calls.at(-1)[0];
+
+      await expect(watcherStartCb({ name: 'local' })).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Failed to sync hass discovery for watcher [local] (watcher publish failed)',
+      );
+    });
+
     test('deregister drains active discovery sync and drops stale queued work', async () => {
       let releasePublish!: () => void;
       let markPublishStarted!: () => void;

--- a/app/triggers/providers/mqtt/Hass.test.ts
+++ b/app/triggers/providers/mqtt/Hass.test.ts
@@ -1535,6 +1535,118 @@ describe('hass discovery startup resync (#708)', () => {
     });
   });
 
+  test('retains a live update emitted before its stale startup snapshot is processed', async () => {
+    let releaseFirstSnapshot!: () => void;
+    let markFirstSnapshotStarted!: () => void;
+    const firstSnapshotStarted = new Promise<void>((resolve) => {
+      markFirstSnapshotStarted = resolve;
+    });
+    const firstSnapshotGate = new Promise<void>((resolve) => {
+      releaseFirstSnapshot = resolve;
+    });
+    const orderingClient = {
+      publish: vi.fn((topic: string) => {
+        if (topic === 'homeassistant/update/topic_local_first/config') {
+          markFirstSnapshotStarted();
+          return firstSnapshotGate;
+        }
+        return undefined;
+      }),
+    };
+    const orderingHass = new Hass({
+      client: orderingClient,
+      configuration: {
+        topic: 'topic',
+        hass: { discovery: true, prefix: 'homeassistant' },
+      },
+      log,
+      isContainerAllowed: () => true,
+    });
+    const firstSnapshot = {
+      id: 'ctr-first',
+      name: 'first',
+      watcher: 'local',
+      displayName: 'First snapshot',
+    };
+    const staleSecondSnapshot = {
+      id: 'ctr-second',
+      name: 'second',
+      watcher: 'local',
+      displayName: 'Stale snapshot',
+    };
+    const liveSecondUpdate = {
+      ...staleSecondSnapshot,
+      displayName: 'Live update',
+    };
+    vi.spyOn(containerStore, 'getContainers').mockReturnValue([
+      firstSnapshot,
+      staleSecondSnapshot,
+    ] as any);
+    vi.spyOn(orderingHass, 'updateContainerSensors').mockResolvedValue(undefined);
+    const containerUpdatedCb = registerContainerUpdated.mock.calls.at(-1)[0];
+
+    const resync = getResyncDiscovery(orderingHass)();
+    await firstSnapshotStarted;
+    const liveUpdate = containerUpdatedCb(liveSecondUpdate);
+    await flushMicrotasks();
+    releaseFirstSnapshot();
+    await Promise.all([resync, liveUpdate]);
+
+    const secondDiscoveryPayloads = orderingClient.publish.mock.calls
+      .filter(([topic]) => topic === 'homeassistant/update/topic_local_second/config')
+      .map(([, payload]) => JSON.parse(payload));
+    expect(secondDiscoveryPayloads).toHaveLength(2);
+    expect(secondDiscoveryPayloads.at(-1)).toMatchObject({ name: 'Live update' });
+  });
+
+  test('continues a queued container sync after the preceding publish fails', async () => {
+    let rejectFirstPublish!: (error: Error) => void;
+    let markFirstPublishStarted!: () => void;
+    const firstPublishStarted = new Promise<void>((resolve) => {
+      markFirstPublishStarted = resolve;
+    });
+    const firstPublish = new Promise<void>((_resolve, reject) => {
+      rejectFirstPublish = reject;
+    });
+    let publishCount = 0;
+    const resilientClient = {
+      publish: vi.fn(() => {
+        publishCount += 1;
+        if (publishCount === 1) {
+          markFirstPublishStarted();
+          return firstPublish;
+        }
+        return undefined;
+      }),
+    };
+    new Hass({
+      client: resilientClient,
+      configuration: {
+        topic: 'topic',
+        hass: { discovery: true, prefix: 'homeassistant' },
+      },
+      log,
+      isContainerAllowed: () => true,
+    });
+    const containerUpdatedCb = registerContainerUpdated.mock.calls.at(-1)[0];
+    const container = { id: 'ctr-queued', name: 'queued', watcher: 'local' };
+
+    const failedUpdate = containerUpdatedCb({ ...container, displayName: 'Failed update' });
+    await firstPublishStarted;
+    const laterUpdate = containerUpdatedCb({ ...container, displayName: 'Later update' });
+    rejectFirstPublish(new Error('broker publish failed'));
+
+    await expect(failedUpdate).rejects.toThrow('broker publish failed');
+    await expect(laterUpdate).resolves.toBeUndefined();
+    const discoveryCalls = resilientClient.publish.mock.calls.filter(
+      ([topic]) => topic === 'homeassistant/update/topic_local_queued/config',
+    );
+    expect(discoveryCalls).toHaveLength(2);
+    expect(JSON.parse(discoveryCalls.at(-1)[1])).toMatchObject({
+      name: 'Later update',
+    });
+  });
+
   test('cleans retained discovery for stored containers excluded by this trigger', async () => {
     const container = { id: 'ctr-excluded', name: 'redis', watcher: 'local' };
     vi.spyOn(containerStore, 'getContainers').mockReturnValue([container] as any);

--- a/app/triggers/providers/mqtt/Hass.ts
+++ b/app/triggers/providers/mqtt/Hass.ts
@@ -269,13 +269,13 @@ class Hass {
 
     // Subscribe to container events to sync HA
     this.unregisterContainerAdded = registerContainerAdded((container) =>
-      this.enqueueContainerSync(container, () => this.syncContainerSensor(container)),
+      this.isolateContainerSync(container, () => this.syncContainerSensor(container)),
     );
     this.unregisterContainerUpdated = registerContainerUpdated((container) =>
-      this.enqueueContainerSync(container, () => this.syncContainerSensor(container)),
+      this.isolateContainerSync(container, () => this.syncContainerSensor(container)),
     );
     this.unregisterContainerRemoved = registerContainerRemoved((container) =>
-      this.enqueueContainerSync(container, () => {
+      this.isolateContainerSync(container, () => {
         // #491 — a re-included container starts clean again, so drop its key
         // here too (not just on re-inclusion in syncContainerSensor).
         this.cleanedExcludedContainerKeys.delete(this.getContainerSyncKey(container));
@@ -747,6 +747,17 @@ class Hass {
     });
     this.containerSyncQueueByKey.set(containerKey, trackedSync);
     return trackedSync;
+  }
+
+  private isolateContainerSync(
+    container: Container | ContainerLifecycleEventPayload,
+    sync: () => Promise<void> | void,
+  ): Promise<void> {
+    return this.enqueueContainerSync(container, sync).catch((error: unknown) => {
+      this.log.warn(
+        `Failed to sync hass discovery for container [${container.name}] (${getErrorMessage(error)})`,
+      );
+    });
   }
 
   /**

--- a/app/triggers/providers/mqtt/Hass.ts
+++ b/app/triggers/providers/mqtt/Hass.ts
@@ -229,6 +229,8 @@ class Hass {
 
   private containerSyncQueueByKey = new Map<string, Promise<void>>();
 
+  private acceptingContainerSync = true;
+
   private unregisterContainerAdded?: () => void;
   private unregisterContainerUpdated?: () => void;
   private unregisterContainerRemoved?: () => void;
@@ -293,6 +295,8 @@ class Hass {
   }
 
   async deregister(): Promise<void> {
+    this.acceptingContainerSync = false;
+
     this.unregisterContainerAdded?.();
     this.unregisterContainerAdded = undefined;
 
@@ -307,6 +311,10 @@ class Hass {
 
     this.unregisterWatcherStop?.();
     this.unregisterWatcherStop = undefined;
+
+    while (this.containerSyncQueueByKey.size > 0) {
+      await Promise.allSettled(this.containerSyncQueueByKey.values());
+    }
 
     // #210 — unwind the command subscription, if one was ever established
     if (this.commandMessageHandler && hasHassCommandCapableClient(this.client)) {
@@ -738,7 +746,14 @@ class Hass {
   ): Promise<void> {
     const containerKey = this.getContainerSyncKey(container);
     const previousSync = this.containerSyncQueueByKey.get(containerKey) ?? Promise.resolve();
-    const nextSync = previousSync.catch(() => undefined).then(sync);
+    const nextSync = previousSync
+      .catch(() => undefined)
+      .then(() => {
+        if (!this.acceptingContainerSync) {
+          return;
+        }
+        return sync();
+      });
     let trackedSync: Promise<void>;
     trackedSync = nextSync.finally(() => {
       if (this.containerSyncQueueByKey.get(containerKey) === trackedSync) {

--- a/app/triggers/providers/mqtt/Hass.ts
+++ b/app/triggers/providers/mqtt/Hass.ts
@@ -229,6 +229,8 @@ class Hass {
 
   private containerSyncQueueByKey = new Map<string, Promise<void>>();
 
+  private aggregateSensorSync: Promise<void> = Promise.resolve();
+
   private acceptingContainerSync = true;
 
   private unregisterContainerAdded?: () => void;
@@ -287,10 +289,10 @@ class Hass {
 
     // Subscribe to watcher events to sync HA
     this.unregisterWatcherStart = registerWatcherStart((watcher) =>
-      this.updateWatcherSensors({ watcher, isRunning: true }),
+      this.isolateWatcherSync(watcher, true),
     );
     this.unregisterWatcherStop = registerWatcherStop((watcher) =>
-      this.updateWatcherSensors({ watcher, isRunning: false }),
+      this.isolateWatcherSync(watcher, false),
     );
   }
 
@@ -937,6 +939,14 @@ class Hass {
   }
 
   async updateContainerSensors(container) {
+    const nextSync = this.aggregateSensorSync
+      .catch(() => undefined)
+      .then(() => this.updateContainerSensorsNow(container));
+    this.aggregateSensorSync = nextSync;
+    return nextSync;
+  }
+
+  private async updateContainerSensorsNow(container) {
     const containerAgentName = normalizeAgentValue(container?.agent);
     const watcherSensorPrefix = this.getWatcherTopicPrefix({
       watcherName: container.watcher,
@@ -1141,6 +1151,14 @@ class Hass {
     await this.updateSensor({
       topic: watcherStatusSensor.topic,
       value: isRunning,
+    });
+  }
+
+  private isolateWatcherSync(watcher, isRunning: boolean): Promise<void> {
+    return this.updateWatcherSensors({ watcher, isRunning }).catch((error: unknown) => {
+      this.log.warn(
+        `Failed to sync hass discovery for watcher [${watcher.name}] (${getErrorMessage(error)})`,
+      );
     });
   }
 

--- a/app/triggers/providers/mqtt/Hass.ts
+++ b/app/triggers/providers/mqtt/Hass.ts
@@ -3,6 +3,7 @@ import { recordAuditEvent } from '../../../api/audit-events.js';
 import { providers as iconProviders, normalizeSlug } from '../../../api/icons/providers.js';
 import { getVersion } from '../../../configuration/index.js';
 import {
+  type ContainerLifecycleEventPayload,
   registerContainerAdded,
   registerContainerRemoved,
   registerContainerUpdated,
@@ -226,6 +227,8 @@ class Hass {
   // re-exclusion cleans again.
   private cleanedExcludedContainerKeys = new Set<string>();
 
+  private containerSyncQueueByKey = new Map<string, Promise<void>>();
+
   private unregisterContainerAdded?: () => void;
   private unregisterContainerUpdated?: () => void;
   private unregisterContainerRemoved?: () => void;
@@ -266,17 +269,19 @@ class Hass {
 
     // Subscribe to container events to sync HA
     this.unregisterContainerAdded = registerContainerAdded((container) =>
-      this.syncContainerSensor(container),
+      this.enqueueContainerSync(container, () => this.syncContainerSensor(container)),
     );
     this.unregisterContainerUpdated = registerContainerUpdated((container) =>
-      this.syncContainerSensor(container),
+      this.enqueueContainerSync(container, () => this.syncContainerSensor(container)),
     );
-    this.unregisterContainerRemoved = registerContainerRemoved((container) => {
-      // #491 — a re-included container starts clean again, so drop its key
-      // here too (not just on re-inclusion in syncContainerSensor).
-      this.cleanedExcludedContainerKeys.delete(this.getContainerSyncKey(container));
-      return this.removeContainerSensor(container);
-    });
+    this.unregisterContainerRemoved = registerContainerRemoved((container) =>
+      this.enqueueContainerSync(container, () => {
+        // #491 — a re-included container starts clean again, so drop its key
+        // here too (not just on re-inclusion in syncContainerSensor).
+        this.cleanedExcludedContainerKeys.delete(this.getContainerSyncKey(container));
+        return this.removeContainerSensor(container);
+      }),
+    );
 
     // Subscribe to watcher events to sync HA
     this.unregisterWatcherStart = registerWatcherStart((watcher) =>
@@ -385,15 +390,23 @@ class Hass {
       return;
     }
 
-    for (const container of containers) {
-      try {
+    let previousSnapshot = Promise.resolve();
+    const snapshotSyncs = containers.map((container) => {
+      const waitForPreviousSnapshot = previousSnapshot;
+      const queuedSync = this.enqueueContainerSync(container, async () => {
+        await waitForPreviousSnapshot;
         await this.syncContainerSensor(container);
-      } catch (error: unknown) {
+      });
+      const isolatedSync = queuedSync.catch((error: unknown) => {
         this.log.warn(
           `Failed to resync hass discovery for container [${container.name}] (${getErrorMessage(error)})`,
         );
-      }
-    }
+      });
+      previousSnapshot = isolatedSync;
+      return isolatedSync;
+    });
+
+    await Promise.all(snapshotSyncs);
   }
 
   /**
@@ -717,6 +730,23 @@ class Hass {
     this.log.warn(
       `Multiple agents share watcher name "${watcherName}" but the Home Assistant MQTT topic layout has no agent segment, so their topics/sensors will collide. Set DD_NOTIFICATION_MQTT_<name>_HASS_AGENTTOPICSEGMENT=true to opt into the corrected layout before it becomes the default in v1.7.0.`,
     );
+  }
+
+  private enqueueContainerSync(
+    container: Container | ContainerLifecycleEventPayload,
+    sync: () => Promise<void> | void,
+  ): Promise<void> {
+    const containerKey = this.getContainerSyncKey(container);
+    const previousSync = this.containerSyncQueueByKey.get(containerKey) ?? Promise.resolve();
+    const nextSync = previousSync.catch(() => undefined).then(sync);
+    let trackedSync: Promise<void>;
+    trackedSync = nextSync.finally(() => {
+      if (this.containerSyncQueueByKey.get(containerKey) === trackedSync) {
+        this.containerSyncQueueByKey.delete(containerKey);
+      }
+    });
+    this.containerSyncQueueByKey.set(containerKey, trackedSync);
+    return trackedSync;
   }
 
   /**

--- a/app/triggers/providers/mqtt/Hass.ts
+++ b/app/triggers/providers/mqtt/Hass.ts
@@ -12,6 +12,7 @@ import {
 import type { Container } from '../../../model/container.js';
 import * as containerStore from '../../../store/container.js';
 import { requestContainerUpdate, UpdateRequestError } from '../../../updates/request-update.js';
+import { getErrorMessage } from '../../../util/error.js';
 import { HassCommandRateLimiter } from './hass-command-rate-limiter.js';
 import {
   getHassCommandTopicFilters,
@@ -365,6 +366,33 @@ class Hass {
       }
       this.commandMessageHandler = undefined;
       this.commandSubscriptionActive = false;
+    }
+  }
+
+  /**
+   * Reconcile retained Home Assistant discovery with every container already
+   * loaded from the durable store. Container-level failures are isolated so a
+   * broker publish failure cannot abort MQTT trigger startup.
+   */
+  async resyncDiscovery(): Promise<void> {
+    let containers: Container[];
+    try {
+      containers = containerStore.getContainers({}) as Container[];
+    } catch (error: unknown) {
+      this.log.warn(
+        `Failed to load containers for hass discovery resync (${getErrorMessage(error)})`,
+      );
+      return;
+    }
+
+    for (const container of containers) {
+      try {
+        await this.syncContainerSensor(container);
+      } catch (error: unknown) {
+        this.log.warn(
+          `Failed to resync hass discovery for container [${container.name}] (${getErrorMessage(error)})`,
+        );
+      }
     }
   }
 

--- a/app/triggers/providers/mqtt/Hass.ts
+++ b/app/triggers/providers/mqtt/Hass.ts
@@ -231,7 +231,9 @@ class Hass {
 
   private aggregateSensorSync: Promise<void> = Promise.resolve();
 
-  private acceptingContainerSync = true;
+  private acceptingProviderWork = true;
+
+  private providerWork = new Set<Promise<void>>();
 
   private unregisterContainerAdded?: () => void;
   private unregisterContainerUpdated?: () => void;
@@ -297,7 +299,7 @@ class Hass {
   }
 
   async deregister(): Promise<void> {
-    this.acceptingContainerSync = false;
+    this.acceptingProviderWork = false;
 
     this.unregisterContainerAdded?.();
     this.unregisterContainerAdded = undefined;
@@ -314,8 +316,8 @@ class Hass {
     this.unregisterWatcherStop?.();
     this.unregisterWatcherStop = undefined;
 
-    while (this.containerSyncQueueByKey.size > 0) {
-      await Promise.allSettled(this.containerSyncQueueByKey.values());
+    while (this.providerWork.size > 0) {
+      await Promise.allSettled(this.providerWork);
     }
 
     // #210 — unwind the command subscription, if one was ever established
@@ -751,7 +753,7 @@ class Hass {
     const nextSync = previousSync
       .catch(() => undefined)
       .then(() => {
-        if (!this.acceptingContainerSync) {
+        if (!this.acceptingProviderWork) {
           return;
         }
         return sync();
@@ -770,11 +772,13 @@ class Hass {
     container: Container | ContainerLifecycleEventPayload,
     sync: () => Promise<void> | void,
   ): Promise<void> {
-    return this.enqueueContainerSync(container, sync).catch((error: unknown) => {
-      this.log.warn(
-        `Failed to sync hass discovery for container [${container.name}] (${getErrorMessage(error)})`,
-      );
-    });
+    return this.trackProviderWork(() =>
+      this.enqueueContainerSync(container, sync).catch((error: unknown) => {
+        this.log.warn(
+          `Failed to sync hass discovery for container [${container.name}] (${getErrorMessage(error)})`,
+        );
+      }),
+    );
   }
 
   /**
@@ -1155,11 +1159,23 @@ class Hass {
   }
 
   private isolateWatcherSync(watcher, isRunning: boolean): Promise<void> {
-    return this.updateWatcherSensors({ watcher, isRunning }).catch((error: unknown) => {
-      this.log.warn(
-        `Failed to sync hass discovery for watcher [${watcher.name}] (${getErrorMessage(error)})`,
-      );
-    });
+    return this.trackProviderWork(() =>
+      this.updateWatcherSensors({ watcher, isRunning }).catch((error: unknown) => {
+        this.log.warn(
+          `Failed to sync hass discovery for watcher [${watcher.name}] (${getErrorMessage(error)})`,
+        );
+      }),
+    );
+  }
+
+  private trackProviderWork(start: () => Promise<void>): Promise<void> {
+    if (!this.acceptingProviderWork) {
+      return Promise.resolve();
+    }
+    const work = start();
+    this.providerWork.add(work);
+    void work.finally(() => this.providerWork.delete(work));
+    return work;
   }
 
   /**

--- a/app/triggers/providers/mqtt/Mqtt.test.ts
+++ b/app/triggers/providers/mqtt/Mqtt.test.ts
@@ -872,7 +872,7 @@ describe('hass command lifecycle ordering (#210)', () => {
     vi.restoreAllMocks();
   });
 
-  test('initTrigger should construct Hass and await initCommandSubscription before resolving', async () => {
+  test('initTrigger should await command subscription, then discovery resync, before resolving', async () => {
     mqtt.configuration = {
       ...configurationValid,
       clientid: 'dd',
@@ -889,6 +889,7 @@ describe('hass command lifecycle ordering (#210)', () => {
 
     const order: string[] = [];
     let resolveInitCommandSubscription: () => void;
+    let resolveResyncDiscovery: () => void;
     const initCommandSubscriptionSpy = vi
       .spyOn(Hass.prototype, 'initCommandSubscription')
       .mockImplementation(function mockedInitCommandSubscription() {
@@ -896,6 +897,17 @@ describe('hass command lifecycle ordering (#210)', () => {
         return new Promise<void>((resolve) => {
           resolveInitCommandSubscription = () => {
             order.push('initCommandSubscription-resolved');
+            resolve();
+          };
+        });
+      });
+    const resyncDiscoverySpy = vi
+      .spyOn(Hass.prototype, 'resyncDiscovery')
+      .mockImplementation(function mockedResyncDiscovery() {
+        order.push('resyncDiscovery-called');
+        return new Promise<void>((resolve) => {
+          resolveResyncDiscovery = () => {
+            order.push('resyncDiscovery-resolved');
             resolve();
           };
         });
@@ -912,14 +924,27 @@ describe('hass command lifecycle ordering (#210)', () => {
     expect(order).toEqual(['initCommandSubscription-called']);
 
     resolveInitCommandSubscription!();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(order).toEqual([
+      'initCommandSubscription-called',
+      'initCommandSubscription-resolved',
+      'resyncDiscovery-called',
+    ]);
+
+    resolveResyncDiscovery!();
     await initTriggerPromise;
 
     expect(order).toEqual([
       'initCommandSubscription-called',
       'initCommandSubscription-resolved',
+      'resyncDiscovery-called',
+      'resyncDiscovery-resolved',
       'initTrigger-resolved',
     ]);
     expect(initCommandSubscriptionSpy).toHaveBeenCalledTimes(1);
+    expect(resyncDiscoverySpy).toHaveBeenCalledTimes(1);
   });
 
   test('re-init should await the previous Hass.deregister() before constructing a new Hass', async () => {

--- a/app/triggers/providers/mqtt/Mqtt.ts
+++ b/app/triggers/providers/mqtt/Mqtt.ts
@@ -250,6 +250,7 @@ class Mqtt extends Trigger<MqttConfiguration> {
         isContainerAllowed: (container) => this.mustTrigger(container),
       });
       await this.hass.initCommandSubscription(); // #210
+      await this.hass.resyncDiscovery();
     }
     this.unregisterContainerAdded = registerContainerAdded((container) =>
       this.handleContainerEvent(container),


### PR DESCRIPTION
## Summary

- resync retained Home Assistant discovery for containers already loaded at MQTT startup
- run the resync after command subscription so Install buttons reflect live broker capability
- isolate store and per-container publish failures so trigger initialization continues

## Verification

- RED: five focused startup-resync tests failed because `resyncDiscovery` did not exist
- RED: MQTT lifecycle ordering resolved before discovery resync
- GREEN: 172 MQTT/Home Assistant tests pass
- GREEN: full backend suite passes 12,859 tests with 100% statement, branch, function, and line coverage
- GREEN: lint, typecheck, app/UI builds, workflow tests, qlty, and zizmor pass through the full pre-push hook

Closes #708


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added `Hass.resyncDiscovery()` to reload stored containers and republish Home Assistant discovery configurations.
- 🔧 Changed MQTT trigger initialization to resynchronize discovery after `initCommandSubscription()`.
- 🔧 Serialized per-container discovery updates and drained queued synchronization during deregistration.
- 🐛 Fixed stale retained discovery payloads after broker capability changes.
- 🐛 Fixed excluded-container discovery cleanup and command metadata updates.
- 🔧 Isolated store and per-container publish failures so MQTT initialization continues.
- ✨ Added tests for resynchronization, failure handling, ordering, initialization timing, and deregistration lifecycle behavior.

- Verify that keyed synchronization matches the provider event-handling convention.
- Confirm that error logging includes sufficient container context for store and publish failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->