### PR TITLE
test(e2e): target tooltip anchors deterministically

### DIFF
--- a/e2e/playwright/helpers/tooltip-target.mjs
+++ b/e2e/playwright/helpers/tooltip-target.mjs
@@ -1,0 +1,6 @@
+/** @param {import('@playwright/test').Locator} anchor */
+async function showTooltipFor(anchor) {
+  await anchor.dispatchEvent('mouseenter');
+}
+
+export { showTooltipFor };

--- a/e2e/playwright/v16-modes-pins.spec.ts
+++ b/e2e/playwright/v16-modes-pins.spec.ts
@@ -327,7 +327,7 @@ test.describe('v1.6 update modes, scheduling, and pinned tags', () => {
     const cardState = card.locator('[data-test="container-card-update-state"]');
     await expect(cardState).toHaveText('Image update');
     await expect(cardState).not.toContainText('Digest update');
-    await cardState.hover();
+    await showTooltipFor(cardState);
     await expect(page.getByRole('tooltip')).toHaveText(
       'The tag 28.5.1 now points to a different image build. Redeploy to pull the new image; the version tag itself has not changed.',
     );

--- a/e2e/playwright/v16-modes-pins.spec.ts
+++ b/e2e/playwright/v16-modes-pins.spec.ts
@@ -4,6 +4,7 @@ import {
   escapeRegExp,
   registerServerAvailabilityCheck,
 } from './helpers/test-helpers';
+import { showTooltipFor } from './helpers/tooltip-target.mjs';
 
 registerServerAvailabilityCheck(test);
 
@@ -315,7 +316,7 @@ test.describe('v1.6 update modes, scheduling, and pinned tags', () => {
     const tableState = row.locator('[data-test="container-update-state"]');
     await expect(tableState).toHaveText('Image update');
     await expect(tableState).not.toContainText('Digest update');
-    await tableState.locator(':scope > span').first().hover();
+    await showTooltipFor(tableState.locator(':scope > span').first());
     await expect(page.getByRole('tooltip')).toHaveText(
       'The tag 28.5.1 now points to a different image build. Redeploy to pull the new image; the version tag itself has not changed.',
     );

--- a/e2e/tests/tooltip-target.test.js
+++ b/e2e/tests/tooltip-target.test.js
@@ -1,4 +1,6 @@
 const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
 const test = require('node:test');
 
 test('targets the bound anchor without a physical pointer that layout shifts can retarget', async () => {
@@ -16,4 +18,15 @@ test('targets the bound anchor without a physical pointer that layout shifts can
   await showTooltipFor(anchor);
 
   assert.deepEqual(events, ['mouseenter']);
+});
+
+test('same-tag digest tooltip assertions target both bound anchors directly', () => {
+  const source = readFileSync(join(__dirname, '../playwright/v16-modes-pins.spec.ts'), 'utf8');
+  const digestTest = source.slice(
+    source.indexOf("test('#498 explains same-tag digest changes"),
+    source.indexOf("test('#498 keeps Host visible"),
+  );
+
+  assert.equal(digestTest.match(/showTooltipFor\(/g)?.length, 2);
+  assert.doesNotMatch(digestTest, /\.hover\(\)/);
 });

--- a/e2e/tests/tooltip-target.test.js
+++ b/e2e/tests/tooltip-target.test.js
@@ -21,12 +21,14 @@ test('targets the bound anchor without a physical pointer that layout shifts can
 });
 
 test('same-tag digest tooltip assertions target both bound anchors directly', () => {
+  const rawHoverPattern = /\.hover\s*\(/;
   const source = readFileSync(join(__dirname, '../playwright/v16-modes-pins.spec.ts'), 'utf8');
   const digestTest = source.slice(
     source.indexOf("test('#498 explains same-tag digest changes"),
     source.indexOf("test('#498 keeps Host visible"),
   );
 
+  assert.match('await anchor.hover({ force: true });', rawHoverPattern);
   assert.equal(digestTest.match(/showTooltipFor\(/g)?.length, 2);
-  assert.doesNotMatch(digestTest, /\.hover\(\)/);
+  assert.doesNotMatch(digestTest, rawHoverPattern);
 });

--- a/e2e/tests/tooltip-target.test.js
+++ b/e2e/tests/tooltip-target.test.js
@@ -1,0 +1,19 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+test('targets the bound anchor without a physical pointer that layout shifts can retarget', async () => {
+  const { showTooltipFor } = await import('../playwright/helpers/tooltip-target.mjs');
+  const events = [];
+  const anchor = {
+    async dispatchEvent(event) {
+      events.push(event);
+    },
+    async hover() {
+      assert.fail('physical hover can move onto a different row during a layout shift');
+    },
+  };
+
+  await showTooltipFor(anchor);
+
+  assert.deepEqual(events, ['mouseenter']);
+});


### PR DESCRIPTION
## What changed

- target the exact Vue tooltip anchor with mouseenter in the OwnTone digest assertion
- add a focused regression contract that rejects physical pointer hover for this assertion
- keep product tooltip behavior unchanged

## Root cause

The failing trace resolves the correct OwnTone span, but the containers table continues to relayout after the physical pointer is placed. A different row can move under the stationary pointer, updating the shared tooltip before the assertion. Dispatching mouseenter on the already-resolved anchor makes this content assertion independent of later layout movement.

## Validation

- deterministic regression: 1 passed
- affected v16 modes/pins spec: 7 passed
- E2E support tests: 14 passed
- full Playwright suite: 33 passed, 1 skipped
- full pre-push gate: passed (259.20s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added `showTooltipFor(anchor)` to dispatch `mouseenter` on the exact tooltip anchor.
- 🔧 Changed v16 modes and pins tests to use `showTooltipFor` instead of `.hover()`.
- 🐛 Fixed the OwnTone digest assertion race caused by physical pointer hover and table relayout.
- ✨ Added regression tests that prohibit `.hover()` for same-tag digest tooltip assertions.
- 🔧 Validated deterministic regression, affected tests, E2E support tests, the full Playwright suite, and the pre-push gate.

## Concerns

- Confirm all tooltip assertions that require deterministic targeting use `showTooltipFor`.
- Keep product tooltip behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->