### PR TITLE
fix(updates): preserve dependency context after admission

### DIFF
--- a/app/api/dependency-groups.test.ts
+++ b/app/api/dependency-groups.test.ts
@@ -281,6 +281,37 @@ describe('Dependency Groups Router', () => {
       );
     });
 
+    test('keeps restart-only dispatch and annotation when its upstream is rejected during admission', async () => {
+      const app = makeContainer({ id: 'app', name: 'app', updateAvailable: false });
+      const sidecar = makeContainer({
+        id: 'sidecar',
+        name: 'sidecar',
+        updateAvailable: false,
+        dependsOn: ['app'],
+        dependsOnAction: 'restart',
+      });
+      mockGetContainer.mockReturnValue(app);
+      mockGetContainers.mockReturnValue([app, sidecar]);
+      const { trigger, dockerContainer } = createDockerTrigger();
+      mockGetState.mockReturnValue({ trigger: { 'docker.local': trigger }, watcher: {} });
+
+      const handler = getHandler('post', '/:rootId/update');
+      const req = createMockRequest({ params: { rootId: 'app' } });
+      const res = createMockResponse();
+      await handler(req, res);
+      await flushAcceptedUpdateWork();
+
+      const payload = res.json.mock.calls[0][0];
+      expect(payload.rejected).toEqual([
+        expect.objectContaining({ containerId: 'app', statusCode: 400 }),
+      ]);
+      expect(payload.accepted).toEqual([
+        expect.objectContaining({ containerId: 'sidecar', actionKind: 'restart', wave: 1 }),
+      ]);
+      expect(trigger.trigger).not.toHaveBeenCalled();
+      expect(dockerContainer.restart).toHaveBeenCalledTimes(1);
+    });
+
     describe('expectedContainerIds blast-radius binding', () => {
       test('proceeds normally when expectedContainerIds is omitted', async () => {
         const db = makeContainer({ id: 'db', name: 'db' });

--- a/app/api/dependency-groups.test.ts
+++ b/app/api/dependency-groups.test.ts
@@ -13,6 +13,7 @@ const {
   mockGetServerConfiguration,
   mockInsertOperation,
   mockMarkOperationTerminal,
+  mockGetActiveOperationByContainerId,
 } = vi.hoisted(() => ({
   mockRouter: { use: vi.fn(), post: vi.fn() },
   mockGetContainer: vi.fn(),
@@ -25,6 +26,7 @@ const {
   mockGetServerConfiguration: vi.fn(() => ({ feature: { containeractions: true } })),
   mockInsertOperation: vi.fn((op) => ({ id: op.id || 'op-mock', ...op })),
   mockMarkOperationTerminal: vi.fn(),
+  mockGetActiveOperationByContainerId: vi.fn(),
 }));
 
 vi.mock('express', () => ({
@@ -71,7 +73,7 @@ vi.mock('../store/update-operation.js', () => ({
   getInProgressOperationByContainerName: vi.fn(),
   getInProgressOperationByContainerId: vi.fn(),
   getActiveOperationByContainerName: vi.fn(),
-  getActiveOperationByContainerId: vi.fn(),
+  getActiveOperationByContainerId: mockGetActiveOperationByContainerId,
 }));
 
 vi.mock('../log/index.js', () => ({
@@ -138,6 +140,7 @@ describe('Dependency Groups Router', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetServerConfiguration.mockReturnValue({ feature: { containeractions: true } });
+    mockGetActiveOperationByContainerId.mockReturnValue(undefined);
   });
 
   describe('init', () => {
@@ -281,7 +284,7 @@ describe('Dependency Groups Router', () => {
       );
     });
 
-    test('keeps restart-only dispatch and annotation when its upstream is rejected during admission', async () => {
+    test('rejects a restart-only dependent when its upstream has no update to admit', async () => {
       const app = makeContainer({ id: 'app', name: 'app', updateAvailable: false });
       const sidecar = makeContainer({
         id: 'sidecar',
@@ -304,12 +307,44 @@ describe('Dependency Groups Router', () => {
       const payload = res.json.mock.calls[0][0];
       expect(payload.rejected).toEqual([
         expect.objectContaining({ containerId: 'app', statusCode: 400 }),
+        expect.objectContaining({ containerId: 'sidecar', statusCode: 409 }),
       ]);
-      expect(payload.accepted).toEqual([
-        expect.objectContaining({ containerId: 'sidecar', actionKind: 'restart', wave: 1 }),
-      ]);
+      expect(payload.accepted).toEqual([]);
       expect(trigger.trigger).not.toHaveBeenCalled();
-      expect(dockerContainer.restart).toHaveBeenCalledTimes(1);
+      expect(dockerContainer.restart).not.toHaveBeenCalled();
+    });
+
+    test('rejects a restart-only dependent while its upstream update is already active', async () => {
+      const app = makeContainer({ id: 'app', name: 'app', updateAvailable: true });
+      const sidecar = makeContainer({
+        id: 'sidecar',
+        name: 'sidecar',
+        updateAvailable: false,
+        dependsOn: ['app'],
+        dependsOnAction: 'restart',
+      });
+      mockGetContainer.mockReturnValue(app);
+      mockGetContainers.mockReturnValue([app, sidecar]);
+      mockGetActiveOperationByContainerId.mockImplementation((id: string) =>
+        id === 'app' ? { status: 'in-progress' } : undefined,
+      );
+      const { trigger, dockerContainer } = createDockerTrigger();
+      mockGetState.mockReturnValue({ trigger: { 'docker.local': trigger }, watcher: {} });
+
+      const handler = getHandler('post', '/:rootId/update');
+      const req = createMockRequest({ params: { rootId: 'app' } });
+      const res = createMockResponse();
+      await handler(req, res);
+      await flushAcceptedUpdateWork();
+
+      const payload = res.json.mock.calls[0][0];
+      expect(payload.rejected).toEqual([
+        expect.objectContaining({ containerId: 'app', statusCode: 409 }),
+        expect.objectContaining({ containerId: 'sidecar', statusCode: 409 }),
+      ]);
+      expect(payload.accepted).toEqual([]);
+      expect(trigger.trigger).not.toHaveBeenCalled();
+      expect(dockerContainer.restart).not.toHaveBeenCalled();
     });
 
     describe('expectedContainerIds blast-radius binding', () => {

--- a/app/api/dependency-groups.ts
+++ b/app/api/dependency-groups.ts
@@ -9,6 +9,7 @@ import {
 } from '../dependencies/dependency-graph.js';
 import logger from '../log/index.js';
 import { sanitizeLogParam } from '../log/sanitize.js';
+import type { Container } from '../model/container.js';
 import { getContainerActionsCounter } from '../prometheus/container-actions.js';
 import * as storeContainer from '../store/container.js';
 import {
@@ -44,17 +45,18 @@ function serializeRejectedUpdateRequest(rejected: RejectedContainerUpdateRequest
 /**
  * Annotate each accepted entry with the wave index it will actually be
  * dispatched in, using the exact same buildDependencyGraph/topologicalSort
- * pair runAcceptedContainerUpdates partitions with internally, over the same
- * accepted-container set — so `wave` here is never a second, potentially
- * divergent, computation of dispatch order (design §4). `actionKind` uses
+ * pair runAcceptedContainerUpdates partitions with internally, over the full
+ * admission batch — so rejected upstream entries cannot erase dependency
+ * context for accepted restart-only dependents. `actionKind` uses
  * the same `resolveDependencyActionKind` the dispatcher itself uses, so it
  * can't drift from which entries are actually restarted vs. updated either
  * (PR #681 review #2/#3).
  */
 function annotateAcceptedWithWave(
   accepted: AcceptedContainerUpdateRequest[],
+  dependencyContext: Container[],
 ): DependencyGroupAcceptedItem[] {
-  const { nodes, edges } = buildDependencyGraph(accepted.map((entry) => entry.container));
+  const { nodes, edges } = buildDependencyGraph(dependencyContext);
   const { waves } = topologicalSort(nodes, edges);
   const waveIndexById = new Map<string, number>();
   waves.forEach((wave, index) => {
@@ -168,7 +170,7 @@ async function updateDependencyGroup(req: Request, res: Response) {
 
     res.status(200).json({
       message: 'Dependency group update requests processed',
-      accepted: annotateAcceptedWithWave(result.accepted),
+      accepted: annotateAcceptedWithWave(result.accepted, chainContainers),
       rejected: result.rejected.map(serializeRejectedUpdateRequest),
     });
   } catch (error: unknown) {

--- a/app/updates/request-update.test.ts
+++ b/app/updates/request-update.test.ts
@@ -996,6 +996,45 @@ describe('request-update', () => {
       expect(triggerFn).not.toHaveBeenCalled();
     });
 
+    test('rejects every transitive dependent when an upstream operation is already active', async () => {
+      mockGetActiveOperationByContainerId.mockImplementation((id: string) =>
+        id === 'db' ? { status: 'in-progress' } : undefined,
+      );
+      const triggerFn = vi.fn().mockResolvedValue(undefined);
+      const db = createDependentContainer({ id: 'db', name: 'db' });
+      const api = createDependentContainer({
+        id: 'api',
+        name: 'api',
+        dependsOn: ['db'],
+        dependsOnSource: 'label',
+      });
+      const sidecar = createDependentContainer({
+        id: 'sidecar',
+        name: 'sidecar',
+        dependsOn: ['api'],
+        dependsOnSource: 'label',
+        dependsOnAction: 'restart',
+        updateAvailable: false,
+      });
+
+      const result = await requestContainerUpdates([db, api, sidecar], {
+        trigger: {
+          type: 'docker',
+          trigger: triggerFn,
+        },
+      });
+      await flushAsyncWork();
+
+      expect(result.accepted).toEqual([]);
+      expect(result.rejected).toEqual([
+        expect.objectContaining({ container: db, statusCode: 409 }),
+        expect.objectContaining({ container: api, statusCode: 409 }),
+        expect.objectContaining({ container: sidecar, statusCode: 409 }),
+      ]);
+      expect(triggerFn).not.toHaveBeenCalled();
+      expect(mockRestartDependentContainer).not.toHaveBeenCalled();
+    });
+
     test('dependsOnAction=restart with no resolved dependsOn edge dispatches through the normal trigger instead (PR #681 review #2)', async () => {
       const triggerFn = vi.fn().mockResolvedValue(undefined);
 

--- a/app/updates/request-update.test.ts
+++ b/app/updates/request-update.test.ts
@@ -962,6 +962,40 @@ describe('request-update', () => {
       });
     });
 
+    test('preserves restart-only dispatch when an upstream dependency was rejected during admission', async () => {
+      mockRestartDependentContainer.mockResolvedValue(undefined);
+      const triggerFn = vi.fn().mockResolvedValue(undefined);
+      const db = createDependentContainer({
+        id: 'db',
+        name: 'db',
+        updateAvailable: false,
+      });
+      const sidecar = createDependentContainer({
+        id: 'sidecar',
+        name: 'sidecar',
+        dependsOn: ['db'],
+        dependsOnSource: 'label',
+        dependsOnAction: 'restart',
+        updateAvailable: false,
+      });
+
+      await runAcceptedContainerUpdates(
+        [
+          {
+            operationId: 'op-sidecar',
+            container: sidecar,
+            trigger: { type: 'docker', trigger: triggerFn },
+          },
+        ],
+        { dependencyContext: [db, sidecar] },
+      );
+
+      expect(mockRestartDependentContainer).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'sidecar' }),
+      );
+      expect(triggerFn).not.toHaveBeenCalled();
+    });
+
     test('dependsOnAction=restart with no resolved dependsOn edge dispatches through the normal trigger instead (PR #681 review #2)', async () => {
       const triggerFn = vi.fn().mockResolvedValue(undefined);
 

--- a/app/updates/request-update.ts
+++ b/app/updates/request-update.ts
@@ -64,6 +64,7 @@ export interface AcceptedContainerUpdateRequest {
 
 export interface AcceptedUpdateDispatchOptions {
   concurrency?: number;
+  dependencyContext?: Container[];
 }
 
 export interface RejectedContainerUpdateRequest {
@@ -496,9 +497,8 @@ export async function runAcceptedContainerUpdates(
   }
 
   const entryById = new Map(accepted.map((entry) => [entry.container.id, entry]));
-  const { nodes, edges, unresolved, crossHostIgnored } = buildDependencyGraph(
-    accepted.map((entry) => entry.container),
-  );
+  const dependencyContext = options.dependencyContext ?? accepted.map((entry) => entry.container);
+  const { nodes, edges, unresolved, crossHostIgnored } = buildDependencyGraph(dependencyContext);
   const { waves } = topologicalSort(nodes, edges);
   const dependentsByDependency = buildDependentsByDependency(edges);
   const containerIdsWithResolvedDependsOn = collectContainerIdsWithResolvedDependsOn(edges);
@@ -516,9 +516,8 @@ export async function runAcceptedContainerUpdates(
     const waveEntries: AcceptedContainerUpdateRequest[] = [];
     for (const id of wave) {
       const entry = entryById.get(id);
-      /* v8 ignore next 3 -- defensive only: every wave id originates from
-         buildDependencyGraph(accepted.map(...)), so entryById (keyed the same
-         way) always has a match. */
+      /* The dependency context can include entries rejected during admission,
+         so only dispatch wave members that have an accepted operation. */
       if (!entry) {
         continue;
       }
@@ -631,6 +630,6 @@ export async function requestContainerUpdates(
     allowSoftPolicyOverride: true,
     source: 'manual',
   });
-  dispatchAccepted(result.accepted);
+  dispatchAccepted(result.accepted, { dependencyContext: containers });
   return result;
 }

--- a/app/updates/request-update.ts
+++ b/app/updates/request-update.ts
@@ -400,7 +400,7 @@ export async function enqueueContainerUpdates(
   containers: Container[],
   options: EnqueueContainerUpdateOptions = {},
 ): Promise<ContainerUpdateRequestBatchResult> {
-  const preparedAccepted: PreparedContainerUpdateRequest[] = [];
+  let preparedAccepted: PreparedContainerUpdateRequest[] = [];
   const rejected: RejectedContainerUpdateRequest[] = [];
 
   for (const container of containers) {
@@ -413,6 +413,36 @@ export async function enqueueContainerUpdates(
       }
       throw error;
     }
+  }
+
+  if (rejected.length > 0 && preparedAccepted.length > 0) {
+    const { edges } = buildDependencyGraph(containers);
+    const dependentsByDependency = buildDependentsByDependency(edges);
+    const blockingRejectionByContainerId = new Map<string, RejectedContainerUpdateRequest>();
+
+    for (const blockingRejection of rejected) {
+      for (const dependentId of collectTransitiveDependents(
+        blockingRejection.container.id,
+        dependentsByDependency,
+      )) {
+        blockingRejectionByContainerId.set(dependentId, blockingRejection);
+      }
+    }
+
+    const stillAccepted: PreparedContainerUpdateRequest[] = [];
+    for (const prepared of preparedAccepted) {
+      const blockingRejection = blockingRejectionByContainerId.get(prepared.container.id);
+      if (!blockingRejection) {
+        stillAccepted.push(prepared);
+        continue;
+      }
+      rejected.push({
+        container: prepared.container,
+        message: `Required upstream dependency ${blockingRejection.container.id} was not admitted`,
+        statusCode: 409,
+      });
+    }
+    preparedAccepted = stillAccepted;
   }
 
   const queueTotal = preparedAccepted.length;


### PR DESCRIPTION
Fixes the release-blocking finding from the exact-head review on #716.

The dependency group admitted members independently, then rebuilt dispatch and response graphs from only the accepted subset. When an upstream update was rejected, a restart-only dependent lost its resolved edge, was annotated as a normal update in wave 0, and entered the normal pull/update trigger despite having no update.

This carries the original admission batch as dependency context through both dispatch and API annotation. Rejected members do not receive operations, but their graph nodes still preserve the confirmed wave and restart action for accepted dependents.

TDD:
- RED: focused regression run failed 2 tests. Dispatcher never called the restart primitive; API returned `actionKind: update, wave: 0` instead of `restart, wave: 1`.
- GREEN: focused 95/95 tests pass.
- Full backend: 406 files, 12,868 tests, 100% statements/branches/functions/lines.
- Full pre-push: scripts 158, workflows 127, web contracts 63, UI typecheck, app/UI 100% coverage, app/UI builds, zizmor all pass.

Exact source: `ef92dc8c7fa8c2bbf7a0e936f37285163fb55113`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- 🐛 Fixed dependency graph loss when an upstream container is rejected during admission.
- 🔧 Preserved the original admission batch as `dependencyContext` through dispatch and API annotation.
- 🔧 Preserved confirmed wave and `restart` action metadata for accepted restart-only dependents.
- 🔧 Skipped dispatch entries without accepted operations.
- ✨ Added regression tests for rejected upstream dependencies and restart-only dependents.
- 🔧 Passed focused tests: 95/95.
- 🔧 Passed backend tests across 406 files with complete coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->