### PR TITLE
fix(agents): make edge poll interval configurable

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -242,7 +242,6 @@ a45d533b6a2e3450556dc9407da60d6b10ce2553:content/docs/v1.4/configuration/webhook
 ab7027d791b5aac9d59436c20a782d34f67859fa:app/registries/providers/custom/Custom.test.ts:generic-api-key:62
 ab7027d791b5aac9d59436c20a782d34f67859fa:website/app/page.tsx:generic-api-key:168
 app/agent/components/Agent.test.ts:private-key:152
-app/api/portwing-ws.test.ts:generic-api-key:583
 app/authentications/providers/oidc/Oidc.test.ts:generic-api-key:613
 app/debug/redact.test.ts:generic-api-key:74
 app/registries/BaseRegistry.test.ts:generic-api-key:3549

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -585,7 +585,7 @@ describe('hello verification — rejection paths', () => {
         dockerVersion: 'unknown',
         hostname: 'test',
         capabilities: [],
-        tokenHash: 'abcdef1234567890',
+        tokenHash: 'present',
       },
     });
     await new Promise((r) => setTimeout(r, 0));

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -23,7 +23,12 @@ import {
   PORTWING_WS_ROUTE_PATTERN,
 } from './portwing-ws.js';
 
+const { mockGetPortwingPollInterval } = vi.hoisted(() => ({
+  mockGetPortwingPollInterval: vi.fn(() => 300),
+}));
+
 vi.mock('../configuration/index.js', () => ({
+  getPortwingPollInterval: mockGetPortwingPollInterval,
   getServerConfiguration: vi.fn(() => ({})),
   getVersion: vi.fn(() => '9.9.9-test'),
 }));
@@ -966,6 +971,40 @@ describe('hello verification — happy path', () => {
     expect(welcome.data.pollInterval).toBeGreaterThan(0);
     expect(welcome.data.config.serverCompatLevel).toBe('1.4.0');
     expect(welcome.data.config.supportedProtocols).toBe('portwing/1.0');
+  });
+
+  test('uses the controller-configured poll interval in the welcome and agent metadata', async () => {
+    mockGetPortwingPollInterval.mockReturnValueOnce(5);
+    const { privateKey, pubkeyBase64, keyId } = generateKeyPair();
+    const ts = Math.floor(Date.now() / 1000);
+    const nonce = 'd2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7';
+    const sig = signHello(privateKey, ts, nonce);
+    const record: AgentKeyRecord = {
+      keyId,
+      pubkey: pubkeyBase64,
+      label: 'test',
+      createdAt: new Date().toISOString(),
+      revokedAt: null,
+    };
+
+    const { gateway, getUpgradedWs } = createGateway(record);
+    gateway.handleUpgrade(
+      createRequest('/api/portwing/ws'),
+      createMockSocket() as unknown as Socket,
+      Buffer.alloc(0),
+    );
+    const ws = getUpgradedWs()!;
+
+    sendMessageToGateway(ws, buildHello(keyId, ts, nonce, sig));
+    await vi.waitFor(() => {
+      expect(ws.sentMessages.length).toBeGreaterThan(0);
+    });
+
+    const welcome = JSON.parse(ws.sentMessages[0]) as {
+      data: { pollInterval: number };
+    };
+    expect(welcome.data.pollInterval).toBe(5);
+    expect(getLastAgentClientInstance()?.info).toMatchObject({ pollInterval: '5' });
   });
 
   test('protocol portwing/1.0 is accepted', async () => {

--- a/app/api/portwing-ws.ts
+++ b/app/api/portwing-ws.ts
@@ -19,7 +19,11 @@ import {
   type WebSocketLike,
 } from '../agent/EdgeAgentAdapter.js';
 import { getAgent } from '../agent/manager.js';
-import { getServerConfiguration, getVersion } from '../configuration/index.js';
+import {
+  getPortwingPollInterval,
+  getServerConfiguration,
+  getVersion,
+} from '../configuration/index.js';
 import logger from '../log/index.js';
 import * as agentKeys from '../store/agent-keys.js';
 import { save as saveStore } from '../store/index.js';
@@ -793,7 +797,7 @@ async function processHello(
   }
 
   // Step 11: Send WELCOME
-  const pollInterval = 300;
+  const pollInterval = getPortwingPollInterval();
   const welcome = {
     type: 'welcome',
     data: {

--- a/app/configuration/index.test.ts
+++ b/app/configuration/index.test.ts
@@ -20,6 +20,7 @@ const TEST_DIRECTORY = getTestDirectory();
 afterEach(() => {
   configuration.setDetectedServerName(undefined);
   delete configuration.ddEnvVars.DD_SERVER_RATELIMIT_MAX;
+  delete configuration.ddEnvVars.DD_PORTWING_POLL_INTERVAL;
 });
 
 test('getVersion should return dd version', async () => {
@@ -121,6 +122,24 @@ test('getExperimentalPortwingEnabled should return false for non-"true" values',
   expect(configuration.getExperimentalPortwingEnabled()).toStrictEqual(false);
   delete configuration.ddEnvVars.DD_EXPERIMENTAL_PORTWING;
 });
+
+test('getPortwingPollInterval should default to 300 seconds', () => {
+  delete configuration.ddEnvVars.DD_PORTWING_POLL_INTERVAL;
+  expect(configuration.getPortwingPollInterval()).toBe(300);
+});
+
+test('getPortwingPollInterval should accept a positive integer', () => {
+  configuration.ddEnvVars.DD_PORTWING_POLL_INTERVAL = ' 5 ';
+  expect(configuration.getPortwingPollInterval()).toBe(5);
+});
+
+test.each(['0', '-1', '1.5', '5seconds', '', '9007199254740992'])(
+  'getPortwingPollInterval should use the default for invalid value %j',
+  (value) => {
+    configuration.ddEnvVars.DD_PORTWING_POLL_INTERVAL = value;
+    expect(configuration.getPortwingPollInterval()).toBe(300);
+  },
+);
 
 test('getWudCardCompatEnabled should default to false', () => {
   delete configuration.ddEnvVars.DD_COMPAT_WUDCARD;

--- a/app/configuration/index.ts
+++ b/app/configuration/index.ts
@@ -5,6 +5,7 @@ import joi from 'joi';
 import setValue from 'set-value';
 import { logWarn } from '../log/warn.js';
 import { resolveConfiguredPath } from '../runtime/paths.js';
+import { toPositiveInteger } from '../util/parse.js';
 
 const VAR_FILE_SUFFIX = '__FILE';
 const MAX_SECRET_FILE_SIZE_BYTES = 1024 * 1024;
@@ -20,6 +21,7 @@ const DEFAULT_GRYPE_WORKER_IMAGE =
   'anchore/grype@sha256:af65fbc0c664691067788fe95ff88760b435543e45595eb2ca6f102fc476fbe1';
 const DEFAULT_SYFT_WORKER_IMAGE =
   'anchore/syft@sha256:5999d209a342e55e9edf70bf8930fb5b86d8f2a783fa401178372c50e21b1d36';
+const DEFAULT_PORTWING_POLL_INTERVAL = 300;
 
 export type SecuritySeverity = (typeof SECURITY_SEVERITY_VALUES)[number];
 export type SecuritySbomFormat = (typeof SECURITY_SBOM_FORMAT_VALUES)[number];
@@ -217,6 +219,10 @@ export function getExperimentalPortwingEnabled() {
     return true;
   }
   return envFlagEnabled(value);
+}
+
+export function getPortwingPollInterval(): number {
+  return toPositiveInteger(ddEnvVars.DD_PORTWING_POLL_INTERVAL, DEFAULT_PORTWING_POLL_INTERVAL);
 }
 
 /**

--- a/content/docs/current/configuration/agents/index.mdx
+++ b/content/docs/current/configuration/agents/index.mdx
@@ -30,6 +30,17 @@ The WebSocket endpoint is `WS /api/v1/portwing/ws` (compatibility alias: `/api/p
 
 You can also preload keys at startup with `DD_PORTWING_AUTHORIZED_KEYS=/path/to/authorized_keys`. The file format is `ed25519 <base64-raw-pubkey> [comment]`, and the file must not be world-readable.
 
+The controller owns each edge agent's container-refresh cadence and sends it in
+the authenticated welcome frame:
+
+| Env var | Required | Description | Default |
+| :--- | :---: | :--- | :--- |
+| `DD_PORTWING_POLL_INTERVAL` | ⚪ | Edge-agent container refresh interval in seconds | `300` |
+
+Invalid, zero, or negative values fall back to the 300-second default. This is
+separate from `DD_AGENT_{name}_*`, which configures controller-initiated Standard
+Mode connections rather than Portwing dial-out sessions.
+
 ### Edge-agent example (Docker Compose)
 
 A [Portwing](https://github.com/CodesWhat/portwing) edge agent runs on the remote/NAT'd host and dials out — no inbound ports need to be published on that side:
@@ -58,7 +69,7 @@ secrets:
 
 <Callout type="warn">This example bind-mounts the raw Docker socket into the Portwing container for brevity, and `:ro` is not a security boundary — it only prevents modifying the socket file itself, while every Docker Engine API operation (create, exec, delete) remains available through it. In production, front it with a socket filter instead — see the [sockguard tab](/docs/guides/security#isolate-the-docker-socket) of the Security Hardening Guide, and sockguard's [`examples/compose/tri-tool/`](https://github.com/CodesWhat/sockguard/tree/main/examples/compose/tri-tool) bundle for a runnable compose stack that fronts an Edge agent's Docker socket with sockguard instead of a raw bind mount.</Callout>
 
-The Drydock controller needs the agent's public key registered before it connects. No Portwing-specific environment variable is required:
+The Drydock controller needs the agent's public key registered before it connects. No additional Portwing setting is required unless you want to change the default poll cadence:
 
 ```yaml
 services:
@@ -66,6 +77,8 @@ services:
     image: codeswhat/drydock
     ports:
       - "3000:3000"
+    environment:
+      - DD_PORTWING_POLL_INTERVAL=60
 ```
 
 Generate the agent's keypair with `portwing keygen -comment "edge-host-01"`, then register the printed public key with the controller (`POST /api/v1/portwing/keys`, or preload it via `DD_PORTWING_AUTHORIZED_KEYS`) before starting the agent — see the REST API table above.

--- a/scripts/portwing-transport-docs.test.mjs
+++ b/scripts/portwing-transport-docs.test.mjs
@@ -7,6 +7,10 @@ const portwingApi = readFileSync(
   new URL('../content/docs/current/api/portwing.mdx', import.meta.url),
   'utf8',
 );
+const agentConfiguration = readFileSync(
+  new URL('../content/docs/current/configuration/agents/index.mdx', import.meta.url),
+  'utf8',
+);
 
 test('Portwing FAQ links to the current controller-owned transport heading', () => {
   assert.match(
@@ -29,4 +33,12 @@ test('Portwing FAQ does not claim partial markers or Compose have a working fall
     faq,
     /older or partial Portwing markers and Docker Compose actions have no working Portwing fallback/u,
   );
+});
+
+test('edge-agent configuration documents the controller-owned poll interval', () => {
+  assert.match(
+    agentConfiguration,
+    /\| `DD_PORTWING_POLL_INTERVAL` \| ⚪ \| Edge-agent container refresh interval in seconds \| `300` \|/u,
+  );
+  assert.doesNotMatch(agentConfiguration, /`DD_AGENT_POLL_INTERVAL`/u);
 });

--- a/scripts/portwing-transport-docs.test.mjs
+++ b/scripts/portwing-transport-docs.test.mjs
@@ -11,6 +11,7 @@ const agentConfiguration = readFileSync(
   new URL('../content/docs/current/configuration/agents/index.mdx', import.meta.url),
   'utf8',
 );
+const obsoletePollIntervalPattern = /\bDD_AGENT_POLL_INTERVAL\b/u;
 
 test('Portwing FAQ links to the current controller-owned transport heading', () => {
   assert.match(
@@ -40,5 +41,15 @@ test('edge-agent configuration documents the controller-owned poll interval', ()
     agentConfiguration,
     /\| `DD_PORTWING_POLL_INTERVAL` \| ⚪ \| Edge-agent container refresh interval in seconds \| `300` \|/u,
   );
-  assert.doesNotMatch(agentConfiguration, /`DD_AGENT_POLL_INTERVAL`/u);
+  assert.doesNotMatch(agentConfiguration, obsoletePollIntervalPattern);
+});
+
+test('obsolete poll interval detection is independent of documentation formatting', () => {
+  for (const value of [
+    'DD_AGENT_POLL_INTERVAL',
+    '`DD_AGENT_POLL_INTERVAL`',
+    '**DD_AGENT_POLL_INTERVAL**',
+  ]) {
+    assert.match(value, obsoletePollIntervalPattern);
+  }
 });


### PR DESCRIPTION
Closes #688

## What changed

- add `DD_PORTWING_POLL_INTERVAL` for controller-owned Edge refresh cadence
- validate positive integer seconds with a 300-second fallback
- send the configured value in the authenticated welcome frame and agent metadata
- document the setting and protect the public contract with tests

## Verification

- focused configuration and WebSocket tests: 418 passed
- full backend: 12,879 passed, 100% statements/branches/functions/lines
- scripts: 162 passed
- workflows: 160 passed
- full pre-push gate: passed, including app/UI coverage and production builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

✨ Added `getPortwingPollInterval()` with `DD_PORTWING_POLL_INTERVAL` support.

🔧 Changed the authenticated WebSocket welcome frame and agent metadata to use the configured interval.

🔧 Changed invalid or unspecified values to fall back to `300` seconds.

✨ Added configuration, handshake, metadata, and documentation contract tests.

✨ Documented the controller-owned setting and added a Docker Compose example with a `60`-second interval.

🗑️ Removed the obsolete `.gitleaksignore` exception for the test token hash.

## Concerns

- Verify the controller-provided interval remains the Edge/WebSocket override for agent-side polling.
- Preserve rejection of fractional, non-positive, non-numeric, empty, and unsafe-integer values.
- Keep `DD_AGENT_POLL_INTERVAL` excluded from the documentation contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->