### PR TITLE
fix(agents): surface edge exec end reasons

### DIFF
--- a/app/agent/EdgeAgentAdapter.test.ts
+++ b/app/agent/EdgeAgentAdapter.test.ts
@@ -914,6 +914,62 @@ describe('EdgeAgentAdapter — exec outputCallback via startExec', () => {
   });
 });
 
+describe('EdgeAgentAdapter — exec endCallback via startExec', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('endCallback receives the exact exec_end reason', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+    const endCallback = vi.fn((_reason?: string) => {});
+    const execId = await adapter.startExec('c1', ['/bin/bash'], { endCallback });
+
+    sendFrame(ws, 'exec_end', {
+      execId,
+      reason: 'exec denied: privileged exec is not allowed',
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(endCallback).toHaveBeenCalledOnce();
+    expect(endCallback).toHaveBeenCalledWith('exec denied: privileged exec is not allowed');
+  });
+
+  test.each([
+    ['absent', {}],
+    ['non-string', { reason: { message: 'do not coerce me' } }],
+  ])('endCallback receives undefined when exec_end reason is %s', async (_name, data) => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+    const endCallback = vi.fn((_reason?: string) => {});
+    const execId = await adapter.startExec('c1', ['/bin/bash'], { endCallback });
+
+    sendFrame(ws, 'exec_end', { execId, ...data });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(endCallback).toHaveBeenCalledOnce();
+    expect(endCallback).toHaveBeenCalledWith(undefined);
+  });
+
+  test('a throwing endCallback cannot retain the closed session', async () => {
+    const { adapter, ws } = createAdapter();
+    adapter.activate();
+    const endCallback = vi.fn(() => {
+      throw new Error('consumer callback failed');
+    });
+    const execId = await adapter.startExec('c1', ['/bin/bash'], { endCallback });
+    const adapterInternal = adapter as unknown as {
+      execSessions: Map<string, unknown>;
+    };
+
+    sendFrame(ws, 'exec_end', { execId, reason: 'exited' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(endCallback).toHaveBeenCalledOnce();
+    expect(adapterInternal.execSessions.has(execId)).toBe(false);
+  });
+});
+
 describe('EdgeAgentAdapter — requestContainerLogs', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/app/agent/EdgeAgentAdapter.test.ts
+++ b/app/agent/EdgeAgentAdapter.test.ts
@@ -598,6 +598,27 @@ describe('EdgeAgentAdapter — disconnect cleanup', () => {
     ).toBe(true);
   });
 
+  test('onDisconnect continues cleanup when an exec endCallback throws', async () => {
+    const { adapter } = createAdapter();
+    adapter.activate();
+    const throwingEndCallback = vi.fn(() => {
+      throw new Error('consumer callback failed');
+    });
+    const laterEndCallback = vi.fn((_reason?: string) => {});
+    await adapter.startExec('c1', ['/bin/first'], { endCallback: throwingEndCallback });
+    await adapter.startExec('c2', ['/bin/second'], { endCallback: laterEndCallback });
+    const adapterInternal = adapter as unknown as {
+      execSessions: Map<string, unknown>;
+    };
+
+    await expect(adapter.onDisconnect()).resolves.toBeUndefined();
+
+    expect(throwingEndCallback).toHaveBeenCalledOnce();
+    expect(laterEndCallback).toHaveBeenCalledOnce();
+    expect(adapterInternal.execSessions.size).toBe(0);
+    expect(manager.removeAgent).toHaveBeenCalled();
+  });
+
   test('onDisconnect calls removeAgent', async () => {
     const { adapter } = createAdapter();
     adapter.activate();

--- a/app/agent/EdgeAgentAdapter.ts
+++ b/app/agent/EdgeAgentAdapter.ts
@@ -55,7 +55,7 @@ export interface HelloMessage {
 interface ExecSession {
   execId: string;
   outputHandler?: (data: Buffer) => void;
-  close: () => void;
+  close: (reason?: string) => void;
 }
 
 interface PendingRequest {
@@ -898,7 +898,7 @@ export class EdgeAgentAdapter {
     }
     const session = this.execSessions.get(execId);
     if (session) {
-      session.close();
+      session.close(typeof data.reason === 'string' ? data.reason : undefined);
     }
   }
 
@@ -1194,6 +1194,7 @@ export class EdgeAgentAdapter {
    * Start an exec session on the edge agent.
    * Returns the execId once the exec_start frame is sent.
    * outputCallback receives decoded bytes for each exec_output frame.
+   * endCallback receives the optional reason from the terminal exec_end frame.
    */
   startExec(
     containerId: string,
@@ -1204,6 +1205,7 @@ export class EdgeAgentAdapter {
       rows?: number;
       tty?: boolean;
       outputCallback?: (data: Buffer) => void;
+      endCallback?: (reason?: string) => void;
     },
   ): Promise<string> {
     if (this.execSessions.size >= MAX_EXEC_SESSIONS) {
@@ -1212,16 +1214,18 @@ export class EdgeAgentAdapter {
 
     const execId = uuidv7();
     const outputCallback = options?.outputCallback;
+    const endCallback = options?.endCallback;
 
     // Pre-register the session with the callback so exec_output frames arriving
     // before the caller has a chance to wire up the handler are not lost.
     const session: ExecSession = {
       execId,
       outputHandler: outputCallback,
-      close: () => {
+      close: (reason?: string) => {
         // O5: notify the edge so it can tear down the Docker exec process/goroutine.
         this.sendExecEnd(execId);
         this.execSessions.delete(execId);
+        endCallback?.(reason);
       },
     };
     this.execSessions.set(execId, session);

--- a/app/agent/EdgeAgentAdapter.ts
+++ b/app/agent/EdgeAgentAdapter.ts
@@ -1330,7 +1330,13 @@ export class EdgeAgentAdapter {
 
     // Close all exec sessions — session.close() sends exec_end before deleting (O5)
     for (const session of this.execSessions.values()) {
-      session.close();
+      try {
+        session.close();
+      } catch (error: unknown) {
+        log.warn(
+          `Failed to notify exec consumer during disconnect for ${session.execId}: ${getErrorMessage(error)}`,
+        );
+      }
     }
     this.execSessions.clear();
 


### PR DESCRIPTION
Closes #635

## What changed

- preserve the optional Portwing `exec_end.reason` at the Edge session boundary
- expose an optional `endCallback` to the internal exec consumer
- delete the completed session before invoking consumer code so a throwing callback cannot leak state
- isolate callback failures during disconnect so later sessions and agent cleanup still complete
- keep outbound teardown and non-string reason handling unchanged

## Verification

- RED: four reason/callback contracts failed because the reason was dropped
- RED: disconnect cleanup rejected on the first throwing callback and skipped later sessions
- GREEN: focused adapter suite 161/161
- full pre-push gate passed in 284 seconds
- app and UI coverage remain 100%
- application and UI production builds passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added optional `endCallback` support for exec consumers.
- ✨ Added Portwing `exec_end.reason` propagation.
- 🔧 Updated `ExecSession.close(code?, reason?)` to forward string reasons.
- 🐛 Deleted completed sessions before invoking callbacks.
- 🐛 Isolated disconnect callback failures so cleanup continues.
- ✨ Added regression tests for reason validation, callback failures, and disconnect cleanup.
- 🔒 Preserved outbound teardown and non-string reason behavior.
- ✅ Verified focused adapter tests, the full pre-push gate, coverage, and production builds.

## Concerns

- Confirm that `endCallback` remains internal and does not require public API documentation.
- Confirm that callback errors use the project’s standard logging utility and error format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->