### PR TITLE
fix(agent): normalize controller-owned registry identities

### DIFF
--- a/app/agent/AgentClient.test.ts
+++ b/app/agent/AgentClient.test.ts
@@ -17,7 +17,7 @@ const mockCreateSbomStorage = vi.hoisted(() => vi.fn(() => ({ storage: 'controll
 const mockRegistryState = vi.hoisted(() => ({
   trigger: {},
   watcher: {} as Record<string, { watchContainer?: ReturnType<typeof vi.fn> }>,
-  registry: {},
+  registry: {} as Record<string, unknown>,
   authentication: {},
   agent: {},
 }));
@@ -87,6 +87,7 @@ vi.mock('../registry/index.js', () => ({
 
 import * as event from '../event/index.js';
 import * as gateWatch from '../maturity/gate-watch.js';
+import Hub from '../registries/providers/hub/Hub.js';
 import * as registry from '../registry/index.js';
 import * as storeContainer from '../store/container.js';
 import * as updateOperationStore from '../store/update-operation.js';
@@ -104,6 +105,9 @@ describe('AgentClient', () => {
     vi.mocked(updateOperationStore.getOperationById).mockReturnValue(undefined);
     for (const watcherId of Object.keys(mockRegistryState.watcher)) {
       delete mockRegistryState.watcher[watcherId];
+    }
+    for (const registryId of Object.keys(mockRegistryState.registry)) {
+      delete mockRegistryState.registry[registryId];
     }
     vi.useFakeTimers();
     client = new AgentClient('test-agent', {
@@ -8061,6 +8065,12 @@ describe('AgentClient', () => {
   });
 
   describe('Portwing Docker API transport', () => {
+    async function registerAnonymousHub() {
+      const hub = new Hub();
+      await hub.register('registry', 'hub', 'public', {});
+      mockRegistryState.registry[hub.getId()] = hub;
+    }
+
     test('reports whether a watcher uses controller Docker transport', async () => {
       await client.handleComponentSync(
         [
@@ -8193,6 +8203,55 @@ describe('AgentClient', () => {
       );
     });
 
+    test('marker-mode inventory normalizes a raw Portwing Docker Hub image through the configured provider', async () => {
+      await registerAnonymousHub();
+      vi.mocked(storeContainer.getContainer).mockReturnValue(undefined);
+      vi.mocked(storeContainer.insertContainer).mockImplementation((value) => value);
+      await client.handleComponentSync(
+        [
+          {
+            type: 'docker',
+            name: 'docker',
+            configuration: {
+              transport: 'docker-api',
+              execution: 'controller',
+              events: 'portwing',
+            },
+          },
+        ],
+        [],
+      );
+
+      await client.handleContainerSync([
+        {
+          id: 'c1',
+          name: 'busybox',
+          watcher: 'docker',
+          image: {
+            id: 'sha256:current',
+            registry: { name: 'unknown', url: 'docker.io' },
+            name: 'busybox',
+            tag: { value: '1.36.0', semver: false },
+            digest: { watch: false },
+            architecture: 'arm64',
+            os: 'linux',
+          },
+        } as never,
+      ]);
+
+      expect(storeContainer.insertContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image: expect.objectContaining({
+            name: 'library/busybox',
+            registry: {
+              name: 'hub.public',
+              url: 'https://registry-1.docker.io/v2',
+            },
+          }),
+        }),
+      );
+    });
+
     test('marker-mode incremental events cannot clear controller-owned update enrichment', async () => {
       const existing = {
         id: 'c1',
@@ -8279,6 +8338,61 @@ describe('AgentClient', () => {
           agent: 'test-agent',
           image: { id: 'sha256:changed' },
           labels: { 'com.example.channel': 'stable' },
+        }),
+        { emitBatchEvent: true },
+      );
+    });
+
+    test('marker-mode Portwing events give the native watcher a configured registry identity', async () => {
+      await registerAnonymousHub();
+      const refreshContainer = vi.fn().mockResolvedValue({
+        container: { id: 'c1', watcher: 'docker', updateAvailable: false },
+        changed: false,
+      });
+      await client.handleComponentSync(
+        [
+          {
+            type: 'docker',
+            name: 'docker',
+            configuration: {
+              transport: 'docker-api',
+              execution: 'controller',
+              events: 'portwing',
+            },
+          },
+        ],
+        [],
+      );
+      mockRegistryState.watcher['test-agent.docker.docker'] = {
+        watchContainer: refreshContainer,
+      };
+      vi.mocked(storeContainer.getContainer).mockReturnValue(undefined);
+      vi.mocked(storeContainer.insertContainer).mockImplementation((value) => value);
+
+      await client.handleEvent('dd:container-updated', {
+        id: 'c1',
+        name: 'busybox',
+        watcher: 'docker',
+        image: {
+          id: 'sha256:current',
+          registry: { name: 'unknown', url: 'docker.io' },
+          name: 'busybox',
+          tag: { value: '1.36.0', semver: false },
+          digest: { watch: false },
+          architecture: 'arm64',
+          os: 'linux',
+        },
+      });
+
+      expect(refreshContainer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image: expect.objectContaining({
+            name: 'library/busybox',
+            registry: {
+              name: 'hub.public',
+              url: 'https://registry-1.docker.io/v2',
+            },
+          }),
         }),
         { emitBatchEvent: true },
       );

--- a/app/agent/AgentClient.ts
+++ b/app/agent/AgentClient.ts
@@ -54,6 +54,7 @@ import * as updateOperationStore from '../store/update-operation.js';
 import { getRequestedOperationId } from '../triggers/providers/docker/update-runtime-context.js';
 import { getErrorMessage } from '../util/error.js';
 import { uuidv7 } from '../util/uuid.js';
+import { normalizeContainer } from '../watchers/providers/docker/image-comparison.js';
 import type { AgentAuthMode } from './components/Agent.js';
 import { usesControllerDockerTransport } from './controller-docker-transport.js';
 import type { EdgeAgentAdapter } from './EdgeAgentAdapter.js';
@@ -788,9 +789,15 @@ export class AgentClient {
       };
     }
     container.agent = this.name;
+    if (
+      this.controllerDockerTransportWatchers.has(container.watcher) &&
+      container.image?.registry?.url
+    ) {
+      container = normalizeContainer(container);
+    }
     container = this.preserveControllerDockerEnrichment(container);
-    // The container coming from Agent should already be normalized and have results
-    // We rely on the Agent to perform Registry checks if configured
+    // Traditional agents own registry normalization and results. Controller-owned
+    // Docker transport instead applies the controller's configured registry above.
 
     // Strip redaction metadata (e.g. `sensitive`) that the agent's event
     // emitter may attach — the controller's Joi schema does not allow it.


### PR DESCRIPTION
Closes #687

## What changed

- normalize complete controller-owned Portwing image records through the existing configured-provider path
- use the canonical registry name, URL, credentials, and image identity before persistence and native refresh
- preserve traditional agent behavior and partial-event handling
- cover initial inventory and subsequent Portwing event ingestion

## Verification

- RED: both inventory and event paths retained `registry.name=unknown` and skipped the native registry query
- GREEN: affected AgentClient/image-comparison suite 607/607
- full backend 12,872 tests at 100% coverage on the fix commit
- full pre-push gate passed in 276 seconds after current-dev integration
- live exact-commit tri-tool smoke returned watch-now HTTP 200, queried `hub.public`, detected BusyBox `1.36.1`, made 46 native Docker GETs, and made zero legacy watcher POSTs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added controller-side normalization for Portwing containers from Docker transport watchers.
- 🔧 Changed inventory and incremental event handling to use configured registry identity, URL, credentials, and image identity.
- 🔧 Preserved traditional agent normalization and partial-event handling.
- 🐛 Fixed controller-owned registry checks for agent-synced containers.
- ✨ Added tests for anonymous Docker Hub registration, image normalization, and native watcher identity.
- 🔧 Verified affected tests, the backend suite, the pre-push gate, and live tri-tool smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->