### PR TITLE
fix(registries): propagate manifest created fetch failures

### DIFF
--- a/app/registries/Registry.test.ts
+++ b/app/registries/Registry.test.ts
@@ -523,6 +523,103 @@ describe('getImageManifestDigest', () => {
     );
   });
 
+  test('should propagate non-object schemaVersion 2 manifest config failures', async () => {
+    const registryMocked = createMockedRegistry();
+    registryMocked.callRegistry = vi.fn((options) => {
+      if (options.method === 'head') {
+        return { headers: { 'docker-content-digest': 'sha256:manifest' } };
+      }
+      if (options.url === 'url/image/manifests/tag') {
+        return {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+        };
+      }
+      if (
+        options.url === 'url/image/manifests/sha256:manifest' &&
+        options.method === 'get' &&
+        options.headers?.Accept === 'application/vnd.docker.distribution.manifest.v2+json'
+      ) {
+        throw 'manifest config unavailable';
+      }
+      throw new Error(`Unexpected request: ${JSON.stringify(options)}`);
+    });
+
+    await expect(registryMocked.getImageManifestDigest(imageInput())).rejects.toBe(
+      'manifest config unavailable',
+    );
+  });
+
+  test('should preserve the digest when schemaVersion 2 created metadata redirects', async () => {
+    const registryMocked = createMockedRegistry();
+    const redirectError = Object.assign(new Error('Request failed with status code 302'), {
+      response: { status: 302 },
+    });
+    registryMocked.callRegistry = vi.fn((options) => {
+      if (options.method === 'head') {
+        return { headers: { 'docker-content-digest': 'sha256:manifest' } };
+      }
+      if (options.url === 'url/image/manifests/tag') {
+        return {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+        };
+      }
+      if (
+        options.url === 'url/image/manifests/sha256:manifest' &&
+        options.method === 'get' &&
+        options.headers?.Accept === 'application/vnd.docker.distribution.manifest.v2+json'
+      ) {
+        return {
+          schemaVersion: 2,
+          config: {
+            digest: 'sha256:config',
+          },
+        };
+      }
+      if (options.url === 'url/image/blobs/sha256:config') {
+        throw redirectError;
+      }
+      throw new Error(`Unexpected request: ${JSON.stringify(options)}`);
+    });
+
+    await expect(registryMocked.getImageManifestDigest(imageInput())).resolves.toStrictEqual({
+      version: 2,
+      digest: 'sha256:manifest',
+    });
+  });
+
+  test('should preserve the digest when the schemaVersion 2 manifest config redirects', async () => {
+    const registryMocked = createMockedRegistry();
+    const redirectError = Object.assign(new Error('Request failed with status code 307'), {
+      response: { status: 307 },
+    });
+    registryMocked.callRegistry = vi.fn((options) => {
+      if (options.method === 'head') {
+        return { headers: { 'docker-content-digest': 'sha256:manifest' } };
+      }
+      if (options.url === 'url/image/manifests/tag') {
+        return {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+        };
+      }
+      if (
+        options.url === 'url/image/manifests/sha256:manifest' &&
+        options.method === 'get' &&
+        options.headers?.Accept === 'application/vnd.docker.distribution.manifest.v2+json'
+      ) {
+        throw redirectError;
+      }
+      throw new Error(`Unexpected request: ${JSON.stringify(options)}`);
+    });
+
+    await expect(registryMocked.getImageManifestDigest(imageInput())).resolves.toStrictEqual({
+      version: 2,
+      digest: 'sha256:manifest',
+    });
+  });
+
   test('should return digest for container.image.v1 (schemaVersion 1)', async () => {
     const registryMocked = createMockedRegistry();
     registryMocked.callRegistry = (options) => {

--- a/app/registries/Registry.test.ts
+++ b/app/registries/Registry.test.ts
@@ -620,6 +620,36 @@ describe('getImageManifestDigest', () => {
     });
   });
 
+  test('should propagate a 304 response from schemaVersion 2 manifest config', async () => {
+    const registryMocked = createMockedRegistry();
+    const notModifiedError = Object.assign(new Error('Request failed with status code 304'), {
+      response: { status: 304 },
+    });
+    registryMocked.callRegistry = vi.fn((options) => {
+      if (options.method === 'head') {
+        return { headers: { 'docker-content-digest': 'sha256:manifest' } };
+      }
+      if (options.url === 'url/image/manifests/tag') {
+        return {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+        };
+      }
+      if (
+        options.url === 'url/image/manifests/sha256:manifest' &&
+        options.method === 'get' &&
+        options.headers?.Accept === 'application/vnd.docker.distribution.manifest.v2+json'
+      ) {
+        throw notModifiedError;
+      }
+      throw new Error(`Unexpected request: ${JSON.stringify(options)}`);
+    });
+
+    await expect(registryMocked.getImageManifestDigest(imageInput())).rejects.toBe(
+      notModifiedError,
+    );
+  });
+
   test('should return digest for container.image.v1 (schemaVersion 1)', async () => {
     const registryMocked = createMockedRegistry();
     registryMocked.callRegistry = (options) => {

--- a/app/registries/Registry.test.ts
+++ b/app/registries/Registry.test.ts
@@ -348,6 +348,9 @@ describe('getImageManifestDigest', () => {
           platformManifest('armv7', 'linux', 'digest_y', 'fail'),
         ]);
       }
+      if (options.url?.includes('/blobs/')) {
+        return {};
+      }
       throw new Error('Boom!');
     };
     await expect(registryMocked.getImageManifestDigest(imageInput())).resolves.toStrictEqual({
@@ -492,8 +495,9 @@ describe('getImageManifestDigest', () => {
     });
   });
 
-  test('should continue when schemaVersion 2 manifest config fetch fails', async () => {
+  test('should propagate schemaVersion 2 manifest config fetch failures', async () => {
     const registryMocked = createMockedRegistry();
+    const manifestConfigError = new Error('manifest config unavailable');
     registryMocked.callRegistry = vi.fn((options) => {
       if (options.method === 'head') {
         return { headers: { 'docker-content-digest': 'sha256:manifest' } };
@@ -509,15 +513,14 @@ describe('getImageManifestDigest', () => {
         options.method === 'get' &&
         options.headers?.Accept === 'application/vnd.docker.distribution.manifest.v2+json'
       ) {
-        throw new Error('manifest config unavailable');
+        throw manifestConfigError;
       }
       throw new Error(`Unexpected request: ${JSON.stringify(options)}`);
     });
 
-    await expect(registryMocked.getImageManifestDigest(imageInput())).resolves.toStrictEqual({
-      version: 2,
-      digest: 'sha256:manifest',
-    });
+    await expect(registryMocked.getImageManifestDigest(imageInput())).rejects.toBe(
+      manifestConfigError,
+    );
   });
 
   test('should return digest for container.image.v1 (schemaVersion 1)', async () => {
@@ -779,8 +782,9 @@ describe('getImageManifestDigest', () => {
     );
   });
 
-  test('should gracefully handle blob fetch error for legacy manifest config', async () => {
+  test('should propagate blob fetch failures for legacy manifest config', async () => {
     const registryMocked = createMockedRegistry();
+    const blobFetchError = new Error('blob fetch failed');
     registryMocked.callRegistry = vi.fn((options) => {
       if (options.headers?.Accept === ALL_MANIFEST_ACCEPT) {
         return manifestListResponse([
@@ -793,12 +797,11 @@ describe('getImageManifestDigest', () => {
         ]);
       }
       if (options.url?.includes('/blobs/')) {
-        throw new Error('blob fetch failed');
+        throw blobFetchError;
       }
       throw new Error(`Unexpected request: ${JSON.stringify(options)}`);
     });
-    const result = await registryMocked.getImageManifestDigest(imageInput());
-    expect(result).toStrictEqual({ version: 1, digest: 'digest_x' });
+    await expect(registryMocked.getImageManifestDigest(imageInput())).rejects.toBe(blobFetchError);
   });
 
   test('should include created date when legacy manifest config blob metadata is present', async () => {
@@ -1424,6 +1427,7 @@ describe('getImageManifestDigest', () => {
     // Kill line 411 StringLiteral `` mutant: error log must include image identifier
     const registryMocked = createMockedRegistry();
     const debugSpy = vi.fn();
+    const blobFetchError = new Error('blob-access-denied');
     registryMocked.log = { debug: debugSpy } as any;
     registryMocked.callRegistry = vi.fn((options) => {
       if (options.method === 'head') {
@@ -1439,14 +1443,12 @@ describe('getImageManifestDigest', () => {
         return { config: { digest: 'sha256:blob' } };
       }
       if (options.url?.includes('/blobs/')) {
-        throw new Error('blob-access-denied');
+        throw blobFetchError;
       }
       throw new Error(`Unexpected: ${JSON.stringify(options)}`);
     });
 
-    const result = await registryMocked.getImageManifestDigest(imageInput());
-    // Should still succeed (error caught), result has no created date
-    expect(result.digest).toBe('sha256:mfst');
+    await expect(registryMocked.getImageManifestDigest(imageInput())).rejects.toBe(blobFetchError);
     // Debug log should mention blob error
     const debugMessages = debugSpy.mock.calls.map(([msg]) => msg);
     expect(
@@ -1569,10 +1571,11 @@ describe('getImageManifestDigest logging', () => {
     rootDebugSpy.mockRestore();
   });
 
-  test('should keep manifest-config fallback debug logs on the child logger', async () => {
+  test('should keep manifest-config failure debug logs on the child logger', async () => {
     const registryMocked = new Registry();
     await registryMocked.register('registry', 'hub', 'test', {});
     const childDebug = vi.fn();
+    const manifestConfigError = new Error('manifest config unavailable');
     registryMocked.log = { debug: childDebug } as any;
     const rootDebugSpy = vi.spyOn(log, 'debug').mockImplementation(() => undefined);
 
@@ -1591,17 +1594,14 @@ describe('getImageManifestDigest logging', () => {
         options.method === 'get' &&
         options.headers?.Accept === 'application/vnd.docker.distribution.manifest.v2+json'
       ) {
-        throw new Error('manifest config unavailable');
+        throw manifestConfigError;
       }
       throw new Error(`Unexpected request: ${JSON.stringify(options)}`);
     });
 
-    await expect(
-      registryMocked.getImageManifestDigest(imageInput({ name: 'image' })),
-    ).resolves.toStrictEqual({
-      version: 2,
-      digest: 'sha256:manifest',
-    });
+    await expect(registryMocked.getImageManifestDigest(imageInput({ name: 'image' }))).rejects.toBe(
+      manifestConfigError,
+    );
 
     expect(rootDebugSpy).not.toHaveBeenCalled();
     expect(childDebug).toHaveBeenCalledWith(

--- a/app/registries/Registry.ts
+++ b/app/registries/Registry.ts
@@ -83,7 +83,10 @@ function isRedirectError(error: unknown): boolean {
     error != null && typeof error === 'object'
       ? (error as { response?: { status?: unknown } }).response?.status
       : undefined;
-  return typeof status === 'number' && status >= 300 && status < 400;
+  return (
+    typeof status === 'number' &&
+    ((status >= 301 && status <= 303) || status === 307 || status === 308)
+  );
 }
 
 /**

--- a/app/registries/Registry.ts
+++ b/app/registries/Registry.ts
@@ -409,8 +409,9 @@ class Registry<
     manifestDigest: string,
     mediaType: string,
   ): Promise<string | undefined> {
+    let manifestResponse: RegistryManifestResponse;
     try {
-      const manifestResponse = await this.callRegistry<RegistryManifestResponse>({
+      manifestResponse = await this.callRegistry<RegistryManifestResponse>({
         image,
         method: 'get',
         url: `${image.registry.url}/${image.name}/manifests/${manifestDigest}`,
@@ -418,11 +419,6 @@ class Registry<
           Accept: mediaType,
         },
       });
-      const configDigest = manifestResponse?.config?.digest;
-      if (!configDigest) {
-        return undefined;
-      }
-      return this.fetchImageCreatedFromBlob(image, configDigest);
     } catch (error: unknown) {
       this.log.debug(
         `Unable to fetch manifest config created date for ${this.getImageFullName(
@@ -430,8 +426,13 @@ class Registry<
           manifestDigest,
         )} (${getErrorMessage(error)})`,
       );
+      throw error;
+    }
+    const configDigest = manifestResponse?.config?.digest;
+    if (!configDigest) {
       return undefined;
     }
+    return this.fetchImageCreatedFromBlob(image, configDigest);
   }
 
   private async fetchImageCreatedFromBlob(
@@ -459,7 +460,7 @@ class Registry<
           digest,
         )} (${getErrorMessage(error)})`,
       );
-      return undefined;
+      throw error;
     }
   }
 

--- a/app/registries/Registry.ts
+++ b/app/registries/Registry.ts
@@ -78,6 +78,14 @@ function isLegacyImageConfig(mediaType: string | undefined): boolean {
   );
 }
 
+function isRedirectError(error: unknown): boolean {
+  const status =
+    error != null && typeof error === 'object'
+      ? (error as { response?: { status?: unknown } }).response?.status
+      : undefined;
+  return typeof status === 'number' && status >= 300 && status < 400;
+}
+
 /**
  * Filter a manifest list to find the best match for the requested platform.
  * Returns the matched manifest entry or undefined.
@@ -426,6 +434,9 @@ class Registry<
           manifestDigest,
         )} (${getErrorMessage(error)})`,
       );
+      if (isRedirectError(error)) {
+        return undefined;
+      }
       throw error;
     }
     const configDigest = manifestResponse?.config?.digest;
@@ -460,6 +471,9 @@ class Registry<
           digest,
         )} (${getErrorMessage(error)})`,
       );
+      if (isRedirectError(error)) {
+        return undefined;
+      }
       throw error;
     }
   }


### PR DESCRIPTION
Closes #606

## What changed

- propagate exhausted manifest and blob transport failures instead of converting them to successful `undefined`
- preserve resolved digest results only when optional created-metadata requests return 301, 302, 303, 307, or 308, while keeping redirect following disabled
- keep contextual child debug logging and rethrow the original 304, 4xx, 5xx, network, and non-object failures
- preserve optional handling for missing config digests, absent or non-string `created`, and invalid dates

## Why

The first implementation correctly fixed #606, but the exact-head Playwright fixture exposed the mirror registry returning 302 for optional blob metadata. Because registry requests intentionally use `maxRedirects: 0`, rethrowing that 302 aborted digest watch and hid a real Nginx update. CodeRabbit then caught that a broad 3xx predicate also swallowed `304 Not Modified`; the final allowlist excludes non-redirect statuses.

## Verification

- RED: four original failure cases resolved successfully instead of rejecting
- RED: schema v2 blob 302 and manifest 307 rejected instead of preserving the resolved digest
- RED: manifest 304 resolved with a digest instead of rethrowing the original error
- GREEN: redirect and failure-propagation focus 5/5
- GREEN: Registry, BaseRegistry, image-comparison, and Docker boundary 597/597
- GREEN: full pre-push in 273.80 seconds, including 323 script/workflow tests, app/UI 100% coverage, and both builds
- exact patch is limited to `app/registries/Registry.ts` and `app/registries/Registry.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 **Fixed:** Propagate manifest configuration and blob transport failures instead of returning `undefined`.
- 🐛 **Fixed:** Preserve original rejection values, including non-`Error` values.
- ✨ **Added:** Preserve resolved digests for optional metadata requests that return HTTP 301, 302, 303, 307, or 308.
- 🔧 **Changed:** Keep redirect following disabled.
- 🔧 **Changed:** Preserve contextual debug logging for non-redirect failures.
- ✨ **Added:** Tests for HTTP 304, 4xx, 5xx, network, redirect, missing metadata, invalid dates, child logging, and legacy blob mocks.
- 🔧 **Changed:** Limit implementation changes to `Registry.ts` and `Registry.test.ts`.

## Concerns

- Verify `isRedirectError` matches only HTTP 301, 302, 303, 307, and 308.
- Verify `BaseRegistry` caching preserves prior digest-watch verdicts after propagated failures.
- Verify tag-only requests still treat missing or invalid `created` metadata as optional.
- Check whether an existing shared HTTP-status utility should replace `isRedirectError`.
- Check whether `Registry` error handling remains consistent with the `BaseRegistry` provider pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->