### PR TITLE
test(web): bind approved CTA combinations

### DIFF
--- a/apps/web/scripts/analytics-contract.test.mjs
+++ b/apps/web/scripts/analytics-contract.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import * as analyticsContract from "../src/lib/analytics-contract.ts";
 import {
   canonicalizePathname,
   createBeforeSend,
@@ -95,17 +96,13 @@ test("CTA tuples are finite and surface-aware", () => {
   assert.equal(isAllowedCta("marketing", "github_repository", "unknown"), false);
 });
 
-test("CTA allowlist exactly covers every approved site combination", () => {
-  const surfaces = ["marketing", "docs"];
-  const ctaIds = [
-    "docs_root",
-    "github_repository",
-    "community_discord",
-    "install_quick",
-    "install_secure",
-    "docs_security",
-  ];
-  const placements = ["header", "hero", "comparison", "get_started", "footer", "star_history"];
+test("CTA allowlist exactly matches the canonical exported tuple contract", () => {
+  const canonicalTuples = analyticsContract.ANALYTICS_CTA_TUPLES;
+  assert.ok(Array.isArray(canonicalTuples), "runtime must export its canonical CTA tuples");
+
+  const surfaces = [...new Set(canonicalTuples.map(([surface]) => surface))];
+  const ctaIds = [...new Set(canonicalTuples.map(([, ctaId]) => ctaId))];
+  const placements = [...new Set(canonicalTuples.map(([, , placement]) => placement))];
   const actual = surfaces.flatMap((surface) =>
     ctaIds.flatMap((ctaId) =>
       placements
@@ -113,9 +110,11 @@ test("CTA allowlist exactly covers every approved site combination", () => {
         .map((placement) => `${surface}\0${ctaId}\0${placement}`),
     ),
   );
-  const expected = APPROVED_CTA_TUPLES.map((tuple) => tuple.join("\0"));
+  const canonical = canonicalTuples.map((tuple) => tuple.join("\0"));
+  const approved = APPROVED_CTA_TUPLES.map((tuple) => tuple.join("\0"));
 
-  assert.deepEqual(actual.sort(), expected.sort());
+  assert.deepEqual(canonical.sort(), approved.sort());
+  assert.deepEqual(actual.sort(), canonical.sort());
 });
 
 test("pageviews are rebuilt from the canonical production URL and a minimal envelope", () => {

--- a/apps/web/scripts/analytics-contract.test.mjs
+++ b/apps/web/scripts/analytics-contract.test.mjs
@@ -13,6 +13,26 @@ import {
 } from "../src/lib/analytics-contract.ts";
 
 const ROUTES = new Set(["/", "/compare", "/docs/v1.7", "/docs/v1.7/guides/security"]);
+const APPROVED_CTA_TUPLES = [
+  ["marketing", "docs_root", "header"],
+  ["marketing", "github_repository", "header"],
+  ["docs", "docs_root", "header"],
+  ["docs", "github_repository", "header"],
+  ["marketing", "docs_root", "hero"],
+  ["marketing", "github_repository", "hero"],
+  ["marketing", "docs_root", "comparison"],
+  ["marketing", "github_repository", "comparison"],
+  ["marketing", "install_quick", "get_started"],
+  ["marketing", "install_secure", "get_started"],
+  ["marketing", "docs_security", "get_started"],
+  ["marketing", "docs_root", "footer"],
+  ["marketing", "github_repository", "footer"],
+  ["marketing", "community_discord", "footer"],
+  ["docs", "docs_root", "footer"],
+  ["docs", "github_repository", "footer"],
+  ["docs", "community_discord", "footer"],
+  ["marketing", "github_repository", "star_history"],
+];
 
 test("analytics requires the complete exact public environment contract", () => {
   assert.deepEqual(
@@ -73,6 +93,29 @@ test("CTA tuples are finite and surface-aware", () => {
   assert.equal(isAllowedCta("docs", "github_repository", "hero"), false);
   assert.equal(isAllowedCta("marketing", "live_demo", "hero"), false);
   assert.equal(isAllowedCta("marketing", "github_repository", "unknown"), false);
+});
+
+test("CTA allowlist exactly covers every approved site combination", () => {
+  const surfaces = ["marketing", "docs"];
+  const ctaIds = [
+    "docs_root",
+    "github_repository",
+    "community_discord",
+    "install_quick",
+    "install_secure",
+    "docs_security",
+  ];
+  const placements = ["header", "hero", "comparison", "get_started", "footer", "star_history"];
+  const actual = surfaces.flatMap((surface) =>
+    ctaIds.flatMap((ctaId) =>
+      placements
+        .filter((placement) => isAllowedCta(surface, ctaId, placement))
+        .map((placement) => `${surface}\0${ctaId}\0${placement}`),
+    ),
+  );
+  const expected = APPROVED_CTA_TUPLES.map((tuple) => tuple.join("\0"));
+
+  assert.deepEqual(actual.sort(), expected.sort());
 });
 
 test("pageviews are rebuilt from the canonical production URL and a minimal envelope", () => {

--- a/apps/web/src/lib/analytics-contract.ts
+++ b/apps/web/src/lib/analytics-contract.ts
@@ -6,26 +6,28 @@ const PROJECT_TOKEN_PATTERN = /^phc_[A-Za-z0-9_-]+$/u;
 const OTHER_PATH = "/_other";
 const COOKILESS_DISTINCT_ID = "$posthog_cookieless";
 
-const ALLOWED_CTA_TUPLES = new Set([
-  "marketing\0docs_root\0header",
-  "marketing\0github_repository\0header",
-  "docs\0docs_root\0header",
-  "docs\0github_repository\0header",
-  "marketing\0docs_root\0hero",
-  "marketing\0github_repository\0hero",
-  "marketing\0docs_root\0comparison",
-  "marketing\0github_repository\0comparison",
-  "marketing\0install_quick\0get_started",
-  "marketing\0install_secure\0get_started",
-  "marketing\0docs_security\0get_started",
-  "marketing\0docs_root\0footer",
-  "marketing\0github_repository\0footer",
-  "marketing\0community_discord\0footer",
-  "docs\0docs_root\0footer",
-  "docs\0github_repository\0footer",
-  "docs\0community_discord\0footer",
-  "marketing\0github_repository\0star_history",
-]);
+export const ANALYTICS_CTA_TUPLES = [
+  ["marketing", "docs_root", "header"],
+  ["marketing", "github_repository", "header"],
+  ["docs", "docs_root", "header"],
+  ["docs", "github_repository", "header"],
+  ["marketing", "docs_root", "hero"],
+  ["marketing", "github_repository", "hero"],
+  ["marketing", "docs_root", "comparison"],
+  ["marketing", "github_repository", "comparison"],
+  ["marketing", "install_quick", "get_started"],
+  ["marketing", "install_secure", "get_started"],
+  ["marketing", "docs_security", "get_started"],
+  ["marketing", "docs_root", "footer"],
+  ["marketing", "github_repository", "footer"],
+  ["marketing", "community_discord", "footer"],
+  ["docs", "docs_root", "footer"],
+  ["docs", "github_repository", "footer"],
+  ["docs", "community_discord", "footer"],
+  ["marketing", "github_repository", "star_history"],
+] as const;
+
+const ALLOWED_CTA_TUPLES = new Set(ANALYTICS_CTA_TUPLES.map((tuple) => tuple.join("\0")));
 
 const WEB_VITAL_KEYS = [
   "$web_vitals_CLS_value",


### PR DESCRIPTION
## Summary

- enumerate every approved analytics CTA tuple
- prove the runtime allowlist exposes every documented CTA ID and placement
- close the exhaustive-coverage gap found during the dev-to-main promotion review

## Verification

- mutation RED: removing `marketing\0install_quick\0get_started` fails the new exhaustive contract
- GREEN: focused analytics contracts pass 8/8
- full normal pre-push passes, including 100% app/UI coverage and both builds

Refs #732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
✨ Added `ANALYTICS_CTA_TUPLES` as the canonical list of approved surface, CTA, and placement combinations.
🔧 Derived `ALLOWED_CTA_TUPLES` from `ANALYTICS_CTA_TUPLES`.
✨ Added exhaustive contract tests with `APPROVED_CTA_TUPLES`.
✨ Verified that exported tuples and `isAllowedCta` match the approved allowlist.
✨ Verified the mutation test, 8 focused analytics contract tests, full pre-push suite, 100% app/UI coverage, and both builds.

- No actionable concerns identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->