### PR TITLE
fix(compose): refresh image-inherited runtime defaults

### DIFF
--- a/app/triggers/providers/dockercompose/Dockercompose.compose-exec-and-hooks.test.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.compose-exec-and-hooks.test.ts
@@ -145,6 +145,65 @@ describe('Dockercompose Trigger', () => {
     expect(startContainerSpy).toHaveBeenCalledTimes(1);
   });
 
+  test('updateContainerWithCompose should remove stale image-inherited env defaults while preserving runtime env', async () => {
+    trigger.configuration.dryrun = false;
+    const currentContainer = makeDockerContainerHandle({
+      image: 'example/app:old',
+    });
+    currentContainer.inspect.mockResolvedValue({
+      Id: 'container-id',
+      Name: '/nginx',
+      Config: {
+        Image: 'example/app:old',
+        Env: ['APP_VERSION=old', 'RUNTIME_VALUE=keep'],
+        Labels: {},
+      },
+      HostConfig: {},
+      NetworkSettings: { Networks: {} },
+      State: { Running: true },
+    });
+    mockDockerApi.getContainer.mockReturnValue(currentContainer);
+    mockDockerApi.getImage.mockImplementation((imageRef) => ({
+      inspect: vi.fn().mockResolvedValue(
+        imageRef === 'example/app:old'
+          ? { Config: { Env: ['APP_VERSION=old'] } }
+          : {
+              Architecture: process.arch === 'x64' ? 'amd64' : process.arch,
+              Os: 'linux',
+              Config: { Env: ['APP_VERSION=new'] },
+            },
+      ),
+    }));
+    vi.spyOn(trigger, 'pullImage').mockResolvedValue();
+    vi.spyOn(trigger, 'stopContainer').mockResolvedValue();
+    vi.spyOn(trigger, 'removeContainer').mockResolvedValue();
+    const createContainerSpy = vi.spyOn(trigger, 'createContainer').mockResolvedValue({
+      start: vi.fn().mockResolvedValue(undefined),
+    } as any);
+
+    await trigger.updateContainerWithCompose(
+      '/opt/drydock/test/stack.yml',
+      'nginx',
+      makeContainer(),
+      {
+        skipPull: true,
+        runtimeContext: {
+          dockerApi: mockDockerApi,
+          newImage: 'example/app:new',
+        },
+      },
+    );
+
+    expect(createContainerSpy).toHaveBeenCalledWith(
+      mockDockerApi,
+      expect.objectContaining({
+        Env: ['RUNTIME_VALUE=keep'],
+      }),
+      'nginx',
+      expect.anything(),
+    );
+  });
+
   test('updateContainerWithCompose should preserve stopped runtime state', async () => {
     trigger.configuration.dryrun = false;
     const pullImageSpy = vi.spyOn(trigger, 'pullImage').mockResolvedValue();

--- a/app/triggers/providers/dockercompose/Dockercompose.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.ts
@@ -2412,11 +2412,12 @@ class Dockercompose extends Docker<DockercomposeTriggerConfiguration> {
     newImage,
     container,
     logContainer: { info: (msg: string) => void; warn: (msg: string) => void },
+    cloneRuntimeConfigOptions,
   ): Promise<void> {
     const containerToCreateInspect = this.cloneContainer(
       currentContainerSpec,
       newImage,
-      logContainer,
+      cloneRuntimeConfigOptions,
     );
     let newContainer: unknown;
 
@@ -2512,6 +2513,12 @@ class Dockercompose extends Docker<DockercomposeTriggerConfiguration> {
     // before performing any destructive step. On arch mismatch the old
     // container is left running and we throw without touching it.
     await this.verifyPulledImageCompatibility(dockerApi as DockerApiLike, newImage, logContainer);
+    const cloneRuntimeConfigOptions = await this.runtimeConfigManager.getCloneRuntimeConfigOptions(
+      dockerApi,
+      currentContainerSpec,
+      newImage,
+      logContainer,
+    );
 
     // Capture the original container spec for rollback before we do anything
     // destructive. The Config.Image field holds the old image reference.
@@ -2550,6 +2557,7 @@ class Dockercompose extends Docker<DockercomposeTriggerConfiguration> {
         newImage,
         container,
         logContainer,
+        cloneRuntimeConfigOptions,
       );
     } catch (recreateError: unknown) {
       const rollbackOutcome = await this.attemptRollbackRestoreOldContainer(


### PR DESCRIPTION
## Summary
- pass the existing ContainerRuntimeConfigManager clone options through Compose Docker API refreshes
- remove stale image-inherited environment defaults while preserving runtime overrides

## Verification
- RED: Compose refresh regression reproduced APP_VERSION=old surviving target image default APP_VERSION=new
- GREEN: focused Compose test passes, full Compose file 68/68, Docker 253/253, runtime manager 39/39
- full pre-push passed before the dev/v1.7 sync: 100% app/UI coverage and both builds

Closes #734

## Frozen sync metadata
- Base dev/v1.7: commit 25c49bacb37e7a70f6cf8e46a3a366b4ff616e2a, tree b3cd1d00173a153c310ef918c81e4c8b00cd6a6a.
- Final feature head: merge commit 1074a1f6fd84c9285ff52e7ca651f7962b33bdf0, tree d12fdabec7af49027fc0ff9a050c5fd92b60c9b4.
- Merge parents: D10 929d18901297ce5d0088d7975c312608cfa76f69, dev/v1.7 25c49bacb37e7a70f6cf8e46a3a366b4ff616e2a.
- Final diff from dev contains only app/triggers/providers/dockercompose/Dockercompose.ts and app/triggers/providers/dockercompose/Dockercompose.compose-exec-and-hooks.test.ts.
- No merge, approval, or manual Greptile request performed.