### PR TITLE
fix(web): forward $raw_user_agent and $host for cookieless ingestion

### DIFF
--- a/apps/web/scripts/analytics-contract.test.mjs
+++ b/apps/web/scripts/analytics-contract.test.mjs
@@ -14,6 +14,15 @@ import {
 } from "../src/lib/analytics-contract.ts";
 
 const ROUTES = new Set(["/", "/compare", "/docs/v1.7", "/docs/v1.7/guides/security"]);
+// posthog-js attaches these to every envelope by default. PostHog's
+// cookieless server-hash ingestion reads them straight off event.properties
+// and drops the event with a cookieless_missing_user_agent /
+// cookieless_missing_host warning if either is absent, so before_send must
+// require and forward them.
+const COOKIELESS_HASH_PROPERTIES = {
+  $raw_user_agent: "Mozilla/5.0 (Test Runner)",
+  $host: "getdrydock.com",
+};
 const APPROVED_CTA_TUPLES = [
   ["marketing", "docs_root", "header"],
   ["marketing", "github_repository", "header"],
@@ -126,6 +135,7 @@ test("pageviews are rebuilt from the canonical production URL and a minimal enve
     timestamp,
     $set: { email: "secret@example.com" },
     properties: {
+      ...COOKIELESS_HASH_PROPERTIES,
       token: "attacker-token",
       distinct_id: "$posthog_cookieless",
       $cookieless_mode: true,
@@ -152,8 +162,45 @@ test("pageviews are rebuilt from the canonical production URL and a minimal enve
       surface: "marketing",
       path: "/compare",
       $current_url: `${PRODUCTION_ORIGIN}/compare`,
+      ...COOKIELESS_HASH_PROPERTIES,
     },
   });
+});
+
+test("before_send requires and forwards the cookieless server-hash fields", () => {
+  const beforeSend = createBeforeSend("phc_public-token_123", ROUTES);
+  const validProperties = {
+    ...COOKIELESS_HASH_PROPERTIES,
+    path: "/",
+  };
+
+  const result = beforeSend({
+    uuid: "018f0000-0000-7000-8000-000000000005",
+    event: "$pageview",
+    properties: validProperties,
+  });
+  assert.ok(result);
+  assert.equal(result.properties.$raw_user_agent, COOKIELESS_HASH_PROPERTIES.$raw_user_agent);
+  assert.equal(result.properties.$host, COOKIELESS_HASH_PROPERTIES.$host);
+  assert.equal("$ip" in result.properties, false);
+
+  // Regression guard: if before_send ever goes back to rebuilding properties
+  // from an allowlist that forgets these two keys, cookieless ingestion drops
+  // every event again with zero warning-free indication beyond
+  // cookieless_missing_user_agent / cookieless_missing_host.
+  for (const missingKey of Object.keys(COOKIELESS_HASH_PROPERTIES)) {
+    const withoutField = { ...validProperties };
+    delete withoutField[missingKey];
+    assert.equal(
+      beforeSend({
+        uuid: "018f0000-0000-7000-8000-000000000006",
+        event: "$pageview",
+        properties: withoutField,
+      }),
+      null,
+      `before_send must drop events missing ${missingKey}`,
+    );
+  }
 });
 
 test("CTA events require an allowlisted tuple and retain no extra properties", () => {
@@ -162,6 +209,7 @@ test("CTA events require an allowlisted tuple and retain no extra properties", (
     uuid: "018f0000-0000-7000-8000-000000000002",
     event: "cta activated",
     properties: {
+      ...COOKIELESS_HASH_PROPERTIES,
       path: "/docs/v1.7/guides/security",
       cta_id: "github_repository",
       placement: "footer",
@@ -180,6 +228,7 @@ test("CTA events require an allowlisted tuple and retain no extra properties", (
       path: "/docs/v1.7/guides/security",
       cta_id: "github_repository",
       placement: "footer",
+      ...COOKIELESS_HASH_PROPERTIES,
     },
   });
   assert.equal(
@@ -197,6 +246,7 @@ test("web vitals keep only finite nonnegative allowlisted metric values", () => 
     uuid: "018f0000-0000-7000-8000-000000000003",
     event: "$web_vitals",
     properties: {
+      ...COOKIELESS_HASH_PROPERTIES,
       $current_url: `${PRODUCTION_ORIGIN}/docs/v1.7?secret=yes#private`,
       $web_vitals_CLS_value: 0.01,
       $web_vitals_FCP_value: 123.4,
@@ -218,13 +268,14 @@ test("web vitals keep only finite nonnegative allowlisted metric values", () => 
       path: "/docs/v1.7",
       $web_vitals_CLS_value: 0.01,
       $web_vitals_FCP_value: 123.4,
+      ...COOKIELESS_HASH_PROPERTIES,
     },
   });
   assert.equal(
     beforeSend({
       uuid: "018f0000-0000-7000-8000-000000000004",
       event: "$web_vitals",
-      properties: { $current_url: PRODUCTION_ORIGIN },
+      properties: { ...COOKIELESS_HASH_PROPERTIES, $current_url: PRODUCTION_ORIGIN },
     }),
     null,
   );

--- a/apps/web/scripts/analytics-contract.test.mjs
+++ b/apps/web/scripts/analytics-contract.test.mjs
@@ -201,6 +201,19 @@ test("before_send requires and forwards the cookieless server-hash fields", () =
       `before_send must drop events missing ${missingKey}`,
     );
   }
+
+  for (const emptyKey of Object.keys(COOKIELESS_HASH_PROPERTIES)) {
+    const withEmptyField = { ...validProperties, [emptyKey]: "" };
+    assert.equal(
+      beforeSend({
+        uuid: "018f0000-0000-7000-8000-000000000007",
+        event: "$pageview",
+        properties: withEmptyField,
+      }),
+      null,
+      `before_send must drop events with empty ${emptyKey}`,
+    );
+  }
 });
 
 test("CTA events require an allowlisted tuple and retain no extra properties", () => {

--- a/apps/web/scripts/analytics-integration.test.mjs
+++ b/apps/web/scripts/analytics-integration.test.mjs
@@ -78,6 +78,22 @@ test("tracked links validate explicit CTA ids and placements at activation time"
   assert.match(trackedLink, /data-analytics-placement/u);
 });
 
+test("the cookieless envelope keeps the fields PostHog's server hash requires", () => {
+  const contract = source("src/lib/analytics-contract.ts");
+
+  // PostHog's cookieless server-hash ingestion step reads $raw_user_agent and
+  // $host straight off event.properties and drops the event — with a
+  // cookieless_missing_user_agent / cookieless_missing_host ingestion warning
+  // and zero rows ingested — if either is absent. posthog-js attaches both by
+  // default; before_send must require and forward them, not silently strip
+  // them. Regression guard: if these keys ever disappear from before_send (or
+  // the comment explaining why they're there), every cookieless event on
+  // Drydock drops with no PostHog-side error beyond the ingestion warning.
+  assert.match(contract, /\$raw_user_agent/u);
+  assert.match(contract, /\$host/u);
+  assert.match(contract, /cookieless_missing_user_agent|cookieless server-hash/u);
+});
+
 test("all approved Drydock CTA families have exact annotations", () => {
   const header = source("src/components/site-header.tsx");
   const buttons = source("src/components/cta-buttons.tsx");

--- a/apps/web/src/lib/analytics-contract.ts
+++ b/apps/web/src/lib/analytics-contract.ts
@@ -204,8 +204,27 @@ export function createBeforeSend(token: string, routes: ReadonlySet<string>) {
       return null;
     }
 
+    // PostHog's cookieless server-hash ingestion reads $raw_user_agent and
+    // $host straight off event properties and drops the event (silently,
+    // with a cookieless_missing_user_agent / cookieless_missing_host
+    // ingestion warning) if either is absent. Require and forward both.
+    // $ip is intentionally never forwarded: PostHog's capture service fills
+    // it in server-side from the request connection.
+    const rawUserAgent = input.properties.$raw_user_agent;
+    const host = input.properties.$host;
+    if (
+      typeof rawUserAgent !== "string" ||
+      rawUserAgent === "" ||
+      typeof host !== "string" ||
+      host === ""
+    ) {
+      return null;
+    }
+
     const rawPath = getRawPath(input.properties);
     const properties = createCommonProperties(token, input.properties, rawPath, routes);
+    properties.$raw_user_agent = rawUserAgent;
+    properties.$host = host;
 
     if (input.event === "$pageview") {
       properties.$current_url = `${PRODUCTION_ORIGIN}${properties.path}`;


### PR DESCRIPTION
## Summary

- `before_send` in `apps/web/src/lib/analytics-contract.ts` rebuilt every outgoing PostHog event from a hard allowlist that dropped `$raw_user_agent` and `$host`. PostHog's cookieless server-hash ingestion step reads those two fields straight off `event.properties` and silently drops the event (`cookieless_missing_user_agent` / `cookieless_missing_host`) if either is absent — same bug fixed in CodesWhat/portwing#124.
- `createBeforeSend` now requires both fields (drops the event if either is missing or empty) and forwards them through unchanged. `$ip` is deliberately never forwarded — PostHog's capture service fills it in server-side from the request connection.

## Test plan

- [x] `apps/web/scripts/analytics-contract.test.mjs` — added a dedicated regression test pinning that `$raw_user_agent`/`$host` are required and forwarded, and that events missing either are dropped; updated existing fixtures to carry the new required fields.
- [x] `apps/web/scripts/analytics-integration.test.mjs` — added a source-scan regression guard analogous to portwing's `web-analytics-source.test.mjs`.
- [x] `npm run test:scripts` (apps/web) — 87/87 passing
- [x] `npm run type-check` (apps/web) — clean
- [x] `npm run lint` (apps/web) — clean
- [x] full pre-push hook suite (qlty, workflow-tests, typecheck-ui, web-scripts-test, coverage, build) — all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- 🔧 Changed `createBeforeSend` to require non-empty `$raw_user_agent` and `$host`.
- 🗑️ Dropped events that omit either cookieless ingestion field.
- 🔧 Forwarded `$raw_user_agent` and `$host` in sanitized events.
- 🔒 Continued excluding `$ip`; PostHog supplies it server-side.
- ✨ Added regression and source-scan coverage.
- 🔧 Updated analytics fixtures and invalid-input cases.
- ✅ Script tests, type checks, linting, and pre-push checks pass.

- Confirm that all analytics event producers provide non-empty `$raw_user_agent` and `$host`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->