### PR TITLE
ci: migrate workflow security to the reusable go-ci caller

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -63,6 +63,10 @@ test('security-actions calls the reusable go-ci workflow-security gate', () => {
     'CodesWhat/.github/.github/workflows/go-ci.yml@01bf40b06b110946f12a49b82e407d77c6480df7',
   );
   expect(job?.with?.['run-workflow-security']).toBe(true);
+  expect(job?.with?.['workflow-security-egress-policy']).toBe('block');
+  expect(job?.with?.['workflow-security-allowed-endpoints']).toBe(
+    'ghcr.io:443 github.com:443 pkg-containers.githubusercontent.com:443',
+  );
 
   const runFlags = Object.keys(job?.with ?? {}).filter(
     (key) => key.startsWith('run-') && key !== 'run-workflow-security',

--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -45,11 +45,29 @@ function getTestJobStep(name: string): WorkflowStep | undefined {
 test('required ci-verify jobs publish stable plain-text check names', () => {
   const workflow = loadWorkflow();
 
-  expect(workflow.jobs?.zizmor?.name).toBe('Security: Actions');
+  expect(workflow.jobs?.['legacy-security-actions']?.name).toBe('Security: Actions');
   expect(workflow.jobs?.lint?.name).toBe('Quality: Lint');
   expect(workflow.jobs?.test?.name).toBe('Quality: Test & Coverage');
   expect(workflow.jobs?.build?.name).toBe('Build');
   expect(workflow.jobs?.e2e?.name).toBe('E2E: Cucumber');
+});
+
+test('security-actions calls the reusable go-ci workflow-security gate', () => {
+  const workflow = loadWorkflow();
+  const job = workflow.jobs?.['security-actions'] as
+    | { uses?: string; with?: Record<string, unknown>; name?: string }
+    | undefined;
+
+  expect(job?.name).toBe('Security: Actions');
+  expect(job?.uses).toBe(
+    'CodesWhat/.github/.github/workflows/go-ci.yml@01bf40b06b110946f12a49b82e407d77c6480df7',
+  );
+  expect(job?.with?.['run-workflow-security']).toBe(true);
+
+  const runFlags = Object.keys(job?.with ?? {}).filter(
+    (key) => key.startsWith('run-') && key !== 'run-workflow-security',
+  );
+  expect(runFlags).toStrictEqual([]);
 });
 
 test('script node tests are wired into local and CI gates', () => {
@@ -107,7 +125,7 @@ test('secret scanning gates full history and the tracked working tree', () => {
 
   expect(job).toMatchObject({
     name: '🔑 Security: Secrets',
-    needs: ['zizmor'],
+    needs: ['security-actions'],
     'runs-on': 'ubuntu-latest',
     'timeout-minutes': 10,
   });
@@ -168,12 +186,12 @@ test('ci-verify can dispatch the complete release-candidate matrix manually', ()
     expect(workflow.jobs?.[jobId]?.if).toContain("github.event_name == 'workflow_dispatch'");
   }
 
-  for (const jobId of ['zizmor', 'changes', 'lint', 'test', 'build']) {
+  for (const jobId of ['security-actions', 'changes', 'lint', 'test', 'build']) {
     expect(workflow.jobs?.[jobId]?.if).toBeUndefined();
   }
 
-  expect(workflow.jobs?.codeql?.needs).toStrictEqual(['zizmor']);
-  expect(workflow.jobs?.fuzz?.needs).toStrictEqual(['zizmor']);
+  expect(workflow.jobs?.codeql?.needs).toStrictEqual(['security-actions']);
+  expect(workflow.jobs?.fuzz?.needs).toStrictEqual(['security-actions']);
   expect(workflow.jobs?.web?.needs).toStrictEqual(['changes']);
   expect(workflow.jobs?.['dast-zap-baseline']?.needs).toStrictEqual(['build']);
   expect(workflow.jobs?.e2e?.needs).toStrictEqual(['build', 'changes']);

--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -60,16 +60,20 @@ test('security-actions calls the reusable go-ci workflow-security gate', () => {
 
   expect(job?.name).toBe('Security: Actions');
   expect(job?.uses).toBe(
-    'CodesWhat/.github/.github/workflows/go-ci.yml@01bf40b06b110946f12a49b82e407d77c6480df7',
+    'CodesWhat/.github/.github/workflows/go-ci.yml@47820bd85d49eb6cd0a935c31789c7d7ce037401',
   );
   expect(job?.with?.['run-workflow-security']).toBe(true);
   expect(job?.with?.['workflow-security-egress-policy']).toBe('block');
   expect(job?.with?.['workflow-security-allowed-endpoints']).toBe(
     'ghcr.io:443 github.com:443 pkg-containers.githubusercontent.com:443',
   );
+  // drydock is Go-less, so both Go jobs go-ci.yml gained must stay disabled.
+  expect(job?.with?.['run-test']).toBe(false);
+  expect(job?.with?.['run-lint']).toBe(false);
 
   const runFlags = Object.keys(job?.with ?? {}).filter(
-    (key) => key.startsWith('run-') && key !== 'run-workflow-security',
+    (key) =>
+      key.startsWith('run-') && !['run-workflow-security', 'run-test', 'run-lint'].includes(key),
   );
   expect(runFlags).toStrictEqual([]);
 });

--- a/.github/tests/harden-runner-workflow.test.ts
+++ b/.github/tests/harden-runner-workflow.test.ts
@@ -66,6 +66,16 @@ test('legacy-security-actions bridge runs Harden Runner in fail-closed mode', ()
 
   expect(firstStep?.uses).toBe(hardenRunnerRef);
   expect(firstStep?.with?.['egress-policy']).toBe('block');
+
+  // Fail-closed contract: the bridge must always run (even when the caller
+  // fails or is skipped) and must convert anything but caller success into
+  // its own failure, so the plain "Security: Actions" context never goes
+  // green on a failed or skipped security scan.
+  expect(job?.needs).toBe('security-actions');
+  expect(job?.if).toBe('${{ always() }}');
+  const gateStep = job?.steps?.find((step) => step.run?.includes('test "${RESULT}"'));
+  expect(gateStep?.env?.RESULT).toBe('${{ needs.security-actions.result }}');
+  expect(gateStep?.run?.trim()).toBe('test "${RESULT}" = "success"');
 });
 
 test('Harden Runner comments match the pinned release version', () => {

--- a/.github/tests/harden-runner-workflow.test.ts
+++ b/.github/tests/harden-runner-workflow.test.ts
@@ -28,6 +28,12 @@ function loadWorkflowFiles(): Array<{
     });
 }
 
+// legacy-security-actions is a temporary fail-closed bridge job: it only
+// republishes ci-verify.yml's security-actions result under the old plain
+// check name and makes no outbound calls of its own, so it runs with
+// egress-policy: block instead of the audit policy every other job uses.
+const blockEgressJobs = new Set(['ci-verify.yml/legacy-security-actions']);
+
 test('GitHub-hosted workflow jobs start with current pinned Harden Runner', () => {
   const violations: string[] = [];
 
@@ -43,13 +49,23 @@ test('GitHub-hosted workflow jobs start with current pinned Harden Runner', () =
         continue;
       }
 
-      if (firstStep.with?.['egress-policy'] !== 'audit') {
-        violations.push(`${file}/${jobId} missing audit egress policy`);
+      const expectedEgressPolicy = blockEgressJobs.has(`${file}/${jobId}`) ? 'block' : 'audit';
+      if (firstStep.with?.['egress-policy'] !== expectedEgressPolicy) {
+        violations.push(`${file}/${jobId} missing ${expectedEgressPolicy} egress policy`);
       }
     }
   }
 
   expect(violations).toStrictEqual([]);
+});
+
+test('legacy-security-actions bridge runs Harden Runner in fail-closed mode', () => {
+  const ciVerify = loadWorkflowFiles().find(({ file }) => file === 'ci-verify.yml');
+  const job = ciVerify?.workflow.jobs?.['legacy-security-actions'];
+  const firstStep = job?.steps?.[0];
+
+  expect(firstStep?.uses).toBe(hardenRunnerRef);
+  expect(firstStep?.with?.['egress-policy']).toBe('block');
 });
 
 test('Harden Runner comments match the pinned release version', () => {

--- a/.github/tests/reusable-ci-config.test.ts
+++ b/.github/tests/reusable-ci-config.test.ts
@@ -19,7 +19,7 @@ interface WorkflowWithReusableJobs {
 // The go-ci.yml SHA every CodesWhat/.github reusable-workflow caller in this
 // repo must be pinned to. Bumping the reusable workflow means bumping this
 // constant and re-verifying every caller in the same change.
-const frozenGoCiSha = '01bf40b06b110946f12a49b82e407d77c6480df7';
+const frozenGoCiSha = '47820bd85d49eb6cd0a935c31789c7d7ce037401';
 const goCiUses = `CodesWhat/.github/.github/workflows/go-ci.yml@${frozenGoCiSha}`;
 
 const workflowsDir = fileURLToPath(new URL('../workflows', import.meta.url));
@@ -116,4 +116,17 @@ test('security-actions caller grants exactly the statically-validated permission
     contents: 'read',
     'security-events': 'write',
   });
+});
+
+test('security-actions caller disables the Go test and lint jobs', () => {
+  const job = reusableCallerJobs().find(
+    ({ file, jobId }) => file === 'ci-verify.yml' && jobId === 'security-actions',
+  )?.job;
+
+  expect(job).toBeDefined();
+  // drydock is Go-less: go-ci.yml's run-test/run-lint jobs have nothing to
+  // run here and must be disabled, or CI Verify would fail on a repo with no
+  // Go module.
+  expect(job?.with?.['run-test']).toBe(false);
+  expect(job?.with?.['run-lint']).toBe(false);
 });

--- a/.github/tests/reusable-ci-config.test.ts
+++ b/.github/tests/reusable-ci-config.test.ts
@@ -101,14 +101,19 @@ test('CodesWhat/.github reusable-workflow callers do not inherit secrets', () =>
   expect(inheritLines).toStrictEqual([]);
 });
 
-test('security-actions caller permissions are exactly actions:read and contents:read', () => {
+test('security-actions caller grants exactly the statically-validated permission set', () => {
   const job = reusableCallerJobs().find(
     ({ file, jobId }) => file === 'ci-verify.yml' && jobId === 'security-actions',
   )?.job;
 
   expect(job).toBeDefined();
+  // security-events: write is required even though run-codeql is unset:
+  // GitHub validates the called workflow's job-level permissions statically
+  // (go-ci.yml's nested codeql job declares it), regardless of if: gating.
+  // Granting less makes every CI Verify run end in startup_failure.
   expect(job?.permissions).toStrictEqual({
     actions: 'read',
     contents: 'read',
+    'security-events': 'write',
   });
 });

--- a/.github/tests/reusable-ci-config.test.ts
+++ b/.github/tests/reusable-ci-config.test.ts
@@ -1,0 +1,114 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'yaml';
+
+interface ReusableCallerJob {
+  name?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  secrets?: string | Record<string, unknown>;
+  permissions?: Record<string, string>;
+}
+
+interface WorkflowWithReusableJobs {
+  jobs?: Record<string, ReusableCallerJob>;
+}
+
+// The go-ci.yml SHA every CodesWhat/.github reusable-workflow caller in this
+// repo must be pinned to. Bumping the reusable workflow means bumping this
+// constant and re-verifying every caller in the same change.
+const frozenGoCiSha = '01bf40b06b110946f12a49b82e407d77c6480df7';
+const goCiUses = `CodesWhat/.github/.github/workflows/go-ci.yml@${frozenGoCiSha}`;
+
+const workflowsDir = fileURLToPath(new URL('../workflows', import.meta.url));
+
+function loadWorkflowFiles(): Array<{
+  file: string;
+  path: string;
+  source: string;
+  workflow: WorkflowWithReusableJobs;
+}> {
+  return readdirSync(workflowsDir)
+    .filter((file) => file.endsWith('.yml') || file.endsWith('.yaml'))
+    .sort()
+    .map((file) => {
+      const path = join(workflowsDir, file);
+      const source = readFileSync(path, 'utf8');
+      return {
+        file,
+        path,
+        source,
+        workflow: yaml.parse(source) as WorkflowWithReusableJobs,
+      };
+    });
+}
+
+function reusableCallerJobs(): Array<{
+  file: string;
+  jobId: string;
+  job: ReusableCallerJob;
+}> {
+  return loadWorkflowFiles().flatMap(({ file, workflow }) =>
+    Object.entries(workflow.jobs ?? {})
+      .filter(
+        ([, job]) => typeof job.uses === 'string' && job.uses.startsWith('CodesWhat/.github/'),
+      )
+      .map(([jobId, job]) => ({ file, jobId, job })),
+  );
+}
+
+test('every CodesWhat/.github reusable-workflow caller is pinned to the frozen SHA', () => {
+  const violations = reusableCallerJobs()
+    .filter(({ job }) => job.uses !== goCiUses)
+    .map(({ file, jobId, job }) => `${file}/${jobId} uses ${job.uses}`);
+
+  expect(violations).toStrictEqual([]);
+});
+
+test('no CodesWhat/.github uses ref in source is unpinned or off the frozen SHA', () => {
+  const violations = loadWorkflowFiles().flatMap(({ file, source }) =>
+    source
+      .split('\n')
+      .map((line, index) => ({ line, lineNumber: index + 1 }))
+      .filter(({ line }) => line.includes('CodesWhat/.github/'))
+      .filter(
+        ({ line }) =>
+          !line.includes(`CodesWhat/.github/.github/workflows/go-ci.yml@${frozenGoCiSha}`),
+      )
+      .map(({ lineNumber }) => `${file}:${lineNumber}`),
+  );
+
+  expect(violations).toStrictEqual([]);
+});
+
+test('CodesWhat/.github reusable-workflow callers do not inherit secrets', () => {
+  const violations = reusableCallerJobs()
+    .filter(({ job }) => job.secrets !== undefined)
+    .map(({ file, jobId, job }) => `${file}/${jobId} secrets=${JSON.stringify(job.secrets)}`);
+
+  expect(violations).toStrictEqual([]);
+
+  const inheritLines = loadWorkflowFiles().flatMap(({ file, source }) =>
+    source
+      .split('\n')
+      .map((line, index) => ({ line, lineNumber: index + 1 }))
+      .filter(({ line }) => /secrets:\s*inherit\b/.test(line))
+      .map(({ lineNumber }) => `${file}:${lineNumber}`),
+  );
+
+  expect(inheritLines).toStrictEqual([]);
+});
+
+test('security-actions caller permissions are exactly actions:read and contents:read', () => {
+  const job = reusableCallerJobs().find(
+    ({ file, jobId }) => file === 'ci-verify.yml' && jobId === 'security-actions',
+  )?.job;
+
+  expect(job).toBeDefined();
+  expect(job?.permissions).toStrictEqual({
+    actions: 'read',
+    contents: 'read',
+  });
+});

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -51,36 +51,39 @@ concurrency:
 permissions: {}
 
 jobs:
-  zizmor:
+  security-actions:
     name: "Security: Actions"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
     permissions:
-      contents: read
-      security-events: write
       actions: read
+      contents: read
+    uses: CodesWhat/.github/.github/workflows/go-ci.yml@01bf40b06b110946f12a49b82e407d77c6480df7
+    with:
+      run-workflow-security: true
+      workflow-security-egress-policy: block
+      workflow-security-allowed-endpoints: "ghcr.io:443 github.com:443 pkg-containers.githubusercontent.com:443"
 
+  # Temporary fail-closed bridge: republishes the reusable caller's result
+  # under the old plain "Security: Actions" check context so branch
+  # protection keeps working unchanged during the migration window. Remove
+  # once the ruleset is repointed at "Security: Actions / Workflow Security".
+  legacy-security-actions:
+    name: "Security: Actions"
+    needs: security-actions
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        with:
-          persist-credentials: false
-
-      - name: Run zizmor
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa  # v0.5.7
-        with:
-          version: v1.25.2
-          advanced-security: true
-          token: ${{ github.token }}
+          egress-policy: block
+      - env:
+          RESULT: ${{ needs.security-actions.result }}
+        run: test "${RESULT}" = "success"
 
   secrets:
     name: "🔑 Security: Secrets"
-    needs: [zizmor]
+    needs: [security-actions]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -163,7 +166,7 @@ jobs:
   codeql:
     name: "🛡️ SAST: CodeQL"
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    needs: [zizmor]
+    needs: [security-actions]
     runs-on: ubuntu-latest
     timeout-minutes: 60  # CodeQL init/autobuild/analyze can be long on cache misses
     permissions:
@@ -203,7 +206,7 @@ jobs:
   fuzz:
     name: "🎯 Fuzz Testing"
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    needs: [zizmor]
+    needs: [security-actions]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -53,9 +53,14 @@ permissions: {}
 jobs:
   security-actions:
     name: "Security: Actions"
+    # go-ci.yml's nested codeql job declares security-events: write even
+    # though run-codeql stays unset here — GitHub validates a called
+    # workflow's job-level permissions statically, regardless of if:
+    # gating, so the caller must still grant it.
     permissions:
       actions: read
       contents: read
+      security-events: write
     uses: CodesWhat/.github/.github/workflows/go-ci.yml@01bf40b06b110946f12a49b82e407d77c6480df7
     with:
       run-workflow-security: true

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -61,11 +61,13 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: CodesWhat/.github/.github/workflows/go-ci.yml@01bf40b06b110946f12a49b82e407d77c6480df7
+    uses: CodesWhat/.github/.github/workflows/go-ci.yml@47820bd85d49eb6cd0a935c31789c7d7ce037401
     with:
       run-workflow-security: true
       workflow-security-egress-policy: block
       workflow-security-allowed-endpoints: "ghcr.io:443 github.com:443 pkg-containers.githubusercontent.com:443"
+      run-test: false
+      run-lint: false
 
   # Temporary fail-closed bridge: republishes the reusable caller's result
   # under the old plain "Security: Actions" check context so branch


### PR DESCRIPTION
## Summary
- Replace the inline `zizmor` job in `ci-verify.yml` with a caller job (`security-actions`) into `CodesWhat/.github`'s `go-ci.yml` reusable `workflow-security` gate, pinned at `01bf40b06b110946f12a49b82e407d77c6480df7`.
- Add a temporary fail-closed bridge job (`legacy-security-actions`) that republishes the caller's result under the old plain `Security: Actions` check context, so branch protection keeps working unchanged during the migration window.
- Repoint every job that depended on the removed `zizmor` job (`secrets`, `codeql`, `fuzz`) at `security-actions`.

## Naming resolution
- Caller job: key `security-actions`, `name: "Security: Actions"` → GitHub reports this as the composite context `Security: Actions / Workflow Security` (reusable-workflow-call jobs report as `<caller job name> / <called workflow job name>`).
- Bridge job: key `legacy-security-actions`, `name: "Security: Actions"` → reports as the plain context `Security: Actions`, identical to what the removed inline job published.
- These are two different job keys with the same display `name`, which GitHub allows (job identity for check-run purposes is the job key + workflow, not the display name) and produces two distinct, non-colliding check contexts because one is a reusable-workflow-call job and the other isn't.

## Test plan
- [x] `npm run test:workflows` — 166/166 passing (17 files), including new `.github/tests/reusable-ci-config.test.ts` and extended `ci-verify-workflow.test.ts` / `harden-runner-workflow.test.ts`
- [x] `node --test scripts/*.test.mjs` — passing (ran as part of pre-push hook)
- [x] `npx biome check .` — clean
- [x] Local `zizmor` pre-push hook scan of `.github/workflows/*.yml` — no findings
- [x] Full pre-push hook chain (clean-tree, ts-nocheck, biome, qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, coverage, build, zizmor) — all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- 🔒 Added a pinned `security-actions` reusable workflow caller from `CodesWhat/.github/go-ci.yml`.
- 🔧 Disabled Go test and lint jobs for this Go-less repository.
- ✨ Added a fail-closed `legacy-security-actions` bridge for the existing `Security: Actions` branch-protection context.
- 🔧 Updated `secrets`, `codeql`, and `fuzz` job dependencies.
- 🔒 Required `actions:read`, `contents:read`, and `security-events:write`.
- 🔧 Added validation for workflow pinning, permissions, disabled Go jobs, bridge behavior, and blocked egress.
- 🗑️ Removed the inline `zizmor` job.

## Concerns

- Remove `legacy-security-actions` after branch protection no longer requires `Security: Actions`.
- Keep the frozen `go-ci.yml` SHA synchronized with the approved revision.
- Preserve the fail-closed bridge contract and `egress-policy: block`.
- Confirm the reusable workflow remains compatible with the required `security-events: write` permission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->