### PR TITLE
fix(store): persist updatePolicyRetentionCache across process restart

### DIFF
--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -6,6 +6,7 @@ import { updateContainerFromInspect } from '../watchers/providers/docker/contain
 import { pruneOldContainers } from '../watchers/providers/docker/container-init.js';
 import * as container from './container.js';
 import * as updateLifecycleCacheStore from './update-lifecycle-cache.js';
+import * as updatePolicyRetentionCacheStore from './update-policy-retention-cache.js';
 
 vi.mock('./migrate');
 vi.mock('../event');
@@ -5603,6 +5604,59 @@ describe('updatePolicyRetentionCache carry-forward (#496)', () => {
     return collection;
   }
 
+  function createPolicyRetentionStoreCollection(
+    initialDocs: updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord[] = [],
+  ) {
+    const docs = [...initialDocs];
+    return {
+      findOne: vi.fn(
+        (
+          query: Record<string, unknown>,
+        ): updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord | null =>
+          docs.find((doc) =>
+            Object.entries(query).every(([k, v]) => (doc as Record<string, unknown>)[k] === v),
+          ) ?? null,
+      ),
+      find: vi.fn(
+        (
+          query?: Record<string, unknown>,
+        ): updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord[] => {
+          if (!query || Object.keys(query).length === 0) {
+            return [...docs];
+          }
+          return docs.filter((doc) =>
+            Object.entries(query).every(([k, v]) => (doc as Record<string, unknown>)[k] === v),
+          );
+        },
+      ),
+      insert: vi.fn((doc: updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord) => {
+        docs.push(doc);
+      }),
+      update: vi.fn(),
+      remove: vi.fn((doc: updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord) => {
+        const index = docs.indexOf(doc);
+        if (index !== -1) {
+          docs.splice(index, 1);
+        }
+      }),
+    };
+  }
+
+  function mountPolicyRetentionStore(
+    initialDocs: updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord[] = [],
+  ) {
+    const collection = createPolicyRetentionStoreCollection(initialDocs);
+    updatePolicyRetentionCacheStore.createCollections({
+      getCollection: () => collection,
+      addCollection: () => collection,
+    });
+    return collection;
+  }
+
+  beforeEach(() => {
+    updatePolicyRetentionCacheStore.clearCollectionForTesting();
+  });
+
   test('carries updatePolicy forward across a container recreate (new id, same watcher+name)', () => {
     const oldFixture = makePolicyFixture({
       id: 'policy-old-1',
@@ -5996,6 +6050,121 @@ describe('updatePolicyRetentionCache carry-forward (#496)', () => {
     // preceding replacement-delete must not inherit anything
     const later = container.insertContainer(makePolicyFixture({ id: 'policy-once-later' }));
     expect(later.updatePolicy).toBeUndefined();
+  });
+
+  test('deleteContainer write-throughs the stash to the durable store', () => {
+    mountPolicyRetentionStore();
+    const oldFixture = makePolicyFixture({
+      id: 'policy-durable-old-1',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-durable-old-1', { replacementExpected: true });
+
+    const [record] = updatePolicyRetentionCacheStore.listRecords();
+    expect(record).toMatchObject({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: MATURITY_POLICY,
+    });
+  });
+
+  test('insertContainer deletes the persisted record on a consumed cache hit', () => {
+    mountPolicyRetentionStore();
+    const oldFixture = makePolicyFixture({
+      id: 'policy-durable-old-2',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+    container.deleteContainer('policy-durable-old-2', { replacementExpected: true });
+    expect(updatePolicyRetentionCacheStore.listRecords()).toHaveLength(1);
+
+    container.insertContainer(makePolicyFixture({ id: 'policy-durable-new-2' }));
+
+    expect(updatePolicyRetentionCacheStore.listRecords()).toEqual([]);
+  });
+
+  test('rehydrateUpdatePolicyRetentionCacheFromStore repopulates the in-memory Map from non-expired persisted records only', () => {
+    const nowMs = Date.now();
+    mountPolicyRetentionStore([
+      {
+        cacheKey: '::local::live-app',
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 60_000,
+      },
+      {
+        cacheKey: '::local::expired-app',
+        updatePolicyOverrides: { maturityMode: 'all' },
+        expiresAt: nowMs - 1,
+      },
+    ]);
+
+    container.rehydrateUpdatePolicyRetentionCacheFromStore();
+
+    const policyRetentionCache = container._getUpdatePolicyRetentionCacheForTests();
+    expect(policyRetentionCache.has('::local::live-app')).toBe(true);
+    expect(policyRetentionCache.get('::local::live-app')?.updatePolicyOverrides).toEqual(
+      MATURITY_POLICY,
+    );
+    expect(policyRetentionCache.has('::local::expired-app')).toBe(false);
+  });
+
+  test('rehydrateUpdatePolicyRetentionCacheFromStore prunes expired records from the durable store, not just the in-memory Map', () => {
+    const nowMs = Date.now();
+    mountPolicyRetentionStore([
+      {
+        cacheKey: '::local::live-app-2',
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 60_000,
+      },
+      {
+        cacheKey: '::local::expired-app-2',
+        updatePolicyOverrides: { maturityMode: 'all' },
+        expiresAt: nowMs - 1,
+      },
+    ]);
+
+    container.rehydrateUpdatePolicyRetentionCacheFromStore();
+
+    const persistedKeys = updatePolicyRetentionCacheStore
+      .listRecords()
+      .map((record) => record.cacheKey);
+    expect(persistedKeys).toEqual(['::local::live-app-2']);
+  });
+
+  // #565: unlike the lifecycle/clock cache (#556), updatePolicyRetentionCache never got a
+  // durable write-through store, so a self-update (recreate -> SIGTERM -> new process) lost
+  // the stashed maturity policy even though the clock survived it. This pins the fix.
+  test('end-to-end: a simulated process restart still carries updatePolicy forward', () => {
+    mountPolicyRetentionStore();
+    const oldFixture = makePolicyFixture({
+      id: 'policy-persist-restart-old',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    // 1. Self-update fires: the old container is torn down and its policy overrides are
+    //    stashed into both the in-memory Map and (write-through) the durable store.
+    container.deleteContainer('policy-persist-restart-old', { replacementExpected: true });
+    expect(updatePolicyRetentionCacheStore.listRecords()).toHaveLength(1);
+
+    // 2. SIGTERM: simulate the old process exiting — the in-memory Map is gone, but the
+    //    durable store (our stand-in for the persisted dd.json) survives untouched.
+    container._resetContainerStoreStateForTests();
+    expect(container._getUpdatePolicyRetentionCacheForTests().size).toBe(0);
+
+    // 3. New process boots: store/index.ts's createCollections() would call
+    //    rehydrateUpdatePolicyRetentionCacheFromStore() right after re-creating the
+    //    collections.
+    container.rehydrateUpdatePolicyRetentionCacheFromStore();
+    expect(container._getUpdatePolicyRetentionCacheForTests().has('::local::myapp')).toBe(true);
+
+    // 4. The watcher discovers the replacement container under the same watcher+name —
+    //    insertContainer's Map lookup now hits even though it's a brand-new process.
+    const inserted = container.insertContainer(
+      makePolicyFixture({ id: 'policy-persist-restart-new' }),
+    );
+    expect(inserted.updatePolicy).toEqual(MATURITY_POLICY);
   });
 });
 

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -32,6 +32,7 @@ import {
 } from '../model/update-policy.js';
 import { resolveTriggerLabelValuesPure } from '../watchers/providers/docker/trigger-label-resolution.js';
 import * as updateLifecycleCacheStore from './update-lifecycle-cache.js';
+import * as updatePolicyRetentionCacheStore from './update-policy-retention-cache.js';
 import { initCollection } from './util.js';
 
 let containers: ReturnType<typeof initCollection> | undefined;
@@ -1000,15 +1001,23 @@ function stashUpdatePolicyForReplacement(containerRaw) {
     return;
   }
   updatePolicyRetentionCache.delete(cacheKey);
-  updatePolicyRetentionCache.set(cacheKey, {
+  const entry: UpdatePolicyRetentionCacheEntry = {
     updatePolicyOverrides,
     expiresAt: Date.now() + UPDATE_POLICY_RETENTION_CACHE_TTL_MS,
-  });
+  };
+  updatePolicyRetentionCache.set(cacheKey, entry);
+  // #565: write-through to the durable store so this stash survives the
+  // cross-process recreation that IS drydock's own self-update (recreate
+  // action -> SIGTERM -> shutdown()'s store.save() -> new process ->
+  // rehydrateUpdatePolicyRetentionCacheFromStore()) — the same failure mode
+  // #556 already fixed for the lifecycle/clock cache.
+  updatePolicyRetentionCacheStore.upsertRecord({ cacheKey, ...entry });
   if (updatePolicyRetentionCache.size > UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES) {
     const nowMs = Date.now();
     for (const [expiredKey, expiredEntry] of updatePolicyRetentionCache.entries()) {
       if (expiredEntry.expiresAt <= nowMs) {
         updatePolicyRetentionCache.delete(expiredKey);
+        updatePolicyRetentionCacheStore.deleteRecord(expiredKey);
       }
     }
   }
@@ -1019,6 +1028,7 @@ function stashUpdatePolicyForReplacement(containerRaw) {
       break;
     }
     updatePolicyRetentionCache.delete(oldestKey);
+    updatePolicyRetentionCacheStore.deleteRecord(oldestKey);
   }
 }
 
@@ -1046,6 +1056,7 @@ function restoreRetainedUpdatePolicy(container) {
     return;
   }
   updatePolicyRetentionCache.delete(cacheKey);
+  updatePolicyRetentionCacheStore.deleteRecord(cacheKey);
   if (entry.expiresAt <= Date.now()) {
     return;
   }
@@ -1597,6 +1608,30 @@ export function rehydrateUpdateLifecycleCacheFromStore(): void {
       firstSeenAt: record.firstSeenAt,
       maturityGatePendingSince: record.maturityGatePendingSince,
       resultSignature: record.resultSignature,
+      expiresAt: record.expiresAt,
+    });
+  }
+}
+
+/**
+ * Repopulate the in-memory updatePolicyRetentionCache Map from its durable store
+ * counterpart. Called once at startup (see store/index.ts's createCollections())
+ * after both the containers collection and the update-policy-retention-cache
+ * collection have been created. Drops any record whose TTL already lapsed while
+ * the process was down rather than resurrecting a stale stash (#565).
+ */
+export function rehydrateUpdatePolicyRetentionCacheFromStore(): void {
+  const nowMs = Date.now();
+  for (const record of updatePolicyRetentionCacheStore.listRecords()) {
+    if (record.expiresAt <= nowMs) {
+      // Prune expired records from the durable store too, not just skip them —
+      // otherwise a long-stopped process leaves dead rows in the collection
+      // forever (it only ever grows via the write-through path elsewhere).
+      updatePolicyRetentionCacheStore.deleteRecord(record.cacheKey);
+      continue;
+    }
+    updatePolicyRetentionCache.set(record.cacheKey, {
+      updatePolicyOverrides: record.updatePolicyOverrides as container.ContainerUpdatePolicy,
       expiresAt: record.expiresAt,
     });
   }

--- a/app/store/index.test.ts
+++ b/app/store/index.test.ts
@@ -56,6 +56,7 @@ const {
       getContainersRaw: vi.fn(() => []),
       updateContainer: vi.fn(),
       rehydrateUpdateLifecycleCacheFromStore: vi.fn(),
+      rehydrateUpdatePolicyRetentionCacheFromStore: vi.fn(),
       ...overrides,
     };
   }
@@ -153,6 +154,7 @@ vi.mock('./settings', createCollectionsMock);
 vi.mock('./ui-preferences', createCollectionsMock);
 vi.mock('./update-lifecycle-cache', createCollectionsMock);
 vi.mock('./update-operation', createCollectionsMock);
+vi.mock('./update-policy-retention-cache', createCollectionsMock);
 vi.mock('../log', createLogMock);
 
 describe('Store Module', () => {
@@ -187,6 +189,7 @@ describe('Store Module', () => {
     const uiPreferences = await import('./ui-preferences.js');
     const updateLifecycleCache = await import('./update-lifecycle-cache.js');
     const updateOperation = await import('./update-operation.js');
+    const updatePolicyRetentionCache = await import('./update-policy-retention-cache.js');
 
     expect(app.createCollections).toHaveBeenCalled();
     expect(container.createCollections).toHaveBeenCalled();
@@ -211,6 +214,20 @@ describe('Store Module', () => {
     );
     expect(
       container.rehydrateUpdateLifecycleCacheFromStore.mock.invocationCallOrder[0],
+    ).toBeLessThan(app.completeStartupInitialization.mock.invocationCallOrder[0]);
+
+    // #565: same rationale as #556 above, for the update-policy retention cache — the
+    // collection must exist, and container's in-memory Map must be rehydrated from it,
+    // before startup is considered complete.
+    expect(updatePolicyRetentionCache.createCollections).toHaveBeenCalled();
+    expect(container.createCollections.mock.invocationCallOrder[0]).toBeLessThan(
+      updatePolicyRetentionCache.createCollections.mock.invocationCallOrder[0],
+    );
+    expect(updatePolicyRetentionCache.createCollections.mock.invocationCallOrder[0]).toBeLessThan(
+      container.rehydrateUpdatePolicyRetentionCacheFromStore.mock.invocationCallOrder[0],
+    );
+    expect(
+      container.rehydrateUpdatePolicyRetentionCacheFromStore.mock.invocationCallOrder[0],
     ).toBeLessThan(app.completeStartupInitialization.mock.invocationCallOrder[0]);
   });
 

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -25,6 +25,7 @@ import * as settings from './settings.js';
 import * as uiPreferences from './ui-preferences.js';
 import * as updateLifecycleCacheStore from './update-lifecycle-cache.js';
 import * as updateOperation from './update-operation.js';
+import * as updatePolicyRetentionCacheStore from './update-policy-retention-cache.js';
 
 // Store Configuration Schema
 const configurationSchema = joi.object().keys({
@@ -69,6 +70,11 @@ function createCollections() {
   // repopulates container.ts's in-memory Map from it.
   updateLifecycleCacheStore.createCollections(db);
   container.rehydrateUpdateLifecycleCacheFromStore();
+  // #565: same rationale as #556 above, for the update-policy retention cache —
+  // the collection must exist before rehydration repopulates container.ts's
+  // in-memory Map from it.
+  updatePolicyRetentionCacheStore.createCollections(db);
+  container.rehydrateUpdatePolicyRetentionCacheFromStore();
   nameBindings.createCollections(db);
   notification.createCollections(db);
   notificationHistory.createCollections(db);

--- a/app/store/update-policy-retention-cache.test.ts
+++ b/app/store/update-policy-retention-cache.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the update-policy-retention-cache store — the durable backing for
+ * container.ts's in-memory updatePolicyRetentionCache Map (#565).
+ */
+import * as updatePolicyRetentionCache from './update-policy-retention-cache.js';
+
+function createMockCollection(
+  initialDocs: updatePolicyRetentionCache.UpdatePolicyRetentionCacheRecord[] = [],
+) {
+  const docs = [...initialDocs];
+  return {
+    docs,
+    findOne: vi.fn(
+      (
+        query: Record<string, unknown>,
+      ): updatePolicyRetentionCache.UpdatePolicyRetentionCacheRecord | null => {
+        const match = docs.find((doc) => {
+          return Object.entries(query).every(([k, v]) => (doc as Record<string, unknown>)[k] === v);
+        });
+        return match ?? null;
+      },
+    ),
+    find: vi.fn(
+      (
+        query?: Record<string, unknown>,
+      ): updatePolicyRetentionCache.UpdatePolicyRetentionCacheRecord[] => {
+        if (!query || Object.keys(query).length === 0) {
+          return [...docs];
+        }
+        return docs.filter((doc) =>
+          Object.entries(query).every(([k, v]) => (doc as Record<string, unknown>)[k] === v),
+        );
+      },
+    ),
+    insert: vi.fn((doc: updatePolicyRetentionCache.UpdatePolicyRetentionCacheRecord) => {
+      docs.push(doc);
+    }),
+    update: vi.fn(),
+    remove: vi.fn((doc: updatePolicyRetentionCache.UpdatePolicyRetentionCacheRecord) => {
+      const index = docs.indexOf(doc);
+      if (index !== -1) {
+        docs.splice(index, 1);
+      }
+    }),
+  };
+}
+
+function createMockDb(collection = createMockCollection()) {
+  return {
+    getCollection: vi.fn(() => collection),
+    addCollection: vi.fn(() => collection),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updatePolicyRetentionCache.clearCollectionForTesting();
+});
+
+describe('createCollections', () => {
+  test('uses existing collection when present', () => {
+    const collection = createMockCollection();
+    const db = createMockDb(collection);
+    updatePolicyRetentionCache.createCollections(db);
+    expect(db.addCollection).not.toHaveBeenCalled();
+  });
+
+  test('creates collection when not present', () => {
+    const collection = createMockCollection();
+    const db = {
+      getCollection: vi.fn(() => null),
+      addCollection: vi.fn(() => collection),
+    };
+    updatePolicyRetentionCache.createCollections(db);
+    expect(db.addCollection).toHaveBeenCalled();
+  });
+});
+
+describe('upsertRecord', () => {
+  test('inserts a new record when none exists for the cacheKey', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'mature', maturityMinAgeDays: 5 },
+      expiresAt: 1_000,
+    });
+
+    expect(collection.insert).toHaveBeenCalledWith({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'mature', maturityMinAgeDays: 5 },
+      expiresAt: 1_000,
+    });
+    expect(updatePolicyRetentionCache.listRecords()).toHaveLength(1);
+  });
+
+  test('updates fields in place on a second call for the same cacheKey', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'mature' },
+      expiresAt: 1_000,
+    });
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'all' },
+      expiresAt: 2_000,
+    });
+
+    expect(collection.insert).toHaveBeenCalledTimes(1);
+    expect(collection.update).toHaveBeenCalledTimes(1);
+    const [record] = updatePolicyRetentionCache.listRecords();
+    expect(record.updatePolicyOverrides).toEqual({ maturityMode: 'all' });
+    expect(record.expiresAt).toBe(2_000);
+  });
+
+  test('is a no-op when the collection has not been initialized', () => {
+    expect(() =>
+      updatePolicyRetentionCache.upsertRecord({
+        cacheKey: '::local::myapp',
+        updatePolicyOverrides: {},
+        expiresAt: 1_000,
+      }),
+    ).not.toThrow();
+    expect(updatePolicyRetentionCache.listRecords()).toEqual([]);
+  });
+});
+
+describe('deleteRecord', () => {
+  test('removes the record for the given cacheKey', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'mature' },
+      expiresAt: 1_000,
+    });
+
+    updatePolicyRetentionCache.deleteRecord('::local::myapp');
+
+    expect(collection.remove).toHaveBeenCalledTimes(1);
+    expect(updatePolicyRetentionCache.listRecords()).toEqual([]);
+  });
+
+  test('is a no-op when no record exists for the cacheKey', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+
+    expect(() => updatePolicyRetentionCache.deleteRecord('never-stashed')).not.toThrow();
+    expect(collection.remove).not.toHaveBeenCalled();
+  });
+
+  test('is a no-op when the collection has not been initialized', () => {
+    expect(() => updatePolicyRetentionCache.deleteRecord('::local::myapp')).not.toThrow();
+  });
+});
+
+describe('listRecords', () => {
+  test('returns an empty array when the collection has not been initialized', () => {
+    expect(updatePolicyRetentionCache.listRecords()).toEqual([]);
+  });
+
+  test('returns every persisted record', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::app-1',
+      updatePolicyOverrides: { maturityMode: 'mature' },
+      expiresAt: 1_000,
+    });
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::app-2',
+      updatePolicyOverrides: { maturityMode: 'all' },
+      expiresAt: 2_000,
+    });
+
+    expect(updatePolicyRetentionCache.listRecords()).toHaveLength(2);
+  });
+});
+
+describe('clearCollectionForTesting', () => {
+  test('resets the module back to the uninitialized state', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'mature' },
+      expiresAt: 1_000,
+    });
+    expect(updatePolicyRetentionCache.listRecords()).toHaveLength(1);
+
+    updatePolicyRetentionCache.clearCollectionForTesting();
+
+    expect(updatePolicyRetentionCache.listRecords()).toEqual([]);
+    expect(() =>
+      updatePolicyRetentionCache.upsertRecord({
+        cacheKey: '::local::myapp',
+        updatePolicyOverrides: { maturityMode: 'mature' },
+        expiresAt: 1_000,
+      }),
+    ).not.toThrow();
+    expect(updatePolicyRetentionCache.listRecords()).toEqual([]); // still a no-op post-clear
+  });
+});

--- a/app/store/update-policy-retention-cache.ts
+++ b/app/store/update-policy-retention-cache.ts
@@ -1,0 +1,103 @@
+/**
+ * Persisted update-policy retention cache: survives drydock's own container recreation.
+ *
+ * Backs the in-memory `updatePolicyRetentionCache` Map in app/store/container.ts — the
+ * cache that lets a recreated container inherit its predecessor's updatePolicyOverrides
+ * (maturity mode, min-days, skip list, snooze) instead of losing them. Mirrors
+ * update-lifecycle-cache.ts: one LokiJS collection, loaded/autosaved by the shared
+ * store, one document per cache entry.
+ *
+ * Without this, the cache lived only in a bare process-memory Map — wiped on every
+ * restart, including the SIGTERM-driven restart that IS drydock's own self-update
+ * (recreate action -> SIGTERM -> shutdown() -> store.save() -> process.exit ->
+ * new process). Every self-update therefore lost the stash before the replacement
+ * container could consume it, silently dropping controller-set update policy (#565).
+ * Persisting the cache means a restarted process still has the stash before the
+ * replacement container is discovered.
+ */
+import { initCollection } from './util.js';
+
+export interface UpdatePolicyRetentionCacheRecord {
+  cacheKey: string; // deriveContainerIdentityKey() — same key the in-memory Map uses
+  updatePolicyOverrides: unknown;
+  expiresAt: number; // epoch ms — same TTL semantics as the in-memory Map
+}
+
+interface UpdatePolicyRetentionCacheCollection {
+  findOne(query: Record<string, unknown>): UpdatePolicyRetentionCacheRecord | null;
+  find(query?: Record<string, unknown>): UpdatePolicyRetentionCacheRecord[];
+  insert(document: UpdatePolicyRetentionCacheRecord): void;
+  update(document: UpdatePolicyRetentionCacheRecord): void;
+  remove(document: UpdatePolicyRetentionCacheRecord): void;
+}
+
+interface UpdatePolicyRetentionCacheStoreDb {
+  getCollection(name: string): UpdatePolicyRetentionCacheCollection | null;
+  addCollection(
+    name: string,
+    options?: Record<string, unknown>,
+  ): UpdatePolicyRetentionCacheCollection;
+}
+
+let updatePolicyRetentionCacheCollection: UpdatePolicyRetentionCacheCollection | undefined;
+
+/**
+ * Create the update-policy-retention-cache collection.
+ * @param db
+ */
+export function createCollections(db: UpdatePolicyRetentionCacheStoreDb): void {
+  updatePolicyRetentionCacheCollection = initCollection(db, 'update-policy-retention-cache', {
+    indices: ['cacheKey'],
+  }) as UpdatePolicyRetentionCacheCollection;
+}
+
+/**
+ * Insert or update the persisted record for record.cacheKey.
+ * A no-op (rather than a throw) when the collection has not been initialized
+ * yet — callers (container.ts) run this on every replacement-expected
+ * deleteContainer and must not fail the stash just because the durable store
+ * isn't wired up (e.g. in unit tests that only exercise the in-memory cache).
+ */
+export function upsertRecord(record: UpdatePolicyRetentionCacheRecord): void {
+  if (!updatePolicyRetentionCacheCollection) {
+    return;
+  }
+  const existing = updatePolicyRetentionCacheCollection.findOne({ cacheKey: record.cacheKey });
+  if (existing) {
+    existing.updatePolicyOverrides = record.updatePolicyOverrides;
+    existing.expiresAt = record.expiresAt;
+    updatePolicyRetentionCacheCollection.update(existing);
+    return;
+  }
+  updatePolicyRetentionCacheCollection.insert(record);
+}
+
+/**
+ * Delete the persisted record for cacheKey, if any.
+ */
+export function deleteRecord(cacheKey: string): void {
+  if (!updatePolicyRetentionCacheCollection) {
+    return;
+  }
+  const existing = updatePolicyRetentionCacheCollection.findOne({ cacheKey });
+  if (existing) {
+    updatePolicyRetentionCacheCollection.remove(existing);
+  }
+}
+
+/**
+ * List every persisted record. Used once at startup to rehydrate the in-memory
+ * updatePolicyRetentionCache Map — see
+ * rehydrateUpdatePolicyRetentionCacheFromStore() in container.ts.
+ */
+export function listRecords(): UpdatePolicyRetentionCacheRecord[] {
+  if (!updatePolicyRetentionCacheCollection) {
+    return [];
+  }
+  return updatePolicyRetentionCacheCollection.find();
+}
+
+/** Exposed for tests to reset module state between cases. */
+export function clearCollectionForTesting(): void {
+  updatePolicyRetentionCacheCollection = undefined;
+}


### PR DESCRIPTION
## Summary
- Round 3 of the #565 thread: a controller self-update (recreate -> SIGTERM -> new process) still wiped stashed maturity-policy overrides for a replacement container, even though the sibling lifecycle/clock cache (`updateLifecycleCache`) already survives the same restart per #556.
- `updatePolicyRetentionCache` only ever lived in a bare in-memory `Map`, so `stashUpdatePolicyForReplacement()`'s stash was gone before the replacement container's `insertContainer()` call could consume it in the new process.
- Gives `updatePolicyRetentionCache` the same durable, write-through-backed collection `updateLifecycleCache` already has: a new `app/store/update-policy-retention-cache.ts` module, write-through on stash, delete-on-consume, and `rehydrateUpdatePolicyRetentionCacheFromStore()` wired into `store/index.ts` startup before the first `insertContainer` runs.
- Does not touch the round-1 (clock-restart, #568) or round-2 (empty-override-authoritative, #624) fixes, which are already correct.
- The remaining half of the report — policy loss from a pure 0-container remote-agent handshake with no controller restart — isn't explained by this fix. The existing zero-container handshake path already skips `pruneOldContainers`/`deleteContainer` entirely, so that part needs more repro detail from the reporter before a second root cause can be pinned down.

## Test plan
- [x] `npx vitest run store/container.test.ts store/index.test.ts store/update-lifecycle-cache.test.ts store/update-policy-retention-cache.test.ts` — new "simulated process restart" test pins the fix; also new dedicated unit tests for the new store module and wiring-order assertions in `store/index.test.ts`
- [x] `npm test` in `app/` — 12907 tests pass, 100% coverage
- [x] `npx tsc --noEmit` and `npx biome check .` clean
- [x] Pre-push hooks (biome, qlty, workflow-tests, typecheck-ui, coverage, build) all green

Fixes: #565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added a durable LokiJS-backed store for update-policy retention records.
- 🔧 Changed `updatePolicyRetentionCache` to write through to persistent storage.
- 🔧 Changed cache consumption, expiration, and size eviction to delete persistent records.
- 🔧 Changed startup to rehydrate unexpired records before the first `insertContainer` call.
- 🐛 Fixed maturity-policy overrides being lost during controller process restarts.
- ✨ Added tests for persistence, rehydration, expiration pruning, eviction, deletion, and startup ordering.

## Concerns

- Verify behavior during zero-container remote-agent handshakes without a controller restart. This PR does not cover that loss path.
- Verify the new store follows existing store initialization and persistence conventions.
- Review whether `unknown` for `updatePolicyOverrides` preserves the required type safety.
- Check whether cache persistence and rehydration logic duplicates existing store utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->