### PR TITLE
ci(verify): remove legacy security-actions bridge

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -45,11 +45,36 @@ function getTestJobStep(name: string): WorkflowStep | undefined {
 test('required ci-verify jobs publish stable plain-text check names', () => {
   const workflow = loadWorkflow();
 
-  expect(workflow.jobs?.['legacy-security-actions']?.name).toBe('Security: Actions');
   expect(workflow.jobs?.lint?.name).toBe('Quality: Lint');
   expect(workflow.jobs?.test?.name).toBe('Quality: Test & Coverage');
   expect(workflow.jobs?.build?.name).toBe('Build');
   expect(workflow.jobs?.e2e?.name).toBe('E2E: Cucumber');
+});
+
+test('the retired "legacy-security-actions" bridge job and its plain check name stay removed', () => {
+  const workflow = loadWorkflow();
+  const source = readFileSync(workflowPath, 'utf8');
+
+  // Ruleset 13077055 was narrowed to require the composite "Security: Actions
+  // / Workflow Security" context directly, so the fail-closed bridge that
+  // republished the old plain "Security: Actions" context is gone.
+  expect(workflow.jobs?.['legacy-security-actions']).toBeUndefined();
+
+  // No job may republish the retired plain "Security: Actions" context. The
+  // security-actions caller's own name: field legitimately reads "Security:
+  // Actions" too -- for a `uses:` job GitHub only ever consumes it as the
+  // "<caller name> / <called job name>" composite prefix, never as a
+  // standalone check -- so it's the one expected exception here.
+  const otherJobsWithBareName = Object.entries(workflow.jobs ?? {}).filter(
+    ([jobId, job]) => jobId !== 'security-actions' && job?.name === 'Security: Actions',
+  );
+  expect(otherJobsWithBareName).toStrictEqual([]);
+
+  // Anchored to `name:` at (optionally indented) line-start with optional
+  // quotes so this can't false-positive on an input key that merely ends in
+  // "name:", e.g. `workflow-security-check-name: Security: Actions`.
+  const bareNameLines = [...source.matchAll(/^[ \t]*name:\s*["']?Security: Actions["']?\s*$/gmu)];
+  expect(bareNameLines).toHaveLength(1);
 });
 
 test('security-actions calls the reusable go-ci workflow-security gate', () => {

--- a/.github/tests/harden-runner-workflow.test.ts
+++ b/.github/tests/harden-runner-workflow.test.ts
@@ -28,12 +28,6 @@ function loadWorkflowFiles(): Array<{
     });
 }
 
-// legacy-security-actions is a temporary fail-closed bridge job: it only
-// republishes ci-verify.yml's security-actions result under the old plain
-// check name and makes no outbound calls of its own, so it runs with
-// egress-policy: block instead of the audit policy every other job uses.
-const blockEgressJobs = new Set(['ci-verify.yml/legacy-security-actions']);
-
 test('GitHub-hosted workflow jobs start with current pinned Harden Runner', () => {
   const violations: string[] = [];
 
@@ -49,33 +43,13 @@ test('GitHub-hosted workflow jobs start with current pinned Harden Runner', () =
         continue;
       }
 
-      const expectedEgressPolicy = blockEgressJobs.has(`${file}/${jobId}`) ? 'block' : 'audit';
-      if (firstStep.with?.['egress-policy'] !== expectedEgressPolicy) {
-        violations.push(`${file}/${jobId} missing ${expectedEgressPolicy} egress policy`);
+      if (firstStep.with?.['egress-policy'] !== 'audit') {
+        violations.push(`${file}/${jobId} missing audit egress policy`);
       }
     }
   }
 
   expect(violations).toStrictEqual([]);
-});
-
-test('legacy-security-actions bridge runs Harden Runner in fail-closed mode', () => {
-  const ciVerify = loadWorkflowFiles().find(({ file }) => file === 'ci-verify.yml');
-  const job = ciVerify?.workflow.jobs?.['legacy-security-actions'];
-  const firstStep = job?.steps?.[0];
-
-  expect(firstStep?.uses).toBe(hardenRunnerRef);
-  expect(firstStep?.with?.['egress-policy']).toBe('block');
-
-  // Fail-closed contract: the bridge must always run (even when the caller
-  // fails or is skipped) and must convert anything but caller success into
-  // its own failure, so the plain "Security: Actions" context never goes
-  // green on a failed or skipped security scan.
-  expect(job?.needs).toBe('security-actions');
-  expect(job?.if).toBe('${{ always() }}');
-  const gateStep = job?.steps?.find((step) => step.run?.includes('test "${RESULT}"'));
-  expect(gateStep?.env?.RESULT).toBe('${{ needs.security-actions.result }}');
-  expect(gateStep?.run?.trim()).toBe('test "${RESULT}" = "success"');
 });
 
 test('Harden Runner comments match the pinned release version', () => {

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -69,25 +69,6 @@ jobs:
       run-test: false
       run-lint: false
 
-  # Temporary fail-closed bridge: republishes the reusable caller's result
-  # under the old plain "Security: Actions" check context so branch
-  # protection keeps working unchanged during the migration window. Remove
-  # once the ruleset is repointed at "Security: Actions / Workflow Security".
-  legacy-security-actions:
-    name: "Security: Actions"
-    needs: security-actions
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions: {}
-    steps:
-      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
-        with:
-          egress-policy: block
-      - env:
-          RESULT: ${{ needs.security-actions.result }}
-        run: test "${RESULT}" = "success"
-
   secrets:
     name: "🔑 Security: Secrets"
     needs: [security-actions]


### PR DESCRIPTION
## Summary
- Ruleset 13077055 was narrowed to require `Security: Actions / Workflow Security` (the reusable go-ci caller's composite context) instead of the old plain `Security: Actions` context. The `legacy-security-actions` fail-closed bridge job in `.github/workflows/ci-verify.yml`, which existed only to republish the old plain name, is now unreferenced by branch protection and has been removed.
- Updated `.github/tests/ci-verify-workflow.test.ts` to drop the assertion on the removed job's name and add a retired-context rejection test (mirrors portwing #122 / sockguard #260): asserts the `legacy-security-actions` job is gone and that no job (other than the legitimate `security-actions` reusable caller, whose `name:` field is the composite prefix, not a standalone check) republishes the bare `Security: Actions` name. The regex is anchored to `^[ \t]*name:` with optional quotes so it can't false-positive on an input key like `workflow-security-check-name:`.
- Updated `.github/tests/harden-runner-workflow.test.ts` to drop the block-egress carve-out and dedicated bridge test that only existed for the removed job; every remaining Harden Runner step now uses the standard `audit` policy.

## Test plan
- [x] `npm run test:workflows` — 167/167 pass
- [x] Full `git push` pre-push gate (clean-tree, ts-nocheck, biome, qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, coverage, build, zizmor) — all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🗑️ Removed the obsolete `legacy-security-actions` bridge job from `.github/workflows/ci-verify.yml`.
- 🔧 Updated workflow tests to reject the retired job and bare `Security: Actions` check context.
- 🔒 Removed the Harden Runner egress-policy exception for the bridge job.
- 🔧 Removed the bridge-specific Harden Runner test.
- 🔧 Verified workflow tests and the full pre-push gate pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->