### PR TITLE
test(workflows): exclude nested worktrees from vitest discovery

### DIFF
--- a/.github/tests/vitest.config.mjs
+++ b/.github/tests/vitest.config.mjs
@@ -1,7 +1,15 @@
+import { configDefaults } from 'vitest/config';
+
 export default {
   test: {
     globals: true,
     environment: 'node',
     fileParallelism: false,
+    // Preserved git worktrees live under .claude/worktrees/ (and legacy
+    // .codex/worktrees/) inside the repo; without this exclude, `vitest run
+    // .github/tests` from the primary checkout also discovers every nested
+    // worktree's copy of the suite, so a parked WIP worktree can fail the
+    // pre-push hook for unrelated pushes.
+    exclude: [...configDefaults.exclude, '**/.claude/**', '**/.codex/**'],
   },
 };


### PR DESCRIPTION
The primary checkout's pre-push workflow-tests gate runs `vitest run .github/tests`, which also discovers every nested preserved worktree's copy of the suite under `.claude/worktrees/` (and legacy `.codex/worktrees/`). A parked WIP worktree with intentionally-failing tests (e.g. the held Warpchart README branch awaiting its Crowdin cycle) then blocks unrelated pushes from the primary checkout, including branch deletions. Exclude those paths from discovery; each worktree still runs its own suite from its own root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changelog

- ✨ Added Vitest exclusions for `.claude/worktrees/` and `.codex/worktrees/`.
- 🔧 Changed the configuration to extend `configDefaults.exclude`.
- 🐛 Fixed test discovery in the primary checkout by ignoring nested preserved worktrees.

### Concerns

- Verify that each worktree runs Vitest from its own root and is not excluded by these patterns.
- Add or update tests for both worktree paths if coverage is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->