### PR TITLE
test(configuration): restore digest-pinned node base image guard

### DIFF
--- a/app/configuration/dockerfile-defaults.test.ts
+++ b/app/configuration/dockerfile-defaults.test.ts
@@ -7,6 +7,14 @@ describe('Dockerfile release defaults', () => {
     expect(dockerfile).toMatch(/FROM base AS release\s+ENV DD_LOG_FORMAT=text/u);
   });
 
+  test('release image builds from the digest-pinned Node base image', () => {
+    const dockerfile = fs.readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
+
+    expect(dockerfile).toContain(
+      'FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS base',
+    );
+  });
+
   test('release image copies Trivy from the digest-pinned multi-arch image', () => {
     const dockerfile = fs.readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
 


### PR DESCRIPTION
## Summary
- The regression test `release image builds from the digest-pinned Node base image` in `app/configuration/dockerfile-defaults.test.ts` was silently dropped at a70d406e ("chore(release): promote v1.7.0-rc.1 to main"). Restored it exactly as it read at a70d406e^.
- No digest bump: the Dockerfile still pins `node:24-alpine@sha256:d32cdf6...`, and resolving the `node:24-alpine` tag against Docker Hub's registry API confirms that digest is still current, so there's no newer image to move to (and no basis to link this to CVE-2026-58055/nghttp2-libs at this time).

## Test plan
- [x] `npx vitest run configuration/dockerfile-defaults.test.ts` — 5 passed
- [x] `npm run lint` (biome) — clean
- [x] `git push` — full pre-push hook chain (biome, qlty, coverage 100%, build) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added a regression test for the digest-pinned `node:24-alpine` base image in `app/configuration/dockerfile-defaults.test.ts`.
- 🐛 Fixed missing coverage for release image builds after the v1.7.0-rc.1 promotion.

## Validation

- Vitest passed.
- Biome linting passed.
- Pre-push checks passed.
- Coverage passed.
- Build passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->