### PR TITLE
fix(ui): guard container view against remote property injection

### DIFF
--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -858,14 +858,18 @@ watch(
 );
 
 function normalizeQueryRecord(query: Record<string, unknown>): Record<string, string> {
-  const normalized: Record<string, string> = {};
+  // Route query keys originate from the URL and are therefore untrusted. Accumulate
+  // them in a Map (rather than writing `record[key] = value` on a plain object) so no
+  // dynamically-named property write can ever reach the object literal's prototype
+  // chain, then materialize the result in one shot via Object.fromEntries.
+  const normalized = new Map<string, string>();
   for (const [key, value] of Object.entries(query)) {
     const normalizedValue = firstQueryValue(value);
     if (normalizedValue !== undefined) {
-      normalized[key] = normalizedValue;
+      normalized.set(key, normalizedValue);
     }
   }
-  return normalized;
+  return Object.fromEntries(normalized);
 }
 
 function buildSyncedRouteQuery(): Record<string, string> {

--- a/ui/tests/views/ContainersView.spec.ts
+++ b/ui/tests/views/ContainersView.spec.ts
@@ -925,6 +925,52 @@ describe('ContainersView', () => {
     });
   });
 
+  describe('remote property injection guard (CodeQL #556)', () => {
+    // JSON.parse creates own data properties (CreateDataProperty), which is the only
+    // reliable way to construct an object with a literal "__proto__" key in a test —
+    // the `{ __proto__: ... }` object-literal syntax is special-cased by the engine and
+    // would silently no-op instead of reproducing what a malicious URL query string
+    // parses into.
+    function maliciousRouteQuery(): Record<string, unknown> {
+      return JSON.parse('{"__proto__":"polluted","normalKey":"kept"}');
+    }
+
+    it('normalizeQueryRecord does not let a "__proto__" query key alter Object.prototype', async () => {
+      const wrapper = await mountContainersView([makeContainer()]);
+      const vm = wrapper.vm as any;
+
+      const normalized = vm.normalizeQueryRecord(maliciousRouteQuery());
+
+      // The real prototype chain is untouched — no denial-of-service via a poisoned
+      // Object.prototype.
+      expect(Object.getPrototypeOf(normalized)).toBe(Object.prototype);
+      expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+
+      // The attacker-controlled key still round-trips as an inert own data property
+      // (never as a prototype mutation), and legitimate keys are preserved untouched.
+      const protoDescriptor = Object.getOwnPropertyDescriptor(normalized, '__proto__');
+      expect(protoDescriptor?.value).toBe('polluted');
+      expect(normalized.normalKey).toBe('kept');
+    });
+
+    it('does not pollute Object.prototype when syncing a malicious route query to the URL', async () => {
+      mockRoute.query = maliciousRouteQuery();
+      await mountContainersView([makeContainer()]);
+
+      mockFilterSearch.value = 'nginx';
+      await flushPromises();
+
+      expect(mockRouterReplace).toHaveBeenCalled();
+      const lastCall = mockRouterReplace.mock.calls.at(-1)?.[0];
+      const nextQuery = lastCall?.query as Record<string, unknown>;
+
+      expect(Object.getPrototypeOf(nextQuery)).toBe(Object.prototype);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(Object.hasOwn(nextQuery, '__proto__')).toBe(true);
+      expect(nextQuery.normalKey).toBe('kept');
+    });
+  });
+
   describe('collapsed filter summary', () => {
     it('shows active filter chips when filters are collapsed', async () => {
       const wrapper = await mountContainersView([


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #556 (`js/remote-property-injection`, CWE-250/CWE-400) in `ui/src/views/ContainersView.vue`.

- **Sink**: `normalizeQueryRecord()` copied `route.query` into a plain `Record<string, string>` via `normalized[key] = normalizedValue`, where `key` comes directly from the URL query string (`Object.entries(route.query)`). CodeQL flags any dynamically-computed property name write reached from a remote/URL-controlled value, regardless of the target object's shape — the alert pointed at two call sites that flow into this same write (`buildSyncedRouteQuery` and `syncRouteQueryFromState`).
- **Fix**: accumulate the normalized entries in a `Map<string, string>` instead of writing onto a plain object with bracket notation, then materialize the result in one shot with `Object.fromEntries(map)`. `Map.set` and `Object.fromEntries` are method calls, not syntactic property writes, so there's no `obj[dynamicKey] = value` pattern for the sink to match. `Object.fromEntries` also uses `CreateDataProperty` semantics rather than `[[Set]]`, so even an attacker-chosen key like `__proto__` lands as an inert own data property instead of mutating the object's actual prototype chain — closing the underlying vulnerability class, not just satisfying the checker.
- No suppression comments were used; this is a root-cause fix, and behavior for legitimate query keys is unchanged (verified by existing + new tests).

## Test plan

- [x] Added `ui/tests/views/ContainersView.spec.ts` → `describe('remote property injection guard (CodeQL #556)')`:
  - unit-tests `normalizeQueryRecord` directly with a malicious `"__proto__"` query key (constructed via `JSON.parse` so it's a real own property, since object-literal `{ __proto__: ... }` syntax is special-cased and would silently no-op) and asserts `Object.prototype` is untouched while the legitimate key is preserved.
  - exercises the full `route.query` → `router.replace` sync path with the same malicious query and asserts the emitted query object still has a normal prototype and no global pollution occurred.
- [x] `cd ui && npx vitest run tests/views/ContainersView.spec.ts` — 164 tests pass (162 existing + 2 new).
- [x] `cd ui && npm run lint` — clean.
- [x] `cd ui && npm run typecheck` — clean.
- [x] `git push` — full pre-push hook suite passed (biome, qlty, qlty-smells, coverage @ 100% for app+ui, app+ui build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔒 **Security:** Prevent prototype pollution from attacker-controlled query keys in `normalizeQueryRecord()`.
- 🔧 **Changed:** Normalize query entries with `Map<string, string>` and `Object.fromEntries`.
- ✨ **Added:** Regression tests for `__proto__` normalization and route-query synchronization.
- 🔧 **Changed:** Verify legitimate query keys remain intact and `Object.prototype` remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->