### PR TITLE
feat(triggers): add onauto auto mode and dd.action.auto label plumbing

### DIFF
--- a/app/model/container.ts
+++ b/app/model/container.ts
@@ -211,6 +211,8 @@ export interface Container {
   actionTriggerExclude?: string;
   notificationTriggerInclude?: string;
   notificationTriggerExclude?: string;
+  /** Action category only — no notification counterpart, no deprecated mirror. */
+  actionTriggerAuto?: string;
   /** @deprecated compat mirror for /api/v1, persisted store, and mixed-version agents. */
   triggerInclude?: string;
   /** @deprecated compat mirror. */
@@ -367,6 +369,7 @@ const schema = joi.object({
   actionTriggerExclude: joi.string(),
   notificationTriggerInclude: joi.string(),
   notificationTriggerExclude: joi.string(),
+  actionTriggerAuto: joi.string(),
   triggerInclude: joi.string(),
   triggerExclude: joi.string(),
   dependsOn: joi.array().items(joi.string()).optional(),

--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -220,6 +220,29 @@ describe('category-scoped trigger label normalization (#494)', () => {
 
     expect(saved.triggerInclude).toBe('docker');
   });
+
+  test('derives actionTriggerAuto from dd.action.auto (no mirror to fall back to)', () => {
+    const saved = saveAndCapture({
+      labels: { 'dd.action.auto': 'docker:patch' },
+    });
+
+    expect(saved.actionTriggerAuto).toBe('docker:patch');
+  });
+
+  test('leaves actionTriggerAuto unset when there are no labels', () => {
+    const saved = saveAndCapture({ labels: undefined });
+
+    expect(saved.actionTriggerAuto).toBeUndefined();
+  });
+
+  test('never overwrites an already-populated actionTriggerAuto field', () => {
+    const saved = saveAndCapture({
+      labels: { 'dd.action.auto': 'docker:patch' },
+      actionTriggerAuto: 'explicit',
+    });
+
+    expect(saved.actionTriggerAuto).toBe('explicit');
+  });
 });
 
 test('updateContainer should use collection update when available for existing containers', async () => {

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -30,6 +30,7 @@ import {
   applyUpdatePolicyOverrides,
   getUpdatePolicyOverrides,
 } from '../model/update-policy.js';
+import { ddActionAuto } from '../watchers/providers/docker/label.js';
 import { resolveTriggerLabelValuesPure } from '../watchers/providers/docker/trigger-label-resolution.js';
 import * as updateLifecycleCacheStore from './update-lifecycle-cache.js';
 import * as updatePolicyRetentionCacheStore from './update-policy-retention-cache.js';
@@ -943,10 +944,11 @@ export function createCollections(db) {
 }
 
 /**
- * Normalize the four category-scoped trigger label fields (#494). Applied on
- * every insert/update so incoming agent snapshots are repaired too, not only
- * rows touched by store/migrate.ts's startup migration. Never overwrites an
- * already-populated scoped field, and never touches the mirror itself.
+ * Normalize the four category-scoped trigger label fields (#494), plus the
+ * action-only `actionTriggerAuto` field. Applied on every insert/update so
+ * incoming agent snapshots are repaired too, not only rows touched by
+ * store/migrate.ts's startup migration. Never overwrites an already-populated
+ * scoped field, and never touches the mirror itself.
  *
  * Resolved per direction. When the labels carry any trigger label for that
  * direction, the scoped values win and the deprecated
@@ -977,6 +979,14 @@ function normalizeContainerTriggerLabelFields<T extends Partial<container.Contai
   } else {
     containerToNormalize.actionTriggerExclude ??= containerToNormalize.triggerExclude;
     containerToNormalize.notificationTriggerExclude ??= containerToNormalize.triggerExclude;
+  }
+
+  // dd.action.auto has no mirror to fall back to (it was never conflated with
+  // a category-agnostic label), so this is a plain label-presence repair: an
+  // incoming snapshot that carries labels but not the derived field yet
+  // (e.g. an older agent) gets it filled in from the label directly.
+  if (labels) {
+    containerToNormalize.actionTriggerAuto ??= labels[ddActionAuto];
   }
 
   return containerToNormalize;

--- a/app/triggers/providers/Trigger.test.ts
+++ b/app/triggers/providers/Trigger.test.ts
@@ -245,7 +245,7 @@ test('validateConfiguration should normalize auto=false to none', () => {
   expect(validatedConfiguration.auto).toBe('none');
 });
 
-test('validateConfiguration should accept and normalize auto all/none/oninclude values', () => {
+test('validateConfiguration should accept and normalize auto all/none/oninclude/onauto values', () => {
   expect(
     trigger.validateConfiguration({
       ...configurationValid,
@@ -266,6 +266,13 @@ test('validateConfiguration should accept and normalize auto all/none/oninclude 
       auto: 'oninclude',
     }).auto,
   ).toBe('oninclude');
+
+  expect(
+    trigger.validateConfiguration({
+      ...configurationValid,
+      auto: 'onauto',
+    }).auto,
+  ).toBe('onauto');
 });
 
 test('validateConfiguration should normalize mixed-case auto value', () => {
@@ -274,6 +281,14 @@ test('validateConfiguration should normalize mixed-case auto value', () => {
     auto: 'OnInclude',
   });
   expect(validatedConfiguration.auto).toBe('oninclude');
+});
+
+test('validateConfiguration should normalize mixed-case onauto value', () => {
+  const validatedConfiguration = trigger.validateConfiguration({
+    ...configurationValid,
+    auto: 'OnAuto',
+  });
+  expect(validatedConfiguration.auto).toBe('onauto');
 });
 
 test('validateConfiguration should default auto to all for notification triggers', () => {
@@ -452,6 +467,27 @@ test('init should register auto listeners when auto is oninclude', async () => {
   trigger.configuration = trigger.validateConfiguration({
     ...configurationValid,
     auto: 'oninclude',
+    mode: 'simple',
+  });
+
+  await trigger.init();
+
+  expect(reportSpy).toHaveBeenCalled();
+  expect(updateAppliedSpy).toHaveBeenCalled();
+  expect(updateFailedSpy).toHaveBeenCalled();
+  expect(securityAlertSpy).toHaveBeenCalled();
+  expect(agentDisconnectedSpy).toHaveBeenCalled();
+});
+
+test('init should register auto listeners when auto is onauto', async () => {
+  const reportSpy = vi.spyOn(event, 'registerContainerReport');
+  const updateAppliedSpy = vi.spyOn(event, 'registerContainerUpdateApplied');
+  const updateFailedSpy = vi.spyOn(event, 'registerContainerUpdateFailed');
+  const securityAlertSpy = vi.spyOn(event, 'registerSecurityAlert');
+  const agentDisconnectedSpy = vi.spyOn(event, 'registerAgentDisconnected');
+  trigger.configuration = trigger.validateConfiguration({
+    ...configurationValid,
+    auto: 'onauto',
     mode: 'simple',
   });
 
@@ -1219,6 +1255,41 @@ test('mustTrigger should fire with include label when auto is oninclude', () => 
   trigger.type = 'docker';
   trigger.name = 'update';
   trigger.configuration.auto = 'oninclude';
+
+  expect(
+    trigger.mustTrigger({
+      actionTriggerInclude: 'update:minor',
+      updateKind: {
+        kind: 'tag',
+        semverDiff: 'minor',
+      },
+    }),
+  ).toBe(true);
+});
+
+// This slice (6.0.1 #1) makes 'onauto' behave exactly like 'oninclude':
+// closed by default absent an explicit dd.action.include label. The
+// auto-label-only-grants-access semantics (decision 2 of spec-6.0.1) land
+// with the resolver module in a later slice.
+test('mustTrigger should not fire without include label when auto is onauto', () => {
+  trigger.type = 'docker';
+  trigger.name = 'update';
+  trigger.configuration.auto = 'onauto';
+
+  expect(
+    trigger.mustTrigger({
+      updateKind: {
+        kind: 'tag',
+        semverDiff: 'minor',
+      },
+    }),
+  ).toBe(false);
+});
+
+test('mustTrigger should fire with include label when auto is onauto', () => {
+  trigger.type = 'docker';
+  trigger.name = 'update';
+  trigger.configuration.auto = 'onauto';
 
   expect(
     trigger.mustTrigger({

--- a/app/triggers/providers/Trigger.ts
+++ b/app/triggers/providers/Trigger.ts
@@ -49,7 +49,7 @@ import {
 } from './trigger-threshold.js';
 
 type SupportedThreshold = (typeof SUPPORTED_THRESHOLDS)[number];
-type TriggerAutoMode = 'all' | 'oninclude' | 'none';
+type TriggerAutoMode = 'all' | 'oninclude' | 'onauto' | 'none';
 type DigestEventKind = 'update-available-digest' | 'security-alert-digest';
 
 /**
@@ -2624,7 +2624,12 @@ class Trigger<
 
   isTriggerIncluded(containerResult: Container, triggerInclude: string | undefined) {
     if (!triggerInclude) {
-      return this.getAutoMode() !== 'oninclude';
+      // 'onauto' behaves exactly like 'oninclude' here in this slice (closed
+      // by default absent an explicit include label) — its real semantics
+      // (auto-label-only grants access too) land with the resolver in
+      // app/model/action-policy.ts in a later slice.
+      const autoMode = this.getAutoMode();
+      return autoMode !== 'oninclude' && autoMode !== 'onauto';
     }
     return this.isTriggerIncludedOrExcluded(containerResult, triggerInclude);
   }
@@ -2674,7 +2679,7 @@ class Trigger<
       const shouldRegisterBatchHandler = Trigger.isBatchCapableMode(this.configuration.mode);
       const shouldRegisterDigestHandler = Trigger.isDigestCapableMode(this.configuration.mode);
       this.log.info(
-        autoMode === 'oninclude'
+        autoMode === 'oninclude' || autoMode === 'onauto'
           ? 'Registering for auto execution (only containers with explicit include labels)'
           : 'Registering for auto execution (all watched containers)',
       );
@@ -2851,7 +2856,10 @@ class Trigger<
     const schemaWithDefaultOptions = schema.append({
       auto: this.joi
         .alternatives()
-        .try(this.joi.bool(), this.joi.string().insensitive().valid('all', 'oninclude', 'none'))
+        .try(
+          this.joi.bool(),
+          this.joi.string().insensitive().valid('all', 'oninclude', 'onauto', 'none'),
+        )
         .default(this.getCategory() === 'action' ? 'oninclude' : true),
       order: this.joi.number().default(100),
       threshold: this.joi

--- a/app/watchers/providers/docker/Docker.containers.details.test.ts
+++ b/app/watchers/providers/docker/Docker.containers.details.test.ts
@@ -577,6 +577,27 @@ describe('Docker Watcher', () => {
       expect(result.triggerInclude).toBe('action.default:major');
     });
 
+    test('should derive actionTriggerAuto from dd.action.auto with no notification counterpart', async () => {
+      const container = await setupContainerDetailTest(docker, {
+        container: {
+          Image: 'ghcr.io/home-assistant/home-assistant:2026.2.1',
+          Names: ['/homeassistant'],
+          Labels: { 'dd.action.auto': 'action.default:patch' },
+        },
+        imageDetails: {
+          Variant: 'v8',
+          RepoDigests: ['ghcr.io/home-assistant/home-assistant@sha256:abc123'],
+        },
+        parseImpl: createHaParseMock(),
+        semverValue: { major: 2026, minor: 2, patch: 1 },
+        registryId: 'ghcr',
+      });
+
+      const result = await docker.addImageDetailsToContainer(container);
+
+      expect(result.actionTriggerAuto).toBe('action.default:patch');
+    });
+
     test('should apply tagFamily from container labels', async () => {
       const container = await setupContainerDetailTest(docker, {
         container: {

--- a/app/watchers/providers/docker/container-init-coverage.test.ts
+++ b/app/watchers/providers/docker/container-init-coverage.test.ts
@@ -256,6 +256,7 @@ describe('container-init coverage', () => {
         actionTriggerExclude: 'compose',
         notificationTriggerInclude: 'slack',
         notificationTriggerExclude: 'ntfy',
+        actionTriggerAuto: undefined,
         triggerInclude: 'docker',
         triggerExclude: 'compose',
       });
@@ -320,6 +321,7 @@ describe('container-init coverage', () => {
         actionTriggerExclude: undefined,
         notificationTriggerInclude: undefined,
         notificationTriggerExclude: undefined,
+        actionTriggerAuto: undefined,
         triggerInclude: undefined,
         triggerExclude: undefined,
       });
@@ -399,9 +401,25 @@ describe('container-init coverage', () => {
         actionTriggerExclude: undefined,
         notificationTriggerInclude: undefined,
         notificationTriggerExclude: undefined,
+        actionTriggerAuto: undefined,
         triggerInclude: undefined,
         triggerExclude: undefined,
       });
+    });
+
+    test('resolves actionTriggerAuto from dd.action.auto with no notification counterpart', () => {
+      const resolved = resolveTriggerLabelOverrides({ 'dd.action.auto': 'docker:patch' });
+
+      expect(resolved.actionTriggerAuto).toBe('docker:patch');
+    });
+
+    test('actionTriggerAuto override takes priority over the label', () => {
+      const resolved = resolveTriggerLabelOverrides(
+        { 'dd.action.auto': 'docker:patch' },
+        { actionTriggerAuto: 'override' },
+      );
+
+      expect(resolved.actionTriggerAuto).toBe('override');
     });
   });
 
@@ -628,6 +646,22 @@ describe('container-init coverage', () => {
       expect(container.triggerInclude).toBe('docker');
     });
 
+    test('derives actionTriggerAuto from dd.action.auto with no notification counterpart', () => {
+      const container = makeContainer();
+
+      applyDerivedLabelFieldsToContainer(container, { 'dd.action.auto': 'docker:patch' });
+
+      expect(container.actionTriggerAuto).toBe('docker:patch');
+    });
+
+    test('leaves actionTriggerAuto unset when dd.action.auto is absent', () => {
+      const container = makeContainer({ actionTriggerAuto: 'stale' });
+
+      applyDerivedLabelFieldsToContainer(container, {});
+
+      expect(container.actionTriggerAuto).toBeUndefined();
+    });
+
     test('never emits the category-scope warning on the event path (labels here are imgset-blind)', () => {
       mockGetState.mockReturnValue({ trigger: { 'slack.notify': { type: 'slack' } } });
       const container = makeContainer({ name: 'imgset-backed' });
@@ -808,6 +842,15 @@ describe('container-init coverage', () => {
         expect.objectContaining({ tagFamily: 'strict', tagPinInfo: true }),
       );
     });
+  });
+
+  test('mergeConfigWithImgset passes actionTriggerAuto through with no imgset counterpart', () => {
+    expect(mergeConfigWithImgset({ actionTriggerAuto: 'docker:patch' }, undefined, {})).toEqual(
+      expect.objectContaining({ actionTriggerAuto: 'docker:patch' }),
+    );
+    expect(mergeConfigWithImgset({}, undefined, {})).toEqual(
+      expect.objectContaining({ actionTriggerAuto: undefined }),
+    );
   });
 
   test('filterRecreatedContainerAliases skips aliases that are still fresh', () => {

--- a/app/watchers/providers/docker/container-init-coverage.test.ts
+++ b/app/watchers/providers/docker/container-init-coverage.test.ts
@@ -421,6 +421,15 @@ describe('container-init coverage', () => {
 
       expect(resolved.actionTriggerAuto).toBe('override');
     });
+
+    test('an explicit empty actionTriggerAuto override is preserved over the label', () => {
+      const resolved = resolveTriggerLabelOverrides(
+        { 'dd.action.auto': 'docker:patch' },
+        { actionTriggerAuto: '' },
+      );
+
+      expect(resolved.actionTriggerAuto).toBe('');
+    });
   });
 
   describe('warnTriggerCategoryScopeChangeIfNeeded', () => {

--- a/app/watchers/providers/docker/container-init.ts
+++ b/app/watchers/providers/docker/container-init.ts
@@ -363,7 +363,7 @@ export function resolveTriggerLabelOverrides(
     actionTriggerExclude: excludeResolved.action,
     notificationTriggerInclude: includeResolved.notification,
     notificationTriggerExclude: excludeResolved.notification,
-    actionTriggerAuto: overrides.actionTriggerAuto || getLabel(containerLabels, ddActionAuto),
+    actionTriggerAuto: overrides.actionTriggerAuto ?? getLabel(containerLabels, ddActionAuto),
     triggerInclude: includeResolved.mirror,
     triggerExclude: excludeResolved.mirror,
   };

--- a/app/watchers/providers/docker/container-init.ts
+++ b/app/watchers/providers/docker/container-init.ts
@@ -21,6 +21,7 @@ import {
 } from './docker-helpers.js';
 import type { ContainerLabelOverrides } from './docker-image-details-orchestration.js';
 import {
+  ddActionAuto,
   ddActionExclude,
   ddActionInclude,
   ddDependsOn,
@@ -88,6 +89,8 @@ interface ResolvedContainerLabelOverrides {
   actionTriggerExclude?: string;
   notificationTriggerInclude?: string;
   notificationTriggerExclude?: string;
+  /** Action category only — no notification counterpart, no deprecated mirror. */
+  actionTriggerAuto?: string;
   /** @deprecated compat mirror — see Container.triggerInclude/triggerExclude. */
   triggerInclude?: string;
   /** @deprecated compat mirror. */
@@ -200,9 +203,10 @@ const containerLabelOverrideMappings = [
   },
   { key: 'displayName', ddKey: ddDisplayName, overrideKey: 'displayName' },
   { key: 'displayIcon', ddKey: ddDisplayIcon, overrideKey: 'displayIcon' },
-  // Trigger include/exclude are NOT in this generic table: dd.action.*/dd.notification.*/
-  // dd.trigger.* resolve into 4 category-scoped fields plus a deprecated mirror, which
-  // doesn't fit the single-key shape below. See resolveTriggerLabelOverrides().
+  // Trigger include/exclude/auto are NOT in this generic table: dd.action.*/
+  // dd.notification.*/dd.trigger.* resolve into scoped fields (plus, for
+  // include/exclude, a deprecated mirror), which doesn't fit the single-key
+  // shape below. See resolveTriggerLabelOverrides().
 ] as const satisfies ReadonlyArray<{
   key: keyof ResolvedContainerLabelOverrides;
   ddKey: string;
@@ -320,9 +324,12 @@ function resolveTriggerLabelDirection(
 
 /**
  * Resolve the four category-scoped trigger label fields plus the deprecated
- * triggerInclude/triggerExclude mirror. `overrides` (already-resolved values
- * from an earlier pass over the same labels) take priority, matching the
- * override-vs-label precedence used for every other label-derived field.
+ * triggerInclude/triggerExclude mirror, plus the action-only `actionTriggerAuto`
+ * field (dd.action.auto — no notification counterpart, no mirror, so it skips
+ * the direction/mirror machinery above and is just a plain override-or-label
+ * read). `overrides` (already-resolved values from an earlier pass over the
+ * same labels) take priority, matching the override-vs-label precedence used
+ * for every other label-derived field.
  */
 export function resolveTriggerLabelOverrides(
   containerLabels: Record<string, string>,
@@ -334,6 +341,7 @@ export function resolveTriggerLabelOverrides(
   | 'actionTriggerExclude'
   | 'notificationTriggerInclude'
   | 'notificationTriggerExclude'
+  | 'actionTriggerAuto'
   | 'triggerInclude'
   | 'triggerExclude'
 > {
@@ -355,6 +363,7 @@ export function resolveTriggerLabelOverrides(
     actionTriggerExclude: excludeResolved.action,
     notificationTriggerInclude: includeResolved.notification,
     notificationTriggerExclude: excludeResolved.notification,
+    actionTriggerAuto: overrides.actionTriggerAuto || getLabel(containerLabels, ddActionAuto),
     triggerInclude: includeResolved.mirror,
     triggerExclude: excludeResolved.mirror,
   };
@@ -1054,6 +1063,7 @@ export function applyDerivedLabelFieldsToContainer(
   container.actionTriggerExclude = resolved.actionTriggerExclude;
   container.notificationTriggerInclude = resolved.notificationTriggerInclude;
   container.notificationTriggerExclude = resolved.notificationTriggerExclude;
+  container.actionTriggerAuto = resolved.actionTriggerAuto;
   container.triggerInclude = resolved.triggerInclude;
   container.triggerExclude = resolved.triggerExclude;
   const dependsOnResolution = resolveDependsOnFromLabels(labels, container.name);
@@ -1368,6 +1378,9 @@ export function mergeConfigWithImgset(
       labelOverrides.notificationTriggerExclude,
       matchingImgset?.triggerExclude,
     ),
+    // No imgset counterpart (unlike triggerInclude/triggerExclude above) —
+    // dd.action.auto is action-only and imgsets don't carry a matching key.
+    actionTriggerAuto: labelOverrides.actionTriggerAuto,
     triggerInclude: getContainerConfigValue(
       labelOverrides.triggerInclude,
       matchingImgset?.triggerInclude,

--- a/app/watchers/providers/docker/docker-image-details-orchestration.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.ts
@@ -52,6 +52,8 @@ export interface ContainerLabelOverrides {
   actionTriggerExclude?: string;
   notificationTriggerInclude?: string;
   notificationTriggerExclude?: string;
+  /** Action category only — no notification counterpart, no deprecated mirror. */
+  actionTriggerAuto?: string;
   /** @deprecated compat mirror — see Container.triggerInclude/triggerExclude. */
   triggerInclude?: string;
   /** @deprecated compat mirror. */
@@ -126,6 +128,7 @@ interface ResolvedContainerLabelOverrides {
   actionTriggerExclude?: string;
   notificationTriggerInclude?: string;
   notificationTriggerExclude?: string;
+  actionTriggerAuto?: string;
   triggerInclude?: string;
   triggerExclude?: string;
   lookupImage?: string;
@@ -147,6 +150,7 @@ interface ResolvedContainerConfig {
   actionTriggerExclude?: string;
   notificationTriggerInclude?: string;
   notificationTriggerExclude?: string;
+  actionTriggerAuto?: string;
   triggerInclude?: string;
   triggerExclude?: string;
   lookupImage?: string;
@@ -903,6 +907,7 @@ export async function addImageDetailsToContainerOrchestration(
     actionTriggerExclude: resolvedConfig.actionTriggerExclude,
     notificationTriggerInclude: resolvedConfig.notificationTriggerInclude,
     notificationTriggerExclude: resolvedConfig.notificationTriggerExclude,
+    actionTriggerAuto: resolvedConfig.actionTriggerAuto,
     triggerInclude: resolvedConfig.triggerInclude,
     triggerExclude: resolvedConfig.triggerExclude,
     image: {

--- a/app/watchers/providers/docker/label.ts
+++ b/app/watchers/providers/docker/label.ts
@@ -108,6 +108,15 @@ export const ddNotificationExclude = 'dd.notification.exclude';
 export const ddTriggerExclude = 'dd.trigger.exclude';
 
 /**
+ * Optional list of triggers to auto-execute against. Action category only —
+ * auto-execution is an action-only concept, so there is no
+ * `dd.notification.auto` counterpart. Listing a trigger here grants both
+ * auto-execution AND manual access for that trigger (see
+ * `app/model/action-policy.ts`, added in a later slice).
+ */
+export const ddActionAuto = 'dd.action.auto';
+
+/**
  * Optional source repository override used for release-notes lookup.
  */
 export const ddSourceRepo = 'dd.source.repo';

--- a/app/watchers/providers/docker/trigger-label-resolution.test.ts
+++ b/app/watchers/providers/docker/trigger-label-resolution.test.ts
@@ -117,9 +117,22 @@ describe('resolveTriggerLabelFieldsPure', () => {
       actionTriggerExclude: 'compose',
       notificationTriggerInclude: 'slack',
       notificationTriggerExclude: 'ntfy',
+      actionTriggerAuto: undefined,
       triggerInclude: 'docker',
       triggerExclude: 'compose',
     });
+  });
+
+  test('resolves dd.action.auto with no notification counterpart and no mirror participation', () => {
+    const fields = resolveTriggerLabelFieldsPure({
+      'dd.action.auto': 'docker',
+      'dd.notification.include': 'slack',
+    });
+
+    expect(fields.actionTriggerAuto).toBe('docker');
+    // dd.action.auto never contributes to the include/exclude mirror.
+    expect(fields.triggerInclude).toBe('slack');
+    expect(fields.notificationTriggerInclude).toBe('slack');
   });
 
   test('a lone action include leaves the notification include unset (strict scoping)', () => {
@@ -145,6 +158,7 @@ describe('resolveTriggerLabelFieldsPure', () => {
       actionTriggerExclude: undefined,
       notificationTriggerInclude: undefined,
       notificationTriggerExclude: undefined,
+      actionTriggerAuto: undefined,
       triggerInclude: undefined,
       triggerExclude: undefined,
     });

--- a/app/watchers/providers/docker/trigger-label-resolution.ts
+++ b/app/watchers/providers/docker/trigger-label-resolution.ts
@@ -1,4 +1,5 @@
 import {
+  ddActionAuto,
   ddActionExclude,
   ddActionInclude,
   ddNotificationExclude,
@@ -19,6 +20,12 @@ export interface ResolvedTriggerLabelFields {
   actionTriggerExclude?: string;
   notificationTriggerInclude?: string;
   notificationTriggerExclude?: string;
+  /**
+   * Action category only — no notification counterpart, and (unlike
+   * include/exclude) no deprecated mirror; `dd.action.auto` was never
+   * conflated with a category-agnostic label.
+   */
+  actionTriggerAuto?: string;
   /** @deprecated compat mirror. */
   triggerInclude?: string;
   /** @deprecated compat mirror. */
@@ -87,6 +94,7 @@ export function resolveTriggerLabelFieldsPure(
     actionTriggerExclude: excludeResolved.action,
     notificationTriggerInclude: includeResolved.notification,
     notificationTriggerExclude: excludeResolved.notification,
+    actionTriggerAuto: labels[ddActionAuto],
     triggerInclude: includeResolved.mirror,
     triggerExclude: excludeResolved.mirror,
   };


### PR DESCRIPTION
Slice 1 of the 6.0.1 per-action policy package (#511): inert plumbing only.

- `TriggerAutoMode` widens to `all | oninclude | onauto | none`; in this slice `onauto` behaves identically to `oninclude` (closed by default, auto handlers register). Its real semantics — `dd.action.include` grants manual, `dd.action.auto` grants auto — land with the policy resolver in the next slice.
- New `dd.action.auto` label constant and `actionTriggerAuto` field threaded through label resolution, the container model, and store normalization, mirroring `actionTriggerInclude`'s flow exactly (override-vs-label precedence, no deprecated mirror, action category only).
- Nothing consumes `actionTriggerAuto` yet.

Full suite: 12,922 tests, 100% coverage both gates.

Part of the v1.7 per-action access/auto-execution policy (prerequisite for the DEPRECATIONS.md soft-to-hard blocker flip, which ships in the final slice of this package, never alone).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
✨ Added
- Added `dd.action.auto` label support.
- Added optional `actionTriggerAuto` to the `Container` model and Joi schema.
- Added `actionTriggerAuto` to trigger-label resolution, Docker overrides, container derivation, and store normalization.
- Added `onauto` to `TriggerAutoMode` and the `AUTO` Joi enum.
- Added tests for label mapping, precedence, normalization, filtering, and Docker propagation.

🔧 Changed
- `onauto` follows `oninclude` behavior.
- Label resolution limits `dd.action.auto` to the action category.
- Nullish fallback preserves explicit empty `actionTriggerAuto` overrides.
- The label does not create a deprecated mirror.

Concerns:
- `actionTriggerAuto` has no consumer. Add policy resolution in the next slice.
- Confirm all `AUTO` enum declarations and validation paths include `onauto`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->