### PR TITLE
feat(model): add per-action policy resolver

### DIFF
--- a/app/api/docker-trigger.test.ts
+++ b/app/api/docker-trigger.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 import {
   findDockerTriggerForContainer,
+  getDockerTriggerSpecificity,
   isTriggerCompatibleWithContainer,
   NO_DOCKER_TRIGGER_FOUND_ERROR,
 } from './docker-trigger.js';
@@ -269,6 +270,29 @@ describe('docker-trigger helper', () => {
     });
 
     expect(result).toBe(false);
+  });
+
+  test('getDockerTriggerSpecificity ranks a mismatched configured file as compose-catch-all, not compose-file-matched', () => {
+    // isTriggerCompatibleWithContainer would already reject this trigger as a
+    // *candidate* (see the compatibility test above using the same fixture),
+    // so selectActionTrigger never reaches this branch in practice — but
+    // getDockerTriggerSpecificity is a standalone exported function with its
+    // own contract, independent of any particular caller's pre-filtering.
+    const trigger = {
+      type: 'dockercompose',
+      configuration: { file: '/opt/drydock/test/mysql' },
+      getDefaultComposeFilePath: () => '/opt/drydock/test/mysql',
+      getComposeFilesForContainer: () => ['/opt/drydock/test/monitoring/compose.yaml'],
+    };
+
+    const result = getDockerTriggerSpecificity(trigger, {
+      id: 'c1',
+      labels: {
+        'com.docker.compose.project.config_files': '/opt/drydock/test/monitoring/compose.yaml',
+      },
+    });
+
+    expect(result).toBe('compose-catch-all');
   });
 
   test('treats compose trigger as compatible when no configured file path', () => {

--- a/app/api/docker-trigger.test.ts
+++ b/app/api/docker-trigger.test.ts
@@ -286,7 +286,6 @@ describe('docker-trigger helper', () => {
     };
 
     const result = getDockerTriggerSpecificity(trigger, {
-      id: 'c1',
       labels: {
         'com.docker.compose.project.config_files': '/opt/drydock/test/monitoring/compose.yaml',
       },

--- a/app/api/docker-trigger.ts
+++ b/app/api/docker-trigger.ts
@@ -29,7 +29,7 @@ interface FindDockerTriggerForContainerOptions {
   triggerTypes?: string[];
 }
 
-interface DockerTriggerCandidate {
+export interface DockerTriggerCandidate {
   type: string;
   agent?: string;
   configuration?: object;
@@ -43,8 +43,24 @@ interface DockerTriggerCandidate {
 
 type TriggerWithComposeAffinity = DockerTriggerCandidate;
 
-type ContainerTriggerContext = Pick<Container, 'agent' | 'labels'> &
+export type ContainerTriggerContext = Pick<Container, 'agent' | 'labels'> &
   Partial<Pick<Container, 'name' | 'watcher'>>;
+
+/**
+ * Relative specificity of a compatible docker/dockercompose trigger, used by
+ * `model/action-policy.ts`'s `selectActionTrigger` to rank multiple
+ * compatible candidates (spec-6.0.1-action-policy.md decision 3): a
+ * dockercompose trigger whose configured file was actually verified against
+ * one of the container's own compose files outranks a dockercompose trigger
+ * that matched only because it has no configured file (or because the
+ * container's compose files couldn't be determined), which in turn outranks
+ * a generic (non-compose) docker trigger. Ties within a tier are broken by
+ * registry insertion order at the call site.
+ */
+export type DockerTriggerSpecificity =
+  | 'compose-file-matched'
+  | 'compose-catch-all'
+  | 'docker-generic';
 
 function normalizeComposeFilePath(value: unknown): string | null {
   if (typeof value !== 'string') {
@@ -256,6 +272,40 @@ export function isTriggerCompatibleWithContainer(
   }
 
   return true;
+}
+
+/**
+ * Compute a compatible trigger's specificity tier for the hybrid
+ * multi-trigger walk (`model/action-policy.ts`'s `selectActionTrigger`).
+ * Callers are expected to have already filtered to compatible triggers via
+ * `isTriggerCompatibleWithContainer` — a dockercompose trigger with a
+ * configured file that does NOT match the container's compose files would
+ * already have been excluded there, so `'compose-file-matched'` is the only
+ * reachable outcome once a configured file and a non-empty compose-file list
+ * are both present.
+ */
+export function getDockerTriggerSpecificity(
+  trigger: DockerTriggerCandidate,
+  container: ContainerTriggerContext,
+): DockerTriggerSpecificity {
+  if (trigger.type !== 'dockercompose') {
+    return 'docker-generic';
+  }
+
+  const configuredComposeFilePath = getConfiguredComposeFilePath(trigger);
+  if (!configuredComposeFilePath) {
+    return 'compose-catch-all';
+  }
+
+  const composeFilesForContainer = getComposeFilesForContainer(trigger, container);
+  if (composeFilesForContainer.length === 0) {
+    return 'compose-catch-all';
+  }
+
+  const isVerifiedMatch = composeFilesForContainer.some((composeFilePath) =>
+    doesComposeFileMatchConfiguredFile(composeFilePath, configuredComposeFilePath),
+  );
+  return isVerifiedMatch ? 'compose-file-matched' : 'compose-catch-all';
 }
 
 /**

--- a/app/model/action-policy.test.ts
+++ b/app/model/action-policy.test.ts
@@ -424,7 +424,9 @@ describe('selectActionTrigger — tied-candidate WARN', () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('warn-first'));
   });
 
-  test('does not warn when there is only one candidate at the top specificity tier', () => {
+  test('does not warn when there is only one candidate at the top specificity tier', async () => {
+    const logger = (await import('../log/index.js')).default;
+    vi.mocked(logger.warn).mockClear();
     const container = makeContainer({
       labels: {
         'com.docker.compose.project.config_files': '/opt/drydock/test/nowarn/compose.yaml',
@@ -442,11 +444,8 @@ describe('selectActionTrigger — tied-candidate WARN', () => {
     });
     const triggers = { 'nowarn.catch-all': catchAll, 'nowarn.matched': fileMatched };
     selectActionTrigger(triggers, container);
-    // No assertion on call count here beyond "did not throw" — the shared
-    // logger mock's call count is already exercised precisely by the test
-    // above; this test's job is only to prove a clean single-winner tier
-    // doesn't touch the tie path at all (no crash, deterministic winner).
     expect(selectActionTrigger(triggers, container)?.triggerId).toBe('nowarn.matched');
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/app/model/action-policy.test.ts
+++ b/app/model/action-policy.test.ts
@@ -1,0 +1,573 @@
+import { findDockerTriggerForContainer } from '../api/docker-trigger.js';
+import {
+  type ActionPolicyTrigger,
+  resolveForTrigger,
+  selectActionTrigger,
+} from './action-policy.js';
+import type { Container } from './container.js';
+
+vi.mock('../log/index.js', () => ({
+  default: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    child: () => ({ warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeContainer(overrides: Partial<Container> = {}): Container {
+  return {
+    id: 'c1',
+    name: 'web',
+    watcher: 'local',
+    updateKind: { kind: 'tag', localValue: '1.0.0', remoteValue: '1.1.0', semverDiff: 'minor' },
+    ...overrides,
+  } as Container;
+}
+
+function makeTrigger(
+  id: string,
+  overrides: Partial<ActionPolicyTrigger> = {},
+): ActionPolicyTrigger {
+  return {
+    type: 'docker',
+    getId: () => id,
+    configuration: {},
+    ...overrides,
+  } as ActionPolicyTrigger;
+}
+
+// ---------------------------------------------------------------------------
+// resolveForTrigger — migration table (spec-6.0.1-action-policy.md)
+//
+// `onauto` cannot pre-exist, so these 8 rows are exhaustive for upgrades.
+// Each test asserts the POST-6.0.1 resolver state; the resolver has no
+// notion of severity (that stays a call-site/BLOCKER_SEVERITY concern), so
+// "blocked" here covers both the soft-blocked and hard-blocked pre/post rows.
+// ---------------------------------------------------------------------------
+
+describe('resolveForTrigger — migration table', () => {
+  test('row 1: all + any include + no exclude -> auto (access+auto, unchanged)', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'all' } });
+    const container = makeContainer({ actionTriggerInclude: 'docker.update' });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({ state: 'auto' });
+  });
+
+  test('row 2: all + any include + exclude -> blocked (unchanged)', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'all' } });
+    const container = makeContainer({
+      actionTriggerInclude: 'docker.update',
+      actionTriggerExclude: 'docker.update',
+    });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({
+      state: 'blocked',
+      reason: 'excluded',
+    });
+  });
+
+  test('row 3: none + any include + no exclude + any auto label -> manual (unchanged)', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'none' } });
+    const container = makeContainer({
+      actionTriggerInclude: 'docker.update',
+      actionTriggerAuto: 'docker.update',
+    });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({ state: 'manual' });
+  });
+
+  test('row 4: none + any include + exclude + any auto label -> blocked (unchanged)', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'none' } });
+    const container = makeContainer({
+      actionTriggerInclude: 'docker.update',
+      actionTriggerAuto: 'docker.update',
+      actionTriggerExclude: 'docker.update',
+    });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({
+      state: 'blocked',
+      reason: 'excluded',
+    });
+  });
+
+  test('row 5: oninclude + absent include + no exclude -> blocked (item-7 hard flip is slice 6)', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'oninclude' } });
+    const container = makeContainer();
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({
+      state: 'blocked',
+      reason: 'not-included',
+    });
+  });
+
+  test('row 6: oninclude + matching include + no exclude -> auto (load-bearing, unchanged)', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'oninclude' } });
+    const container = makeContainer({ actionTriggerInclude: 'docker.update' });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({ state: 'auto' });
+  });
+
+  test('row 7: oninclude + matching include + exclude -> blocked (unchanged)', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'oninclude' } });
+    const container = makeContainer({
+      actionTriggerInclude: 'docker.update',
+      actionTriggerExclude: 'docker.update',
+    });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({
+      state: 'blocked',
+      reason: 'excluded',
+    });
+  });
+
+  test('row 8: oninclude + include present but no match + no exclude -> blocked for this trigger', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'oninclude' } });
+    const container = makeContainer({ actionTriggerInclude: 'other.trigger' });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({
+      state: 'blocked',
+      reason: 'not-included',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveForTrigger — regression matrix cases 1-4, 13-16
+// (5-10 are multi-trigger walk cases, covered under selectActionTrigger below)
+// ---------------------------------------------------------------------------
+
+describe('resolveForTrigger — regression matrix', () => {
+  test('case 1: oninclude default, no labels -> blocked, no auto fire', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'oninclude' } });
+    expect(resolveForTrigger(trigger, makeContainer())).toStrictEqual({
+      state: 'blocked',
+      reason: 'not-included',
+    });
+  });
+
+  test('case 2: include only resolves manual under onauto, auto under frozen oninclude', () => {
+    const container = makeContainer({ actionTriggerInclude: 'docker.update' });
+    expect(
+      resolveForTrigger(
+        makeTrigger('docker.update', { configuration: { auto: 'onauto' } }),
+        container,
+      ),
+    ).toStrictEqual({ state: 'manual' });
+    expect(
+      resolveForTrigger(
+        makeTrigger('docker.update', { configuration: { auto: 'oninclude' } }),
+        container,
+      ),
+    ).toStrictEqual({ state: 'auto' });
+  });
+
+  test('case 3: dd.action.auto alone grants manual+auto access under onauto (decision 2)', () => {
+    // No actionTriggerInclude at all — access comes from the auto label alone.
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'onauto' } });
+    const container = makeContainer({ actionTriggerAuto: 'docker.update' });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({ state: 'auto' });
+  });
+
+  test('case 4: exclude beats include+auto -> blocked, excluded', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'onauto' } });
+    const container = makeContainer({
+      actionTriggerInclude: 'docker.update',
+      actionTriggerAuto: 'docker.update',
+      actionTriggerExclude: 'docker.update',
+    });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({
+      state: 'blocked',
+      reason: 'excluded',
+    });
+  });
+
+  test('case 13: AUTO=none caps at manual even with a matching dd.action.auto label (fail closed)', () => {
+    // The startup migration/fail-closed WARN itself is slice 5 surface
+    // (startup WARNs); this asserts the state behavior the WARN would be
+    // reporting on.
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'none' } });
+    const container = makeContainer({ actionTriggerAuto: 'docker.update' });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({ state: 'manual' });
+  });
+
+  test('case 14: legacy auto:true/false booleans behave exactly like all/none', () => {
+    const open = makeContainer();
+    expect(
+      resolveForTrigger(makeTrigger('docker.update', { configuration: { auto: true } }), open),
+    ).toStrictEqual(
+      resolveForTrigger(makeTrigger('docker.update', { configuration: { auto: 'all' } }), open),
+    );
+    expect(
+      resolveForTrigger(makeTrigger('docker.update', { configuration: { auto: false } }), open),
+    ).toStrictEqual(
+      resolveForTrigger(makeTrigger('docker.update', { configuration: { auto: 'none' } }), open),
+    );
+
+    const excluded = makeContainer({ actionTriggerExclude: 'docker.update' });
+    expect(
+      resolveForTrigger(makeTrigger('docker.update', { configuration: { auto: true } }), excluded),
+    ).toStrictEqual(
+      resolveForTrigger(makeTrigger('docker.update', { configuration: { auto: 'all' } }), excluded),
+    );
+  });
+
+  test('case 15: include and auto lists honor independent thresholds', () => {
+    // semverDiff 'minor': 'patch' threshold is not reached, 'minor' is.
+    const container = makeContainer({
+      updateKind: { kind: 'tag', localValue: '1.0.0', remoteValue: '1.1.0', semverDiff: 'minor' },
+      actionTriggerInclude: 'docker.update:patch',
+      actionTriggerAuto: 'docker.update:minor',
+    });
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'onauto' } });
+    // Included via the (independently thresholded) auto list, not the include list.
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({ state: 'auto' });
+  });
+
+  test('case 16: include naming a different trigger falls through to default deny', () => {
+    const trigger = makeTrigger('docker.update', { configuration: { auto: 'onauto' } });
+    const container = makeContainer({ actionTriggerInclude: 'other-trigger' });
+    expect(resolveForTrigger(trigger, container)).toStrictEqual({
+      state: 'blocked',
+      reason: 'not-included',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectActionTrigger — hybrid multi-trigger walk (decision 3) and
+// regression matrix cases 5-10
+// ---------------------------------------------------------------------------
+
+describe('selectActionTrigger — hybrid walk', () => {
+  test('case 5: two compatible triggers, one authorized — the authorized one wins', () => {
+    const container = makeContainer({ actionTriggerInclude: 'case5-b' });
+    const triggers = {
+      a: makeTrigger('case5-a', { configuration: { auto: 'oninclude' } }), // not included
+      b: makeTrigger('case5-b', { configuration: { auto: 'oninclude' } }), // included
+    };
+    const result = selectActionTrigger(triggers, container);
+    expect(result?.triggerId).toBe('case5-b');
+    expect(result?.state).toBe('auto');
+  });
+
+  test('case 6: two auto-authorized triggers — only the ranked winner is returned', () => {
+    const container = makeContainer();
+    const triggers = {
+      first: makeTrigger('case6-first', { configuration: { auto: 'all' } }),
+      second: makeTrigger('case6-second', { configuration: { auto: 'all' } }),
+    };
+    const result = selectActionTrigger(triggers, container, { requireAuto: true });
+    expect(result?.triggerId).toBe('case6-first');
+    expect(result?.state).toBe('auto');
+    // The resolver-level precondition for double-dispatch closure: exactly one
+    // winner is ever returned for a given container. The dispatch-side
+    // assertion ("second handler never invoked") requires real dispatching
+    // trigger instances and belongs to the auto-dispatch wiring slice.
+  });
+
+  test('case 7: exclude on the higher-ranked trigger hard-stops past a permissive catch-all', () => {
+    const container = makeContainer({ actionTriggerExclude: 'case7-specific' });
+    const triggers = {
+      specific: makeTrigger('case7-specific', { configuration: { auto: 'all' } }),
+      catchAll: makeTrigger('case7-catch-all', { configuration: { auto: 'all' } }),
+    };
+    const result = selectActionTrigger(triggers, container);
+    expect(result).toStrictEqual({
+      state: 'blocked',
+      reason: 'excluded',
+      trigger: triggers.specific,
+      triggerId: 'case7-specific',
+    });
+  });
+
+  test('case 8: not-included on the higher-ranked trigger falls through to an authorized catch-all', () => {
+    const container = makeContainer({ actionTriggerInclude: 'case8-catch-all' });
+    const triggers = {
+      specific: makeTrigger('case8-specific', { configuration: { auto: 'oninclude' } }),
+      catchAll: makeTrigger('case8-catch-all', { configuration: { auto: 'oninclude' } }),
+    };
+    const result = selectActionTrigger(triggers, container);
+    expect(result?.triggerId).toBe('case8-catch-all');
+    expect(result?.state).toBe('auto');
+  });
+
+  test('case 9: file-matched dockercompose wins over registration order', () => {
+    const container = makeContainer({
+      labels: {
+        'com.docker.compose.project.config_files': '/opt/drydock/test/monitoring/compose.yaml',
+      },
+    });
+    const catchAll = makeTrigger('dockercompose.catch-all', {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+    });
+    const fileMatched = makeTrigger('dockercompose.monitoring', {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+      getDefaultComposeFilePath: () => '/opt/drydock/test/monitoring/compose.yaml',
+      getComposeFilesForContainer: () => ['/opt/drydock/test/monitoring/compose.yaml'],
+    });
+    // Registered "wrong way round": catch-all first, file-matched second.
+    const triggers = {
+      'dockercompose.catch-all': catchAll,
+      'dockercompose.monitoring': fileMatched,
+    };
+    const result = selectActionTrigger(triggers, container);
+    expect(result?.triggerId).toBe('dockercompose.monitoring');
+  });
+
+  test('a compose trigger with a configured file but no compose labels on the container still ranks catch-all', () => {
+    // getDockerTriggerSpecificity mirrors isComposeTriggerCompatibleWithContainer's
+    // "no compose files reported for this container" fallback: compatible (and
+    // thus a candidate), but ranked as compose-catch-all rather than
+    // compose-file-matched since there is nothing to verify against.
+    const container = makeContainer();
+    const trigger = makeTrigger('case9c-configured-no-labels', {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+      getDefaultComposeFilePath: () => '/opt/drydock/test/monitoring/compose.yaml',
+      getComposeFilesForContainer: () => [],
+    });
+    const result = selectActionTrigger({ trigger }, container);
+    expect(result?.triggerId).toBe('case9c-configured-no-labels');
+    expect(result?.state).toBe('auto');
+  });
+
+  test('case 9b: ambiguous compose-suffix match stays conservative (not selected)', () => {
+    // Mirrors docker-trigger.test.ts's compatibility-layer ambiguous-suffix
+    // fixture — proves the conservative behavior flows through unmodified
+    // via isTriggerCompatibleWithContainer (reused, not reimplemented).
+    const container = makeContainer({
+      labels: {
+        'com.docker.compose.project.config_files': '/mnt/volume1/docker/stacks/compose.yaml',
+      },
+    });
+    const ambiguous = makeTrigger('dockercompose.ambiguous', {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+      getDefaultComposeFilePath: () => '/opt/drydock/stacks/compose.yaml',
+      getComposeFilesForContainer: () => ['/mnt/volume1/docker/stacks/compose.yaml'],
+    });
+    const result = selectActionTrigger({ 'dockercompose.ambiguous': ambiguous }, container);
+    expect(result).toBeUndefined();
+  });
+
+  test('case 10: same-name containers on different agents resolve independently', () => {
+    const triggers = {
+      a: makeTrigger('docker.a', { agent: 'agent-a', configuration: { auto: 'oninclude' } }),
+      b: makeTrigger('docker.b', { agent: 'agent-b', configuration: { auto: 'oninclude' } }),
+    };
+    const containerA = makeContainer({
+      name: 'web',
+      agent: 'agent-a',
+      actionTriggerInclude: 'docker.a',
+    });
+    const containerB = makeContainer({
+      name: 'web',
+      agent: 'agent-b',
+      actionTriggerInclude: 'docker.b',
+    });
+    expect(selectActionTrigger(triggers, containerA)?.triggerId).toBe('docker.a');
+    expect(selectActionTrigger(triggers, containerB)?.triggerId).toBe('docker.b');
+  });
+});
+
+describe('selectActionTrigger — requireAuto', () => {
+  test('without requireAuto, the first ranked non-blocked candidate wins even when manual', () => {
+    const container = makeContainer({ actionTriggerInclude: 'req-manual,req-auto' });
+    const triggers = {
+      manual: makeTrigger('req-manual', { configuration: { auto: 'onauto' } }), // no auto-label match
+      auto: makeTrigger('req-auto', { configuration: { auto: 'all' } }),
+    };
+    const result = selectActionTrigger(triggers, container, { requireAuto: false });
+    expect(result?.triggerId).toBe('req-manual');
+    expect(result?.state).toBe('manual');
+  });
+
+  test('with requireAuto, a manual-only candidate is skipped in favor of a lower-ranked auto candidate', () => {
+    const container = makeContainer({ actionTriggerInclude: 'req-manual,req-auto' });
+    const triggers = {
+      manual: makeTrigger('req-manual', { configuration: { auto: 'onauto' } }),
+      auto: makeTrigger('req-auto', { configuration: { auto: 'all' } }),
+    };
+    const result = selectActionTrigger(triggers, container, { requireAuto: true });
+    expect(result?.triggerId).toBe('req-auto');
+    expect(result?.state).toBe('auto');
+  });
+
+  test('with requireAuto, returns undefined when every candidate resolves manual', () => {
+    const container = makeContainer({ actionTriggerInclude: 'req2-manual' });
+    const triggers = {
+      manual: makeTrigger('req2-manual', { configuration: { auto: 'onauto' } }),
+    };
+    expect(selectActionTrigger(triggers, container, { requireAuto: true })).toBeUndefined();
+  });
+});
+
+describe('selectActionTrigger — tied-candidate WARN', () => {
+  test('warns once (not twice) when equally specific candidates tie on registration order', async () => {
+    const logger = (await import('../log/index.js')).default;
+    // The logger mock is module-scoped and other tests above this one also
+    // trip tied-candidate warnings (e.g. case 6); clear it so this test only
+    // observes calls triggered by its own two selectActionTrigger calls.
+    vi.mocked(logger.warn).mockClear();
+    const container = makeContainer();
+    const triggers = {
+      first: makeTrigger('warn-first', { configuration: { auto: 'all' } }),
+      second: makeTrigger('warn-second', { configuration: { auto: 'all' } }),
+    };
+
+    const first = selectActionTrigger(triggers, container);
+    const second = selectActionTrigger(triggers, container);
+
+    expect(first?.triggerId).toBe('warn-first');
+    expect(second?.triggerId).toBe('warn-first');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('warn-first'));
+  });
+
+  test('does not warn when there is only one candidate at the top specificity tier', () => {
+    const container = makeContainer({
+      labels: {
+        'com.docker.compose.project.config_files': '/opt/drydock/test/nowarn/compose.yaml',
+      },
+    });
+    const catchAll = makeTrigger('nowarn.catch-all', {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+    });
+    const fileMatched = makeTrigger('nowarn.matched', {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+      getDefaultComposeFilePath: () => '/opt/drydock/test/nowarn/compose.yaml',
+      getComposeFilesForContainer: () => ['/opt/drydock/test/nowarn/compose.yaml'],
+    });
+    const triggers = { 'nowarn.catch-all': catchAll, 'nowarn.matched': fileMatched };
+    selectActionTrigger(triggers, container);
+    // No assertion on call count here beyond "did not throw" — the shared
+    // logger mock's call count is already exercised precisely by the test
+    // above; this test's job is only to prove a clean single-winner tier
+    // doesn't touch the tie path at all (no crash, deterministic winner).
+    expect(selectActionTrigger(triggers, container)?.triggerId).toBe('nowarn.matched');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Equivalence with findDockerTriggerForContainer (behavior preservation)
+//
+// Absent onauto config and dd.action.auto labels, selectActionTrigger(...,
+// {requireAuto:false}) must return the same trigger findDockerTriggerForContainer
+// returns, for every scenario in docker-trigger.test.ts that exercises
+// findDockerTriggerForContainer's return value. Trigger fixtures are ported
+// verbatim from that file's literals, with a `getId` added (real Trigger
+// instances always have one; the plain-object fixtures there don't, because
+// findDockerTriggerForContainer itself never calls it).
+// ---------------------------------------------------------------------------
+
+describe('selectActionTrigger — equivalence with findDockerTriggerForContainer', () => {
+  test('returns undefined when trigger map is missing', () => {
+    const container = makeContainer({ id: 'c1' });
+    expect(selectActionTrigger(undefined, container)).toBeUndefined();
+    expect(findDockerTriggerForContainer(undefined, container)).toBeUndefined();
+  });
+
+  test('returns undefined when no docker trigger exists', () => {
+    const triggers = {
+      'slack.default': makeTrigger('slack.default', { type: 'slack' }),
+      'http.default': makeTrigger('http.default', { type: 'http' }),
+    };
+    const container = makeContainer({ id: 'c1' });
+    expect(selectActionTrigger(triggers, container)).toBeUndefined();
+    expect(findDockerTriggerForContainer(triggers, container)).toBeUndefined();
+  });
+
+  test('includes compose triggers by default', () => {
+    const composeTrigger = makeTrigger('dockercompose.default', {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+    });
+    const triggers = { 'dockercompose.default': composeTrigger };
+    const container = makeContainer({ id: 'c1' });
+    expect(selectActionTrigger(triggers, container)?.trigger).toBe(composeTrigger);
+    expect(findDockerTriggerForContainer(triggers, container)).toBe(composeTrigger);
+  });
+
+  test('skips docker triggers with a different agent than the container', () => {
+    const nonMatching = makeTrigger('docker.wrong', {
+      type: 'docker',
+      agent: 'agent-b',
+      configuration: { auto: 'all' },
+    });
+    const matching = makeTrigger('docker.right', {
+      type: 'docker',
+      agent: 'agent-a',
+      configuration: { auto: 'all' },
+    });
+    const triggers = { 'docker.wrong': nonMatching, 'docker.right': matching };
+    const container = makeContainer({ id: 'c1', agent: 'agent-a' });
+    expect(selectActionTrigger(triggers, container)?.trigger).toBe(matching);
+    expect(findDockerTriggerForContainer(triggers, container)).toBe(matching);
+  });
+
+  test('skips local docker triggers when container belongs to an agent', () => {
+    const localDocker = makeTrigger('docker.local', {
+      type: 'docker',
+      configuration: { auto: 'all' },
+    });
+    const agentDocker = makeTrigger('docker.remote', {
+      type: 'docker',
+      agent: 'remote-1',
+      configuration: { auto: 'all' },
+    });
+    const triggers = { 'docker.local': localDocker, 'docker.remote': agentDocker };
+    const container = makeContainer({ id: 'c1', agent: 'remote-1' });
+    expect(selectActionTrigger(triggers, container)?.trigger).toBe(agentDocker);
+    expect(findDockerTriggerForContainer(triggers, container)).toBe(agentDocker);
+  });
+
+  test('returns the first matching local docker trigger for local containers', () => {
+    const firstDocker = makeTrigger('docker.first', {
+      type: 'docker',
+      configuration: { auto: 'all' },
+    });
+    const secondDocker = makeTrigger('docker.second', {
+      type: 'docker',
+      agent: 'remote-1',
+      configuration: { auto: 'all' },
+    });
+    const triggers = { 'docker.first': firstDocker, 'docker.second': secondDocker };
+    const container = makeContainer({ id: 'c1' });
+    expect(selectActionTrigger(triggers, container)?.trigger).toBe(firstDocker);
+    expect(findDockerTriggerForContainer(triggers, container)).toBe(firstDocker);
+  });
+
+  test('prefers the compose trigger whose configured file matches the container compose labels', () => {
+    const mysqlComposeTrigger = makeTrigger('dockercompose.mysql', {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+      getDefaultComposeFilePath: () => '/opt/drydock/test/mysql/compose.yaml',
+      getComposeFilesForContainer: () => [
+        '/mnt/volume1/docker/stacks/test/monitoring/compose.yaml',
+      ],
+    });
+    const monitoringComposeTrigger = makeTrigger('dockercompose.monitoring', {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+      getDefaultComposeFilePath: () => '/opt/drydock/test/monitoring/compose.yaml',
+      getComposeFilesForContainer: () => [
+        '/mnt/volume1/docker/stacks/test/monitoring/compose.yaml',
+      ],
+    });
+    const triggers = {
+      'dockercompose.mysql': mysqlComposeTrigger,
+      'dockercompose.monitoring': monitoringComposeTrigger,
+    };
+    const container = makeContainer({
+      id: 'c1',
+      labels: {
+        'com.docker.compose.project.config_files':
+          '/mnt/volume1/docker/stacks/test/monitoring/compose.yaml',
+      },
+    });
+    expect(selectActionTrigger(triggers, container)?.trigger).toBe(monitoringComposeTrigger);
+    expect(findDockerTriggerForContainer(triggers, container)).toBe(monitoringComposeTrigger);
+  });
+});

--- a/app/model/action-policy.ts
+++ b/app/model/action-policy.ts
@@ -1,0 +1,276 @@
+import {
+  type ContainerTriggerContext,
+  type DockerTriggerCandidate,
+  type DockerTriggerSpecificity,
+  getDockerTriggerSpecificity,
+  isTriggerCompatibleWithContainer,
+} from '../api/docker-trigger.js';
+import logger from '../log/index.js';
+import { matchesTriggerReferenceList } from '../triggers/providers/trigger-reference-matching.js';
+import type { Container } from './container.js';
+
+/**
+ * Per-action access and automatic-execution policy resolver
+ * (spec-6.0.1-action-policy.md). Sibling of `update-eligibility.ts`.
+ *
+ * Kept a pure leaf module deliberately: it must NOT import `Trigger.ts` as a
+ * value. `Trigger.ts` imports `updates/request-update.js`, which imports
+ * `model/update-eligibility.js` (see `triggers/trigger-category.ts`'s
+ * documented require-cycle constraint) — and `update-eligibility.ts` imports
+ * THIS module, so `Trigger.ts` -> `request-update.ts` -> `update-eligibility.ts`
+ * -> `action-policy.ts` -> `Trigger.ts` would close the cycle. Every
+ * dependency below is either a type-only import or a genuine leaf module
+ * (`api/docker-trigger.ts`, `triggers/providers/trigger-reference-matching.ts`,
+ * `log/index.ts`) with no path back here.
+ */
+
+export type ActionPolicyAutoMode = 'all' | 'oninclude' | 'onauto' | 'none';
+export type ActionPolicyState = 'blocked' | 'manual' | 'auto';
+export type ActionPolicyBlockedReason = 'excluded' | 'not-included';
+
+export interface ActionPolicyResult {
+  state: ActionPolicyState;
+  reason?: ActionPolicyBlockedReason;
+}
+
+/**
+ * Structural trigger shape the resolver needs. Real `Trigger` (`Docker` /
+ * `DockerCompose`) instances satisfy this without a cast beyond the same
+ * `as unknown as` pattern `update-eligibility.ts` already uses for
+ * `TriggerInstanceMethods` — deliberately duck-typed rather than importing
+ * `Trigger` as a value, for the require-cycle reason above.
+ */
+export interface ActionPolicyTrigger extends DockerTriggerCandidate {
+  configuration?: DockerTriggerCandidate['configuration'] & {
+    auto?: boolean | ActionPolicyAutoMode;
+  };
+  getId: () => string;
+}
+
+export interface SelectActionTriggerOptions {
+  /**
+   * When true, the walk only accepts a candidate whose resolved state is
+   * `'auto'`; a candidate that resolves `'manual'` is treated like a skip
+   * (not a hard stop) and the walk continues to the next-ranked candidate.
+   * Used by auto-dispatch (a later slice); display and manual-admission
+   * callers pass `false`/omit.
+   */
+  requireAuto?: boolean;
+}
+
+export interface SelectActionTriggerResult extends ActionPolicyResult {
+  trigger: ActionPolicyTrigger;
+  triggerId: string;
+}
+
+const CANDIDATE_TRIGGER_TYPES = new Set(['docker', 'dockercompose']);
+
+const SPECIFICITY_RANK: Record<DockerTriggerSpecificity, number> = {
+  'compose-file-matched': 0,
+  'compose-catch-all': 1,
+  'docker-generic': 2,
+};
+
+/**
+ * Dedup set for the one-time "tied triggers" WARN — keyed by the sorted set
+ * of tied trigger ids, so the same ambiguous configuration only logs once
+ * per process lifetime no matter how many containers (or eligibility
+ * recomputations) hit it.
+ */
+const tiedSpecificityWarningsSeen = new Set<string>();
+
+/**
+ * Normalize a trigger's `auto` configuration value the same way
+ * `Trigger.normalizeAutoMode` (private, `triggers/providers/Trigger.ts`)
+ * does: legacy `true`/`false` booleans map to `'all'`/`'none'`; a string
+ * value is lowercased as-is.
+ *
+ * Deliberately duplicated rather than imported: unlike the include/exclude/
+ * auto-label matching grammar (extracted to
+ * `triggers/providers/trigger-reference-matching.ts` for exactly this
+ * reason), this is a trivial 3-way value coercion, not "matching machinery"
+ * — reimplementing three lines here carries negligible drift risk, and
+ * `Trigger.ts` cannot be imported as a value from this module without
+ * closing the require cycle described above.
+ */
+function normalizeAutoMode(auto: boolean | ActionPolicyAutoMode | undefined): ActionPolicyAutoMode {
+  if (auto === false) {
+    return 'none';
+  }
+  if (auto === true || auto === undefined) {
+    return 'all';
+  }
+  return auto.toLowerCase() as ActionPolicyAutoMode;
+}
+
+/**
+ * Resolve a single trigger's per-container action policy.
+ *
+ * spec-6.0.1-action-policy.md resolver pseudocode:
+ *
+ *   if exclude matches                     -> blocked (reason: excluded)
+ *   autoMode = trigger auto mode           # all|oninclude|onauto|none
+ *   if autoMode in {all, none}: included = true          # access open (legacy)
+ *   else: included = include matches OR (autoMode==onauto AND auto matches)
+ *   if !included                           -> blocked (reason: not-included)
+ *   switch autoMode:
+ *     none      -> manual                  # structurally cannot auto
+ *     all       -> auto                    # legacy meaning frozen
+ *     oninclude -> auto                    # legacy conflation frozen
+ *     onauto    -> auto if auto-label matches else manual
+ *
+ * Pure: no I/O, no logging, no global state. The global `updateMode` ceiling
+ * ('manual' clamps a resolved 'auto' down to 'manual'; 'notify' is a
+ * separate admission-level gate) is intentionally NOT applied here — that
+ * composition happens at call sites so this resolver stays reusable
+ * unmodified for display, manual admission, and auto-dispatch alike.
+ */
+export function resolveForTrigger(
+  trigger: ActionPolicyTrigger,
+  container: Container,
+): ActionPolicyResult {
+  const triggerId = trigger.getId();
+  const autoMode = normalizeAutoMode(trigger.configuration?.auto);
+
+  if (matchesTriggerReferenceList(triggerId, container.actionTriggerExclude, container)) {
+    return { state: 'blocked', reason: 'excluded' };
+  }
+
+  const accessOpen = autoMode === 'all' || autoMode === 'none';
+  const includeMatches =
+    !accessOpen &&
+    matchesTriggerReferenceList(triggerId, container.actionTriggerInclude, container);
+  const autoMatches = matchesTriggerReferenceList(
+    triggerId,
+    container.actionTriggerAuto,
+    container,
+  );
+  const included = accessOpen || includeMatches || (autoMode === 'onauto' && autoMatches);
+
+  if (!included) {
+    return { state: 'blocked', reason: 'not-included' };
+  }
+
+  switch (autoMode) {
+    case 'none':
+      return { state: 'manual' };
+    case 'onauto':
+      return { state: autoMatches ? 'auto' : 'manual' };
+    default:
+      // 'all' and 'oninclude' both freeze the legacy "access implies auto" meaning.
+      return { state: 'auto' };
+  }
+}
+
+interface RankedCandidate {
+  id: string;
+  trigger: ActionPolicyTrigger;
+  specificity: DockerTriggerSpecificity;
+}
+
+function getCompatibleCandidates(
+  triggers: Record<string, ActionPolicyTrigger> | undefined,
+  container: ContainerTriggerContext,
+): RankedCandidate[] {
+  if (!triggers) {
+    return [];
+  }
+  const candidates: RankedCandidate[] = [];
+  for (const [id, trigger] of Object.entries(triggers)) {
+    if (!CANDIDATE_TRIGGER_TYPES.has(trigger.type)) {
+      continue;
+    }
+    if (!isTriggerCompatibleWithContainer(trigger, container)) {
+      continue;
+    }
+    candidates.push({ id, trigger, specificity: getDockerTriggerSpecificity(trigger, container) });
+  }
+  return candidates;
+}
+
+function warnAboutTiedCandidates(tied: RankedCandidate[]): void {
+  const triggerIds = tied.map((candidate) => candidate.trigger.getId());
+  const dedupKey = [...triggerIds].sort().join(',');
+  if (tiedSpecificityWarningsSeen.has(dedupKey)) {
+    return;
+  }
+  tiedSpecificityWarningsSeen.add(dedupKey);
+  logger.warn(
+    `Multiple action triggers are equally specific for a container (${triggerIds.join(', ')}); ` +
+      'the one registered first wins. Configure dd.action.include/dd.action.exclude, or a ' +
+      'compose file path, to disambiguate.',
+  );
+}
+
+/**
+ * Rank compatible candidates by specificity tier (file-matched dockercompose
+ * > catch-all dockercompose > generic docker), stably preserving registry
+ * insertion order within a tier. Warns once (per distinct tied-id set) when
+ * the top tier has more than one candidate, since insertion order deciding
+ * the winner in that case is an ambiguous configuration worth flagging.
+ */
+function rankCandidates(candidates: RankedCandidate[]): RankedCandidate[] {
+  const ranked = [...candidates].sort(
+    (a, b) => SPECIFICITY_RANK[a.specificity] - SPECIFICITY_RANK[b.specificity],
+  );
+  if (ranked.length > 1) {
+    const topSpecificity = ranked[0].specificity;
+    const tied = ranked.filter((candidate) => candidate.specificity === topSpecificity);
+    if (tied.length > 1) {
+      warnAboutTiedCandidates(tied);
+    }
+  }
+  return ranked;
+}
+
+/**
+ * Select the winning action trigger for a container across every compatible
+ * docker/dockercompose trigger (agent + compose-file affinity via
+ * `isTriggerCompatibleWithContainer`; command triggers are never candidates
+ * — they aren't in `CANDIDATE_TRIGGER_TYPES`, matching
+ * `findDockerTriggerForContainer`'s default type scope).
+ *
+ * Hybrid specificity walk (spec-6.0.1-action-policy.md decision 3): ranked
+ * candidates are walked in order; an explicit-exclude verdict is a hard stop
+ * (the container is blocked — a more permissive, less-specific trigger
+ * cannot override an explicit exclude), a not-included verdict is skipped
+ * (the walk continues to the next candidate), and the first manual/auto
+ * verdict wins (auto-only when `requireAuto`). Returns `undefined` when no
+ * candidate produces a winning verdict — callers distinguish "no compatible
+ * trigger at all" from "compatible triggers exist but none authorized this
+ * container" using their own compatibility probe (this function does not
+ * report which case occurred; see `update-eligibility.ts`'s
+ * `no-update-trigger-configured` / `agent-mismatch` / `trigger-not-included`
+ * branches).
+ */
+export function selectActionTrigger(
+  triggers: Record<string, ActionPolicyTrigger> | undefined,
+  container: Container,
+  options: SelectActionTriggerOptions = {},
+): SelectActionTriggerResult | undefined {
+  const ranked = rankCandidates(getCompatibleCandidates(triggers, container));
+
+  for (const candidate of ranked) {
+    const result = resolveForTrigger(candidate.trigger, container);
+
+    if (result.state === 'blocked' && result.reason === 'excluded') {
+      // Hard stop: an explicit exclude on a candidate the walk has reached
+      // authoritatively blocks the container, even if a less-specific,
+      // still-unranked candidate would otherwise have authorized it.
+      return { ...result, trigger: candidate.trigger, triggerId: candidate.trigger.getId() };
+    }
+
+    if (result.state === 'blocked') {
+      // not-included: this candidate declines; keep walking.
+      continue;
+    }
+
+    if (options.requireAuto && result.state !== 'auto') {
+      continue;
+    }
+
+    return { ...result, trigger: candidate.trigger, triggerId: candidate.trigger.getId() };
+  }
+
+  return undefined;
+}

--- a/app/model/update-eligibility.test.ts
+++ b/app/model/update-eligibility.test.ts
@@ -72,15 +72,17 @@ function makeContainerWithDigestUpdate(overrides: Partial<Container> = {}): Cont
   });
 }
 
-// A minimal trigger mock with all the methods eligibility needs
+// A minimal trigger mock with everything eligibility (and the action-policy
+// resolver it now delegates the exclude/include verdict to) needs. `auto`
+// defaults to unset, which `resolveForTrigger` normalizes to 'all' (legacy
+// access-always-open, same as the pre-6.0.1 default isTriggerIncluded/
+// isTriggerExcluded mock behavior this replaced).
 function makeTrigger(
   overrides: Partial<{
     type: string;
     agent: string | undefined;
-    configuration: { threshold?: string };
+    configuration: { threshold?: string; auto?: boolean | string };
     getId: () => string;
-    isTriggerIncluded: (c: Container, include: string | undefined) => boolean;
-    isTriggerExcluded: (c: Container, exclude: string | undefined) => boolean;
   }> = {},
 ) {
   return {
@@ -88,8 +90,6 @@ function makeTrigger(
     agent: undefined,
     configuration: { threshold: 'all' },
     getId: () => 'docker.update',
-    isTriggerIncluded: (_c: Container, include: string | undefined) => !include,
-    isTriggerExcluded: (_c: Container, _exclude: string | undefined) => false,
     ...overrides,
   };
 }
@@ -1243,11 +1243,11 @@ describe('computeUpdateEligibility', () => {
     });
 
     test('reads the action-scoped exclude, never the deprecated mirror (#494)', () => {
-      const isTriggerExcluded = vi.fn().mockReturnValue(false);
-      const trigger = makeTrigger({
-        isTriggerExcluded,
-        isTriggerIncluded: () => true,
-      });
+      // The deprecated triggerExclude/notificationTriggerExclude mirror carries a
+      // value that WOULD exclude this trigger if it were (wrongly) consulted.
+      // actionTriggerExclude is left unset, so the resolver — which only ever
+      // reads the action-scoped field — must not exclude.
+      const trigger = makeTrigger();
       const container = makeContainerWithTagUpdate({
         triggerExclude: 'docker.update',
         notificationTriggerExclude: 'docker.update',
@@ -1261,17 +1261,13 @@ describe('computeUpdateEligibility', () => {
         }),
       );
 
-      expect(isTriggerExcluded).toHaveBeenCalledWith(container, undefined);
       expect(result.blockers.find((b) => b.reason === 'trigger-excluded')).toBeUndefined();
     });
   });
 
   describe('trigger-not-included', () => {
-    test('emits trigger-not-included when isTriggerIncluded returns false and not excluded', () => {
-      const trigger = makeTrigger({
-        isTriggerExcluded: () => false,
-        isTriggerIncluded: () => false,
-      });
+    test('emits trigger-not-included when the include label does not match and not excluded', () => {
+      const trigger = makeTrigger({ configuration: { auto: 'oninclude', threshold: 'all' } });
       const container = makeContainerWithTagUpdate({
         actionTriggerInclude: 'other.trigger',
       });
@@ -1288,14 +1284,14 @@ describe('computeUpdateEligibility', () => {
     });
 
     test('reads the action-scoped include, never the deprecated mirror (#494)', () => {
-      const isTriggerIncluded = vi.fn().mockReturnValue(true);
-      const trigger = makeTrigger({
-        isTriggerExcluded: () => false,
-        isTriggerIncluded,
-      });
+      // Under 'oninclude', access is closed by default. The deprecated
+      // triggerInclude/notificationTriggerInclude mirror carries a value that
+      // WOULD grant access if it were (wrongly) consulted; actionTriggerInclude
+      // is left unset, so the resolver must still report trigger-not-included.
+      const trigger = makeTrigger({ configuration: { auto: 'oninclude', threshold: 'all' } });
       const container = makeContainerWithTagUpdate({
-        triggerInclude: 'slack.alert',
-        notificationTriggerInclude: 'slack.alert',
+        triggerInclude: 'docker.update',
+        notificationTriggerInclude: 'docker.update',
       });
 
       const result = computeUpdateEligibility(
@@ -1306,18 +1302,14 @@ describe('computeUpdateEligibility', () => {
         }),
       );
 
-      expect(isTriggerIncluded).toHaveBeenCalledWith(container, undefined);
-      expect(result.blockers.find((b) => b.reason === 'trigger-not-included')).toBeUndefined();
+      expect(result.blockers.find((b) => b.reason === 'trigger-not-included')).toBeDefined();
     });
 
     test('trigger-excluded takes precedence over trigger-not-included', () => {
-      const trigger = makeTrigger({
-        isTriggerExcluded: () => true,
-        isTriggerIncluded: () => false,
-      });
+      const trigger = makeTrigger({ configuration: { auto: 'oninclude', threshold: 'all' } });
       const container = makeContainerWithTagUpdate({
-        triggerExclude: 'docker.update',
-        triggerInclude: 'other',
+        actionTriggerExclude: 'docker.update',
+        actionTriggerInclude: 'other',
       });
       const result = computeUpdateEligibility(
         container,

--- a/app/model/update-eligibility.ts
+++ b/app/model/update-eligibility.ts
@@ -1,6 +1,7 @@
 import { findDockerTriggerForContainer } from '../api/docker-trigger.js';
 import type Trigger from '../triggers/providers/Trigger.js';
 import { isThresholdReached } from '../triggers/providers/trigger-threshold.js';
+import { type ActionPolicyTrigger, selectActionTrigger } from './action-policy.js';
 import type { Container } from './container.js';
 import { isRollbackContainer } from './container.js';
 import {
@@ -167,8 +168,6 @@ interface TriggerInstanceMethods {
   agent?: string;
   configuration?: { threshold?: string };
   getId?: () => string;
-  isTriggerIncluded: (container: Container, include: string | undefined) => boolean;
-  isTriggerExcluded: (container: Container, exclude: string | undefined) => boolean;
 }
 
 function formatSnoozeDate(isoString: string): string {
@@ -533,13 +532,29 @@ export function computeUpdateEligibility(
     }
 
     // 8. trigger-excluded / 9. trigger-not-included
-    // Action admission reads the action-scoped labels explicitly, never the deprecated mirror.
-    const { actionTriggerInclude: triggerInclude, actionTriggerExclude: triggerExclude } =
-      container;
-    const included = t.isTriggerIncluded(container, triggerInclude);
-    const excluded = t.isTriggerExcluded(container, triggerExclude);
+    //
+    // Derived from the action-policy resolver's hybrid multi-trigger walk
+    // (spec-6.0.1-action-policy.md decision 3) rather than a single trigger's
+    // raw include/exclude booleans: an explicit `dd.action.exclude` match
+    // anywhere in the ranked walk is an authoritative hard stop
+    // (trigger-excluded), while a container is only trigger-not-included
+    // when NO compatible candidate resolves to manual/auto access. This can
+    // authorize the container via a different, less-specific trigger than
+    // `t` above when the walk finds an authorized fallback — a deliberate,
+    // spec-called-out improvement over the pre-6.0.1 single-trigger check.
+    // `t` (the raw agent-compatible candidate from
+    // findDockerTriggerForContainer) still backs threshold-not-reached and
+    // rollback-container above, and backs this block's triggerId only in the
+    // trigger-not-included fallback case (no candidate to name a winner
+    // from); wiring those to the walk's winner too is left to a later slice.
+    const selection = selectActionTrigger(
+      context.triggers as unknown as Record<string, ActionPolicyTrigger> | undefined,
+      container,
+      { requireAuto: false },
+    );
 
-    if (excluded) {
+    if (selection?.reason === 'excluded') {
+      const triggerExclude = container.actionTriggerExclude;
       blockers.push(
         makeBlocker({
           reason: 'trigger-excluded',
@@ -549,11 +564,12 @@ export function computeUpdateEligibility(
             'Adjust the `dd.action.include` / `dd.action.exclude` labels on the container.',
           details: {
             triggerExclude,
-            triggerId: t.getId?.(),
+            triggerId: selection.triggerId,
           },
         }),
       );
-    } else if (!included) {
+    } else if (!selection) {
+      const triggerInclude = container.actionTriggerInclude;
       blockers.push(
         makeBlocker({
           reason: 'trigger-not-included',

--- a/app/triggers/providers/Trigger.ts
+++ b/app/triggers/providers/Trigger.ts
@@ -43,12 +43,16 @@ import { OneShotKeyTracker, RecentSignatureSuppressor } from './trigger-deduplic
 import { DigestBuffer } from './trigger-digest-buffer.js';
 import { renderBatch, renderSimple, renderTemplate } from './trigger-expression-parser.js';
 import {
+  doesReferenceMatchId as doesReferenceMatchIdHelper,
+  matchesTriggerReferenceList,
+  parseIncludeOrIncludeTriggerString as parseIncludeOrIncludeTriggerStringHelper,
+} from './trigger-reference-matching.js';
+import {
   isThresholdReached as isThresholdReachedHelper,
   parseThresholdWithDigestBehavior as parseThresholdWithDigestBehaviorHelper,
   SUPPORTED_THRESHOLDS,
 } from './trigger-threshold.js';
 
-type SupportedThreshold = (typeof SUPPORTED_THRESHOLDS)[number];
 type TriggerAutoMode = 'all' | 'oninclude' | 'onauto' | 'none';
 type DigestEventKind = 'update-available-digest' | 'security-alert-digest';
 
@@ -612,10 +616,6 @@ export function resolveNotificationTemplate(
   return templates[notificationEvent.kind] ?? fallback;
 }
 
-function isSupportedThreshold(value: string): value is SupportedThreshold {
-  return SUPPORTED_THRESHOLDS.includes(value as SupportedThreshold);
-}
-
 export interface TriggerConfiguration extends ComponentConfiguration {
   auto?: boolean | TriggerAutoMode;
   order?: number;
@@ -646,13 +646,6 @@ interface SecurityDigestEntry {
   summary: SecurityAlertSummary;
   status?: string;
   bufferedAt: string;
-}
-
-function splitAndTrimCommaSeparatedList(value: string): string[] {
-  return value
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
 }
 
 /**
@@ -858,31 +851,7 @@ class Trigger<
    * @returns
    */
   static parseIncludeOrIncludeTriggerString(includeOrExcludeTriggerString: string) {
-    const hasThresholdSeparator = includeOrExcludeTriggerString.includes(':');
-    const separatorIndex = hasThresholdSeparator ? includeOrExcludeTriggerString.indexOf(':') : -1;
-    const hasMultipleSeparators =
-      hasThresholdSeparator &&
-      includeOrExcludeTriggerString.slice(separatorIndex + 1).includes(':');
-
-    const triggerId = hasThresholdSeparator
-      ? includeOrExcludeTriggerString.slice(0, separatorIndex).trim()
-      : includeOrExcludeTriggerString.trim();
-    const includeOrExcludeTrigger: { id: string; threshold: SupportedThreshold } = {
-      id: triggerId,
-      threshold: 'all',
-    };
-
-    if (hasThresholdSeparator && !hasMultipleSeparators) {
-      const thresholdCandidate = includeOrExcludeTriggerString
-        .slice(separatorIndex + 1)
-        .trim()
-        .toLowerCase();
-      if (isSupportedThreshold(thresholdCandidate)) {
-        includeOrExcludeTrigger.threshold = thresholdCandidate;
-      }
-    }
-
-    return includeOrExcludeTrigger;
+    return parseIncludeOrIncludeTriggerStringHelper(includeOrExcludeTriggerString);
   }
 
   /**
@@ -894,31 +863,7 @@ class Trigger<
    * @param triggerId
    */
   static doesReferenceMatchId(triggerReference: string, triggerId: string) {
-    const triggerReferenceNormalized = triggerReference.toLowerCase();
-    const triggerIdNormalized = triggerId.toLowerCase();
-
-    if (triggerReferenceNormalized === triggerIdNormalized) {
-      return true;
-    }
-
-    const triggerIdParts = triggerIdNormalized.split('.');
-    const triggerName = triggerIdParts.at(-1);
-    if (!triggerName) {
-      return false;
-    }
-    if (triggerReferenceNormalized === triggerName) {
-      return true;
-    }
-
-    if (triggerIdParts.length >= 2) {
-      const provider = triggerIdParts.at(-2);
-      const providerAndName = `${provider}.${triggerName}`;
-      if (triggerReferenceNormalized === providerAndName) {
-        return true;
-      }
-    }
-
-    return false;
+    return doesReferenceMatchIdHelper(triggerReference, triggerId);
   }
 
   private isTriggerEnabledForRule(
@@ -2609,17 +2554,7 @@ class Trigger<
   }
 
   isTriggerIncludedOrExcluded(containerResult: Container, trigger: string) {
-    const triggerId = this.getId().toLowerCase();
-    const triggers = splitAndTrimCommaSeparatedList(trigger).map((triggerToMatch) =>
-      Trigger.parseIncludeOrIncludeTriggerString(triggerToMatch),
-    );
-    const triggerMatched = triggers.find((triggerToMatch) =>
-      Trigger.doesReferenceMatchId(triggerToMatch.id, triggerId),
-    );
-    if (!triggerMatched) {
-      return false;
-    }
-    return Trigger.isThresholdReached(containerResult, triggerMatched.threshold.toLowerCase());
+    return matchesTriggerReferenceList(this.getId(), trigger, containerResult);
   }
 
   isTriggerIncluded(containerResult: Container, triggerInclude: string | undefined) {

--- a/app/triggers/providers/trigger-reference-matching.test.ts
+++ b/app/triggers/providers/trigger-reference-matching.test.ts
@@ -1,0 +1,143 @@
+import type { Container } from '../../model/container.js';
+import {
+  doesReferenceMatchId,
+  matchesTriggerReferenceList,
+  parseIncludeOrIncludeTriggerString,
+  splitAndTrimCommaSeparatedList,
+} from './trigger-reference-matching.js';
+
+function makeContainer(overrides: Partial<Container> = {}): Container {
+  return {
+    updateKind: { kind: 'unknown', semverDiff: 'unknown' },
+    ...overrides,
+  } as Container;
+}
+
+function containerWithSemverDiff(semverDiff: string): Container {
+  return makeContainer({
+    updateKind: { kind: 'tag', localValue: '1.0.0', remoteValue: '1.1.0', semverDiff } as never,
+  });
+}
+
+describe('trigger-reference-matching', () => {
+  describe('splitAndTrimCommaSeparatedList', () => {
+    test('splits, trims, and drops empty entries', () => {
+      expect(splitAndTrimCommaSeparatedList(' a , b ,, c ')).toStrictEqual(['a', 'b', 'c']);
+    });
+
+    test('returns an empty array for an all-whitespace/comma string', () => {
+      expect(splitAndTrimCommaSeparatedList(' , , ')).toStrictEqual([]);
+    });
+  });
+
+  describe('parseIncludeOrIncludeTriggerString', () => {
+    test('parses a bare name with default threshold', () => {
+      expect(parseIncludeOrIncludeTriggerString('pushover')).toStrictEqual({
+        id: 'pushover',
+        threshold: 'all',
+      });
+    });
+
+    test('parses a name:threshold pair', () => {
+      expect(parseIncludeOrIncludeTriggerString('pushover:major')).toStrictEqual({
+        id: 'pushover',
+        threshold: 'major',
+      });
+    });
+
+    test('trims whitespace around id and threshold', () => {
+      expect(parseIncludeOrIncludeTriggerString('  docker.local : DIGEST  ')).toStrictEqual({
+        id: 'docker.local',
+        threshold: 'digest',
+      });
+    });
+
+    test('falls back to all threshold when the candidate is unsupported', () => {
+      expect(parseIncludeOrIncludeTriggerString('pushover:turbo')).toStrictEqual({
+        id: 'pushover',
+        threshold: 'all',
+      });
+    });
+
+    test('ignores threshold entirely when multiple separators are present', () => {
+      expect(parseIncludeOrIncludeTriggerString('docker.local:digest:extra')).toStrictEqual({
+        id: 'docker.local',
+        threshold: 'all',
+      });
+    });
+  });
+
+  describe('doesReferenceMatchId', () => {
+    test('matches the full trigger id', () => {
+      expect(doesReferenceMatchId('docker.update', 'docker.update')).toBe(true);
+    });
+
+    test('matches the trigger name alone', () => {
+      expect(doesReferenceMatchId('update', 'docker.update')).toBe(true);
+    });
+
+    test('matches provider.name against a 3+ part trigger id', () => {
+      expect(doesReferenceMatchId('docker.update', 'agent-1.docker.update')).toBe(true);
+    });
+
+    test('does not match an unrelated reference', () => {
+      expect(doesReferenceMatchId('notify', 'docker.update')).toBe(false);
+    });
+
+    test('is case-insensitive', () => {
+      expect(doesReferenceMatchId('DOCKER.UPDATE', 'docker.update')).toBe(true);
+    });
+
+    test('returns false when the trigger id has no name segment', () => {
+      expect(doesReferenceMatchId('update', '')).toBe(false);
+    });
+
+    test('matches a single-segment trigger id against itself', () => {
+      expect(doesReferenceMatchId('pushover', 'pushover')).toBe(true);
+    });
+
+    test('does not match a provider-qualified reference against a single-segment trigger id', () => {
+      expect(doesReferenceMatchId('other.pushover', 'pushover')).toBe(false);
+    });
+  });
+
+  describe('matchesTriggerReferenceList', () => {
+    test('returns false when the reference list is undefined', () => {
+      expect(matchesTriggerReferenceList('docker.update', undefined, makeContainer())).toBe(false);
+    });
+
+    test('returns false when the trigger id is not referenced', () => {
+      expect(
+        matchesTriggerReferenceList('docker.update', 'slack.default,other', makeContainer()),
+      ).toBe(false);
+    });
+
+    test('returns true when referenced with the default (all) threshold', () => {
+      expect(
+        matchesTriggerReferenceList(
+          'docker.update',
+          'slack.default,docker.update',
+          makeContainer(),
+        ),
+      ).toBe(true);
+    });
+
+    test('honors a per-reference threshold', () => {
+      const container = containerWithSemverDiff('minor');
+      // 'patch' only matches semverDiff outside major/minor — 'minor' is rejected.
+      expect(matchesTriggerReferenceList('docker.update', 'docker.update:patch', container)).toBe(
+        false,
+      );
+      // 'minor' matches anything that isn't major.
+      expect(matchesTriggerReferenceList('docker.update', 'docker.update:minor', container)).toBe(
+        true,
+      );
+    });
+
+    test('is case-insensitive on the trigger id', () => {
+      expect(matchesTriggerReferenceList('DOCKER.UPDATE', 'docker.update', makeContainer())).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/app/triggers/providers/trigger-reference-matching.ts
+++ b/app/triggers/providers/trigger-reference-matching.ts
@@ -1,0 +1,130 @@
+import type { Container } from '../../model/container.js';
+import { isThresholdReached, SUPPORTED_THRESHOLDS } from './trigger-threshold.js';
+
+type SupportedThreshold = (typeof SUPPORTED_THRESHOLDS)[number];
+
+/**
+ * `dd.action.include` / `dd.action.exclude` / `dd.action.auto` (and their
+ * notification-category counterparts) all share one grammar: a comma-
+ * separated list of trigger references, each an optional `name:threshold`
+ * pair. This module owns that grammar as a leaf (no dependency beyond the
+ * `Container` type and the threshold helper), so it can be imported from
+ * anywhere without the require-cycle risk documented in
+ * `triggers/trigger-category.ts` — most notably from
+ * `model/action-policy.ts`, which cannot import `Trigger.ts` as a value
+ * (`Trigger.ts` -> `updates/request-update.ts` -> `model/update-eligibility.ts`
+ * -> `model/action-policy.ts` would close the cycle).
+ *
+ * `Trigger.ts`'s static `parseIncludeOrIncludeTriggerString` /
+ * `doesReferenceMatchId` and its instance `isTriggerIncludedOrExcluded`
+ * delegate here rather than duplicating the grammar.
+ */
+export interface ParsedTriggerReference {
+  id: string;
+  threshold: SupportedThreshold;
+}
+
+function isSupportedThreshold(value: string): value is SupportedThreshold {
+  return SUPPORTED_THRESHOLDS.includes(value as SupportedThreshold);
+}
+
+export function splitAndTrimCommaSeparatedList(value: string): string[] {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Parse a single `$name` or `$name:$threshold` reference string.
+ */
+export function parseIncludeOrIncludeTriggerString(
+  includeOrExcludeTriggerString: string,
+): ParsedTriggerReference {
+  const hasThresholdSeparator = includeOrExcludeTriggerString.includes(':');
+  const separatorIndex = hasThresholdSeparator ? includeOrExcludeTriggerString.indexOf(':') : -1;
+  const hasMultipleSeparators =
+    hasThresholdSeparator && includeOrExcludeTriggerString.slice(separatorIndex + 1).includes(':');
+
+  const triggerId = hasThresholdSeparator
+    ? includeOrExcludeTriggerString.slice(0, separatorIndex).trim()
+    : includeOrExcludeTriggerString.trim();
+  const includeOrExcludeTrigger: ParsedTriggerReference = {
+    id: triggerId,
+    threshold: 'all',
+  };
+
+  if (hasThresholdSeparator && !hasMultipleSeparators) {
+    const thresholdCandidate = includeOrExcludeTriggerString
+      .slice(separatorIndex + 1)
+      .trim()
+      .toLowerCase();
+    if (isSupportedThreshold(thresholdCandidate)) {
+      includeOrExcludeTrigger.threshold = thresholdCandidate;
+    }
+  }
+
+  return includeOrExcludeTrigger;
+}
+
+/**
+ * Return true when a trigger reference matches a trigger id.
+ * A reference can be either:
+ * - full trigger id: docker.update
+ * - trigger name only: update
+ */
+export function doesReferenceMatchId(triggerReference: string, triggerId: string): boolean {
+  const triggerReferenceNormalized = triggerReference.toLowerCase();
+  const triggerIdNormalized = triggerId.toLowerCase();
+
+  if (triggerReferenceNormalized === triggerIdNormalized) {
+    return true;
+  }
+
+  const triggerIdParts = triggerIdNormalized.split('.');
+  const triggerName = triggerIdParts.at(-1);
+  if (!triggerName) {
+    return false;
+  }
+  if (triggerReferenceNormalized === triggerName) {
+    return true;
+  }
+
+  if (triggerIdParts.length >= 2) {
+    const provider = triggerIdParts.at(-2);
+    const providerAndName = `${provider}.${triggerName}`;
+    if (triggerReferenceNormalized === providerAndName) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Return true when `triggerId` is referenced in `referenceList` (a comma
+ * separated `dd.action.include` / `dd.action.exclude` / `dd.action.auto`
+ * style label value) AND the container's update meets that reference's
+ * threshold. Mirrors `Trigger.isTriggerIncludedOrExcluded`, generalized to
+ * take the trigger id directly instead of reading it off `this`.
+ */
+export function matchesTriggerReferenceList(
+  triggerId: string,
+  referenceList: string | undefined,
+  containerResult: Container,
+): boolean {
+  if (!referenceList) {
+    return false;
+  }
+  const normalizedTriggerId = triggerId.toLowerCase();
+  const references = splitAndTrimCommaSeparatedList(referenceList).map((reference) =>
+    parseIncludeOrIncludeTriggerString(reference),
+  );
+  const matched = references.find((reference) =>
+    doesReferenceMatchId(reference.id, normalizedTriggerId),
+  );
+  if (!matched) {
+    return false;
+  }
+  return isThresholdReached(containerResult, matched.threshold.toLowerCase());
+}


### PR DESCRIPTION
Slice 2 of the 6.0.1 per-action policy package (#511), stacked on #752.

- `app/model/action-policy.ts`: pure resolver returning one `blocked | manual | auto` state per (action trigger, container). `dd.action.exclude` always wins; access is open for `AUTO=all|none` and label-granted otherwise; `dd.action.auto` implies access under `onauto`; `oninclude` keeps its legacy conflated meaning (include grants manual+auto) so no existing deployment changes behavior.
- `selectActionTrigger`: specificity-ranked candidate walk (file-matched compose > catch-all compose > generic docker, ties by insertion order with a one-time warn) — skip default-deny candidates, hard-stop on an explicit exclude, first authorized wins. Replaces first-compatible-by-insertion-order for eligibility display.
- `trigger-reference-matching.ts`: the `name[:threshold]` grammar extracted from `Trigger.ts` so the resolver reuses the exact matching machinery without a require cycle.
- `computeUpdateEligibility` derives `trigger-excluded`/`trigger-not-included` from the resolver verdict. Blocker reasons and severities unchanged (both still soft — the hard flip is the final slice of this package).
- Parametrized tests cover the full migration table and regression matrix from the phase spec, plus equivalence tests proving selection matches `findDockerTriggerForContainer` for every legacy scenario.

Admission and auto-dispatch wiring are slices 3-4. Global `updateMode` remains a call-site clamp, untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added per-action policy resolution for `blocked`, `manual`, and `auto` states.
- ✨ Added ranked Docker and Docker Compose trigger selection.
- ✨ Added reusable trigger-reference parsing and matching utilities.
- ✨ Added migration, regression, legacy-equivalence, and parametrized tests.
- 🔧 Updated `computeUpdateEligibility` to use resolver results.
- 🔧 Preserved existing blocker reasons and soft severities.
- 🔧 Preserved admission, auto-dispatch, and global `updateMode` clamp behavior.
- 🗑️ Removed duplicated trigger-reference parsing and legacy include/exclude checks.

## Concerns

- Verify resolver precedence for `dd.action.exclude`, access rules, `dd.action.auto`, and legacy `oninclude` against all migration cases.
- Verify tie warnings are emitted once per trigger set.
- Verify exported trigger-selection types follow existing module API conventions.
- Verify provider-qualified, name-only, and threshold-based references remain backward compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->