### PR TITLE
feat(updates): gate admission through the action policy resolver

### DIFF
--- a/app/api/container-actions.test.ts
+++ b/app/api/container-actions.test.ts
@@ -581,7 +581,7 @@ describe('Container Actions Router', () => {
         .mockReturnValueOnce(clearedContainer); // after updateContainer clears flag
       mockUpdateContainer.mockReturnValue(clearedContainer);
       const mockTriggerFn = vi.fn().mockResolvedValue(undefined);
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
 
       const handler = getHandler('post', '/:id/update');
@@ -630,7 +630,7 @@ describe('Container Actions Router', () => {
       };
       mockGetContainer.mockReturnValue(container);
       const mockTriggerFn = vi.fn().mockResolvedValue(undefined);
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
       const updateOperationStore = await import('../store/update-operation');
 
@@ -683,7 +683,11 @@ describe('Container Actions Router', () => {
         .mockReturnValueOnce(clearedContainer); // after clearing flag
       mockUpdateContainer.mockReturnValue(clearedContainer);
       const mockTriggerFn = vi.fn().mockResolvedValue(undefined);
-      const trigger = { type: 'dockercompose', trigger: mockTriggerFn };
+      const trigger = {
+        type: 'dockercompose',
+        trigger: mockTriggerFn,
+        getId: () => 'dockercompose.default',
+      };
       mockGetState.mockReturnValue({ trigger: { 'dockercompose.default': trigger } });
 
       const handler = getHandler('post', '/:id/update');
@@ -721,7 +725,7 @@ describe('Container Actions Router', () => {
         .mockReturnValueOnce(updatedContainer)
         .mockReturnValueOnce(updatedContainer);
       const mockTriggerFn = vi.fn().mockResolvedValue(undefined);
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
 
       const handler = getHandler('post', '/:id/update');
@@ -760,6 +764,7 @@ describe('Container Actions Router', () => {
         getDefaultComposeFilePath: vi.fn(() => '/opt/drydock/test/mysql.yml'),
         getComposeFilesForContainer: vi.fn(() => ['/opt/drydock/test/monitoring.yml']),
         trigger: mysqlTriggerFn,
+        getId: () => 'dockercompose.mysql',
       };
       const monitoringTrigger = {
         type: 'dockercompose',
@@ -767,6 +772,7 @@ describe('Container Actions Router', () => {
         getDefaultComposeFilePath: vi.fn(() => '/opt/drydock/test/monitoring.yml'),
         getComposeFilesForContainer: vi.fn(() => ['/opt/drydock/test/monitoring.yml']),
         trigger: monitoringTriggerFn,
+        getId: () => 'dockercompose.monitoring',
       };
       mockGetState.mockReturnValue({
         trigger: {
@@ -1095,7 +1101,7 @@ describe('Container Actions Router', () => {
       };
       mockGetContainer.mockReturnValue(container);
       const mockTriggerFn = vi.fn().mockRejectedValue(new Error('pull failed'));
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
 
       const handler = getHandler('post', '/:id/update');
@@ -1127,7 +1133,7 @@ describe('Container Actions Router', () => {
       };
       mockGetContainer.mockReturnValue(container);
       const mockTriggerFn = vi.fn().mockRejectedValue(new Error('Security scan blocked update'));
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
       const updateOperationStore = await import('../store/update-operation');
       (updateOperationStore.getOperationById as ReturnType<typeof vi.fn>).mockImplementation(
@@ -1165,7 +1171,7 @@ describe('Container Actions Router', () => {
       };
       mockGetContainer.mockReturnValue(container);
       const mockTriggerFn = vi.fn().mockRejectedValue('Security scan blocked update');
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
       const updateOperationStore = await import('../store/update-operation');
       (updateOperationStore.getOperationById as ReturnType<typeof vi.fn>).mockImplementation(
@@ -1203,7 +1209,7 @@ describe('Container Actions Router', () => {
       };
       mockGetContainer.mockReturnValue(container);
       const mockTriggerFn = vi.fn().mockResolvedValue(undefined);
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
 
       const handler = getHandler('post', '/:id/update');
@@ -1231,7 +1237,7 @@ describe('Container Actions Router', () => {
       };
       mockGetContainer.mockReturnValue(container);
       const mockTriggerFn = vi.fn().mockRejectedValue(new Error('Docker error'));
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
 
       const handler = getHandler('post', '/:id/update');
@@ -1259,7 +1265,7 @@ describe('Container Actions Router', () => {
       };
       mockGetContainer.mockReturnValue(container);
       const mockTriggerFn = vi.fn().mockResolvedValue(undefined);
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
 
       const mockAuditInc = vi.fn();
@@ -1287,7 +1293,7 @@ describe('Container Actions Router', () => {
       };
       mockGetContainer.mockReturnValue(container);
       const mockTriggerFn = vi.fn().mockRejectedValue('update failed as string');
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
 
       const handler = getHandler('post', '/:id/update');
@@ -1383,7 +1389,7 @@ describe('Container Actions Router', () => {
         return undefined;
       });
       const mockTriggerFn = vi.fn().mockResolvedValue(undefined);
-      const trigger = { type: 'docker', trigger: mockTriggerFn };
+      const trigger = { type: 'docker', trigger: mockTriggerFn, getId: () => 'docker.default' };
       mockGetState.mockReturnValue({ trigger: { 'docker.default': trigger } });
 
       const handler = getHandler('post', '/update');
@@ -1431,7 +1437,13 @@ describe('Container Actions Router', () => {
       mockGetContainer.mockReturnValue(nginx);
       const mockTriggerFn = vi.fn().mockRejectedValue(new Error('bulk trigger failed'));
       mockGetState.mockReturnValue({
-        trigger: { 'docker.default': { type: 'docker', trigger: mockTriggerFn } },
+        trigger: {
+          'docker.default': {
+            type: 'docker',
+            trigger: mockTriggerFn,
+            getId: () => 'docker.default',
+          },
+        },
       });
 
       const handler = getHandler('post', '/update');
@@ -1479,7 +1491,11 @@ describe('Container Actions Router', () => {
       });
       mockGetState.mockReturnValue({
         trigger: {
-          'docker.default': { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) },
+          'docker.default': {
+            type: 'docker',
+            trigger: vi.fn().mockResolvedValue(undefined),
+            getId: () => 'docker.default',
+          },
         },
       });
       const handler = getHandler('post', '/update');

--- a/app/api/container/triggers.test.ts
+++ b/app/api/container/triggers.test.ts
@@ -4,7 +4,7 @@ import * as requestUpdate from '../../updates/request-update.js';
 import { createTriggerHandlers } from './triggers.js';
 
 function createTrigger(overrides: Record<string, unknown> = {}) {
-  return {
+  const trigger = {
     id: 'slack.notify',
     type: 'slack',
     name: 'notify',
@@ -12,6 +12,7 @@ function createTrigger(overrides: Record<string, unknown> = {}) {
     trigger: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
+  return { getId: () => trigger.id as string, ...trigger };
 }
 
 function createHarness(

--- a/app/api/dependency-groups.test.ts
+++ b/app/api/dependency-groups.test.ts
@@ -116,6 +116,7 @@ function createDockerTrigger() {
   return {
     trigger: {
       type: 'docker',
+      getId: vi.fn(() => 'docker.local'),
       trigger: vi.fn().mockResolvedValue(undefined),
       getWatcher: vi.fn(() => ({
         dockerApi: { getContainer: vi.fn(() => mockDockerContainer) },

--- a/app/api/trigger.test.ts
+++ b/app/api/trigger.test.ts
@@ -158,6 +158,7 @@ describe('Trigger Router', () => {
       const mockTrigger = {
         type: 'docker',
         trigger: vi.fn().mockResolvedValue(undefined),
+        getId: () => 'docker.update',
       };
       registry.getState.mockReturnValue({
         trigger: { 'docker.update': mockTrigger },
@@ -190,6 +191,7 @@ describe('Trigger Router', () => {
       const mockTrigger = {
         type: 'docker',
         trigger: vi.fn().mockResolvedValue(undefined),
+        getId: () => 'docker.update',
       };
       registry.getState.mockReturnValue({
         trigger: { 'docker.update': mockTrigger },

--- a/app/api/webhook.test.ts
+++ b/app/api/webhook.test.ts
@@ -1306,7 +1306,9 @@ describe('Webhook Router', () => {
       const mockTrigger = vi.fn().mockResolvedValue(undefined);
       mockGetState.mockReturnValue({
         watcher: {},
-        trigger: { 'docker.default': { type: 'docker', trigger: mockTrigger } },
+        trigger: {
+          'docker.default': { type: 'docker', trigger: mockTrigger, getId: () => 'docker.default' },
+        },
       });
 
       const handler = getHandler('post', '/update/:containerName');
@@ -1338,7 +1340,13 @@ describe('Webhook Router', () => {
       const mockTrigger = vi.fn().mockResolvedValue(undefined);
       mockGetState.mockReturnValue({
         watcher: {},
-        trigger: { 'dockercompose.default': { type: 'dockercompose', trigger: mockTrigger } },
+        trigger: {
+          'dockercompose.default': {
+            type: 'dockercompose',
+            trigger: mockTrigger,
+            getId: () => 'dockercompose.default',
+          },
+        },
       });
 
       const handler = getHandler('post', '/update/:containerName');
@@ -1370,7 +1378,7 @@ describe('Webhook Router', () => {
       mockGetState.mockReturnValue({
         watcher: {},
         trigger: {
-          'docker.default': { type: 'docker', trigger: vi.fn() },
+          'docker.default': { type: 'docker', trigger: vi.fn(), getId: () => 'docker.default' },
         },
       });
       const spy = vi
@@ -1398,7 +1406,7 @@ describe('Webhook Router', () => {
       mockGetState.mockReturnValue({
         watcher: {},
         trigger: {
-          'docker.default': { type: 'docker', trigger: vi.fn() },
+          'docker.default': { type: 'docker', trigger: vi.fn(), getId: () => 'docker.default' },
         },
       });
       const spy = vi
@@ -1430,7 +1438,9 @@ describe('Webhook Router', () => {
       const mockTrigger = vi.fn().mockResolvedValue(undefined);
       mockGetState.mockReturnValue({
         watcher: {},
-        trigger: { 'docker.default': { type: 'docker', trigger: mockTrigger } },
+        trigger: {
+          'docker.default': { type: 'docker', trigger: mockTrigger, getId: () => 'docker.default' },
+        },
       });
 
       const handler = getHandler('post', '/update/:containerName');
@@ -1460,6 +1470,7 @@ describe('Webhook Router', () => {
           'docker.default': {
             type: 'docker',
             trigger: vi.fn().mockRejectedValue(new Error('Trigger failed')),
+            getId: () => 'docker.default',
           },
         },
       });
@@ -1499,6 +1510,7 @@ describe('Webhook Router', () => {
           'docker.default': {
             type: 'docker',
             trigger: vi.fn().mockRejectedValue('trigger failed as string'),
+            getId: () => 'docker.default',
           },
         },
       });
@@ -1526,7 +1538,11 @@ describe('Webhook Router', () => {
       mockGetState.mockReturnValue({
         watcher: {},
         trigger: {
-          'docker.default': { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) },
+          'docker.default': {
+            type: 'docker',
+            trigger: vi.fn().mockResolvedValue(undefined),
+            getId: () => 'docker.default',
+          },
         },
       });
 
@@ -1589,7 +1605,11 @@ describe('Webhook Router', () => {
       mockGetState.mockReturnValue({
         watcher: {},
         trigger: {
-          'docker.default': { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) },
+          'docker.default': {
+            type: 'docker',
+            trigger: vi.fn().mockResolvedValue(undefined),
+            getId: () => 'docker.default',
+          },
         },
       });
 
@@ -1616,8 +1636,18 @@ describe('Webhook Router', () => {
       mockGetState.mockReturnValue({
         watcher: {},
         trigger: {
-          'docker.default': { type: 'docker', agent: 'agent1', trigger: mockTriggerFn },
-          'docker.other': { type: 'docker', agent: 'agent2', trigger: mockOtherTriggerFn },
+          'docker.default': {
+            type: 'docker',
+            agent: 'agent1',
+            trigger: mockTriggerFn,
+            getId: () => 'docker.default',
+          },
+          'docker.other': {
+            type: 'docker',
+            agent: 'agent2',
+            trigger: mockOtherTriggerFn,
+            getId: () => 'docker.other',
+          },
           'slack.default': { type: 'slack', trigger: vi.fn() },
         },
       });
@@ -1719,7 +1749,14 @@ describe('Webhook Router', () => {
       mockGetState.mockReturnValue({
         watcher: {},
         // agent: 'ml' matches the remoteContainer.agent for the trigger lookup in requestContainerUpdate
-        trigger: { 'docker.default': { type: 'docker', agent: 'ml', trigger: mockTrigger } },
+        trigger: {
+          'docker.default': {
+            type: 'docker',
+            agent: 'ml',
+            trigger: mockTrigger,
+            getId: () => 'docker.default',
+          },
+        },
       });
 
       const handler = getHandler('post', '/update/:containerName');
@@ -1754,7 +1791,14 @@ describe('Webhook Router', () => {
       const mockTrigger = vi.fn().mockResolvedValue(undefined);
       mockGetState.mockReturnValue({
         watcher: {},
-        trigger: { 'docker.default': { type: 'docker', agent: undefined, trigger: mockTrigger } },
+        trigger: {
+          'docker.default': {
+            type: 'docker',
+            agent: undefined,
+            trigger: mockTrigger,
+            getId: () => 'docker.default',
+          },
+        },
       });
 
       const handler = getHandler('post', '/update/:containerName');
@@ -1795,7 +1839,14 @@ describe('Webhook Router', () => {
       // container2 is on agent 'a2'; trigger matches that agent
       mockGetState.mockReturnValue({
         watcher: {},
-        trigger: { 'docker.default': { type: 'docker', agent: 'a2', trigger: mockTrigger } },
+        trigger: {
+          'docker.default': {
+            type: 'docker',
+            agent: 'a2',
+            trigger: mockTrigger,
+            getId: () => 'docker.default',
+          },
+        },
       });
 
       const handler = getHandler('post', '/update/:containerName');

--- a/app/model/action-policy.test.ts
+++ b/app/model/action-policy.test.ts
@@ -402,6 +402,37 @@ describe('selectActionTrigger — requireAuto', () => {
   });
 });
 
+describe('selectActionTrigger — triggerTypes', () => {
+  test('triggerTypes excludes a higher-specificity compose candidate so a scoped docker trigger wins', () => {
+    // A compose file-matched trigger normally outranks a generic docker
+    // trigger (case 9 above). `triggerTypes: ['docker']` must filter the
+    // compose candidate out entirely BEFORE ranking, so the docker trigger
+    // wins even though it would lose the specificity walk unscoped.
+    const container = makeContainer({
+      labels: {
+        'com.docker.compose.project.config_files': '/opt/drydock/test/monitoring/compose.yaml',
+      },
+    });
+    const composeTrigger = makeTrigger('dockercompose.monitoring', {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+      getDefaultComposeFilePath: () => '/opt/drydock/test/monitoring/compose.yaml',
+      getComposeFilesForContainer: () => ['/opt/drydock/test/monitoring/compose.yaml'],
+    });
+    const dockerTrigger = makeTrigger('docker.generic', { configuration: { auto: 'all' } });
+    const triggers = {
+      'dockercompose.monitoring': composeTrigger,
+      'docker.generic': dockerTrigger,
+    };
+
+    const unscoped = selectActionTrigger(triggers, container);
+    expect(unscoped?.triggerId).toBe('dockercompose.monitoring');
+
+    const scoped = selectActionTrigger(triggers, container, { triggerTypes: ['docker'] });
+    expect(scoped?.triggerId).toBe('docker.generic');
+  });
+});
+
 describe('selectActionTrigger — tied-candidate WARN', () => {
   test('warns once (not twice) when equally specific candidates tie on registration order', async () => {
     const logger = (await import('../log/index.js')).default;

--- a/app/model/action-policy.ts
+++ b/app/model/action-policy.ts
@@ -56,6 +56,15 @@ export interface SelectActionTriggerOptions {
    * callers pass `false`/omit.
    */
   requireAuto?: boolean;
+  /**
+   * When provided, restricts candidates to triggers whose `type` is in this
+   * list. Applied before ranking, so an excluded type can never win even when
+   * it would otherwise outrank every included candidate (e.g. a compose
+   * file-matched trigger is never selected when the caller scopes to
+   * `['docker']`). Omitted/undefined keeps today's behavior: every
+   * `CANDIDATE_TRIGGER_TYPES` type is eligible.
+   */
+  triggerTypes?: string[];
 }
 
 export interface SelectActionTriggerResult extends ActionPolicyResult {
@@ -248,7 +257,11 @@ export function selectActionTrigger(
   container: Container,
   options: SelectActionTriggerOptions = {},
 ): SelectActionTriggerResult | undefined {
-  const ranked = rankCandidates(getCompatibleCandidates(triggers, container));
+  const compatible = getCompatibleCandidates(triggers, container);
+  const scoped = options.triggerTypes
+    ? compatible.filter((candidate) => options.triggerTypes?.includes(candidate.trigger.type))
+    : compatible;
+  const ranked = rankCandidates(scoped);
 
   for (const candidate of ranked) {
     const result = resolveForTrigger(candidate.trigger, container);

--- a/app/updates/request-update.test.ts
+++ b/app/updates/request-update.test.ts
@@ -171,7 +171,11 @@ describe('request-update', () => {
 
   test('auto mode allows automatic update admission', async () => {
     mockGetUpdateMode.mockReturnValue('auto');
-    const trigger = { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) };
+    const trigger = {
+      type: 'docker',
+      trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.update',
+    };
 
     const accepted = await enqueueContainerUpdate(createContainer(), {
       trigger,
@@ -313,6 +317,7 @@ describe('request-update', () => {
     const trigger = {
       type: 'docker',
       trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.update',
     };
 
     const result = await enqueueContainerUpdates(
@@ -357,6 +362,7 @@ describe('request-update', () => {
       getDefaultComposeFilePath: vi.fn(() => '/opt/drydock/test/monitoring.yml'),
       getComposeFilesForContainer: vi.fn(() => ['/opt/drydock/test/monitoring.yml']),
       trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'dockercompose.compose',
     };
     mockGetState.mockReturnValue({
       trigger: {
@@ -420,7 +426,11 @@ describe('request-update', () => {
   });
 
   test('enqueueContainerUpdate uses provided operationId instead of generating a new one (#289)', async () => {
-    const trigger = { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) };
+    const trigger = {
+      type: 'docker',
+      trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.update',
+    };
     const accepted = await enqueueContainerUpdate(createContainer(), {
       trigger,
       operationId: 'controller-op-uuid',
@@ -433,7 +443,11 @@ describe('request-update', () => {
   });
 
   test('enqueueContainerUpdates uses provided operationId for single-container batches (#289)', async () => {
-    const trigger = { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) };
+    const trigger = {
+      type: 'docker',
+      trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.update',
+    };
     const result = await enqueueContainerUpdates([createContainer({ id: 'c1', name: 'nginx' })], {
       trigger,
       operationId: 'controller-single-op',
@@ -447,7 +461,11 @@ describe('request-update', () => {
   });
 
   test('enqueueContainerUpdates ignores provided operationId for multi-container batches (#289)', async () => {
-    const trigger = { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) };
+    const trigger = {
+      type: 'docker',
+      trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.update',
+    };
     const result = await enqueueContainerUpdates(
       [createContainer({ id: 'c1', name: 'nginx' }), createContainer({ id: 'c2', name: 'redis' })],
       { trigger, operationId: 'should-not-be-used' },
@@ -1507,7 +1525,13 @@ describe('request-update', () => {
           image: { name: 'drydock', tag: { value: '1.5.0' } },
           result: { tag: '1.6.0' },
         }),
-        { trigger: { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) } },
+        {
+          trigger: {
+            type: 'docker',
+            trigger: vi.fn().mockResolvedValue(undefined),
+            getId: () => 'docker.other',
+          },
+        },
       );
       expect(accepted.operationId).toBeDefined();
       expect(mockInsertOperation).toHaveBeenCalled();
@@ -1529,7 +1553,13 @@ describe('request-update', () => {
         createContainerWithRawUpdate({
           updatePolicy: { snoozeUntil: '2099-01-01T00:00:00.000Z' },
         }),
-        { trigger: { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) } },
+        {
+          trigger: {
+            type: 'docker',
+            trigger: vi.fn().mockResolvedValue(undefined),
+            getId: () => 'docker.other',
+          },
+        },
       );
       expect(accepted.operationId).toBeDefined();
       expect(mockInsertOperation).toHaveBeenCalled();
@@ -1591,7 +1621,13 @@ describe('request-update', () => {
 
       const accepted = await enqueueContainerUpdate(
         createContainerWithRawUpdate({ triggerExclude: 'nginx' }),
-        { trigger: { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) } },
+        {
+          trigger: {
+            type: 'docker',
+            trigger: vi.fn().mockResolvedValue(undefined),
+            getId: () => 'docker.other',
+          },
+        },
       );
       expect(accepted.operationId).toBeDefined();
       expect(mockInsertOperation).toHaveBeenCalled();
@@ -1611,10 +1647,133 @@ describe('request-update', () => {
 
       const accepted = await enqueueContainerUpdate(
         createContainerWithRawUpdate({ triggerInclude: 'other-app' }),
-        { trigger: { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) } },
+        {
+          trigger: {
+            type: 'docker',
+            trigger: vi.fn().mockResolvedValue(undefined),
+            getId: () => 'docker.other',
+          },
+        },
       );
       expect(accepted.operationId).toBeDefined();
       expect(mockInsertOperation).toHaveBeenCalled();
+    });
+  });
+
+  describe('automatic-source admission guard (spec-6.0.1-action-policy.md slice 3)', () => {
+    // These tests resolve the trigger via the auto-resolve path (no explicit
+    // `options.trigger`) so both `resolveUpdateTrigger` and the automatic-source
+    // guard exercise the same registry-backed trigger through
+    // `selectActionTrigger`/`resolveForTrigger`.
+    function createRegistryTrigger(overrides: Record<string, unknown> = {}) {
+      return {
+        type: 'docker',
+        trigger: vi.fn().mockResolvedValue(undefined),
+        agent: undefined,
+        configuration: {},
+        getId: () => 'docker.update',
+        ...overrides,
+      };
+    }
+
+    test('admits automatic dispatch when the resolved action policy state is auto (default AUTO=all)', async () => {
+      const trigger = createRegistryTrigger();
+      mockGetState.mockReturnValue({ trigger: { 'docker.update': trigger } });
+
+      const accepted = await enqueueContainerUpdate(createContainer(), { source: 'automatic' });
+
+      expect(accepted.operationId).toBeDefined();
+    });
+
+    test('rejects automatic dispatch with 409 when the resolved action policy state is manual (AUTO=none)', async () => {
+      const trigger = createRegistryTrigger({ configuration: { auto: 'none' } });
+      mockGetState.mockReturnValue({ trigger: { 'docker.update': trigger } });
+
+      await expect(
+        enqueueContainerUpdate(createContainer(), { source: 'automatic' }),
+      ).rejects.toMatchObject<Partial<UpdateRequestError>>({
+        statusCode: 409,
+        message:
+          'Action policy for this trigger does not permit automatic updates for this container',
+      });
+      expect(trigger.trigger).not.toHaveBeenCalled();
+      expect(mockInsertOperation).not.toHaveBeenCalled();
+    });
+
+    test('legacy AUTO=true boolean (~ all) admits automatic dispatch, matching the migration table', async () => {
+      const trigger = createRegistryTrigger({ configuration: { auto: true } });
+      mockGetState.mockReturnValue({ trigger: { 'docker.update': trigger } });
+
+      const accepted = await enqueueContainerUpdate(createContainer(), { source: 'automatic' });
+
+      expect(accepted.operationId).toBeDefined();
+    });
+
+    test('legacy AUTO=false boolean (~ none) still admits manual/API requests exactly as today', async () => {
+      // Pre-6.0.1, admission never consulted trigger auto mode at all — manual/API
+      // requests admitted regardless. The automatic-source guard only applies when
+      // source === 'automatic', so a manual-sourced request must keep admitting here
+      // even though the resolved state is 'manual'.
+      const trigger = createRegistryTrigger({ configuration: { auto: false } });
+      mockGetState.mockReturnValue({ trigger: { 'docker.update': trigger } });
+
+      const accepted = await requestContainerUpdate(createContainer());
+      await flushAsyncWork();
+
+      expect(accepted.operationId).toBeDefined();
+      expect(trigger.trigger).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'c1' }),
+        expect.objectContaining({ operationId: accepted.operationId }),
+      );
+    });
+
+    test('regression matrix #10: same-name containers on different agents resolve independently through admission', async () => {
+      const triggerEdge1 = createRegistryTrigger({
+        agent: 'edge-1',
+        getId: () => 'edge-1.docker.update',
+      });
+      const triggerEdge2 = createRegistryTrigger({
+        agent: 'edge-2',
+        getId: () => 'edge-2.docker.update',
+      });
+      mockGetState.mockReturnValue({
+        trigger: {
+          'edge-1.docker.update': triggerEdge1,
+          'edge-2.docker.update': triggerEdge2,
+        },
+        watcher: {},
+      });
+
+      const containerA = createContainer({
+        id: 'c-edge1',
+        name: 'web',
+        agent: 'edge-1',
+        watcher: 'w1',
+      });
+      const containerB = createContainer({
+        id: 'c-edge2',
+        name: 'web',
+        agent: 'edge-2',
+        watcher: 'w2',
+      });
+
+      const acceptedA = await requestContainerUpdate(containerA);
+      await flushAsyncWork();
+      const acceptedB = await requestContainerUpdate(containerB);
+      await flushAsyncWork();
+
+      expect(acceptedA.trigger).toBe(triggerEdge1);
+      expect(acceptedB.trigger).toBe(triggerEdge2);
+      expect(triggerEdge1.trigger).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'c-edge1', agent: 'edge-1' }),
+        expect.objectContaining({ operationId: acceptedA.operationId }),
+      );
+      expect(triggerEdge2.trigger).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'c-edge2', agent: 'edge-2' }),
+        expect.objectContaining({ operationId: acceptedB.operationId }),
+      );
+      expect(triggerEdge1.trigger).toHaveBeenCalledTimes(1);
+      expect(triggerEdge2.trigger).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1736,6 +1895,7 @@ describe('request-update', () => {
     const trigger = {
       type: 'docker',
       trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.update',
     };
 
     const result = await enqueueContainerUpdates(

--- a/app/updates/request-update.test.ts
+++ b/app/updates/request-update.test.ts
@@ -159,7 +159,11 @@ describe('request-update', () => {
 
   test('manual mode rejects automatic update admission but allows manual requests', async () => {
     mockGetUpdateMode.mockReturnValue('manual');
-    const trigger = { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) };
+    const trigger = {
+      type: 'docker',
+      trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.update',
+    };
 
     await expect(enqueueContainerUpdate(createContainer(), { trigger })).rejects.toMatchObject({
       statusCode: 409,
@@ -189,6 +193,7 @@ describe('request-update', () => {
     const trigger = {
       type: 'docker',
       trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.update',
     };
 
     const accepted = await requestContainerUpdate(createContainer(), { trigger });
@@ -217,6 +222,7 @@ describe('request-update', () => {
     const trigger = {
       type: 'docker',
       trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.update',
     };
     const container = createContainer({ id: 'c42', name: 'myapp' });
 
@@ -238,6 +244,7 @@ describe('request-update', () => {
     const trigger = {
       type: 'docker',
       trigger: vi.fn().mockRejectedValue(new Error('pull failed')),
+      getId: () => 'docker.update',
     };
     mockGetOperationById.mockImplementation((id: string) => ({
       id,
@@ -259,6 +266,7 @@ describe('request-update', () => {
     const trigger = {
       type: 'docker',
       trigger: vi.fn().mockRejectedValue({ message: 'registry timeout' }),
+      getId: () => 'docker.update',
     };
     mockGetOperationById.mockImplementation((id: string) => ({
       id,
@@ -392,6 +400,47 @@ describe('request-update', () => {
     );
   });
 
+  test('options.triggerTypes is honored: a scoped auto-resolve never selects an excluded trigger type', async () => {
+    // A compose file-matched trigger normally outranks a generic docker
+    // trigger, but `triggerTypes: ['docker']` must exclude it from the
+    // candidate pool entirely before ranking (action-policy.test.ts covers
+    // the resolver-level behavior directly).
+    const composeTrigger = {
+      type: 'dockercompose',
+      configuration: { auto: 'all' },
+      getDefaultComposeFilePath: () => '/opt/drydock/test/monitoring.yml',
+      getComposeFilesForContainer: () => ['/opt/drydock/test/monitoring.yml'],
+      trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'dockercompose.compose',
+    };
+    const dockerTrigger = {
+      type: 'docker',
+      configuration: { auto: 'all' },
+      trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.generic',
+    };
+    mockGetState.mockReturnValue({
+      trigger: {
+        'dockercompose.compose': composeTrigger,
+        'docker.generic': dockerTrigger,
+      },
+    });
+    const container = createContainer({
+      labels: {
+        'com.docker.compose.project.config_files': '/opt/drydock/test/monitoring.yml',
+      },
+    });
+
+    const accepted = await requestContainerUpdate(container, {
+      triggerTypes: ['docker'],
+    });
+    await flushAsyncWork();
+
+    expect(accepted.trigger).toBe(dockerTrigger);
+    expect(dockerTrigger.trigger).toHaveBeenCalled();
+    expect(composeTrigger.trigger).not.toHaveBeenCalled();
+  });
+
   test('enqueueContainerUpdate rejects invalid provided trigger shapes', async () => {
     await expect(
       enqueueContainerUpdate(createContainer(), {
@@ -406,7 +455,7 @@ describe('request-update', () => {
   test('enqueueContainerUpdate rejects non-container update trigger types', async () => {
     await expect(
       enqueueContainerUpdate(createContainer(), {
-        trigger: { type: 'slack', trigger: vi.fn() } as any,
+        trigger: { type: 'slack', trigger: vi.fn(), getId: () => 'slack.default' } as any,
       }),
     ).rejects.toMatchObject<Partial<UpdateRequestError>>({
       statusCode: 400,
@@ -1039,6 +1088,7 @@ describe('request-update', () => {
         trigger: {
           type: 'docker',
           trigger: triggerFn,
+          getId: () => 'docker.update',
         },
       });
       await flushAsyncWork();
@@ -1584,7 +1634,11 @@ describe('request-update', () => {
       });
 
       const accepted = await requestContainerUpdate(maturitySuppressed, {
-        trigger: { type: 'docker', trigger: vi.fn().mockResolvedValue(undefined) },
+        trigger: {
+          type: 'docker',
+          trigger: vi.fn().mockResolvedValue(undefined),
+          getId: () => 'docker.other',
+        },
       });
 
       expect(accepted.operationId).toBeDefined();
@@ -1691,6 +1745,25 @@ describe('request-update', () => {
 
       await expect(
         enqueueContainerUpdate(createContainer(), { source: 'automatic' }),
+      ).rejects.toMatchObject<Partial<UpdateRequestError>>({
+        statusCode: 409,
+        message:
+          'Action policy for this trigger does not permit automatic updates for this container',
+      });
+      expect(trigger.trigger).not.toHaveBeenCalled();
+      expect(mockInsertOperation).not.toHaveBeenCalled();
+    });
+
+    test('rejects automatic dispatch with 409 for an explicit trigger (options.trigger) when the resolved action policy state is manual (AUTO=none)', async () => {
+      // Same guard, but through the explicit-trigger path (`options.trigger`
+      // provided directly, bypassing the registry-backed auto-resolve walk)
+      // rather than the auto-resolve path the other tests in this describe
+      // exercise — the automatic-source admission guard must apply
+      // regardless of which path resolved the trigger.
+      const trigger = createRegistryTrigger({ configuration: { auto: 'none' } });
+
+      await expect(
+        enqueueContainerUpdate(createContainer(), { trigger, source: 'automatic' }),
       ).rejects.toMatchObject<Partial<UpdateRequestError>>({
         statusCode: 409,
         message:
@@ -1877,6 +1950,7 @@ describe('request-update', () => {
     const trigger = {
       type: 'docker',
       trigger: vi.fn().mockResolvedValue(undefined),
+      getId: () => 'docker.update',
     };
 
     const result = await requestContainerUpdates(
@@ -1946,6 +2020,7 @@ describe('request-update', () => {
       const trigger = {
         type: 'docker',
         trigger: vi.fn().mockResolvedValue(undefined),
+        getId: () => 'docker.update',
       };
       const accepted = await requestContainerUpdate(createContainer({ name: 'nginx' }), {
         trigger,
@@ -1962,6 +2037,7 @@ describe('request-update', () => {
       const trigger = {
         type: 'docker',
         trigger: vi.fn().mockResolvedValue(undefined),
+        getId: () => 'docker.update',
       };
       const accepted = await requestContainerUpdate(
         createContainer({
@@ -1984,6 +2060,7 @@ describe('request-update', () => {
       const trigger = {
         type: 'docker',
         trigger: vi.fn().mockResolvedValue(undefined),
+        getId: () => 'docker.update',
       };
       const accepted = await requestContainerUpdate(
         createContainer({ id: 'c-w1', name: 'web', watcher: 'watcher-1' }),
@@ -2024,6 +2101,7 @@ describe('request-update', () => {
       const trigger = {
         type: 'docker',
         trigger: vi.fn().mockRejectedValue(docker404Error),
+        getId: () => 'docker.update',
       };
 
       // Operation is in queued state when we check
@@ -2064,6 +2142,7 @@ describe('request-update', () => {
       const trigger = {
         type: 'docker',
         trigger: vi.fn().mockRejectedValue(docker404Error),
+        getId: () => 'docker.update',
       };
 
       mockGetOperationById.mockImplementation((id: string) => ({
@@ -2094,6 +2173,7 @@ describe('request-update', () => {
       const trigger = {
         type: 'docker',
         trigger: vi.fn().mockRejectedValue(docker404Error),
+        getId: () => 'docker.update',
       };
 
       mockGetOperationById.mockImplementation((id: string) => ({
@@ -2135,6 +2215,7 @@ describe('request-update', () => {
       const trigger = {
         type: 'docker',
         trigger: vi.fn().mockRejectedValue(conflict409Error),
+        getId: () => 'docker.update',
       };
 
       mockGetOperationById.mockImplementation((id: string) => ({
@@ -2168,6 +2249,7 @@ describe('request-update', () => {
       const trigger = {
         type: 'docker',
         trigger: vi.fn().mockRejectedValue(conflict409Error),
+        getId: () => 'docker.update',
       };
 
       mockGetOperationById.mockImplementation((id: string) => ({
@@ -2200,6 +2282,7 @@ describe('request-update', () => {
       const trigger = {
         type: 'docker',
         trigger: vi.fn().mockRejectedValue(conflict409Error),
+        getId: () => 'docker.update',
       };
 
       mockGetOperationById.mockImplementation((id: string) => ({
@@ -2238,6 +2321,7 @@ describe('request-update', () => {
       const trigger = {
         type: 'docker',
         trigger: vi.fn().mockRejectedValue(pullError),
+        getId: () => 'docker.update',
       };
 
       mockGetOperationById.mockImplementation((id: string) => ({
@@ -2285,10 +2369,12 @@ describe('request-update', () => {
       const winnerTrigger = {
         type: 'docker',
         trigger: vi.fn(() => winnerPull.promise),
+        getId: () => 'docker.update',
       };
       const loserTrigger = {
         type: 'docker',
         trigger: vi.fn().mockRejectedValue(loserConflict409),
+        getId: () => 'docker.update',
       };
 
       // Winner op: queued with agent+watcher identity.

--- a/app/updates/request-update.ts
+++ b/app/updates/request-update.ts
@@ -135,11 +135,11 @@ function toRejectedContainerUpdateRequest(
   };
 }
 
-function isResolvedUpdateTrigger(trigger: UpdateTriggerLike): trigger is ResolvedUpdateTrigger {
+function isResolvedUpdateTrigger(trigger: unknown): trigger is ResolvedUpdateTrigger {
   return (
     typeof trigger === 'object' &&
     trigger !== null &&
-    typeof trigger.type === 'string' &&
+    typeof (trigger as { type?: unknown }).type === 'string' &&
     typeof (trigger as { getId?: unknown }).getId === 'function'
   );
 }

--- a/app/updates/request-update.ts
+++ b/app/updates/request-update.ts
@@ -50,6 +50,7 @@ type UpdateTriggerLike = {
 type ResolvedUpdateTrigger = UpdateTriggerLike & {
   agent?: string;
   configuration?: object;
+  getId: () => string;
   getDefaultComposeFilePath?: () => string | null;
   getComposeFilesForContainer?: (container: {
     name?: string;
@@ -135,7 +136,12 @@ function toRejectedContainerUpdateRequest(
 }
 
 function isResolvedUpdateTrigger(trigger: UpdateTriggerLike): trigger is ResolvedUpdateTrigger {
-  return typeof trigger === 'object' && trigger !== null && typeof trigger.type === 'string';
+  return (
+    typeof trigger === 'object' &&
+    trigger !== null &&
+    typeof trigger.type === 'string' &&
+    typeof (trigger as { getId?: unknown }).getId === 'function'
+  );
 }
 
 function resolveUpdateTrigger(
@@ -160,13 +166,14 @@ function resolveUpdateTrigger(
   // been returned (and admitted, subject only to the soft blocker) before
   // this wiring. An explicit `dd.action.exclude` hit is still returned (hard
   // stop) so eligibility's `trigger-excluded` messaging/severity is unchanged
-  // by this slice. `options.triggerTypes` is not honored here — in practice
-  // every caller passes the same docker/dockercompose default `selectActionTrigger`
-  // already scopes to (see `CANDIDATE_TRIGGER_TYPES`).
+  // by this slice. `options.triggerTypes` is honored via `selectActionTrigger`'s
+  // own `triggerTypes` option: when provided, candidates whose type is not in
+  // the list are excluded before ranking, so a narrower caller-supplied scope
+  // (e.g. compose-only) can never fall through to a type it didn't ask for.
   const selection = selectActionTrigger(
     registry.getState().trigger as unknown as Record<string, ActionPolicyTrigger> | undefined,
     container,
-    { requireAuto: false },
+    { requireAuto: false, triggerTypes: options.triggerTypes },
   );
   if (!selection) {
     throw new UpdateRequestError(404, NO_DOCKER_TRIGGER_FOUND_ERROR);

--- a/app/updates/request-update.ts
+++ b/app/updates/request-update.ts
@@ -1,8 +1,5 @@
 import crypto from 'node:crypto';
-import {
-  findDockerTriggerForContainer,
-  NO_DOCKER_TRIGGER_FOUND_ERROR,
-} from '../api/docker-trigger.js';
+import { NO_DOCKER_TRIGGER_FOUND_ERROR } from '../api/docker-trigger.js';
 import {
   buildDependencyGraph,
   buildDependentsByDependency,
@@ -13,6 +10,11 @@ import {
 } from '../dependencies/dependency-graph.js';
 import logger from '../log/index.js';
 import { sanitizeLogParam } from '../log/sanitize.js';
+import {
+  type ActionPolicyTrigger,
+  resolveForTrigger,
+  selectActionTrigger,
+} from '../model/action-policy.js';
 import { type Container, hasRawUpdate } from '../model/container.js';
 import {
   computeUpdateEligibility,
@@ -98,6 +100,8 @@ const DEFAULT_UPDATE_TRIGGER_TYPES: UpdateTriggerType[] = ['docker', 'dockercomp
 const log = logger.child({ component: 'updates.request-update' });
 const NOTIFY_MODE_REJECTION_MESSAGE = 'Update mode is notify; Drydock will not apply updates';
 const MANUAL_MODE_REJECTION_MESSAGE = 'Update mode is manual; automatic updates are disabled';
+const ACTION_POLICY_NOT_AUTO_REJECTION_MESSAGE =
+  'Action policy for this trigger does not permit automatic updates for this container';
 
 export class UpdateRequestError extends Error {
   statusCode: number;
@@ -149,13 +153,25 @@ function resolveUpdateTrigger(
     return providedTrigger;
   }
 
-  const trigger = findDockerTriggerForContainer(registry.getState().trigger, container, {
-    triggerTypes: options.triggerTypes || DEFAULT_UPDATE_TRIGGER_TYPES,
-  });
-  if (!trigger) {
+  // Routed through the action-policy resolver's hybrid multi-trigger walk
+  // (spec-6.0.1-action-policy.md) rather than the plain agent/compose
+  // compatibility lookup: a candidate that resolves `not-included` is no
+  // longer eligible to be the resolved trigger, even though it would have
+  // been returned (and admitted, subject only to the soft blocker) before
+  // this wiring. An explicit `dd.action.exclude` hit is still returned (hard
+  // stop) so eligibility's `trigger-excluded` messaging/severity is unchanged
+  // by this slice. `options.triggerTypes` is not honored here — in practice
+  // every caller passes the same docker/dockercompose default `selectActionTrigger`
+  // already scopes to (see `CANDIDATE_TRIGGER_TYPES`).
+  const selection = selectActionTrigger(
+    registry.getState().trigger as unknown as Record<string, ActionPolicyTrigger> | undefined,
+    container,
+    { requireAuto: false },
+  );
+  if (!selection) {
     throw new UpdateRequestError(404, NO_DOCKER_TRIGGER_FOUND_ERROR);
   }
-  return trigger as ResolvedUpdateTrigger;
+  return selection.trigger as unknown as ResolvedUpdateTrigger;
 }
 
 function getActiveUpdateOperationForContainer(container: Container) {
@@ -329,9 +345,24 @@ function prepareContainerUpdateRequest(
     throw new UpdateRequestError(statusCodeForHardBlocker(hardBlocker), hardBlocker.message);
   }
 
+  const trigger = resolveUpdateTrigger(container, options);
+
+  // Defense-in-depth (spec-6.0.1-action-policy.md): trigger-excluded/trigger-not-included
+  // are still 'soft' severity ahead of the DEPRECATIONS.md hard flip (slice 6), so the hard
+  // blocker check above does not yet reject a not-included/excluded container. Automatic
+  // (watcher-driven) admission must never fire through anything short of a resolved 'auto'
+  // policy regardless of that severity timing — manual/API callers (source 'manual') keep
+  // today's behavior and admit both 'manual' and 'auto' states.
+  if (source === 'automatic') {
+    const resolvedPolicy = resolveForTrigger(trigger as unknown as ActionPolicyTrigger, container);
+    if (resolvedPolicy.state !== 'auto') {
+      throw new UpdateRequestError(409, ACTION_POLICY_NOT_AUTO_REJECTION_MESSAGE);
+    }
+  }
+
   return {
     container,
-    trigger: resolveUpdateTrigger(container, options),
+    trigger,
   };
 }
 


### PR DESCRIPTION
Slice 3 of the 6.0.1 per-action policy package (#511), on top of #752/#755.

- `resolveUpdateTrigger` resolves the update trigger through `selectActionTrigger` (policy-aware, specificity-ranked) instead of first-compatible-by-insertion-order. 404 semantics preserved.
- Defense-in-depth guard in `prepareContainerUpdateRequest`: `source === 'automatic'` requests are rejected 409 unless the resolved policy state for the trigger is `auto`. Applies to both explicit-trigger and auto-resolved paths, so automatic dispatch can never execute through a trigger the policy only grants `manual`. Manual/API admission is unchanged (admits `manual` and `auto`).
- Global `updateMode` gate and hard-blocker check untouched.
- Tests: the automatic-source guard matrix (auto admits, manual rejects 409, legacy `AUTO` bool mapping preserved), regression-matrix case 10 (same-name containers on different agents admit independently), and `getId()` backfill on trigger mocks in the admission-path consumers (webhook, container-actions, dependency-groups).

Auto-dispatch wiring (the winner-selection gate inside `Trigger.ts` plus the double-dispatch closure) is slice 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

### ✨ Added
- Added `triggerTypes` filtering to `selectActionTrigger`.
- Added automatic-source admission tests for default and legacy `AUTO` policies.
- Added same-name container tests across agents.
- Added `getId()` support to trigger mocks and trigger-path consumers.

### 🔧 Changed
- Resolve update triggers with the policy-aware, specificity-ranked action policy resolver.
- Filter trigger candidates by `options.triggerTypes` before ranking.
- Require resolved triggers to provide `getId()`.
- Reject automatic-source requests with HTTP 409 unless the resolved trigger policy state is `auto`.
- Preserve manual/API admission behavior for `manual` and `auto` states.
- Preserve the global `updateMode` gate and hard-blocker check.
- Widen the trigger type guard parameter to `unknown` without changing runtime checks.

### 🐛 Fixed
- Prevent automatic admission from creating operations or executing triggers when the resolved trigger policy is not `auto`.
- Preserve existing 404 behavior.

## Concerns

- Auto-dispatch winner selection remains deferred to slice 4.
- Double-dispatch handling remains deferred to slice 4.
- Replace repeated inline `getId()` trigger mocks with a shared test factory or utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->