### PR TITLE
chore(quality): drop the trivy qlty plugin in favor of Grype

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -108,22 +108,10 @@ version = "0.9.0"
 name = "shfmt"
 
 [[plugin]]
-name = "trivy"
-drivers = [
-  "config",
-]
-version = "0.69.3"
-
-[[plugin]]
 name = "trufflehog"
 
 [[plugin]]
 name = "yamllint"
-
-# Entrypoint uses su-exec for runtime privilege drop; no static USER needed
-[[triage]]
-match.rules = ["trivy:DS002", "trivy:DS-0002"]
-set.ignored = true
 
 # markdownlint table style is low-signal for this repository's docs format
 [[triage]]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ Longer-form working notes and the roadmap tracker live under `.planning/` at the
 
 ## Key constraints
 
-- Biome is a direct devDependency in the root workspace; qlty handles all other linters (actionlint, checkov, dockerfmt, hadolint, markdownlint, osv-scanner, shellcheck, shfmt, trivy, trufflehog, yamllint) but not biome — qlty's biome integration doesn't reliably apply fixes.
+- Biome is a direct devDependency in the root workspace; qlty handles all other linters (actionlint, checkov, dockerfmt, hadolint, markdownlint, osv-scanner, shellcheck, shfmt, trufflehog, yamllint) but not biome — qlty's biome integration doesn't reliably apply fixes.
 - `content/docs/` is the source of truth for published docs; the generated copy under `apps/web/content/docs/` is gitignored.
 - `CHANGELOG.md` at the repo root is the single source of truth for the changelog.
 - Regex from user config (tag include/exclude/transform) is compiled via `re2js` for linear-time execution — never introduce a raw `RegExp` on user-supplied patterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Dropped the trivy qlty plugin in favor of Grype.** Grype already owns the vuln-scanning surface (`.github/workflows/security-grype.yml`); trivy's qlty-plugin `config` driver only ever ran its DS*/KSV* Dockerfile misconfiguration checks, which checkov already covers (the `checkov:skip=CKV_DOCKER_3` comment on `Dockerfile` line 1, with matching rationale in `.trivyignore.yaml` for the standalone `trivy` binary the image ships at runtime — a separate concern, untouched here). Removed the `[[plugin]] name = "trivy"` block and the `trivy:DS002`/`trivy:DS-0002` triage entry from `.qlty/qlty.toml`; trufflehog stays as-is. ([#753](https://github.com/CodesWhat/drydock/issues/753))
+
 ## [1.7.0-rc.1] — 2026-08-14
 
 ### Added


### PR DESCRIPTION
## What

Removes the `trivy` qlty plugin block (`drivers = ["config"]`, `version = "0.69.3"`) and its `trivy:DS002`/`trivy:DS-0002` triage entry from `.qlty/qlty.toml`. `trufflehog` is untouched. Also drops `trivy` from the qlty-plugin list documented in `AGENTS.md`'s Key Constraints section, and adds a CHANGELOG entry.

## Why

We deprecated trivy org-wide in favor of Grype for supply-chain/vuln-scanning posture (decided 2026-08-16, recorded in `codeswhat-ops` `standards/security.md`). Grype already owns that surface here via `.github/workflows/security-grype.yml` (grype-deps + grype-image, unchanged by this PR). The qlty trivy plugin only ran its `config` driver — Dockerfile misconfiguration checks (DS002/DS-0002, "missing USER") — which checkov already covers independently: the `checkov:skip=CKV_DOCKER_3` comment on `Dockerfile` line 1 (with the matching rationale carried in `.trivyignore.yaml` for the separate, still-shipped `aquasec/trivy` runtime binary — that binary and its `.trivyignore.yaml` are a different concern from the qlty static-analysis plugin and are left alone here).

House-audit follow-up H3.

Closes #753

## Test plan

- [x] `./scripts/qlty-check-gate.sh all` — passes (1 pre-existing, unrelated `ripgrep:NOTE` advisory in `app/tag/suggest.ts`)
- [x] `npm run lint` (from `app/`) — passes, no fixes needed
- [x] Full pre-push gate chain (ts-nocheck, biome, qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, coverage) — all green, coverage thresholds met (100%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🗑️ Removed the Trivy Qlty plugin and `trivy:DS002`/`trivy:DS-0002` triage rules from `.qlty/qlty.toml`.
- 🔧 Changed `AGENTS.md` to remove Trivy from the Qlty-managed linter list.
- 🔧 Retained Trufflehog, Gitleaks, Grype, and Checkov scanning.
- ✨ Added the related changelog entry.

## Concerns

- Verify Grype covers vulnerability scanning.
- Verify Checkov covers the removed Trivy Dockerfile configuration checks.
- Confirm the unrelated `ripgrep:NOTE` pre-push advisory remains pre-existing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->