### PR TITLE
ci(security): pin hosted runners and annotate remaining action pins

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -159,7 +159,7 @@ test('secret scanning gates full history and the tracked working tree', () => {
   expect(job).toMatchObject({
     name: '🔑 Security: Secrets',
     needs: ['security-actions'],
-    'runs-on': 'ubuntu-latest',
+    'runs-on': 'ubuntu-24.04',
     'timeout-minutes': 10,
   });
   expect(getWorkflowStep('secrets', 'Checkout')).toMatchObject({

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -61,7 +61,12 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: CodesWhat/.github/.github/workflows/go-ci.yml@47820bd85d49eb6cd0a935c31789c7d7ce037401
+    # The org's .github repo has no tags; pinned to a commit on its main
+    # branch as of 2026-08-16, verified by
+    # .github/tests/reusable-ci-config.test.ts. Re-check the org's .github
+    # commit history periodically and bump this pin if the reusable
+    # workflow's inputs change.
+    uses: CodesWhat/.github/.github/workflows/go-ci.yml@47820bd85d49eb6cd0a935c31789c7d7ce037401  # main, 2026-08-16
     with:
       run-workflow-security: true
       workflow-security-egress-policy: block
@@ -72,7 +77,7 @@ jobs:
   secrets:
     name: "🔑 Security: Secrets"
     needs: [security-actions]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -112,7 +117,7 @@ jobs:
 
   changes:
     name: "🔎 Changes: Path Filter"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read
@@ -155,7 +160,7 @@ jobs:
     name: "🛡️ SAST: CodeQL"
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [security-actions]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 60  # CodeQL init/autobuild/analyze can be long on cache misses
     permissions:
       security-events: write
@@ -195,7 +200,7 @@ jobs:
     name: "🎯 Fuzz Testing"
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [security-actions]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     permissions:
       contents: read
@@ -326,7 +331,7 @@ jobs:
   dependency-review:
     name: "📦 Security: Dependency Review"
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -351,7 +356,7 @@ jobs:
 
   lint:
     name: "Quality: Lint"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
@@ -407,7 +412,7 @@ jobs:
 
   test:
     name: "Quality: Test & Coverage"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -513,7 +518,7 @@ jobs:
     # site, so it never blocks backend-only PRs.
     needs: [changes]
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.web == 'true' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
@@ -558,7 +563,7 @@ jobs:
   build:
     name: "Build"
     needs: [lint, test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 35  # Includes UI build + single-arch QA image + multi-arch smoke build
     permissions:
       contents: read
@@ -653,7 +658,7 @@ jobs:
 
   dast-zap-baseline:
     name: "🕷️ DAST: ZAP + Nuclei"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 25  # Includes QA stack startup and scanner container runtime
     # Run on every merge to main (gates the next release-cut), on legacy
     # release branches (back-compat), and on the existing weekly schedules
@@ -1055,7 +1060,7 @@ jobs:
   e2e:
     name: "E2E: Cucumber"
     if: github.event_name == 'workflow_dispatch' || (github.event_name != 'schedule' && needs.changes.outputs.runtime == 'true')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Covers the bounded npm/setup retry budgets, readiness waits, scenario
     # execution, and post-failure evidence collection without racing job expiry.
     timeout-minutes: 40
@@ -1190,7 +1195,7 @@ jobs:
 
   load-test-ci:
     name: "⚡ Load Test: CI"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
     needs: [build]
@@ -1315,7 +1320,7 @@ jobs:
 
   load-test-behavior:
     name: "⚡ Load Test: Behavior + Stress (Advisory)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
     needs: [build]

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -50,7 +50,7 @@ env:
 jobs:
   changes:
     name: "🔎 Changes: Path Filter"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: read
@@ -82,7 +82,7 @@ jobs:
   playwright:
     name: "E2E: Playwright"
     if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.runtime == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 35  # UI build + Docker build + QA stack startup + Playwright pull + UI flow tests
     needs: [changes]
     permissions:

--- a/.github/workflows/i18n-crowdin.yml
+++ b/.github/workflows/i18n-crowdin.yml
@@ -24,7 +24,7 @@ permissions: {}
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment: crowdin
     permissions:

--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   stryker:
     name: "🧬 Quality: Stryker Advisory (${{ matrix.name }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: mutation
     timeout-minutes: 360  # GitHub Actions maximum; mutation testing is expensive and advisory-only
     continue-on-error: true  # advisory by policy; review results, then file focused follow-up work
@@ -271,7 +271,7 @@ jobs:
     name: "🧬 Quality: Aggregate Mutation Score"
     needs: stryker
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: mutation
     continue-on-error: true
     env:

--- a/.github/workflows/quality-portwing-fleet-soak.yml
+++ b/.github/workflows/quality-portwing-fleet-soak.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   fleet-soak:
     name: "⏱️ Cross-repo fleet, exec, reconnect, backpressure"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -51,7 +51,7 @@ env:
 jobs:
   release:
     name: "🚀 Release: Build, Publish, Tag"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 120  # Multi-arch build, signing, attestations, release upload, and CI-success polling budget
     environment: release-publish
     env:

--- a/.github/workflows/security-grype.yml
+++ b/.github/workflows/security-grype.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   grype-deps:
     name: "📦 Security: Grype Dependency Scan (npm lockfiles)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
@@ -89,7 +89,7 @@ jobs:
     # PRs get fast, accurate dependency coverage from grype-deps without
     # paying for a Docker build on every push.
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   analysis:
     name: "🛡️ Security: Scorecard Analysis"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       actions: read  # Allow SARIF upload metadata reads on private repos


### PR DESCRIPTION
House-audit items H5 + H13 (2026-08-16 audit vs `codeswhat-ops/standards/pinning.md`).

- Pins all 23 `runs-on: ubuntu-latest` instances across 9 workflows to `ubuntu-24.04` (ci-verify, e2e-playwright, i18n-crowdin, quality-mutation-monthly, quality-portwing-fleet-soak, release-cut, security-grype, security-scorecard). No macos/windows floating labels existed; `greptile.yml` only calls a reusable workflow and has no `runs-on` of its own.
- Annotates the one unannotated SHA pin: the `go-ci.yml` reusable-workflow call in ci-verify.yml now carries the `# main, 2026-08-16` comment plus the no-tags rationale, matching the convention already used in greptile.yml.
- Verified the qlty shellcheck pin comment already matches its configured 0.9.0 — no change needed there.
- Updates the one workflow-test fixture that asserted `ubuntu-latest` for the secrets job.

Verification: `npm run test:workflows` 171/171; `zizmor .github/workflows/ --min-severity medium` clean (v1.29.0, offline).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed all 23 workflow runners from `ubuntu-latest` to `ubuntu-24.04`.
- 🔧 Changed the workflow-test fixture to expect `ubuntu-24.04`.
- ✨ Added verification and no-tags maintenance comments for the Go CI SHA pin.
- 🔒 Confirmed the qlty shellcheck pin comment matches version `0.9.0`.
- ✨ Verified 171/171 workflow tests pass.
- 🔒 Verified `zizmor` reports no medium-or-higher findings.

## Concerns

- Confirm that all 23 runner replacements are intentional across the 9 workflows.
- Confirm that the `ubuntu-24.04` image is available for every referenced GitHub-hosted job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->