### PR TITLE
ci(security): flip harden-runner to egress block on stage-1 jobs

### DIFF
--- a/.github/tests/harden-runner-workflow.test.ts
+++ b/.github/tests/harden-runner-workflow.test.ts
@@ -77,7 +77,22 @@ test('GitHub-hosted workflow jobs start with current pinned Harden Runner', () =
   expect(violations).toStrictEqual([]);
 });
 
-test('Block-mode jobs carry a non-empty allowed-endpoints list', () => {
+test('Every expectedPolicy key maps to a real local job', () => {
+  const knownKeys = new Set<string>();
+  for (const { file, workflow } of loadWorkflowFiles()) {
+    for (const [jobId, job] of Object.entries(workflow.jobs ?? {})) {
+      if (!job['runs-on'] || !job.steps?.length) {
+        continue;
+      }
+      knownKeys.add(`${file}/${jobId}`);
+    }
+  }
+
+  const staleKeys = Object.keys(expectedPolicy).filter((key) => !knownKeys.has(key));
+  expect(staleKeys).toStrictEqual([]);
+});
+
+test('Block-mode jobs carry a non-empty allowed-endpoints list and disable-sudo', () => {
   const violations: string[] = [];
 
   for (const { file, workflow } of loadWorkflowFiles()) {
@@ -95,6 +110,9 @@ test('Block-mode jobs carry a non-empty allowed-endpoints list', () => {
       const allowedEndpoints = firstStep.with?.['allowed-endpoints'];
       if (typeof allowedEndpoints !== 'string' || allowedEndpoints.trim() === '') {
         violations.push(key);
+      }
+      if (firstStep.with?.['disable-sudo'] !== true) {
+        violations.push(`${key} missing disable-sudo: true`);
       }
     }
   }

--- a/.github/tests/harden-runner-workflow.test.ts
+++ b/.github/tests/harden-runner-workflow.test.ts
@@ -10,6 +10,25 @@ const workflowsDir = fileURLToPath(new URL('../workflows', import.meta.url));
 const hardenRunnerRef = 'step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920';
 const hardenRunnerVersion = 'v2.20.0';
 
+type EgressPolicy = 'audit' | 'block';
+
+// Stage 1 of the audit->block migration (.planning/roadmap/h2-harden-runner-block-plan.md
+// §2). Any job not listed here defaults to 'audit'. This map is the migration
+// checklist — each stage's PR adds exactly the jobs it flips to 'block'.
+const expectedPolicy: Record<string, EgressPolicy> = {
+  'ci-verify.yml/changes': 'block',
+  'ci-verify.yml/dependency-review': 'block',
+  'ci-verify.yml/secrets': 'block',
+  'ci-verify.yml/fuzz': 'block',
+  'ci-verify.yml/test': 'block',
+  'ci-verify.yml/web': 'block',
+  'e2e-playwright.yml/changes': 'block',
+  'quality-mutation-monthly.yml/stryker': 'block',
+  'quality-mutation-monthly.yml/aggregate': 'block',
+  'quality-portwing-fleet-soak.yml/fleet-soak': 'block',
+  'security-grype.yml/grype-deps': 'block',
+};
+
 function loadWorkflowFiles(): Array<{
   file: string;
   source: string;
@@ -34,17 +53,87 @@ test('GitHub-hosted workflow jobs start with current pinned Harden Runner', () =
   for (const { file, workflow } of loadWorkflowFiles()) {
     for (const [jobId, job] of Object.entries(workflow.jobs ?? {})) {
       if (!job['runs-on'] || !job.steps?.length) {
+        // Reusable-workflow calls (e.g. ci-verify.yml's security-actions, via
+        // go-ci.yml) have no local steps to inspect — their harden-runner
+        // policy is asserted where the call sets workflow-security-* inputs.
+        continue;
+      }
+
+      const key = `${file}/${jobId}`;
+      const policy = expectedPolicy[key] ?? 'audit';
+
+      const firstStep = job.steps[0];
+      if (firstStep.uses !== hardenRunnerRef) {
+        violations.push(key);
+        continue;
+      }
+
+      if (firstStep.with?.['egress-policy'] !== policy) {
+        violations.push(`${key} expected egress-policy '${policy}'`);
+      }
+    }
+  }
+
+  expect(violations).toStrictEqual([]);
+});
+
+test('Block-mode jobs carry a non-empty allowed-endpoints list', () => {
+  const violations: string[] = [];
+
+  for (const { file, workflow } of loadWorkflowFiles()) {
+    for (const [jobId, job] of Object.entries(workflow.jobs ?? {})) {
+      if (!job['runs-on'] || !job.steps?.length) {
+        continue;
+      }
+
+      const key = `${file}/${jobId}`;
+      if ((expectedPolicy[key] ?? 'audit') !== 'block') {
         continue;
       }
 
       const firstStep = job.steps[0];
-      if (firstStep.uses !== hardenRunnerRef) {
-        violations.push(`${file}/${jobId}`);
+      const allowedEndpoints = firstStep.with?.['allowed-endpoints'];
+      if (typeof allowedEndpoints !== 'string' || allowedEndpoints.trim() === '') {
+        violations.push(key);
+      }
+    }
+  }
+
+  expect(violations).toStrictEqual([]);
+});
+
+test('Block-mode allowed-endpoints entries are host:443 (optionally wildcard-subdomain)', () => {
+  const endpointPattern = /^(\*\.)?[A-Za-z0-9.-]+:443$/;
+  const violations: string[] = [];
+
+  for (const { file, workflow } of loadWorkflowFiles()) {
+    for (const [jobId, job] of Object.entries(workflow.jobs ?? {})) {
+      if (!job['runs-on'] || !job.steps?.length) {
         continue;
       }
 
-      if (firstStep.with?.['egress-policy'] !== 'audit') {
-        violations.push(`${file}/${jobId} missing audit egress policy`);
+      const key = `${file}/${jobId}`;
+      if ((expectedPolicy[key] ?? 'audit') !== 'block') {
+        continue;
+      }
+
+      const firstStep = job.steps[0];
+      const allowedEndpoints = firstStep.with?.['allowed-endpoints'];
+      if (typeof allowedEndpoints !== 'string') {
+        continue;
+      }
+
+      // Folded `>` block scalars join their source lines with spaces (not
+      // newlines) once parsed, so split on any whitespace run rather than '\n'.
+      const entries = allowedEndpoints
+        .split(/\s+/)
+        .map((entry) => entry.trim())
+        .filter((entry) => entry !== '');
+
+      for (const entry of entries) {
+        if (!endpointPattern.test(entry)) {
+          violations.push(`${key}: ${entry}`);
+        }
       }
     }
   }

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -139,6 +139,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             github.com:443
+            api.github.com:443
             *.actions.githubusercontent.com:443
           disable-sudo: true
 

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -452,6 +452,8 @@ jobs:
             nodejs.org:443
             qlty-releases.s3.amazonaws.com:443
             qlty.sh:443
+            tuf-repo-cdn.sigstore.dev:443
+            tuf-repo.github.com:443
             *.actions.githubusercontent.com:443
           disable-sudo: true
 

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -86,7 +86,13 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -130,7 +136,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -210,7 +220,13 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+            api.github.com:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -341,7 +357,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -422,7 +443,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -527,7 +553,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -225,6 +225,7 @@ jobs:
           allowed-endpoints: >
             github.com:443
             registry.npmjs.org:443
+            nodejs.org:443
             api.github.com:443
             *.actions.githubusercontent.com:443
           disable-sudo: true
@@ -448,6 +449,9 @@ jobs:
           allowed-endpoints: >
             github.com:443
             registry.npmjs.org:443
+            nodejs.org:443
+            qlty-releases.s3.amazonaws.com:443
+            qlty.sh:443
             *.actions.githubusercontent.com:443
           disable-sudo: true
 
@@ -558,6 +562,7 @@ jobs:
           allowed-endpoints: >
             github.com:443
             registry.npmjs.org:443
+            nodejs.org:443
             *.actions.githubusercontent.com:443
           disable-sudo: true
 

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -62,7 +62,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -65,6 +65,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             github.com:443
+            api.github.com:443
             *.actions.githubusercontent.com:443
           disable-sudo: true
 

--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -185,7 +185,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
 
       - name: Checkout
         id: checkout
@@ -281,7 +286,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            *.actions.githubusercontent.com:443
+            dashboard.stryker-mutator.io:443
+          disable-sudo: true
 
       - name: Checkout
         id: checkout

--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -189,6 +189,7 @@ jobs:
           allowed-endpoints: >
             github.com:443
             registry.npmjs.org:443
+            nodejs.org:443
             *.actions.githubusercontent.com:443
           disable-sudo: true
 

--- a/.github/workflows/quality-portwing-fleet-soak.yml
+++ b/.github/workflows/quality-portwing-fleet-soak.yml
@@ -37,7 +37,14 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            registry.npmjs.org:443
+            *.actions.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+          disable-sudo: true
 
       - name: Checkout Drydock
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/quality-portwing-fleet-soak.yml
+++ b/.github/workflows/quality-portwing-fleet-soak.yml
@@ -41,6 +41,7 @@ jobs:
           allowed-endpoints: >
             github.com:443
             registry.npmjs.org:443
+            nodejs.org:443
             *.actions.githubusercontent.com:443
             proxy.golang.org:443
             sum.golang.org:443

--- a/.github/workflows/quality-portwing-fleet-soak.yml
+++ b/.github/workflows/quality-portwing-fleet-soak.yml
@@ -44,6 +44,10 @@ jobs:
             *.actions.githubusercontent.com:443
             proxy.golang.org:443
             sum.golang.org:443
+            api.github.com:443
+            raw.githubusercontent.com:443
+            go.dev:443
+            dl.google.com:443
           disable-sudo: true
 
       - name: Checkout Drydock

--- a/.github/workflows/security-grype.yml
+++ b/.github/workflows/security-grype.yml
@@ -51,6 +51,8 @@ jobs:
             toolbox-data.anchore.io:443
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
+            api.github.com:443
+            raw.githubusercontent.com:443
           disable-sudo: true
 
       - name: Checkout

--- a/.github/workflows/security-grype.yml
+++ b/.github/workflows/security-grype.yml
@@ -48,7 +48,8 @@ jobs:
           allowed-endpoints: >
             github.com:443
             *.actions.githubusercontent.com:443
-            toolbox-data.anchore.io:443
+            get.anchore.io:443
+            grype.anchore.io:443
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             api.github.com:443

--- a/.github/workflows/security-grype.yml
+++ b/.github/workflows/security-grype.yml
@@ -44,7 +44,14 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            *.actions.githubusercontent.com:443
+            toolbox-data.anchore.io:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+          disable-sudo: true
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3


### PR DESCRIPTION
Stage 1 of the harden-runner audit-to-block migration (house-audit item H2; plan in `.planning/roadmap/h2-harden-runner-block-plan.md`, ops drift record updated in codeswhat-ops `1cdc658`).

- Flips 11 job instances from `egress-policy: audit` to `block` with per-job `allowed-endpoints`: `changes` (ci-verify + e2e-playwright), `dependency-review`, `secrets`, `fuzz`, `test`, `web`, `stryker`, `aggregate`, `fleet-soak`, `grype-deps`. These are the jobs whose egress is fully enumerable with high confidence.
- Adds `disable-sudo: true` to every migrated job (no job in the repo uses sudo).
- Rewrites `.github/tests/harden-runner-workflow.test.ts` around a per-job `expectedPolicy` map (default `audit`), asserting block jobs carry non-empty, format-valid allowlists — the map doubles as the migration checklist for later stages.
- Deliberately NOT in this stage: `lint`/`build`/`codeql`/`load-test-*`/`grype-image`/`crowdin-sync` (stage 2, pending a week of egress telemetry for CDN-redirect hosts), `release-cut` (stage 4, after two audited RC cuts), and `dast-zap-baseline`/`e2e`/`playwright`/`scorecard` (recorded exceptions — dynamic endpoint surfaces).

Known watch items post-merge: gitleaks/grype binary downloads carry both GitHub asset-CDN hosts (302 target varies; prune the unused one after observation), and the qlty coverage publish host in `test` is intentionally omitted (step is `continue-on-error`; will add once observed).

Verification: `npm run test:workflows` 173/173; zizmor medium+ clean; actionlint v1.7.12 exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- 🔒 Migrated 11 Harden Runner jobs from `audit` to `block`.
- 🔒 Added per-job `allowed-endpoints` and `disable-sudo: true`.
- 🔧 Updated workflow tests to use per-job `expectedPolicy`, defaulting to `audit`.
- 🔧 Added allowlist validation for block-policy jobs.
- 🔧 Added telemetry-derived endpoints, including `api.github.com`, `raw.githubusercontent.com`, `go.dev`, and `dl.google.com`.
- 🔧 Verified `npm run test:workflows` with 173/173 tests, `zizmor`, and `actionlint v1.7.12`.

## Concerns

- Monitor GitHub asset-CDN redirect hosts used by gitleaks and grype.
- Monitor the qlty coverage publish host.
- Keep the per-datacenter `githubapp.com` host blocked.
- Keep Stage 2 jobs, `release-cut`, and jobs with dynamic endpoint surfaces unchanged until their endpoint requirements are defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->