### PR TITLE
docs(readme): align tail sections and badge wall with house shape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,8 @@ Never use `--no-verify`. If a hook fails, fix the root cause — that's what it'
 
 Pull requests are **squash-only** — the repo has merge commits and rebase merges disabled. Don't rely on `git merge-base --is-ancestor` for anything branch-related in this repo; every merge to `main` mints a new commit that `dev/vX.Y` never had, so ancestry checks fail even on a fully in-sync branch. Compare trees instead (`git diff --quiet <a> <b>`) — see `RELEASING.md` for where this matters.
 
+Applying the `second-opinion` label to a PR triggers `.github/workflows/greptile.yml` (config in `greptile.json`), which summons Greptile as a second-opinion reviewer alongside the standard review.
+
 ## Release & branch model
 
 Feature work and fixes land on `dev/vX.Y` via PR — never target `main` directly (see `CONTRIBUTING.md`). Cutting an actual release (`main` sync, RC/GA tagging, the soak requirement) is a maintainer operation documented in `RELEASING.md`.

--- a/README.de.md
+++ b/README.de.md
@@ -22,12 +22,12 @@
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
-  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+  <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>
 </p>
 
 <hr>
@@ -472,7 +472,7 @@ Nur übergeordnete Themen; Details pro Version finden Sie in [CHANGELOG.md](CHAN
 
 Fragen, Feedback und frühzeitige Unterstützung: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
-Bitte reichen Sie konkrete Fehler und Funktionsanfragen in **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** ein, damit diese nicht im Chat verloren gehen.
+Fehler und konkrete Funktionsanfragen gehören zu **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**; offene Fragen, Ideen und Showcases gehören zu **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**; Echtzeit-Chat findet im **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)** statt.
 
 ### Community-QA
 
@@ -504,8 +504,6 @@ Die vollständige Kompatibilitätsmatrix für alle drei Tools finden Sie in [por
     <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
   </picture>
 </a>
-
-[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
 
 <a href="#drydock">Zurück nach oben</a>
 

--- a/README.de.md
+++ b/README.de.md
@@ -470,7 +470,7 @@ Nur übergeordnete Themen; Details pro Version finden Sie in [CHANGELOG.md](CHAN
 
 ### Gemeinschaft
 
-Fragen, Feedback und frühzeitige Unterstützung: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+Echtzeit-Chat und frühzeitige Unterstützung: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
 Fehler und konkrete Funktionsanfragen gehören zu **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**; offene Fragen, Ideen und Showcases gehören zu **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**; Echtzeit-Chat findet im **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)** statt.
 

--- a/README.es.md
+++ b/README.es.md
@@ -470,7 +470,7 @@ Solo temas generales; consulte [CHANGELOG.md](CHANGELOG.md) para conocer el deta
 
 ### Comunidad
 
-Preguntas, comentarios y soporte temprano: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+Chat en tiempo real y soporte temprano: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
 Los errores y las solicitudes de funciones concretas van a **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**; las preguntas abiertas, ideas y demostraciones van a **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**; el chat en tiempo real ocurre en **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**.
 

--- a/README.es.md
+++ b/README.es.md
@@ -22,12 +22,12 @@
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
-  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+  <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>
 </p>
 
 <hr>
@@ -472,7 +472,7 @@ Solo temas generales; consulte [CHANGELOG.md](CHANGELOG.md) para conocer el deta
 
 Preguntas, comentarios y soporte temprano: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
-Presente errores concretos y solicitudes de funciones en **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** para que no se pierdan en el chat.
+Los errores y las solicitudes de funciones concretas van a **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**; las preguntas abiertas, ideas y demostraciones van a **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**; el chat en tiempo real ocurre en **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**.
 
 ### Control de calidad de la comunidad
 
@@ -504,8 +504,6 @@ Consulte el [COMPATIBILITY.md de portwing](https://github.com/CodesWhat/portwing
     <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
   </picture>
 </a>
-
-[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
 
 <a href="#drydock">Volver arriba</a>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -22,12 +22,12 @@
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
-  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+  <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>
 </p>
 
 <hr>
@@ -472,7 +472,7 @@ Thèmes généraux uniquement ; consultez [CHANGELOG.md](CHANGELOG.md) pour les
 
 Questions, commentaires et assistance précoce : **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
-Veuillez déposer des bogues concrets et des demandes de fonctionnalités dans **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** afin qu'ils ne se perdent pas dans le chat.
+Les bogues et les demandes de fonctionnalités concrètes vont dans **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** ; les questions ouvertes, idées et démonstrations vont dans **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)** ; le chat en temps réel se passe sur **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**.
 
 ### Contrôle qualité de la communauté
 
@@ -504,8 +504,6 @@ Voir le [COMPATIBILITY.md de portwing](https://github.com/CodesWhat/portwing/blo
     <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
   </picture>
 </a>
-
-[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
 
 <a href="#drydock">Retour en haut</a>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -470,7 +470,7 @@ Thèmes généraux uniquement ; consultez [CHANGELOG.md](CHANGELOG.md) pour les
 
 ### Communauté
 
-Questions, commentaires et assistance précoce : **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+Chat en temps réel et assistance précoce : **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
 Les bogues et les demandes de fonctionnalités concrètes vont dans **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** ; les questions ouvertes, idées et démonstrations vont dans **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)** ; le chat en temps réel se passe sur **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**.
 

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ High-level themes only; see [CHANGELOG.md](CHANGELOG.md) for per-release detail.
 
 <h2 align="center" id="community-support">Community & Support</h2>
 
-Questions, feedback, and early support: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+Real-time chat and early support: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
 Bugs and concrete feature requests go to **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**; open-ended questions, ideas, and show-and-tell go to **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**; real-time chat happens on the **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**.
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
-  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+  <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>
 </p>
 
 <hr>
@@ -55,7 +55,8 @@
 - [Roadmap](#roadmap)
 - [Star History](#star-history)
 - [Built With](#built-with)
-- [Community QA](#community-qa)
+- [Community & Support](#community-support)
+- [CodesWhat Ecosystem](#codeswhat-ecosystem)
 
 <hr>
 
@@ -451,7 +452,7 @@ High-level themes only; see [CHANGELOG.md](CHANGELOG.md) for per-release detail.
 
 <hr>
 
-<a id="star-history"></a>
+<h2 align="center" id="star-history">Star History</h2>
 
 <div align="center">
   <a href="https://github.com/CodesWhat/drydock/stargazers">
@@ -466,7 +467,7 @@ High-level themes only; see [CHANGELOG.md](CHANGELOG.md) for per-release detail.
 
 <div align="center">
 
-### Built With
+<h2 align="center" id="built-with">Built With</h2>
 
 [![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
 [![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
@@ -481,11 +482,11 @@ High-level themes only; see [CHANGELOG.md](CHANGELOG.md) for per-release detail.
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
 
-### Community
+<h2 align="center" id="community-support">Community & Support</h2>
 
 Questions, feedback, and early support: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
-Please file concrete bugs and feature requests in **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** so they do not get lost in chat.
+Bugs and concrete feature requests go to **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**; open-ended questions, ideas, and show-and-tell go to **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**; real-time chat happens on the **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**.
 
 ### Community QA
 
@@ -493,7 +494,7 @@ Thanks to the users who helped test v1.4.0 and v1.5.0 release candidates and rep
 
 [@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
 
-### Part of the CodesWhat ecosystem
+<h2 align="center" id="codeswhat-ecosystem">CodesWhat Ecosystem</h2>
 
 <table>
   <tr><th>Tool</th><th>Role</th></tr>
@@ -517,8 +518,6 @@ See [portwing's COMPATIBILITY.md](https://github.com/CodesWhat/portwing/blob/mai
     <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
   </picture>
 </a>
-
-[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
 
 <a href="#drydock">Back to top</a>
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -470,7 +470,7 @@ Tylko motywy ogólne; szczegóły poszczególnych wersji zawiera [CHANGELOG.md](
 
 ### Społeczność
 
-Pytania, opinie i wczesne wsparcie: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+Czat na żywo i wczesne wsparcie: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
 Błędy i konkretne prośby o nowe funkcje trafiają do **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**; otwarte pytania, pomysły i prezentacje trafiają do **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**; czat na żywo odbywa się na **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**.
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -22,12 +22,12 @@
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
-  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+  <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>
 </p>
 
 <hr>
@@ -472,7 +472,7 @@ Tylko motywy ogólne; szczegóły poszczególnych wersji zawiera [CHANGELOG.md](
 
 Pytania, opinie i wczesne wsparcie: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
-Prosimy o zgłaszanie konkretnych błędów i propozycji nowych funkcji w **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**, aby nie zgubiły się na czacie.
+Błędy i konkretne prośby o nowe funkcje trafiają do **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**; otwarte pytania, pomysły i prezentacje trafiają do **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**; czat na żywo odbywa się na **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**.
 
 ### Kontrola jakości społeczności
 
@@ -504,8 +504,6 @@ Zobacz plik [portwing's COMPATIBILITY.md](https://github.com/CodesWhat/portwing/
     <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
   </picture>
 </a>
-
-[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
 
 <a href="#drydock">Powrót do góry</a>
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -470,7 +470,7 @@ Apenas temas gerais; consulte [CHANGELOG.md](CHANGELOG.md) para detalhes de cada
 
 ### Comunidade
 
-Perguntas, comentários e suporte antecipado: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+Chat em tempo real e suporte antecipado: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
 Bugs e solicitações de recursos concretas vão para o **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**; perguntas abertas, ideias e demonstrações vão para o **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**; o chat em tempo real acontece no **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -22,12 +22,12 @@
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
-  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+  <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>
 </p>
 
 <hr>
@@ -472,7 +472,7 @@ Apenas temas gerais; consulte [CHANGELOG.md](CHANGELOG.md) para detalhes de cada
 
 Perguntas, comentários e suporte antecipado: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
-Por favor, registre bugs concretos e solicitações de recursos em **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** para que eles não se percam no bate-papo.
+Bugs e solicitações de recursos concretas vão para o **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**; perguntas abertas, ideias e demonstrações vão para o **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**; o chat em tempo real acontece no **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**.
 
 ### Controle de qualidade da comunidade
 
@@ -504,8 +504,6 @@ Consulte o [COMPATIBILITY.md do portwing](https://github.com/CodesWhat/portwing/
     <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
   </picture>
 </a>
-
-[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
 
 <a href="#drydock">Voltar ao topo</a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -470,7 +470,7 @@ Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。�
 
 ### 社区
 
-问题、反馈和早期支持：**[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
+实时聊天和早期支持：**[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
 明确的错误和功能请求请提交到 **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**；开放式问题、想法和展示请前往 **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**；实时聊天在 **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)** 进行。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,12 +22,12 @@
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
-  <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg" alt="Code Coverage"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
+  <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>
 </p>
 
 <hr>
@@ -472,7 +472,7 @@ Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。�
 
 问题、反馈和早期支持：**[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
-请在 **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)** 中提交具体的错误和功能请求，这样他们就不会在聊天中迷失方向。
+明确的错误和功能请求请提交到 **[GitHub Issues](https://github.com/CodesWhat/drydock/issues)**；开放式问题、想法和展示请前往 **[GitHub Discussions](https://github.com/CodesWhat/drydock/discussions)**；实时聊天在 **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)** 进行。
 
 ### 社区质量检查
 
@@ -504,8 +504,6 @@ Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。�
     <img src="docs/assets/codeswhat-logo-original.svg" alt="CodesWhat" height="28">
   </picture>
 </a>
-
-[![Sponsor](https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/CodesWhat)
 
 <a href="#drydock">返回顶部</a>
 


### PR DESCRIPTION
Follows up on the readme-shape.md and community.md standards codified 2026-08-16/17 (issue #759 items 4 and 5).

- Promotes Star History, Built With, Community & Support, and CodesWhat Ecosystem to `<h2 align="center">` with anchor ids, matching the earlier sections. Updates the Contents TOC to match.
- Moves the sponsor badge into the badge wall's social-proof row and drops it from the footer.
- Drops the qlty test_coverage badge, keeping maintainability as the one Qlty signal on the wall (per readme-shape.md's rule).
- States the Issues/Discussions/Discord routing rule in Community & Support, per community.md.
- Mirrors the badge-wall and routing-sentence changes into the six translated READMEs, keeping each one's external-URL multiset identical to the source (verified against `.github/tests/readme-translations.test.ts`). Translated heading text stays as-is where the test pins the exact string (Built With, Community QA).
- Notes the `greptile.json` + label-gated `.github/workflows/greptile.yml` second-opinion reviewer wiring in AGENTS.md's Merging section.

Doesn't touch the Features table icon column or the comparison table's checkmarks/x's/warnings — that's the recorded semantic-glyph exception.

## Test plan

- [x] `npm run test:workflows` — 171 passed, including readme-translations
- [x] Full pre-push pipeline (biome, qlty, qlty-smells, coverage, build, zizmor) — all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added CodesWhat Ecosystem section and centered `Star History` and `Built With` headings with anchor IDs.
- ✨ Added sponsor, GHCR, Awesome Docker, Crowdin, and mutation-testing badges.
- ✨ Added Greptile second-opinion workflow documentation in `AGENTS.md`.
- 🔧 Changed the table of contents and community guidance.
- 🔧 Applied badge and support-routing updates to six translated READMEs.
- 🗑️ Removed coverage and duplicate footer sponsor badges.
- 🔒 Preserved feature and comparison-table semantic glyphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->