### PR TITLE
test(quality): remove vitest retry and fix the flakes it masked

### DIFF
--- a/app/store/index.test.ts
+++ b/app/store/index.test.ts
@@ -5,7 +5,8 @@ import * as store from './index.js';
 const {
   STORE_CONFIG,
   createLokiMock,
-  createFsMock,
+  fsMock,
+  resetFsMock,
   createConfigMock,
   createCollectionsMock,
   createContainerMock,
@@ -31,16 +32,35 @@ const {
     };
   }
 
-  function createFsMock(overrides = {}) {
-    return {
-      default: {
-        existsSync: vi.fn(),
-        mkdirSync: vi.fn(),
-        chmodSync: vi.fn(),
-        ...overrides,
-      },
-    };
+  // A single, stable object backs every 'node:fs' mock for the whole file.
+  // vi.resetModules() clears vitest's module *instance* cache, so the next
+  // `import('./index.js')` re-resolves 'node:fs' and re-invokes whatever
+  // factory is registered for it — but registration (vi.mock/vi.doMock)
+  // itself survives resetModules. Previously each test swapped in a *new*
+  // mock object via `vi.doMock('node:fs', () => createFsMock(overrides))`,
+  // which meant correctness depended on that fresh factory winning the race
+  // against a freshly re-imported store/index.js resolving 'node:fs' — a
+  // real, previously-diagnosed flake (a stale/incomplete prior fs mock
+  // occasionally got captured instead, so store/index.ts's
+  // `fs.existsSync(legacyPath)` read a bare `vi.fn()` returning undefined,
+  // renameSync was never reached, and the "migrate from wud.json" assertion
+  // saw renameSync called 0 times; see PR #417 / #436 history). Reusing one
+  // object and only ever reconfiguring its methods removes the swap: no
+  // matter when 'node:fs' gets re-resolved relative to test setup, it always
+  // resolves to this exact object.
+  const fsMock: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  function resetFsMock(overrides: Record<string, unknown> = {}) {
+    for (const key of Object.keys(fsMock)) {
+      delete fsMock[key];
+    }
+    Object.assign(
+      fsMock,
+      { existsSync: vi.fn(), mkdirSync: vi.fn(), chmodSync: vi.fn() },
+      overrides,
+    );
   }
+  resetFsMock();
 
   function createConfigMock(config = STORE_CONFIG) {
     return { getStoreConfiguration: vi.fn(() => config) };
@@ -89,7 +109,7 @@ const {
     vi.doMock('lokijs', () =>
       createLokiMock(overrides.loki, overrides.lokiSave, overrides.lokiInstance),
     );
-    vi.doMock('node:fs', () => createFsMock(overrides.fs));
+    resetFsMock(overrides.fs);
     vi.doMock('../configuration', () => ({
       ...createConfigMock(overrides.config ?? STORE_CONFIG),
       getPortwingAuthorizedKeysPath: vi.fn(() => overrides.portwingAuthorizedKeysPath),
@@ -122,7 +142,8 @@ const {
   return {
     STORE_CONFIG,
     createLokiMock,
-    createFsMock,
+    fsMock,
+    resetFsMock,
     createConfigMock,
     createCollectionsMock,
     createContainerMock,
@@ -135,7 +156,7 @@ const {
 // --- Top-level mocks (hoisted, used for the non-resetModules tests) ---
 
 vi.mock('lokijs', () => createLokiMock());
-vi.mock('node:fs', () => createFsMock());
+vi.mock('node:fs', () => ({ default: fsMock }));
 vi.mock('../configuration', () => ({
   ...createConfigMock(),
   getPortwingAuthorizedKeysPath: vi.fn(() => undefined),
@@ -523,7 +544,7 @@ describe('Store Module', () => {
   test('should fall back to schema defaults when store configuration is null', async () => {
     vi.resetModules();
     vi.doMock('lokijs', () => createLokiMock());
-    vi.doMock('node:fs', () => createFsMock({ renameSync: vi.fn() }));
+    resetFsMock({ renameSync: vi.fn() });
     vi.doMock('../configuration', () => ({ getStoreConfiguration: vi.fn(() => null) }));
     vi.doMock('./app', createCollectionsMock);
     vi.doMock('./audit', createCollectionsMock);
@@ -786,9 +807,7 @@ describe('Store Module', () => {
 
     const mockWarn = vi.fn();
     vi.doMock('lokijs', () => createLokiMock());
-    vi.doMock('node:fs', () =>
-      createFsMock({ existsSync: vi.fn(() => true), mkdirSync: vi.fn(), renameSync: vi.fn() }),
-    );
+    resetFsMock({ existsSync: vi.fn(() => true), mkdirSync: vi.fn(), renameSync: vi.fn() });
     vi.doMock('../configuration', () => ({
       ...createConfigMock(STORE_CONFIG),
       getPortwingAuthorizedKeysPath: vi.fn(() => '/bad/authorized_keys'),

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -62,14 +62,19 @@ export default defineConfig({
     environment: 'node',
     // Coverage writes can race with clean-up; keep file execution serial.
     fileParallelism: false,
-    // One retry as a guard against a rare, non-deterministic cross-file
-    // isolation flake (a prior file's module mock occasionally leaks into
-    // registry/index.test.ts under serial execution). This only re-runs a
-    // *failing* test once — green runs and hard failures are unaffected, so it
-    // cannot hide a consistently-broken test. The underlying leak is tracked
-    // separately; this keeps the rare flake from reddening an otherwise-clean
-    // build. Keep it at 1 so genuine new flakiness stays visible.
-    retry: 1,
+    // No test-level retry (house standard: root-cause or quarantine, never
+    // blind-retry). The cross-file flake this used to guard against
+    // (store/index.test.ts, registry/index.test.ts) traced to
+    // store/index.test.ts's 'node:fs' mock: it was swapped per test via
+    // `vi.doMock('node:fs', () => createFsMock(overrides))` after
+    // `vi.resetModules()`, so a freshly re-imported store/index.js could in
+    // principle capture a stale/incomplete prior mock instead of the
+    // just-registered one (symptom: renameSync asserted called 0 times — see
+    // PR #417 / #436 history). Fixed by giving 'node:fs' one stable,
+    // hoisted mock object for the whole file and reconfiguring its methods
+    // in place instead of swapping the mocked module's identity — see
+    // store/index.test.ts. Validated with 100+ shuffled/targeted full-suite
+    // runs (with and without coverage) with retry removed and zero flakes.
     exclude: ['**/node_modules/**', '**/dist/**', '**/.stryker-tmp/**'],
     server: {
       deps: {

--- a/ui/tests/composables/useUpdateMode.spec.ts
+++ b/ui/tests/composables/useUpdateMode.spec.ts
@@ -1,3 +1,5 @@
+import { effectScope } from 'vue';
+
 const mockGetSettings = vi.fn();
 const mockUpdateSettings = vi.fn();
 
@@ -40,6 +42,20 @@ describe('useUpdateMode', () => {
     expect(state.updateMode.value).toBe('auto');
   });
 
+  it('skips refetching once already loaded unless force is requested', async () => {
+    mockGetSettings.mockResolvedValue({ internetlessMode: false, updateMode: 'auto' });
+    const { useUpdateMode } = await import('@/composables/useUpdateMode');
+    const state = useUpdateMode({ autoLoad: false });
+
+    await state.loadUpdateMode();
+    expect(mockGetSettings).toHaveBeenCalledTimes(1);
+
+    await state.loadUpdateMode();
+
+    expect(mockGetSettings).toHaveBeenCalledTimes(1);
+    expect(state.updateMode.value).toBe('auto');
+  });
+
   it('exposes an initial load error without treating the default as loaded', async () => {
     mockGetSettings.mockRejectedValue(new Error('settings unavailable'));
     const { useUpdateMode } = await import('@/composables/useUpdateMode');
@@ -78,6 +94,45 @@ describe('useUpdateMode', () => {
     expect(addDocument).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
     expect(removeWindow).toHaveBeenCalledWith('focus', expect.any(Function));
     expect(removeDocument).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+  });
+
+  it('autoloads by default and registers/tears down revalidation within its effect scope', async () => {
+    mockGetSettings.mockResolvedValue({ internetlessMode: false, updateMode: 'notify' });
+    const addWindow = vi.spyOn(window, 'addEventListener');
+    const removeWindow = vi.spyOn(window, 'removeEventListener');
+    const { useUpdateMode } = await import('@/composables/useUpdateMode');
+
+    const scope = effectScope();
+    let state!: ReturnType<typeof useUpdateMode>;
+    scope.run(() => {
+      state = useUpdateMode();
+    });
+
+    await vi.waitFor(() => expect(mockGetSettings).toHaveBeenCalledTimes(1));
+    expect(state.updateMode.value).toBe('notify');
+    expect(addWindow).toHaveBeenCalledWith('focus', expect.any(Function));
+
+    scope.stop();
+
+    expect(removeWindow).toHaveBeenCalledWith('focus', expect.any(Function));
+  });
+
+  it('only registers/removes revalidation listeners for the first consumer in and the last consumer out', async () => {
+    mockGetSettings.mockResolvedValue({ internetlessMode: false, updateMode: 'manual' });
+    const addWindow = vi.spyOn(window, 'addEventListener');
+    const removeWindow = vi.spyOn(window, 'removeEventListener');
+    const { startUpdateModeRevalidation } = await import('@/composables/useUpdateMode');
+
+    const stopFirst = startUpdateModeRevalidation();
+    const stopSecond = startUpdateModeRevalidation();
+
+    expect(addWindow).toHaveBeenCalledTimes(1);
+
+    stopFirst();
+    expect(removeWindow).not.toHaveBeenCalled();
+
+    stopSecond();
+    expect(removeWindow).toHaveBeenCalledTimes(1);
   });
 
   it('keeps a successful save when an older forced load resolves afterward', async () => {

--- a/ui/tests/views/ConfigView.spec.ts
+++ b/ui/tests/views/ConfigView.spec.ts
@@ -1,4 +1,4 @@
-import { defineComponent, nextTick } from 'vue';
+import { defineComponent, nextTick, ref } from 'vue';
 
 const mockGetServer = vi.fn();
 const mockGetStore = vi.fn();
@@ -192,6 +192,33 @@ vi.mock('@/composables/useIcons', () => ({
   }),
 }));
 
+// useUpdateMode caches its fetched settings in a module-level singleton (see
+// src/composables/useUpdateMode.ts): `loaded` only flips true once, for the
+// lifetime of the module instance, regardless of which component mounted it.
+// ConfigView previously pulled in the *real* composable here, so its own
+// direct getSettings() call (for internetlessMode) and useUpdateMode's
+// internal getSettings() call (for updateMode) both fired on a cold module —
+// 2 calls where the "on mount" test expects 1. Every other real consumer of
+// useUpdateMode (ContainerUpdateDialog.spec.ts, DashboardView.spec.ts,
+// SecurityView.spec.ts) already mocks it out for exactly this reason; this
+// file was the one gap. Mocking it here removes both the redundant fetch and
+// the singleton's cross-test-order dependency.
+const mockUpdateModeValue = ref<'notify' | 'manual' | 'auto'>('manual');
+const mockUpdateModeLoaded = ref(true);
+const mockUpdateModeSaving = ref(false);
+const mockUpdateModeError = ref<string | null>(null);
+const mockSetUpdateMode = vi.fn();
+
+vi.mock('@/composables/useUpdateMode', () => ({
+  useUpdateMode: () => ({
+    updateMode: mockUpdateModeValue,
+    loaded: mockUpdateModeLoaded,
+    saving: mockUpdateModeSaving,
+    error: mockUpdateModeError,
+    setUpdateMode: mockSetUpdateMode,
+  }),
+}));
+
 vi.mock('@/icons', () => ({
   libraryLabels: { 'ph-duotone': 'Phosphor Duotone', lucide: 'Lucide' },
   iconMap: {
@@ -255,6 +282,10 @@ describe('ConfigView', () => {
     resetPreferences();
     setI18nLocale('en');
     resetMockFontState();
+    mockUpdateModeValue.value = 'manual';
+    mockUpdateModeLoaded.value = true;
+    mockUpdateModeSaving.value = false;
+    mockUpdateModeError.value = null;
     mockGetUser.mockResolvedValue({
       username: 'admin',
       email: 'admin@test.com',

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -50,7 +50,6 @@ export default mergeConfig(
       globals: true,
       environment: 'jsdom',
       fileParallelism: false,
-      retry: 1,
       setupFiles: ['./tests/setup.ts'],
       include: ['tests/**/*.spec.ts'],
       css: true,


### PR DESCRIPTION
Removes `retry: 1` from both vitest configs per the house testing standard (runner retries mask flakes instead of fixing them), and fixes what it was actually hiding.

App side: `store/index.test.ts` swapped the node:fs mock's object identity on every test (`vi.doMock` factory after `vi.resetModules()`), so correctness depended on a timing race between mock re-registration and the re-imported module capturing its fs binding. Replaced with one hoisted singleton mock reconfigured in place, which eliminates the race structurally. Zero failures across ~113 targeted/full/shuffled/adversarial-order runs afterward.

UI side: the retry was added purely to mirror the app config (no ui flake was ever diagnosed), but removing it exposed a deterministic order dependence: ConfigView double-fetches settings (its own getSettings plus useUpdateMode's cold load), so the spec's call-count assertion passed only when an earlier test had warmed the composable's module state. The spec now mocks useUpdateMode like the other three consumer specs, and three new composable tests cover the branches that mount previously covered incidentally. The production double-fetch is tracked separately in #780.

Both suites pass at 100% coverage (app 13,049 tests, ui 4,519).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed `node:fs` mock identity and module re-import timing races in `app/store/index.test.ts`.
- 🐛 Fixed `useUpdateMode` module-state and double-fetch order dependence in `ConfigView.spec.ts`.
- ✨ Added `useUpdateMode` tests for cached loading, default autoload, effect-scope cleanup, and listener reference counting.
- 🔧 Removed `retry: 1` from both Vitest configurations.
- 🔧 Replaced per-test filesystem mocks with one hoisted mock and per-test reconfiguration.
- 🔧 Added reactive `useUpdateMode` test state with per-test reset.
- 🐛 Kept the production double-fetch tracked separately in issue `#780`.

## Concerns

- Verify that app and UI suites pass without retries in CI.
- Confirm the reported 100% coverage and test counts: 13,049 app tests and 4,519 UI tests.
- Investigate issue `#780` separately if production double-fetch behavior remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->