### PR TITLE
docs(security): qualify SLSA claims as Build L2

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -561,10 +561,16 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920  # v2.20.0
         with:
           egress-policy: block
+          # fonts.googleapis.com + fonts.gstatic.com: next/font/google in
+          # apps/web/src/app/layout.tsx downloads IBM Plex at build time, but
+          # the web job only runs on web-path changes, so the gap stayed
+          # invisible on every non-web PR after the block-mode flip.
           allowed-endpoints: >
             github.com:443
             registry.npmjs.org:443
             nodejs.org:443
+            fonts.googleapis.com:443
+            fonts.gstatic.com:443
             *.actions.githubusercontent.com:443
           disable-sudo: true
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,7 +41,7 @@ Dispatch with just `release_tag` set, e.g. `v1.6.0-rc.14`. Leave `candidate_tag`
 
 `release_tag` must match `^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` — i.e. `vX.Y.Z` or `vX.Y.Z-<prerelease>` (`v1.6.0` or `v1.6.0-rc.14`). The tag's base version must match every manifest checked by the release precheck: `package.json`, `package-lock.json`, `app/package.json`, `app/package-lock.json`, `ui/package.json`, `ui/package-lock.json`, `e2e/package.json`, `e2e/package-lock.json`, `apps/demo/package.json`, and `apps/demo/package-lock.json`. The tag must not already exist pointing anywhere else.
 
-The workflow builds the multi-arch image (`linux/amd64,linux/arm64`) fresh from `main`, pushes it under a run-scoped staging tag, signs it with cosign (keyless, GitHub OIDC), attests SLSA build provenance and a Trivy SPDX SBOM, generates a `git archive` tarball with matching signature/attestation, and publishes it all as a GitHub prerelease. **Registry tags never carry the `v` prefix** — the workflow strips it itself (`${RELEASE_TAG#v}`), so `v1.6.0-rc.13` publishes as `ghcr.io/codeswhat/drydock:1.6.0-rc.13`, `docker.io/codeswhat/drydock:1.6.0-rc.13`, and the Quay equivalent.
+The workflow builds the multi-arch image (`linux/amd64,linux/arm64`) fresh from `main`, pushes it under a run-scoped staging tag, signs it with cosign (keyless, GitHub OIDC), attests SLSA Build L2 provenance and a Trivy SPDX SBOM, generates a `git archive` tarball with matching signature/attestation, and publishes it all as a GitHub prerelease. **Registry tags never carry the `v` prefix** — the workflow strips it itself (`${RELEASE_TAG#v}`), so `v1.6.0-rc.13` publishes as `ghcr.io/codeswhat/drydock:1.6.0-rc.13`, `docker.io/codeswhat/drydock:1.6.0-rc.13`, and the Quay equivalent.
 
 ## Promoting to GA
 
@@ -79,7 +79,7 @@ The reason is carried between steps as a temp file, not inlined into a `GITHUB_O
 GA never rebuilds the image or the release artifact. It:
 
 1. Downloads the candidate's already-published `.tar.gz`, `.sha256`, `.bundle`, `.sig`, `.pem`, and `.intoto.jsonl` from the RC's GitHub release
-2. Verifies the checksum, the cosign signature, and the SLSA provenance attestation against the RC's original `SOURCE_SHA` (honest at RC-cut time, since source and target SHA were identical then)
+2. Verifies the checksum, the cosign signature, and the SLSA Build L2 provenance attestation against the RC's original `SOURCE_SHA` (honest at RC-cut time, since source and target SHA were identical then)
 3. Rebuilds a fresh `git archive` of the candidate tag's commit today and compares decompressed tar bytes against the downloaded artifact, proving the soaked bytes are still exactly what that source SHA's tree contains
 4. Republishes those same verified bytes under the GA tag/filenames, re-tags the exact RC image digest under the GA image tags (`{major}.{minor}.{patch}`, `{major}.{minor}`, `{major}`, and `latest`) without rebuilding, and re-verifies the exact digest was published in every registry
 5. Pushes the GA git tag pointing at the RC's original commit (not at today's `main` HEAD) and publishes the GitHub release

--- a/content/docs/current/guides/verifying-releases/index.mdx
+++ b/content/docs/current/guides/verifying-releases/index.mdx
@@ -6,7 +6,7 @@ description: "Verify Drydock container images and release archives with cosign a
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
-Every Drydock release is signed with [cosign](https://docs.sigstore.dev/) (keyless, via the Sigstore public-good infrastructure) and ships with [SLSA build provenance](https://slsa.dev/) attestations generated inside GitHub Actions. You can — and should — verify both before running the image or extracting the archive.
+Every Drydock release is signed with [cosign](https://docs.sigstore.dev/) (keyless, via the Sigstore public-good infrastructure) and ships with [SLSA Build L2 provenance](https://slsa.dev/) attestations generated inside GitHub Actions. You can — and should — verify both before running the image or extracting the archive.
 
 The examples on this page use `v1.5.2` as a placeholder. Replace it with the tag you're verifying.
 
@@ -72,7 +72,7 @@ A successful verification prints the signature payload and exits 0. Any other ou
 
 ### Verify image provenance (SLSA)
 
-The container image also carries a signed [SLSA provenance](https://slsa.dev/spec/v1.0/provenance) attestation published to the registry. Verify it with the GitHub CLI:
+The container image also carries a signed [SLSA Build L2 provenance](https://slsa.dev/spec/v1.0/provenance) attestation published to the registry. Verify it with the GitHub CLI:
 
 ```bash
 gh attestation verify \
@@ -94,7 +94,7 @@ Each GitHub release includes six files for the source archive:
 | `drydock-${TAG}.tar.gz.sig` | Cosign detached signature |
 | `drydock-${TAG}.tar.gz.pem` | Signing certificate |
 | `drydock-${TAG}.tar.gz.bundle` | Cosign bundle (sig + cert + Rekor proof) |
-| `drydock-${TAG}.tar.gz.intoto.jsonl` | SLSA provenance attestation |
+| `drydock-${TAG}.tar.gz.intoto.jsonl` | SLSA Build L2 provenance attestation |
 
 ### 1. Download
 
@@ -139,7 +139,7 @@ cosign verify-blob \
 # Verified OK
 ```
 
-### 4. Verify the SLSA provenance
+### 4. Verify the SLSA Build L2 provenance {#4-verify-the-slsa-provenance}
 
 The `.intoto.jsonl` file is a signed [in-toto](https://in-toto.io/) attestation describing how, when, and where the tarball was built. Two ways to verify:
 
@@ -170,7 +170,7 @@ slsa-verifier verify-artifact \
 </Tab>
 </Tabs>
 
-Passing both the cosign signature and the SLSA attestation confirms the tarball came from the release workflow, on this tag, and has not been modified.
+Passing both the cosign signature and the SLSA Build L2 attestation confirms the tarball came from the release workflow, on this tag, and has not been modified.
 
 ## Why some older tags look different
 
@@ -200,4 +200,4 @@ If any verification step fails, do not run the image or extract the archive. Ope
 - [Security Hardening Guide](/docs/guides/security) — lock down a running Drydock deployment
 - [Update Bouncer](/docs/configuration/security) — use Drydock's built-in cosign support to verify the images Drydock itself is watching
 - [Sigstore documentation](https://docs.sigstore.dev/) — background on keyless signing and Rekor transparency log
-- [SLSA framework](https://slsa.dev/) — what the provenance attestation proves
+- [SLSA framework](https://slsa.dev/) — what the SLSA Build L2 provenance attestation proves


### PR DESCRIPTION
House security standard retired unqualified 'SLSA provenance' claims: the shipped level is Build L2 and docs must say so, so L3 stays a deliberate future step instead of an implied one.

RELEASING.md and the current verifying-releases guide now say 'SLSA Build L2 provenance' at every claim site. Tool names (slsa-verifier, gh attestation), the external framework's proper name, and the frozen v1.x doc archives are untouched. The one affected heading kept its original anchor so existing links don't break.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔒 Updated release documentation to identify shipped attestations as **SLSA Build L2 provenance**.
- 🔧 Preserved the existing provenance heading anchor.
- 🔧 Allowed `fonts.googleapis.com` and `fonts.gstatic.com` in the web job egress policy for `next/font/google`.
- 🔧 Kept tool names, external framework names, and frozen v1.x archives unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->