### PR TITLE
ci(quality): upload coverage to codecov instead of qlty cloud

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -467,7 +467,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      id-token: write  # OIDC for the Qlty coverage upload — no stored token
 
     steps:
       - name: Harden Runner
@@ -478,10 +477,10 @@ jobs:
             github.com:443
             registry.npmjs.org:443
             nodejs.org:443
-            qlty-releases.s3.amazonaws.com:443
-            qlty.sh:443
-            tuf-repo-cdn.sigstore.dev:443
-            tuf-repo.github.com:443
+            cli.codecov.io:443
+            api.codecov.io:443
+            ingest.codecov.io:443
+            storage.googleapis.com:443
             *.actions.githubusercontent.com:443
           disable-sudo: true
 
@@ -552,24 +551,37 @@ jobs:
         working-directory: ui
 
       - name: Normalize coverage paths
-        # Rewrites lcov SF: paths to be repo-root-relative (app/…, ui/…) so the
-        # coverage service resolves them against the checkout. This is exactly
-        # the normalization Qlty needs too.
+        # Rewrites lcov SF: paths to be repo-root-relative (app/…, ui/…) so
+        # Codecov resolves them against the checkout.
         run: node scripts/prepare-codecov-reports.mjs
 
-      - name: Publish coverage to Qlty
-        # Org-wide coverage consolidated on Qlty Cloud (replaces Codecov). OIDC
-        # auth — no token to store or rotate. Skipped on fork PRs, which GitHub
-        # does not grant id-token:write. Advisory (continue-on-error): a publish
-        # hiccup never blocks CI — the vitest 100% coverage thresholds enforced
-        # in the app/ui test steps above are the real gate.
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      - name: Upload app coverage to Codecov
+        # Coverage upload moved from Qlty Cloud to Codecov (2026-08-16 house
+        # decision — see codeswhat-ops/standards/quality.md). The Qlty Cloud
+        # app, dashboard, and maintainability badge stay installed with
+        # non-gating checks; only the coverage-cloud upload path moves.
+        # Tokenless for public-repo PRs (including forks, which don't get
+        # secrets anyway); secrets.CODECOV_TOKEN is optional and covers
+        # private-context uploads. Advisory (continue-on-error plus
+        # fail_ci_if_error: false): an upload hiccup never blocks CI — the
+        # vitest 100% coverage thresholds enforced in the app/ui test steps
+        # above are the real gate.
         continue-on-error: true
-        uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637  # v2.3.0
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
-          oidc: true
-          files: coverage/codecov-app.lcov.info,coverage/codecov-ui.lcov.info
-          format: lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/codecov-app.lcov.info
+          flags: app
+          fail_ci_if_error: false
+
+      - name: Upload ui coverage to Codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/codecov-ui.lcov.info
+          flags: ui
+          fail_ci_if_error: false
 
   web:
     name: "🌐 Web: Site Build & Scripts Tests"

--- a/README.de.md
+++ b/README.de.md
@@ -23,6 +23,7 @@
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>

--- a/README.es.md
+++ b/README.es.md
@@ -23,6 +23,7 @@
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>

--- a/README.fr.md
+++ b/README.fr.md
@@ -23,6 +23,7 @@
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>

--- a/README.pl.md
+++ b/README.pl.md
@@ -23,6 +23,7 @@
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -23,6 +23,7 @@
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,7 @@
   <a href="https://www.bestpractices.dev/projects/11915"><img src="https://www.bestpractices.dev/projects/11915/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://qlty.sh/gh/CodesWhat/projects/drydock"><img src="https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg" alt="Maintainability"></a>
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
+  <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>


### PR DESCRIPTION
## Summary

House-audit item H6: qlty Cloud's coverage processing is dead for this repo (out of minutes / billing), so coverage uploads have been silently going nowhere. This switches the coverage publish to Codecov.

## Changes

- `ci-verify.yml` coverage job uploads app + ui lcov to Codecov via `codecov/codecov-action` pinned at v6.0.1 (full SHA, tokenless public-repo upload).
- Coverage badge added to the quality row of README plus all six translations.
- Workflow tests updated for the new step and pin.

## Testing

- `.github/tests` suite green locally.
- Full lefthook pre-push pipeline passed on push.

## Follow-up

- Verify Codecov enrollment shows the first successful upload after merge (tracked in the roadmap).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added Codecov coverage uploads for app and UI LCOV reports.
- ✨ Added Codecov badges to the main README and six translations.
- 🔧 Changed hardened-runner endpoint allowlists from Qlty and Sigstore to Codecov.
- 🗑️ Removed Qlty Cloud coverage publishing and its OIDC permission.

## Concerns

- Verify Codecov enrollment after merge.
- Verify the first successful tokenless upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->