### PR TITLE
refactor(ui): remove locale keys orphaned by the pinned-tag insight UI

### DIFF
--- a/ui/src/locales/ar/containerComponents.json
+++ b/ui/src/locales/ar/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "تعيين المجموعة",
       "rollbackAction": "تراجع",
       "deleteAction": "حذف",
-      "pinnedTooltip": "مثبّت",
       "skippedLabel": "متخطى",
       "upToDateTooltip": "محدّث",
       "imageUpdateTooltip": "أصبح الوسم {tag} يشير الآن إلى بنية صورة مختلفة. أعد النشر لسحب الصورة الجديدة؛ وسم الإصدار نفسه لم يتغيّر.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "مقترح: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "تتوفر نسخة أحدث",
       "tooltip": "تتوفر نسخة أحدث: {tag}. هذا الـ Tag مثبّت، ولن يقوم drydock بتحديثه تلقائيًا."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/de/containerComponents.json
+++ b/ui/src/locales/de/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Gruppe festlegen",
       "rollbackAction": "Rollback",
       "deleteAction": "Löschen",
-      "pinnedTooltip": "Gepinnt",
       "skippedLabel": "Übersprungen",
       "upToDateTooltip": "Aktuell",
       "imageUpdateTooltip": "Der Tag {tag} verweist jetzt auf einen anderen Image-Build. Erneut ausrollen, um das neue Image zu holen; der Versions-Tag selbst hat sich nicht geändert.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Vorgeschlagen: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Neuere verfügbar",
       "tooltip": "Neuere Version verfügbar: {tag}. Dieser Tag ist gepinnt, drydock aktualisiert ihn nicht automatisch."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/en/containerComponents.json
+++ b/ui/src/locales/en/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Set group",
       "rollbackAction": "Rollback",
       "deleteAction": "Delete",
-      "pinnedTooltip": "Pinned",
       "skippedLabel": "Skipped",
       "upToDateTooltip": "Up to date",
       "imageUpdateTooltip": "The tag {tag} now points to a different image build. Redeploy to pull the new image; the version tag itself has not changed.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Suggested: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Newer available",
       "tooltip": "Newer version available: {tag}. This tag is pinned — drydock won't update it automatically."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/es/containerComponents.json
+++ b/ui/src/locales/es/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Definir grupo",
       "rollbackAction": "Rollback",
       "deleteAction": "Eliminar",
-      "pinnedTooltip": "Fijado",
       "skippedLabel": "Omitido",
       "upToDateTooltip": "Actualizado",
       "imageUpdateTooltip": "El tag {tag} ahora apunta a una compilación de imagen diferente. Vuelve a desplegar para obtener la nueva imagen; el tag de versión en sí no ha cambiado.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Sugerido: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Más reciente disponible",
       "tooltip": "Nueva versión disponible: {tag}. Este Tag está fijado, drydock no lo actualizará automáticamente."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/fr/containerComponents.json
+++ b/ui/src/locales/fr/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Définir le groupe",
       "rollbackAction": "Retour en arrière",
       "deleteAction": "Supprimer",
-      "pinnedTooltip": "Épinglé",
       "skippedLabel": "Ignoré",
       "upToDateTooltip": "À jour",
       "imageUpdateTooltip": "Le tag {tag} pointe désormais vers une build d'image différente. Redéployez pour récupérer la nouvelle image ; le tag de version lui-même n'a pas changé.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Suggéré : {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Plus récente disponible",
       "tooltip": "Nouvelle version disponible : {tag}. Ce Tag est épinglé, drydock ne le met pas à jour automatiquement."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/it/containerComponents.json
+++ b/ui/src/locales/it/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Imposta gruppo",
       "rollbackAction": "Rollback",
       "deleteAction": "Elimina",
-      "pinnedTooltip": "Bloccato",
       "skippedLabel": "Saltato",
       "upToDateTooltip": "Aggiornato",
       "imageUpdateTooltip": "Il tag {tag} ora punta a una build immagine diversa. Esegui nuovamente il deploy per scaricare la nuova immagine; il tag di versione in sé non è cambiato.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Suggerito: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Più recente disponibile",
       "tooltip": "Nuova versione disponibile: {tag}. Questo Tag è bloccato, drydock non lo aggiornerà automaticamente."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/ja/containerComponents.json
+++ b/ui/src/locales/ja/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "グループを設定",
       "rollbackAction": "ロールバック",
       "deleteAction": "削除",
-      "pinnedTooltip": "固定済み",
       "skippedLabel": "スキップ済み",
       "upToDateTooltip": "最新の状態です",
       "imageUpdateTooltip": "タグ {tag} は現在別のイメージビルドを指しています。再デプロイして新しいイメージを取得してください。バージョンタグ自体は変更されていません。",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "おすすめ：{tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "新しいバージョンあり",
       "tooltip": "新しいバージョンが利用可能です: {tag}。この Tag は固定済みのため、drydock は自動的に更新しません。"
     },
     "eligibilityBadges": {

--- a/ui/src/locales/ko/containerComponents.json
+++ b/ui/src/locales/ko/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "그룹 설정",
       "rollbackAction": "롤백",
       "deleteAction": "삭제",
-      "pinnedTooltip": "고정됨",
       "skippedLabel": "건너뜀",
       "upToDateTooltip": "최신 버전",
       "imageUpdateTooltip": "태그 {tag}가 이제 다른 이미지 빌드를 가리킵니다. 새 이미지를 가져오려면 다시 배포하세요. 버전 태그 자체는 변경되지 않았습니다.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "추천: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "최신 버전 있음",
       "tooltip": "새 버전 사용 가능: {tag}. 이 Tag는 고정되어 있어 drydock이 자동으로 업데이트하지 않습니다."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/nl/containerComponents.json
+++ b/ui/src/locales/nl/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Groep instellen",
       "rollbackAction": "Terugdraaien",
       "deleteAction": "Verwijderen",
-      "pinnedTooltip": "Vastgezet",
       "skippedLabel": "Overgeslagen",
       "upToDateTooltip": "Up-to-date",
       "imageUpdateTooltip": "De tag {tag} verwijst nu naar een andere image-build. Rol opnieuw uit om de nieuwe image op te halen; de versietag zelf is niet gewijzigd.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Voorgesteld: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Nieuwere beschikbaar",
       "tooltip": "Nieuwere versie beschikbaar: {tag}. Deze Tag is vastgezet, drydock werkt hem niet automatisch bij."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/pl/containerComponents.json
+++ b/ui/src/locales/pl/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Ustaw grupę",
       "rollbackAction": "Wycofaj",
       "deleteAction": "Usuń",
-      "pinnedTooltip": "Przypięty",
       "skippedLabel": "Pominięto",
       "upToDateTooltip": "Aktualne",
       "imageUpdateTooltip": "Tag {tag} wskazuje teraz na inny build obrazu. Wdróż ponownie, aby pobrać nowy obraz; sam tag wersji się nie zmienił.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Sugerowane: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Dostępna nowsza",
       "tooltip": "Dostępna nowsza wersja: {tag}. Ten Tag jest przypięty, drydock nie zaktualizuje go automatycznie."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/pt-BR/containerComponents.json
+++ b/ui/src/locales/pt-BR/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Definir grupo",
       "rollbackAction": "Rollback",
       "deleteAction": "Excluir",
-      "pinnedTooltip": "Fixado",
       "skippedLabel": "Ignorado",
       "upToDateTooltip": "Atualizado",
       "imageUpdateTooltip": "A tag {tag} agora aponta para um build de imagem diferente. Reimplante para baixar a nova imagem; a própria tag de versão não mudou.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Sugerida: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Mais recente disponível",
       "tooltip": "Nova versão disponível: {tag}. Esta Tag está fixada, o drydock não vai atualizá-la automaticamente."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/ru/containerComponents.json
+++ b/ui/src/locales/ru/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Задать группу",
       "rollbackAction": "Откат",
       "deleteAction": "Удалить",
-      "pinnedTooltip": "Закреплён",
       "skippedLabel": "Пропущено",
       "upToDateTooltip": "Актуально",
       "imageUpdateTooltip": "Тег {tag} теперь указывает на другую сборку образа. Разверните заново, чтобы загрузить новый образ; сам тег версии не изменился.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Рекомендуемый: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Доступна новее",
       "tooltip": "Доступна новая версия: {tag}. Этот Tag закреплён, drydock не обновит его автоматически."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/tr/containerComponents.json
+++ b/ui/src/locales/tr/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Grup belirle",
       "rollbackAction": "Geri al",
       "deleteAction": "Sil",
-      "pinnedTooltip": "Sabitlendi",
       "skippedLabel": "Atlandı",
       "upToDateTooltip": "güncel",
       "imageUpdateTooltip": "{tag} etiketi artık farklı bir imaj derlemesine işaret ediyor. Yeni imajı çekmek için yeniden dağıtın; sürüm etiketinin kendisi değişmedi.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Önerilen: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Daha yenisi mevcut",
       "tooltip": "Daha yeni sürüm mevcut: {tag}. Bu Tag sabitlendi, drydock onu otomatik olarak güncellemez."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/uk/containerComponents.json
+++ b/ui/src/locales/uk/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Встановити групу",
       "rollbackAction": "Відкат",
       "deleteAction": "Видалити",
-      "pinnedTooltip": "Закріплено",
       "skippedLabel": "Пропущено",
       "upToDateTooltip": "Актуально",
       "imageUpdateTooltip": "Тег {tag} тепер вказує на іншу збірку образу. Розгорніть повторно, щоб завантажити новий образ; сам тег версії не змінився.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Рекомендовано: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Доступна новіша",
       "tooltip": "Доступна новіша версія: {tag}. Цей Tag закріплено, drydock не оновить його автоматично."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/vi/containerComponents.json
+++ b/ui/src/locales/vi/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "Đặt nhóm",
       "rollbackAction": "Khôi phục",
       "deleteAction": "Xóa",
-      "pinnedTooltip": "Đã ghim",
       "skippedLabel": "Đã bỏ qua",
       "upToDateTooltip": "Đã cập nhật",
       "imageUpdateTooltip": "Tag {tag} hiện trỏ đến bản build image khác. Triển khai lại để tải image mới; tag phiên bản không thay đổi.",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "Gợi ý: {tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "Có bản mới hơn",
       "tooltip": "Đã có phiên bản mới hơn: {tag}. Tag này đã được ghim, drydock sẽ không tự động cập nhật."
     },
     "eligibilityBadges": {

--- a/ui/src/locales/zh-CN/containerComponents.json
+++ b/ui/src/locales/zh-CN/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "设置分组",
       "rollbackAction": "回滚",
       "deleteAction": "删除",
-      "pinnedTooltip": "已固定",
       "skippedLabel": "已跳过",
       "upToDateTooltip": "已是最新",
       "imageUpdateTooltip": "标签 {tag} 现在指向不同的镜像构建。重新部署以拉取新镜像；版本标签本身未变更。",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "建议：{tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "有更新版本",
       "tooltip": "有更新版本可用：{tag}。此 Tag 已固定，drydock 不会自动更新。"
     },
     "eligibilityBadges": {

--- a/ui/src/locales/zh-TW/containerComponents.json
+++ b/ui/src/locales/zh-TW/containerComponents.json
@@ -193,7 +193,6 @@
       "setGroupAction": "設定群組",
       "rollbackAction": "回滾",
       "deleteAction": "刪除",
-      "pinnedTooltip": "已固定",
       "skippedLabel": "已略過",
       "upToDateTooltip": "已是最新",
       "imageUpdateTooltip": "標籤 {tag} 現在指向不同的映像檔建置。重新部署以提取新映像檔；版本標籤本身未變更。",
@@ -361,7 +360,6 @@
       "tooltipWithTag": "建議：{tag}\n{hint}"
     },
     "updateInsight": {
-      "badgeText": "有更新版本",
       "tooltip": "有更新版本可用：{tag}。此 Tag 已固定，drydock 不會自動更新。"
     },
     "eligibilityBadges": {


### PR DESCRIPTION
## Summary

Cleanup surfaced while auditing the closed PR #508 backlog entry: two locale keys have zero remaining code references — `containerComponents.updateInsight.badgeText` ("Newer available", its consumer `UpdateInsightBadge` no longer exists) and `containerComponents.groupedViews.pinnedTooltip` ("Pinned", replaced by the Major/Minor/Patch state pill).

## Changes

- Both keys removed from all 17 locales in lockstep.

## Testing

- `tests/i18n/key-parity.spec.ts` and the full ui suite (4516 tests) green at 100% coverage.
- Full lefthook pre-push pipeline passed on push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🗑️ Removed `containerComponents.updateInsight.badgeText` from all 17 locale files.
- 🗑️ Removed `containerComponents.groupedViews.pinnedTooltip` from all 17 locale files.
- 🐛 Removed orphaned translation keys replaced by state pill UI.
- ✅ Passed i18n key-parity test, 4,516 UI tests, and lefthook pre-push checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->