### PR TITLE
fix(ci): restore secrets scanner policy from base ref on PRs

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -199,6 +199,50 @@ test('secret scanning gates full history and the tracked working tree', () => {
   ).toBe(true);
 });
 
+test('a pull request cannot weaken the secrets gate that scans it', () => {
+  const workflow = loadWorkflow();
+  const steps = workflow.jobs?.secrets?.steps ?? [];
+
+  const checkoutIndex = steps.findIndex((step) => step.name === 'Checkout');
+  const restoreIndex = steps.findIndex(
+    (step) => step.name === 'Restore scanner policy from the base ref',
+  );
+  const installGitleaksIndex = steps.findIndex((step) => step.name === 'Install Gitleaks');
+  const scanIndex = steps.findIndex((step) => step.name === 'Scan secrets');
+
+  // The restore must run after the checkout gives it something to restore
+  // into, and strictly before anything that installs or invokes the scanner,
+  // otherwise a PR-modified script or policy file could still be read.
+  expect(checkoutIndex).toBeGreaterThanOrEqual(0);
+  expect(restoreIndex).toBeGreaterThan(checkoutIndex);
+  expect(installGitleaksIndex).toBeGreaterThan(restoreIndex);
+  expect(scanIndex).toBeGreaterThan(restoreIndex);
+
+  const restoreStep = getWorkflowStep('secrets', 'Restore scanner policy from the base ref');
+  expect(restoreStep).toMatchObject({
+    if: "github.event_name == 'pull_request'",
+    env: {
+      BASE_REF: '${{ github.base_ref }}',
+    },
+  });
+
+  // Only pull_request has a meaningful base_ref/head divergence -- push,
+  // schedule, workflow_dispatch, and workflow_call all run trusted content
+  // already, so gating any wider would be a no-op at best.
+  expect(restoreStep?.if).not.toContain('push');
+  expect(restoreStep?.if).not.toContain('schedule');
+  expect(restoreStep?.if).not.toContain('workflow_dispatch');
+
+  const run = restoreStep?.run ?? '';
+  expect(run).toContain('set -euo pipefail');
+  // Depth-1 fetch of just the base branch tip -- cheap, and the restore only
+  // ever needs the current state of those three files on base, not history.
+  expect(run).toContain('git fetch --no-tags --depth=1 origin "refs/heads/${BASE_REF}"');
+  expect(run).toContain(
+    'git checkout FETCH_HEAD -- scripts/scan-secrets.sh .gitleaks.toml .gitleaksignore',
+  );
+});
+
 test('ci-verify can dispatch the complete release-candidate matrix manually', () => {
   const workflow = loadWorkflow();
 

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -100,6 +100,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Restore scanner policy from the base ref
+        # A PR must not be able to alter the gate that scans it: restore the
+        # scanner script and ignore policy from the protected base ref, so
+        # policy changes only take effect after they merge.
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "refs/heads/${BASE_REF}"
+          git checkout FETCH_HEAD -- scripts/scan-secrets.sh .gitleaks.toml .gitleaksignore
+
       - name: Install Gitleaks
         env:
           GITLEAKS_VERSION: '8.30.1'

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -104,6 +104,14 @@ jobs:
         # A PR must not be able to alter the gate that scans it: restore the
         # scanner script and ignore policy from the protected base ref, so
         # policy changes only take effect after they merge.
+        #
+        # pull_request only. push/schedule/workflow_dispatch/workflow_call all
+        # run already-trusted content, where head and base are the same trust
+        # domain. `merge_group` is deliberately NOT covered: no ruleset enables
+        # a merge queue today, so those events never fire, and `github.base_ref`
+        # is empty there anyway. If a merge queue is ever turned on, extend this
+        # to merge_group via `github.event.merge_group.base_ref` — until then a
+        # queue would evaluate the PR's own unmerged scanner policy.
         if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}


### PR DESCRIPTION
## Summary

Fixes #779. The `🔑 Security: Secrets` job ran `scripts/scan-secrets.sh` plus `.gitleaks.toml`/`.gitleaksignore` from the PR's own checkout, so a PR could weaken the very gate that scans it: modify the scanner or the ignore policy in the same diff and the gate scans itself under its own relaxed rules.

Mirrors the pattern already landed in CodesWhat/portwing rather than inventing a variant.

## Changes

- New `Restore scanner policy from the base ref` step in the `secrets` job, between `Checkout` and `Install Gitleaks`: on `pull_request` events it fetches the base branch tip (depth 1) and restores the three policy files from it, so scanner/policy changes only take effect once they merge.
- Fails loudly (`set -euo pipefail`) rather than silently no-op'ing if the base ref is unreachable, so the scan never proceeds on unrestored files.
- No new egress host needed: the job's harden-runner allowlist already permits `github.com:443`.

## Scope note: `merge_group`

`ci-verify.yml` also declares a `merge_group` trigger, which this step deliberately does not cover, and `github.base_ref` is empty there anyway. That path is currently unreachable: no ruleset enables a merge queue, so `merge_group` events never fire. The condition and the exact fix (`github.event.merge_group.base_ref`) are recorded in a comment on the step, so whoever turns a merge queue on hits the note where it matters instead of in a stale issue.

## Testing

- New test in `.github/tests/ci-verify-workflow.test.ts` asserting step ordering (checkout → restore → install/scan), the exact `pull_request`-only condition, the `BASE_REF` env, and the restore command itself. Verified red→green.
- `npm run test:workflows` 175/175.
- Full lefthook pre-push pipeline passed on push.

Fixes: #779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔒 **Security:** Restore `scripts/scan-secrets.sh`, `.gitleaks.toml`, and `.gitleaksignore` from the base branch before Gitleaks runs on `pull_request` events.
- 🔧 **Changed:** Fetch the base branch with `set -euo pipefail`; fail if the base reference is unavailable.
- ✨ **Added:** Add workflow coverage for step ordering, conditions, `BASE_REF`, fetch behavior, shell flags, and file restoration.

## Concerns

- `merge_group` events remain unprotected because `github.base_ref` is unavailable and the path is inactive.
- Add coverage when `merge_group` support becomes active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->