### PR TITLE
docs(readme): align translated READMEs to the Product shape

### DIFF
--- a/.github/tests/readme-translations.test.ts
+++ b/.github/tests/readme-translations.test.ts
@@ -63,38 +63,38 @@ const localizedSurfaceFragments: Record<
 > = {
   'README.de.md': {
     featureTableHeader: '| | Funktion | Beschreibung |',
-    builtWithHeading: '### Gebaut mit',
+    builtWithHeading: '<h2 align="center" id="built-with">Gebaut mit</h2>',
     communityQaHeading: '### Community-QA',
     releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.1</strong></summary>',
   },
   'README.es.md': {
     featureTableHeader: '| | Característica | Descripción |',
-    builtWithHeading: '### Construido con',
+    builtWithHeading: '<h2 align="center" id="built-with">Construido con</h2>',
     communityQaHeading: '### Control de calidad de la comunidad',
     releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.1</strong></summary>',
   },
   'README.fr.md': {
     featureTableHeader: '| | Fonctionnalité | Descriptif |',
-    builtWithHeading: '### Construit avec',
+    builtWithHeading: '<h2 align="center" id="built-with">Construit avec</h2>',
     communityQaHeading: '### Contrôle qualité de la communauté',
     releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.1</strong></summary>',
   },
   'README.pl.md': {
     featureTableHeader: '| | Funkcja | Opis |',
-    builtWithHeading: '### Zbudowany z',
+    builtWithHeading: '<h2 align="center" id="built-with">Zbudowany z</h2>',
     communityQaHeading: '### Kontrola jakości społeczności',
     releaseHeading:
       '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.1</strong></summary>',
   },
   'README.pt-BR.md': {
     featureTableHeader: '| | Recurso | Descrição |',
-    builtWithHeading: '### Construído com',
+    builtWithHeading: '<h2 align="center" id="built-with">Construído com</h2>',
     communityQaHeading: '### Controle de qualidade da comunidade',
     releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.1</strong></summary>',
   },
   'README.zh-CN.md': {
     featureTableHeader: '| |特色|描述 |',
-    builtWithHeading: '### 技术栈',
+    builtWithHeading: '<h2 align="center" id="built-with">技术栈</h2>',
     communityQaHeading: '### 社区质量检查',
     releaseHeading: '<summary><strong>v1.7.0-rc.1 亮点</strong></summary>',
   },

--- a/README.de.md
+++ b/README.de.md
@@ -41,25 +41,46 @@
 > [!WARNING]
 > **Aktualisierung auf 1.6.0-rc.3 oder neuer?** Weitere Sicherheitsverschärfungen gelten ohne Übergangsfrist. Eine Instanz ohne konfigurierte Authentifizierung oder mit aktivierter, aber unbestätigter anonymer Authentifizierung schlägt beim Upgrade jetzt genauso geschlossen fehl wie eine Neuinstallation: Der Container läuft, geschützte API-Anfragen geben `401` zurück, öffentliche Routen für Authentifizierungserkennung und -status bleiben erreichbar und `/health` gibt `503` zurück. Die SPA-Shell kann weiterhin laden, aber keine geschützten Anwendungsdaten lesen. Setzen Sie vor dem Upgrade `DD_ANONYMOUS_AUTH_CONFIRM=true` oder konfigurieren Sie `DD_AUTH_BASIC_*`/OIDC. Das Sitzungscookie wird von `connect.sid` in `drydock.sid` umbenannt, wodurch alle bestehenden Benutzer einmalig abgemeldet werden. HTTP-Benachrichtigungstrigger sowie der Hass-Webhook und Registry-Icon-Abrufe lösen Hostnamen jetzt über eine geschützte DNS-Suche auf, die Cloud-Metadaten- und Link-Local-Ziele blockiert und Weiterleitungen nie folgt. Setzen Sie `allowmetadata=true` nur für einen bestimmten `DD_NOTIFICATION_HTTP_*`-Trigger, wenn dies wirklich erforderlich ist. Vollständige Migrationshinweise finden Sie in **[DEPRECATIONS.md](DEPRECATIONS.md#enforced-security-changes-no-deprecation-window)**.
 
-<h2 align="center">📑 Inhalt</h2>
+<h2 align="center">Inhalt</h2>
 
-- [📖 Dokumentation](#documentation)
-- [🚀 Schnellstart](#quick-start)
-- [🆕 Aktuelle Updates](#recent-updates)
-- [📸 Screenshots & Live-Demo](#screenshots)
-- [🤔 Warum Drydock](#why-drydock)
-- [✨ Eigenschaften](#features)
-- [🔌 Unterstützte Integrationen](#supported-integrations)
-- [⚖️ Funktionsvergleich](#feature-comparison)
-- [🔄 Migration](#migration)
-- [🗺️ Roadmap](#roadmap)
-- [⭐ Sterngeschichte](#star-history)
-- [🔧 Gebaut mit](#gebaut-mit)
-- [🤝 Community QA](#community-qa)
+- [Dokumentation](#documentation)
+- [Schnellstart](#quick-start)
+- [Aktuelle Updates](#recent-updates)
+- [Screenshots & Live-Demo](#screenshots)
+- [Warum Drydock](#why-drydock)
+- [Eigenschaften](#features)
+- [Unterstützte Integrationen](#supported-integrations)
+- [Funktionsvergleich](#feature-comparison)
+- [Migration](#migration)
+- [Roadmap](#roadmap)
+- [Sterngeschichte](#star-history)
+- [Gebaut mit](#built-with)
+- [Gemeinschaft & Support](#community-support)
+- [CodesWhat-Ökosystem](#codeswhat-ecosystem)
+
+<h2 align="center" id="documentation">Dokumentation</h2>
+
+| Ressource             | Link                                                                                                            |
+| --------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Website               | [getdrydock.com](https://getdrydock.com/)                                                       |
+| Live-Demo             | [demo.getdrydock.com](https://demo.getdrydock.com)                              |
+| Dokumente             | [getdrydock.com/docs](https://getdrydock.com/docs)                                              |
+| Konfiguration         | [Konfiguration](https://getdrydock.com/docs/configuration)                                                      |
+| Schnellstart          | [Schnellstart](https://getdrydock.com/docs/quickstart)                                                          |
+| Änderungsprotokoll    | [`CHANGELOG.md`](CHANGELOG.md)                                                                                  |
+| Deprecations          | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                                                            |
+| Roadmap               | Siehe den Abschnitt [„Roadmap“](#roadmap) oben                                                                  |
+| Mitwirken             | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                                                            |
+| Code of Conduct       | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                                      |
+| Governance            | [`GOVERNANCE.md`](GOVERNANCE.md)                                                                                |
+| Sicherheitsnachweis   | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                                                |
+| Sicherheitsrichtlinie | [`SECURITY.md`](SECURITY.md)                                                                                    |
+| Probleme              | [GitHub Issues](https://github.com/CodesWhat/drydock/issues)                                                    |
+| Diskussionen          | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) – Funktionsanfragen und Ideen willkommen |
 
 <hr>
 
-<h2 align="center" id="quick-start">🚀 Schnellstart</h2>
+<h2 align="center" id="quick-start">Schnellstart</h2>
 
 **Empfohlen: Verwenden Sie einen Socket-Proxy**, um einzuschränken, auf welche Docker-API-Endpunkte Drydock zugreifen kann. Dadurch wird vermieden, dass der Container vollen Zugriff auf den Docker-Socket erhält.
 
@@ -175,7 +196,7 @@ Weitere Informationen zu Docker Compose, Socket-Sicherheit, Reverse-Proxy und al
 
 <hr>
 
-<h2 align="center" id="recent-updates">🆕 Aktuelle Updates</h2>
+<h2 align="center" id="recent-updates">Aktuelle Updates</h2>
 
 <details open><summary><strong>Highlights von v1.7.0-rc.1</strong></summary>
 
@@ -250,7 +271,7 @@ Vollständiger Verlauf in [CHANGELOG.md](./CHANGELOG.md).
 
 <hr>
 
-<h2 align="center" id="screenshots">📸 Screenshots und Live-Demo</h2>
+<h2 align="center" id="screenshots">Screenshots und Live-Demo</h2>
 
 <p align="center">
   <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
@@ -281,7 +302,7 @@ Vollständig interaktiv – echte Benutzeroberfläche, Scheindaten, keine Instal
 
 <hr>
 
-<h2 align="center" id="why-drydock">🤔 Warum Drydock</h2>
+<h2 align="center" id="why-drydock">Warum Drydock</h2>
 
 Containerbilder veralten stillschweigend. Ein Basisimage patcht ein CVE, eine App schneidet eine Version, ein Tag wird verschoben. Sofern Sie nicht jede Registrierung manuell überwachen, bleiben Ihre laufenden Container zurück, bis etwas kaputt geht oder ausgenutzt wird.
 
@@ -289,7 +310,7 @@ Die meisten Tools erzwingen einen Kompromiss. Die Auto-Updater (Watchtower, Ouro
 
 <hr>
 
-<h2 align="center" id="features">✨ Funktionen</h2>
+<h2 align="center" id="features">Funktionen</h2>
 
 | | Funktion | Beschreibung |
 | --- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -311,31 +332,31 @@ Die meisten Tools erzwingen einen Kompromiss. Die Auto-Updater (Watchtower, Ouro
 
 <hr>
 
-<h2 align="center" id="supported-integrations">🔌 Unterstützte Integrationen</h2>
+<h2 align="center" id="supported-integrations">Unterstützte Integrationen</h2>
 
-### 📦 Register (23)
+### Register (23)
 
 Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Quay · LSCR · Harbor · Artifactory · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Custom · DOCR · DHI · IBM Cloud · Oracle Cloud · Alibaba Cloud
 
-### ⚡ Aktionen (3)
+### Aktionen (3)
 
 Docker · Docker Compose · Befehl
 
-### 🔔 Benachrichtigungen (17)
+### Benachrichtigungen (17)
 
 Apprise · Discord · Google Chat · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
 
-### 🔐 Authentifizierung
+### Authentifizierung
 
 Anonym (Opt-in über `DD_ANONYMOUS_AUTH_CONFIRM=true`) · Basic (Benutzername + Passwort-Hash) · OIDC (Authelia, Auth0, Authentik). Alle Authentifizierungsabläufe verweigern bei einem Fehler standardmäßig den Zugriff (Fail-Closed).
 
-### 🥊 Update Bouncer
+### Update Bouncer
 
 Trivy- oder Grype-gestützte Schwachstellenscans blockieren unsichere Updates, bevor sie bereitgestellt werden. Beinhaltet Cosign-Signaturüberprüfung und SBOM-Generierung (CycloneDX & SPDX).
 
 <hr>
 
-<h2 align="center" id="feature-comparison">⚖️ Funktionsvergleich</h2>
+<h2 align="center" id="feature-comparison">Funktionsvergleich</h2>
 
 <details><summary><strong>Wie schneidet drydock im Vergleich zu anderen Container-Update-Tools ab?</strong></summary>
 
@@ -385,7 +406,7 @@ Trivy- oder Grype-gestützte Schwachstellenscans blockieren unsichere Updates, b
 
 <hr>
 
-<h2 align="center" id="migration">🔄Migration</h2>
+<h2 align="center" id="migration">Migration</h2>
 
 <details><summary><strong>Migration von WUD (What's Up Docker?)</strong></summary>
 
@@ -395,7 +416,7 @@ Drydock v1.6 lädt zur Laufzeit keine `WUD_*`-Umgebungsvariablen oder `wud.*`-La
 
 <hr>
 
-<h2 align="center" id="roadmap">🗺️ Roadmap</h2>
+<h2 align="center" id="roadmap">Roadmap</h2>
 
 <details><summary><strong>Versionsthemen und Highlights</strong></summary>
 
@@ -418,29 +439,7 @@ Nur übergeordnete Themen; Details pro Version finden Sie in [CHANGELOG.md](CHAN
 
 <hr>
 
-<h2 align="center" id="documentation">📖 Dokumentation</h2>
-
-| Ressource             | Link                                                                                                            |
-| --------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Website               | [getdrydock.com](https://getdrydock.com/)                                                       |
-| Live-Demo             | [demo.getdrydock.com](https://demo.getdrydock.com)                              |
-| Dokumente             | [getdrydock.com/docs](https://getdrydock.com/docs)                                              |
-| Konfiguration         | [Konfiguration](https://getdrydock.com/docs/configuration)                                                      |
-| Schnellstart          | [Schnellstart](https://getdrydock.com/docs/quickstart)                                                          |
-| Änderungsprotokoll    | [`CHANGELOG.md`](CHANGELOG.md)                                                                                  |
-| Deprecations          | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                                                            |
-| Roadmap               | Siehe den Abschnitt [„Roadmap“](#roadmap) oben                                                                  |
-| Mitwirken             | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                                                            |
-| Code of Conduct       | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                                      |
-| Governance            | [`GOVERNANCE.md`](GOVERNANCE.md)                                                                                |
-| Sicherheitsnachweis   | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                                                |
-| Sicherheitsrichtlinie | [`SECURITY.md`](SECURITY.md)                                                                                    |
-| Probleme              | [GitHub Issues](https://github.com/CodesWhat/drydock/issues)                                                    |
-| Diskussionen          | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) – Funktionsanfragen und Ideen willkommen |
-
-<hr>
-
-<a id="star-history"></a>
+<h2 align="center" id="star-history">Sterngeschichte</h2>
 
 <div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
     <picture>
@@ -454,7 +453,7 @@ Nur übergeordnete Themen; Details pro Version finden Sie in [CHANGELOG.md](CHAN
 
 <div align="center">
 
-### Gebaut mit
+<h2 align="center" id="built-with">Gebaut mit</h2>
 
 [![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
 [![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
@@ -469,7 +468,7 @@ Nur übergeordnete Themen; Details pro Version finden Sie in [CHANGELOG.md](CHAN
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
 
-### Gemeinschaft
+<h2 align="center" id="community-support">Gemeinschaft & Support</h2>
 
 Echtzeit-Chat und frühzeitige Unterstützung: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
@@ -481,7 +480,7 @@ Vielen Dank an die Benutzer, die beim Testen der Release-Kandidaten v1.4.0 und v
 
 [@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
 
-### Teil des CodesWhat-Ökosystems
+<h2 align="center" id="codeswhat-ecosystem">Teil des CodesWhat-Ökosystems</h2>
 
 <table>
   <tbody><tr><th>Werkzeug</th><th>Rolle</th></tr>

--- a/README.es.md
+++ b/README.es.md
@@ -41,25 +41,46 @@
 > [!WARNING]
 > **¿Actualizando a 1.6.0-rc.3 o posterior?** Se aplican más refuerzos de seguridad sin período de gracia. Una instancia sin autenticación configurada, o con autenticación anónima habilitada pero no confirmada, ahora se cierra de forma segura al actualizar, igual que una instalación nueva: el contenedor sigue ejecutándose; las solicitudes protegidas de la API devuelven `401`; las rutas públicas de descubrimiento y estado de autenticación siguen disponibles; y `/health` devuelve `503`. La interfaz SPA puede cargar, pero no puede leer datos protegidos. Configure `DD_ANONYMOUS_AUTH_CONFIRM=true` o `DD_AUTH_BASIC_*`/OIDC antes de actualizar. La cookie de sesión cambia de `connect.sid` a `drydock.sid`, cerrando una vez todas las sesiones existentes. Los activadores HTTP, el webhook de Hass y las descargas de iconos de registros ahora resuelven nombres mediante una consulta DNS protegida que bloquea destinos de metadatos de nube y link-local, y nunca sigue redirecciones. Use `allowmetadata=true` solo en un activador `DD_NOTIFICATION_HTTP_*` que realmente lo necesite. Consulte **[DEPRECATIONS.md](DEPRECATIONS.md#enforced-security-changes-no-deprecation-window)** para ver la guía completa.
 
-<h2 align="center">📑 Contenidos</h2>
+<h2 align="center">Contenidos</h2>
 
-- [📖 Documentación](#documentation)
-- [🚀 Inicio rápido](#quick-start)
-- [🆕 Actualizaciones recientes](#recent-updates)
-- [📸 Capturas de pantalla y demostración en vivo](#screenshots)
-- [🤔 Por qué Drydock](#why-drydock)
-- [✨ Características](#features)
-- [🔌 Integraciones admitidas](#supported-integrations)
-- [⚖️ Comparación de funciones](#feature-comparison)
-- [🔄 Migración](#migration)
-- [🗺️ Hoja de ruta](#roadmap)
-- [⭐ Historia de las estrellas](#star-history)
-- [🔧 Construido con](#construido-con)
-- [🤝 Comunidad QA](#control-de-calidad-de-la-comunidad)
+- [Documentación](#documentation)
+- [Inicio rápido](#quick-start)
+- [Actualizaciones recientes](#recent-updates)
+- [Capturas de pantalla y demostración en vivo](#screenshots)
+- [Por qué Drydock](#why-drydock)
+- [Características](#features)
+- [Integraciones admitidas](#supported-integrations)
+- [Comparación de funciones](#feature-comparison)
+- [Migración](#migration)
+- [Hoja de ruta](#roadmap)
+- [Historia de las estrellas](#star-history)
+- [Construido con](#built-with)
+- [Comunidad y soporte](#community-support)
+- [Ecosistema CodesWhat](#codeswhat-ecosystem)
+
+<h2 align="center" id="documentation">Documentación</h2>
+
+| Recurso               | Enlace                                                                                                                                 |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Sitio web             | [obtenerdrydock.com](https://getdrydock.com/)                                                                          |
+| Demostración en vivo  | [demo.getdrydock.com](https://demo.getdrydock.com)                                                     |
+| Documentos            | [getdrydock.com/docs](https://getdrydock.com/docs)                                                                     |
+| Configuración         | [Configuración](https://getdrydock.com/docs/configuration)                                                                             |
+| Inicio rápido         | [Inicio rápido](https://getdrydock.com/docs/quickstart)                                                                                |
+| Registro de cambios   | [`CHANGELOG.md`](CHANGELOG.md)                                                                                                         |
+| Deprecations          | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                                                                                   |
+| Hoja de ruta          | Consulte la sección [Hoja de ruta](#roadmap) más arriba                                                                                |
+| Contribuyendo         | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                                                                                   |
+| Código de conducta    | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                                                             |
+| Governance            | [`GOVERNANCE.md`](GOVERNANCE.md)                                                                                                       |
+| Garantía de seguridad | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                                                                       |
+| Política de seguridad | [`SECURITY.md`](SECURITY.md)                                                                                                           |
+| Problemas             | [Problemas de GitHub](https://github.com/CodesWhat/drydock/issues)                                                                     |
+| Discusiones           | [Discusiones de GitHub](https://github.com/CodesWhat/drydock/discussions): se aceptan solicitudes de funciones e ideas |
 
 <hr>
 
-<h2 align="center" id="quick-start">🚀 Inicio rápido</h2>
+<h2 align="center" id="quick-start">Inicio rápido</h2>
 
 **Recomendado: use un proxy de socket** para restringir a qué puntos finales de la API de Docker puede acceder Drydock. Esto evita darle al contenedor acceso completo al socket Docker.
 
@@ -175,7 +196,7 @@ Consulte la [guía de inicio rápido](https://getdrydock.com/docs/quickstart) pa
 
 <hr>
 
-<h2 align="center" id="recent-updates">🆕 Actualizaciones recientes</h2>
+<h2 align="center" id="recent-updates">Actualizaciones recientes</h2>
 
 <details open><summary><strong>Aspectos destacados de v1.7.0-rc.1</strong></summary>
 
@@ -250,7 +271,7 @@ Historial completo en [CHANGELOG.md](./CHANGELOG.md).
 
 <hr>
 
-<h2 align="center" id="screenshots">📸 Capturas de pantalla y demostración en vivo</h2>
+<h2 align="center" id="screenshots">Capturas de pantalla y demostración en vivo</h2>
 
 <p align="center">
   <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
@@ -281,7 +302,7 @@ Totalmente interactivo: interfaz de usuario real, datos simulados, no requiere i
 
 <hr>
 
-<h2 align="center" id="why-drydock">🤔 Por qué Drydock</h2>
+<h2 align="center" id="why-drydock">Por qué Drydock</h2>
 
 Las imágenes de los contenedores quedan obsoletas silenciosamente. Una imagen base parchea un CVE, una aplicación corta una versión, una etiqueta se mueve. A menos que esté observando cada registro manualmente, sus contenedores en ejecución se retrasan hasta que algo se rompe o es explotado.
 
@@ -289,7 +310,7 @@ La mayoría de las herramientas obligan a hacer concesiones. Los actualizadores 
 
 <hr>
 
-<h2 align="center" id="features">✨ Características</h2>
+<h2 align="center" id="features">Características</h2>
 
 | | Característica | Descripción |
 | --- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -311,31 +332,31 @@ La mayoría de las herramientas obligan a hacer concesiones. Los actualizadores 
 
 <hr>
 
-<h2 align="center" id="supported-integrations">🔌 Integraciones admitidas</h2>
+<h2 align="center" id="supported-integrations">Integraciones admitidas</h2>
 
-### 📦 Registros (23)
+### Registros (23)
 
 Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Muelle · LSCR · Puerto · Artifactory · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Personalizado · DOCR · DHI · IBM Cloud · Oracle Cloud · Alibaba Cloud
 
-### ⚡ Acciones (3)
+### Acciones (3)
 
 Docker · Docker Compose · Comando
 
-### 🔔 Notificaciones (17)
+### Notificaciones (17)
 
 Informar · Discord · Google Chat · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
 
-### 🔐 Autenticación
+### Autenticación
 
 Anónimo (suscripción a través de `DD_ANONYMOUS_AUTH_CONFIRM=true`) · Básico (nombre de usuario + hash de contraseña) · OIDC (Authelia, Auth0, Authentik). De forma predeterminada, todos los flujos de autenticación deniegan el acceso ante cualquier fallo (fail-closed).
 
-### 🥊 Update Bouncer
+### Update Bouncer
 
 El escaneo de vulnerabilidades impulsado por Trivy o Grype bloquea las actualizaciones no seguras antes de que se implementen. Incluye verificación de firma Cosign y generación de SBOM (CycloneDX y SPDX).
 
 <hr>
 
-<h2 align="center" id="feature-comparison">⚖️ Comparación de funciones</h2>
+<h2 align="center" id="feature-comparison">Comparación de funciones</h2>
 
 <details><summary><strong>¿Cómo se compara drydock con otras herramientas de actualización de contenedores?</strong></summary>
 
@@ -385,7 +406,7 @@ El escaneo de vulnerabilidades impulsado por Trivy o Grype bloquea las actualiza
 
 <hr>
 
-<h2 align="center" id="migration">🔄 Migración</h2>
+<h2 align="center" id="migration">Migración</h2>
 
 <details><summary><strong>Migrando desde WUD (¿Qué pasa Docker?)</strong></summary>
 
@@ -395,7 +416,7 @@ Drydock v1.6 ya no carga variables de entorno `WUD_*` o etiquetas `wud.*` en tie
 
 <hr>
 
-<h2 align="center" id="roadmap">🗺️ Hoja de ruta</h2>
+<h2 align="center" id="roadmap">Hoja de ruta</h2>
 
 <details><summary><strong>Temas y aspectos destacados de la versión</strong></summary>
 
@@ -418,29 +439,7 @@ Solo temas generales; consulte [CHANGELOG.md](CHANGELOG.md) para conocer el deta
 
 <hr>
 
-<h2 align="center" id="documentation">📖 Documentación</h2>
-
-| Recurso               | Enlace                                                                                                                                 |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Sitio web             | [obtenerdrydock.com](https://getdrydock.com/)                                                                          |
-| Demostración en vivo  | [demo.getdrydock.com](https://demo.getdrydock.com)                                                     |
-| Documentos            | [getdrydock.com/docs](https://getdrydock.com/docs)                                                                     |
-| Configuración         | [Configuración](https://getdrydock.com/docs/configuration)                                                                             |
-| Inicio rápido         | [Inicio rápido](https://getdrydock.com/docs/quickstart)                                                                                |
-| Registro de cambios   | [`CHANGELOG.md`](CHANGELOG.md)                                                                                                         |
-| Deprecations          | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                                                                                   |
-| Hoja de ruta          | Consulte la sección [Hoja de ruta](#roadmap) más arriba                                                                                |
-| Contribuyendo         | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                                                                                   |
-| Código de conducta    | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                                                             |
-| Governance            | [`GOVERNANCE.md`](GOVERNANCE.md)                                                                                                       |
-| Garantía de seguridad | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                                                                       |
-| Política de seguridad | [`SECURITY.md`](SECURITY.md)                                                                                                           |
-| Problemas             | [Problemas de GitHub](https://github.com/CodesWhat/drydock/issues)                                                                     |
-| Discusiones           | [Discusiones de GitHub](https://github.com/CodesWhat/drydock/discussions): se aceptan solicitudes de funciones e ideas |
-
-<hr>
-
-<a id="star-history"></a>
+<h2 align="center" id="star-history">Historia de las estrellas</h2>
 
 <div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
     <picture>
@@ -454,7 +453,7 @@ Solo temas generales; consulte [CHANGELOG.md](CHANGELOG.md) para conocer el deta
 
 <div align="center">
 
-### Construido con
+<h2 align="center" id="built-with">Construido con</h2>
 
 [![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
 [![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
@@ -469,7 +468,7 @@ Solo temas generales; consulte [CHANGELOG.md](CHANGELOG.md) para conocer el deta
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
 
-### Comunidad
+<h2 align="center" id="community-support">Comunidad y soporte</h2>
 
 Chat en tiempo real y soporte temprano: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
@@ -481,7 +480,7 @@ Gracias a los usuarios que ayudaron a probar las versiones candidatas v1.4.0 y v
 
 [@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
 
-### Parte del ecosistema CodesWhat
+<h2 align="center" id="codeswhat-ecosystem">Parte del ecosistema CodesWhat</h2>
 
 <table>
   <tbody><tr><th>Herramienta</th><th>Rol</th></tr>

--- a/README.fr.md
+++ b/README.fr.md
@@ -41,25 +41,46 @@
 > [!WARNING]
 > **Mise à niveau vers 1.6.0-rc.3 ou une version ultérieure ?** Des renforcements de sécurité supplémentaires s'appliquent sans délai de grâce. Une instance sans authentification configurée, ou avec l'accès anonyme activé mais non confirmé, échoue désormais en mode fermé lors d'une mise à niveau comme lors d'une nouvelle installation : le conteneur fonctionne, les requêtes API protégées renvoient `401`, les routes publiques de découverte et d'état d'authentification restent disponibles et `/health` renvoie `503`. L'interface SPA peut se charger, mais ne peut pas lire les données protégées. Définissez `DD_ANONYMOUS_AUTH_CONFIRM=true` ou configurez `DD_AUTH_BASIC_*`/OIDC avant la mise à niveau. Le cookie de session passe de `connect.sid` à `drydock.sid`, ce qui déconnecte une fois tous les utilisateurs. Les déclencheurs HTTP, le webhook Hass et les téléchargements d'icônes de registre utilisent désormais une résolution DNS protégée qui bloque les cibles de métadonnées cloud et link-local et ne suit jamais les redirections. Réservez `allowmetadata=true` à un déclencheur `DD_NOTIFICATION_HTTP_*` qui en a réellement besoin. Consultez **[DEPRECATIONS.md](DEPRECATIONS.md#enforced-security-changes-no-deprecation-window)** pour la procédure complète.
 
-<h2 align="center">📑 Contenu</h2>
+<h2 align="center">Contenu</h2>
 
-- [📖Documentation](#documentation)
-- [🚀 Démarrage rapide](#quick-start)
-- [🆕 Mises à jour récentes](#recent-updates)
-- [📸 Captures d'écran et démo en direct](#screenshots)
-- [🤔 Pourquoi Drydock](#why-drydock)
-- [✨ Caractéristiques](#features)
-- [🔌 Intégrations prises en charge](#supported-integrations)
-- [⚖️ Comparaison des fonctionnalités](#feature-comparison)
-- [🔄Migration](#migration)
-- [🗺️ Feuille de route](#roadmap)
-- [⭐ Historique des étoiles](#star-history)
-- [🔧 Construit avec](#construit-avec)
-- [🤝 Communauté QA](#contrôle-qualité-de-la-communauté)
+- [Documentation](#documentation)
+- [Démarrage rapide](#quick-start)
+- [Mises à jour récentes](#recent-updates)
+- [Captures d'écran et démo en direct](#screenshots)
+- [Pourquoi Drydock](#why-drydock)
+- [Caractéristiques](#features)
+- [Intégrations prises en charge](#supported-integrations)
+- [Comparaison des fonctionnalités](#feature-comparison)
+- [Migration](#migration)
+- [Feuille de route](#roadmap)
+- [Historique des étoiles](#star-history)
+- [Construit avec](#built-with)
+- [Communauté et support](#community-support)
+- [Écosystème CodesWhat](#codeswhat-ecosystem)
+
+<h2 align="center" id="documentation">Documentations</h2>
+
+| Ressource                 | Lien                                                                                                                     |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Site Web                  | [getdrydock.com](https://getdrydock.com/)                                                                |
+| Démo en direct            | [demo.getdrydock.com](https://demo.getdrydock.com)                                       |
+| Documents                 | [getdrydock.com/docs](https://getdrydock.com/docs)                                                       |
+| Configuration             | [Configuration](https://getdrydock.com/docs/configuration)                                                               |
+| Démarrage rapide          | [Démarrage rapide](https://getdrydock.com/docs/quickstart)                                                               |
+| Journal des modifications | [`CHANGELOG.md`](CHANGELOG.md)                                                                                           |
+| Dépréciations             | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                                                                     |
+| Feuille de route          | Voir la section [Roadmap](#roadmap) ci-dessus                                                                            |
+| Contribuer                | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                                                                     |
+| Code de conduite          | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                                               |
+| Gouvernance               | [`GOVERNANCE.md`](GOVERNANCE.md)                                                                                         |
+| Assurance de sécurité     | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                                                         |
+| Politique de sécurité     | [`SECURITY.md`](SECURITY.md)                                                                                             |
+| Problèmes                 | [Problèmes GitHub](https://github.com/CodesWhat/drydock/issues)                                                          |
+| Discussions               | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) — demandes de fonctionnalités et idées bienvenues |
 
 <hr>
 
-<h2 align="center" id="quick-start">🚀 Démarrage rapide</h2>
+<h2 align="center" id="quick-start">Démarrage rapide</h2>
 
 **Recommandé : utilisez un proxy de socket** pour restreindre les points de terminaison de l'API Docker auxquels Drydock peut accéder. Cela évite de donner au conteneur un accès complet au socket Docker.
 
@@ -175,7 +196,7 @@ Consultez le [Guide de démarrage rapide](https://getdrydock.com/docs/quickstart
 
 <hr>
 
-<h2 align="center" id="recent-updates">🆕 Mises à jour récentes</h2>
+<h2 align="center" id="recent-updates">Mises à jour récentes</h2>
 
 <details open><summary><strong>Points forts de la v1.7.0-rc.1</strong></summary>
 
@@ -250,7 +271,7 @@ Historique complet dans [CHANGELOG.md](./CHANGELOG.md).
 
 <hr>
 
-<h2 align="center" id="screenshots">📸 Captures d'écran et démo en direct</h2>
+<h2 align="center" id="screenshots">Captures d'écran et démo en direct</h2>
 
 <p align="center">
   <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
@@ -281,7 +302,7 @@ Entièrement interactif : véritable interface utilisateur, données fictives, 
 
 <hr>
 
-<h2 align="center" id="why-drydock">🤔 Pourquoi Drydock</h2>
+<h2 align="center" id="why-drydock">Pourquoi Drydock</h2>
 
 Les images de conteneurs deviennent obsolètes en silence. Une image de base corrige un CVE, une application supprime une version, une balise se déplace. À moins que vous ne surveilliez chaque registre à la main, vos conteneurs en cours d'exécution prennent du retard jusqu'à ce que quelque chose se brise ou soit exploité.
 
@@ -289,7 +310,7 @@ La plupart des outils imposent un compromis. Les mises à jour automatiques (Wat
 
 <hr>
 
-<h2 align="center" id="features">✨ Caractéristiques</h2>
+<h2 align="center" id="features">Caractéristiques</h2>
 
 | | Fonctionnalité | Descriptif |
 | --- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -311,31 +332,31 @@ La plupart des outils imposent un compromis. Les mises à jour automatiques (Wat
 
 <hr>
 
-<h2 align="center" id="supported-integrations">🔌 Supported Integrations</h2>
+<h2 align="center" id="supported-integrations">Supported Integrations</h2>
 
-### 📦 Registres (23)
+### Registres (23)
 
 Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Quay · LSCR · Port · Artefact · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Personnalisé · DOCR · DHI · IBM Cloud · Oracle Cloud · Alibaba Cloud
 
-### ⚡Actions (3)
+### Actions (3)
 
 Docker · Docker Compose · Commande
 
-### 🔔Notifications (17)
+### Notifications (17)
 
 Apprise · Discord · Google Chat · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
 
-### 🔐 Authentification
+### Authentification
 
 Anonyme (inscription via `DD_ANONYMOUS_AUTH_CONFIRM=true`) · Basique (nom d'utilisateur + hachage du mot de passe) · OIDC (Authelia, Auth0, Authentik). Par défaut, tous les flux d’authentification refusent l’accès en cas d’échec (fail-closed).
 
-### 🥊 Update Bouncer
+### Update Bouncer
 
 L'analyse des vulnérabilités basée sur Trivy ou Grype bloque les mises à jour dangereuses avant leur déploiement. Comprend la vérification de la signature Cosign et la génération SBOM (CycloneDX et SPDX).
 
 <hr>
 
-<h2 align="center" id="feature-comparison">⚖️ Comparaison des fonctionnalités</h2>
+<h2 align="center" id="feature-comparison">Comparaison des fonctionnalités</h2>
 
 <details><summary><strong>Comment drydock se compare-t-il aux autres outils de mise à jour de conteneurs ?</strong></summary>
 
@@ -385,7 +406,7 @@ L'analyse des vulnérabilités basée sur Trivy ou Grype bloque les mises à jou
 
 <hr>
 
-<h2 align="center" id="migration">🔄 Migration</h2>
+<h2 align="center" id="migration">Migration</h2>
 
 <details><summary><strong>Migration depuis WUD (What's Up Docker ?)</strong></summary>
 
@@ -395,7 +416,7 @@ Drydock v1.6 ne charge plus les variables d'environnement `WUD_*` ou les étique
 
 <hr>
 
-<h2 align="center" id="roadmap">🗺️ Feuille de route</h2>
+<h2 align="center" id="roadmap">Feuille de route</h2>
 
 <details><summary><strong>Thèmes et faits saillants de la version</strong></summary>
 
@@ -418,29 +439,7 @@ Thèmes généraux uniquement ; consultez [CHANGELOG.md](CHANGELOG.md) pour les
 
 <hr>
 
-<h2 align="center" id="documentation">📖Documentations</h2>
-
-| Ressource                 | Lien                                                                                                                     |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Site Web                  | [getdrydock.com](https://getdrydock.com/)                                                                |
-| Démo en direct            | [demo.getdrydock.com](https://demo.getdrydock.com)                                       |
-| Documents                 | [getdrydock.com/docs](https://getdrydock.com/docs)                                                       |
-| Configuration             | [Configuration](https://getdrydock.com/docs/configuration)                                                               |
-| Démarrage rapide          | [Démarrage rapide](https://getdrydock.com/docs/quickstart)                                                               |
-| Journal des modifications | [`CHANGELOG.md`](CHANGELOG.md)                                                                                           |
-| Dépréciations             | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                                                                     |
-| Feuille de route          | Voir la section [Roadmap](#roadmap) ci-dessus                                                                            |
-| Contribuer                | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                                                                     |
-| Code de conduite          | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                                               |
-| Gouvernance               | [`GOVERNANCE.md`](GOVERNANCE.md)                                                                                         |
-| Assurance de sécurité     | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                                                         |
-| Politique de sécurité     | [`SECURITY.md`](SECURITY.md)                                                                                             |
-| Problèmes                 | [Problèmes GitHub](https://github.com/CodesWhat/drydock/issues)                                                          |
-| Discussions               | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) — demandes de fonctionnalités et idées bienvenues |
-
-<hr>
-
-<a id="star-history"></a>
+<h2 align="center" id="star-history">Historique des étoiles</h2>
 
 <div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
     <picture>
@@ -454,7 +453,7 @@ Thèmes généraux uniquement ; consultez [CHANGELOG.md](CHANGELOG.md) pour les
 
 <div align="center">
 
-### Construit avec
+<h2 align="center" id="built-with">Construit avec</h2>
 
 [![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
 [![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
@@ -469,7 +468,7 @@ Thèmes généraux uniquement ; consultez [CHANGELOG.md](CHANGELOG.md) pour les
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
 
-### Communauté
+<h2 align="center" id="community-support">Communauté et support</h2>
 
 Chat en temps réel et assistance précoce : **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
@@ -481,7 +480,7 @@ Merci aux utilisateurs qui ont aidé à tester les versions candidates v1.4.0 et
 
 [@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
 
-### Fait partie de l'écosystème CodesWhat
+<h2 align="center" id="codeswhat-ecosystem">Fait partie de l'écosystème CodesWhat</h2>
 
 <table>
   <tbody><tr><th>Outil</th><th>Rôle</th></tr>

--- a/README.pl.md
+++ b/README.pl.md
@@ -41,25 +41,46 @@
 > [!WARNING]
 > **Aktualizujesz do 1.6.0-rc.3 lub nowszej wersji?** Dodatkowe zabezpieczenia obowiązują bez okresu przejściowego. Instancja bez skonfigurowanego uwierzytelniania albo z włączonym, lecz niepotwierdzonym dostępem anonimowym po aktualizacji działa teraz w trybie zamkniętym, tak samo jak nowa instalacja: kontener działa, chronione żądania API zwracają `401`, publiczne trasy wykrywania i stanu uwierzytelniania pozostają dostępne, a `/health` zwraca `503`. Powłoka SPA może się załadować, ale nie odczyta chronionych danych. Przed aktualizacją ustaw `DD_ANONYMOUS_AUTH_CONFIRM=true` lub skonfiguruj `DD_AUTH_BASIC_*`/OIDC. Nazwa cookie sesji zmienia się z `connect.sid` na `drydock.sid`, co jednorazowo wyloguje użytkowników. Wyzwalacze powiadomień HTTP, webhook Hass i pobieranie ikon rejestrów rozwiązują teraz nazwy hostów za pomocą chronionego wyszukiwania DNS, które blokuje cele metadanych chmurowych i adresy link-local oraz nigdy nie podąża za przekierowaniami — ustaw `allowmetadata=true` dla konkretnego wyzwalacza `DD_NOTIFICATION_HTTP_*` tylko wtedy, gdy rzeczywiście jest to potrzebne. Pełne wskazówki zawiera **[DEPRECATIONS.md](DEPRECATIONS.md#enforced-security-changes-no-deprecation-window)**.
 
-<h2 align="center">📑Spis treści</h2>
+<h2 align="center">Spis treści</h2>
 
-- [📖 Dokumentacja](#documentation)
-- [🚀 Szybki start](#quick-start)
-- [🆕 Ostatnie aktualizacje](#recent-updates)
-- [📸 Zrzuty ekranu i demonstracja na żywo](#screenshots)
-- [🤔 Dlaczego Drydock](#why-drydock)
-- [✨ Funkcje](#features)
-- [🔌 Obsługiwane integracje](#supported-integrations)
-- [⚖️ Porównanie funkcji](#feature-comparison)
-- [🔄 Migracja](#migration)
-- [🗺️ Plan działania](#roadmap)
-- [⭐ Historia gwiazd](#star-history)
-- [🔧 Zbudowany z](#zbudowany-z)
-- [🤝 Społeczność QA](#kontrola-jakości-społeczności)
+- [Dokumentacja](#documentation)
+- [Szybki start](#quick-start)
+- [Ostatnie aktualizacje](#recent-updates)
+- [Zrzuty ekranu i demonstracja na żywo](#screenshots)
+- [Dlaczego Drydock](#why-drydock)
+- [Funkcje](#features)
+- [Obsługiwane integracje](#supported-integrations)
+- [Porównanie funkcji](#feature-comparison)
+- [Migracja](#migration)
+- [Plan działania](#roadmap)
+- [Historia gwiazd](#star-history)
+- [Zbudowany z](#built-with)
+- [Społeczność i wsparcie](#community-support)
+- [Ekosystem CodesWhat](#codeswhat-ecosystem)
+
+<h2 align="center" id="documentation">Dokumentacja</h2>
+
+| Zasób                      | Link                                                                                                                   |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Strona internetowa         | [getdrydock.com](https://getdrydock.com/)                                                              |
+| Demo na żywo               | [demo.getdrydock.com](https://demo.getdrydock.com)                                     |
+| Dokumenty                  | [getdrydock.com/docs](https://getdrydock.com/docs)                                                     |
+| Konfiguracja               | [Konfiguracja](https://getdrydock.com/docs/configuration)                                                              |
+| Szybki start               | [Szybki start](https://getdrydock.com/docs/quickstart)                                                                 |
+| Dziennik zmian             | [`CHANGELOG.md`](CHANGELOG.md)                                                                                         |
+| Deprecations               | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                                                                   |
+| Mapa drogowa               | Zobacz sekcję [Roadmap](#roadmap) powyżej                                                                              |
+| Contributing               | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                                                                   |
+| Kodeks postępowania        | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                                             |
+| Zarządzanie                | [`GOVERNANCE.md`](GOVERNANCE.md)                                                                                       |
+| Zapewnienie bezpieczeństwa | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                                                       |
+| Polityka bezpieczeństwa    | [`SECURITY.md`](SECURITY.md)                                                                                           |
+| Problemy                   | [Problemy z GitHubem](https://github.com/CodesWhat/drydock/issues)                                                     |
+| Dyskusje                   | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) — prośby o nowe funkcje i pomysły mile widziane |
 
 <hr>
 
-<h2 align="center" id="quick-start">🚀 Szybki start</h2>
+<h2 align="center" id="quick-start">Szybki start</h2>
 
 **Zalecane: użyj gniazda proxy**, aby ograniczyć punkty końcowe Docker API, do których Drydock może uzyskać dostęp. Pozwala to uniknąć zapewnienia kontenerowi pełnego dostępu do gniazda Docker.
 
@@ -175,7 +196,7 @@ Zobacz [Przewodnik szybkiego startu](https://getdrydock.com/docs/quickstart) dla
 
 <hr>
 
-<h2 align="center" id="recent-updates">🆕 Ostatnie aktualizacje</h2>
+<h2 align="center" id="recent-updates">Ostatnie aktualizacje</h2>
 
 <details open><summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.1</strong></summary>
 
@@ -250,7 +271,7 @@ Pełna historia w [CHANGELOG.md](./CHANGELOG.md).
 
 <hr>
 
-<h2 align="center" id="screenshots">📸 Zrzuty ekranu i demonstracja na żywo</h2>
+<h2 align="center" id="screenshots">Zrzuty ekranu i demonstracja na żywo</h2>
 
 <p align="center">
   <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
@@ -281,7 +302,7 @@ W pełni interaktywny — prawdziwy interfejs użytkownika, próbne dane, nie wy
 
 <hr>
 
-<h2 align="center" id="why-drydock">🤔 Dlaczego Drydock</h2>
+<h2 align="center" id="why-drydock">Dlaczego Drydock</h2>
 
 Obrazy kontenerów po cichu stają się nieaktualne. Obraz bazowy łata CVE, aplikacja wycofuje wersję, tag się przenosi. Jeśli nie będziesz oglądać każdego rejestru ręcznie, działające kontenery pozostaną w tyle, dopóki coś się nie zepsuje lub nie zostanie wykorzystane.
 
@@ -289,7 +310,7 @@ Większość narzędzi wymusza kompromis. Automatyczne aktualizacje (Watchtower,
 
 <hr>
 
-<h2 align="center" id="features">✨ Funkcje</h2>
+<h2 align="center" id="features">Funkcje</h2>
 
 | | Funkcja | Opis |
 | --- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -311,31 +332,31 @@ Większość narzędzi wymusza kompromis. Automatyczne aktualizacje (Watchtower,
 
 <hr>
 
-<h2 align="center" id="supported-integrations">🔌 Obsługiwane integracje</h2>
+<h2 align="center" id="supported-integrations">Obsługiwane integracje</h2>
 
-### 📦 Rejestry (23)
+### Rejestry (23)
 
 Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Quay · LSCR · Port · Artifactory · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Niestandardowy · DOCR · DHI · IBM Cloud · Oracle Cloud · Alibaba Cloud
 
-### ⚡ Akcje (3)
+### Akcje (3)
 
 Doker · Docker Compose · Polecenie
 
-### 🔔 Powiadomienia (17)
+### Powiadomienia (17)
 
 Appprise · Discord · Czat Google · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
 
-### 🔐 Uwierzytelnianie
+### Uwierzytelnianie
 
 Anonimowy (opcja poprzez `DD_ANONYMOUS_AUTH_CONFIRM=true`) · Podstawowy (nazwa użytkownika + skrót hasła) · OIDC (Authelia, Auth0, Authentik). Domyślnie każdy błąd przepływu uwierzytelniania powoduje odmowę dostępu (fail-closed).
 
-### 🥊 Update Bouncer
+### Update Bouncer
 
 Skanowanie pod kątem luk w zabezpieczeniach oparte na Trivy lub Grype blokuje niebezpieczne aktualizacje przed ich wdrożeniem. Obejmuje weryfikację podpisu Cosign i generowanie SBOM (CycloneDX i SPDX).
 
 <hr>
 
-<h2 align="center" id="feature-comparison">⚖️ Porównanie funkcji</h2>
+<h2 align="center" id="feature-comparison">Porównanie funkcji</h2>
 
 <details><summary><strong>Jak drydock wypada w porównaniu z innymi narzędziami do aktualizacji kontenerów?</strong></summary>
 
@@ -385,7 +406,7 @@ Skanowanie pod kątem luk w zabezpieczeniach oparte na Trivy lub Grype blokuje n
 
 <hr>
 
-<h2 align="center" id="migration">🔄 Migracja</h2>
+<h2 align="center" id="migration">Migracja</h2>
 
 <details><summary><strong>Migracja z WUD (Co słychać w oknie dokowanym?)</strong></summary>
 
@@ -395,7 +416,7 @@ Drydock v1.6 nie ładuje już zmiennych środowiskowych `WUD_*` ani etykiet `wud
 
 <hr>
 
-<h2 align="center" id="roadmap">🗺️ Roadmap</h2>
+<h2 align="center" id="roadmap">Roadmap</h2>
 
 <details><summary><strong>Motywy i najważniejsze wersje wersji</strong></summary>
 
@@ -418,29 +439,7 @@ Tylko motywy ogólne; szczegóły poszczególnych wersji zawiera [CHANGELOG.md](
 
 <hr>
 
-<h2 align="center" id="documentation">📖 Dokumentacja</h2>
-
-| Zasób                      | Link                                                                                                                   |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Strona internetowa         | [getdrydock.com](https://getdrydock.com/)                                                              |
-| Demo na żywo               | [demo.getdrydock.com](https://demo.getdrydock.com)                                     |
-| Dokumenty                  | [getdrydock.com/docs](https://getdrydock.com/docs)                                                     |
-| Konfiguracja               | [Konfiguracja](https://getdrydock.com/docs/configuration)                                                              |
-| Szybki start               | [Szybki start](https://getdrydock.com/docs/quickstart)                                                                 |
-| Dziennik zmian             | [`CHANGELOG.md`](CHANGELOG.md)                                                                                         |
-| Deprecations               | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                                                                   |
-| Mapa drogowa               | Zobacz sekcję [Roadmap](#roadmap) powyżej                                                                              |
-| Contributing               | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                                                                   |
-| Kodeks postępowania        | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                                             |
-| Zarządzanie                | [`GOVERNANCE.md`](GOVERNANCE.md)                                                                                       |
-| Zapewnienie bezpieczeństwa | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                                                       |
-| Polityka bezpieczeństwa    | [`SECURITY.md`](SECURITY.md)                                                                                           |
-| Problemy                   | [Problemy z GitHubem](https://github.com/CodesWhat/drydock/issues)                                                     |
-| Dyskusje                   | [GitHub Discussions](https://github.com/CodesWhat/drydock/discussions) — prośby o nowe funkcje i pomysły mile widziane |
-
-<hr>
-
-<a id="star-history"></a>
+<h2 align="center" id="star-history">Historia gwiazd</h2>
 
 <div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
     <picture>
@@ -454,7 +453,7 @@ Tylko motywy ogólne; szczegóły poszczególnych wersji zawiera [CHANGELOG.md](
 
 <div align="center">
 
-### Zbudowany z
+<h2 align="center" id="built-with">Zbudowany z</h2>
 
 [![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
 [![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
@@ -469,7 +468,7 @@ Tylko motywy ogólne; szczegóły poszczególnych wersji zawiera [CHANGELOG.md](
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
 
-### Społeczność
+<h2 align="center" id="community-support">Społeczność i wsparcie</h2>
 
 Czat na żywo i wczesne wsparcie: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
@@ -481,7 +480,7 @@ Dziękujemy użytkownikom, którzy pomogli w testowaniu wersji 1.4.0 i 1.5.0 ora
 
 [@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
 
-### Część ekosystemu CodesWhat
+<h2 align="center" id="codeswhat-ecosystem">Część ekosystemu CodesWhat</h2>
 
 <table>
   <tbody><tr><th>Narzędzie</th><th>Rola</th></tr>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -41,25 +41,46 @@
 > [!WARNING]
 > **Atualizando para 1.6.0-rc.3 ou posterior?** Mais reforços de segurança entram em vigor sem período de carência. Uma instância sem autenticação configurada, ou com autenticação anônima ativada mas não confirmada, agora falha de forma fechada após a atualização, assim como uma instalação nova: o contêiner continua em execução, solicitações protegidas da API retornam `401`, as rotas públicas de descoberta e status de autenticação permanecem disponíveis e `/health` retorna `503`. A interface SPA pode carregar, mas não lê dados protegidos. Defina `DD_ANONYMOUS_AUTH_CONFIRM=true` ou configure `DD_AUTH_BASIC_*`/OIDC antes de atualizar. O cookie da sessão muda de `connect.sid` para `drydock.sid`, desconectando todos os usuários uma vez. Gatilhos HTTP, o webhook Hass e buscas de ícones de registro agora usam DNS protegido, bloqueiam destinos de metadados de nuvem e link-local e nunca seguem redirecionamentos. Use `allowmetadata=true` somente no gatilho `DD_NOTIFICATION_HTTP_*` específico que realmente precisar. Consulte **[DEPRECATIONS.md](DEPRECATIONS.md#enforced-security-changes-no-deprecation-window)** para a orientação completa.
 
-<h2 align="center">📑 Conteúdo</h2>
+<h2 align="center">Conteúdo</h2>
 
-- [📖 Documentação](#documentation)
-- [🚀 Início rápido](#quick-start)
-- [🆕 Atualizações recentes](#recent-updates)
-- [📸 Capturas de tela e demonstração ao vivo](#screenshots)
-- [🤔 Por que Drydock](#why-drydock)
-- [✨ Recursos](#features)
-- [🔌 Integrações suportadas](#supported-integrations)
-- [⚖️ Comparação de recursos](#feature-comparison)
-- [🔄 Migração](#migration)
-- [🗺️ Roteiro](#roadmap)
-- [⭐ História da estrela](#star-history)
-- [🔧 Construído com](#construído-com)
-- [🤝 Comunidade QA](#controle-de-qualidade-da-comunidade)
+- [Documentação](#documentation)
+- [Início rápido](#quick-start)
+- [Atualizações recentes](#recent-updates)
+- [Capturas de tela e demonstração ao vivo](#screenshots)
+- [Por que Drydock](#why-drydock)
+- [Recursos](#features)
+- [Integrações suportadas](#supported-integrations)
+- [Comparação de recursos](#feature-comparison)
+- [Migração](#migration)
+- [Roteiro](#roadmap)
+- [História da estrela](#star-history)
+- [Construído com](#built-with)
+- [Comunidade e suporte](#community-support)
+- [Ecossistema CodesWhat](#codeswhat-ecosystem)
+
+<h2 align="center" id="documentation">Documentação</h2>
+
+| Recurso                | Ligação                                                                                                                     |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Site                   | [getdrydock.com](https://getdrydock.com/)                                                                   |
+| Demonstração ao vivo   | [demo.getdrydock.com](https://demo.getdrydock.com)                                          |
+| Documentos             | [getdrydock.com/docs](https://getdrydock.com/docs)                                                          |
+| Configuração           | [Configuração](https://getdrydock.com/docs/configuration)                                                                   |
+| Início rápido          | [Início rápido](https://getdrydock.com/docs/quickstart)                                                                     |
+| Registro de alterações | [`CHANGELOG.md`](CHANGELOG.md)                                                                                              |
+| Deprecations           | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                                                                        |
+| Roadmap                | Consulte a seção [Roteiro](#roadmap) acima                                                                                  |
+| Contribuindo           | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                                                                        |
+| Código de Conduta      | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                                                  |
+| Governança             | [`GOVERNANCE.md`](GOVERNANCE.md)                                                                                            |
+| Garantia de Segurança  | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                                                            |
+| Política de Segurança  | [`SECURITY.md`](SECURITY.md)                                                                                                |
+| Problemas              | [Problemas do GitHub](https://github.com/CodesWhat/drydock/issues)                                                          |
+| Discussões             | [Discussões no GitHub](https://github.com/CodesWhat/drydock/discussions) - solicitações de recursos e ideias são bem-vindas |
 
 <hr>
 
-<h2 align="center" id="quick-start">🚀 Início rápido</h2>
+<h2 align="center" id="quick-start">Início rápido</h2>
 
 **Recomendado: use um proxy de soquete** para restringir quais endpoints da API Docker que Drydock podem acessar. Isso evita dar ao contêiner acesso total ao soquete Docker.
 
@@ -175,7 +196,7 @@ Consulte o [Guia de início rápido](https://getdrydock.com/docs/quickstart) par
 
 <hr>
 
-<h2 align="center" id="recent-updates">🆕 Atualizações recentes</h2>
+<h2 align="center" id="recent-updates">Atualizações recentes</h2>
 
 <details open><summary><strong>Destaques da v1.7.0-rc.1</strong></summary>
 
@@ -250,7 +271,7 @@ Histórico completo em [CHANGELOG.md](./CHANGELOG.md).
 
 <hr>
 
-<h2 align="center" id="screenshots">📸 Capturas de tela e demonstração ao vivo</h2>
+<h2 align="center" id="screenshots">Capturas de tela e demonstração ao vivo</h2>
 
 <p align="center">
   <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
@@ -281,7 +302,7 @@ Totalmente interativo – UI real, dados simulados, sem necessidade de instalaç
 
 <hr>
 
-<h2 align="center" id="why-drydock">🤔 Por que Drydock</h2>
+<h2 align="center" id="why-drydock">Por que Drydock</h2>
 
 As imagens dos contêineres ficam desatualizadas silenciosamente. Uma imagem base corrige um CVE, um aplicativo corta uma versão, uma tag se move. A menos que você observe cada registro manualmente, seus contêineres em execução ficarão para trás até que algo quebre ou seja explorado.
 
@@ -289,7 +310,7 @@ A maioria das ferramentas força uma compensação. Os atualizadores automático
 
 <hr>
 
-<h2 align="center" id="features">✨ Recursos</h2>
+<h2 align="center" id="features">Recursos</h2>
 
 | | Recurso | Descrição |
 | --- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -311,31 +332,31 @@ A maioria das ferramentas força uma compensação. Os atualizadores automático
 
 <hr>
 
-<h2 align="center" id="supported-integrations">🔌 Integrações suportadas</h2>
+<h2 align="center" id="supported-integrations">Integrações suportadas</h2>
 
-### 📦 Registros (23)
+### Registros (23)
 
 Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Cais · LSCR · Porto · Artifactory · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Personalizado · DOCR · DHI · IBM Cloud · Oracle Cloud · Alibaba Cloud
 
-### ⚡ Ações (3)
+### Ações (3)
 
 Docker · Docker Compose · Comando
 
-### 🔔 Notificações (17)
+### Notificações (17)
 
 Apprise · Discord · Google Chat · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
 
-### 🔐 Autenticação
+### Autenticação
 
 Anônimo (opt-in via `DD_ANONYMOUS_AUTH_CONFIRM=true`) · Básico (nome de usuário + hash de senha) · OIDC (Authelia, Auth0, Authentik). Por padrão, qualquer falha no fluxo de autenticação nega o acesso (fail-closed).
 
-### 🥊 Update Bouncer
+### Update Bouncer
 
 A verificação de vulnerabilidades com tecnologia Trivy ou Grype bloqueia atualizações inseguras antes de serem implantadas. Inclui verificação da assinatura Cosign e geração de SBOM (CycloneDX e SPDX).
 
 <hr>
 
-<h2 align="center" id="feature-comparison">⚖️ Comparação de recursos</h2>
+<h2 align="center" id="feature-comparison">Comparação de recursos</h2>
 
 <details><summary><strong>Como o drydock se compara a outras ferramentas de atualização de contêiner?</strong></summary>
 
@@ -385,7 +406,7 @@ A verificação de vulnerabilidades com tecnologia Trivy ou Grype bloqueia atual
 
 <hr>
 
-<h2 align="center" id="migration">🔄 Migração</h2>
+<h2 align="center" id="migration">Migração</h2>
 
 <details><summary><strong>Migrando do WUD (E aí, Docker?)</strong></summary>
 
@@ -395,7 +416,7 @@ Drydock v1.6 não carrega mais variáveis ​​de ambiente `WUD_*` ou rótulos 
 
 <hr>
 
-<h2 align="center" id="roadmap">🗺️ Roadmap</h2>
+<h2 align="center" id="roadmap">Roadmap</h2>
 
 <details><summary><strong>Temas e destaques da versão</strong></summary>
 
@@ -418,29 +439,7 @@ Apenas temas gerais; consulte [CHANGELOG.md](CHANGELOG.md) para detalhes de cada
 
 <hr>
 
-<h2 align="center" id="documentation">📖 Documentação</h2>
-
-| Recurso                | Ligação                                                                                                                     |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| Site                   | [getdrydock.com](https://getdrydock.com/)                                                                   |
-| Demonstração ao vivo   | [demo.getdrydock.com](https://demo.getdrydock.com)                                          |
-| Documentos             | [getdrydock.com/docs](https://getdrydock.com/docs)                                                          |
-| Configuração           | [Configuração](https://getdrydock.com/docs/configuration)                                                                   |
-| Início rápido          | [Início rápido](https://getdrydock.com/docs/quickstart)                                                                     |
-| Registro de alterações | [`CHANGELOG.md`](CHANGELOG.md)                                                                                              |
-| Deprecations           | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                                                                        |
-| Roadmap                | Consulte a seção [Roteiro](#roadmap) acima                                                                                  |
-| Contribuindo           | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                                                                        |
-| Código de Conduta      | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                                                  |
-| Governança             | [`GOVERNANCE.md`](GOVERNANCE.md)                                                                                            |
-| Garantia de Segurança  | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                                                            |
-| Política de Segurança  | [`SECURITY.md`](SECURITY.md)                                                                                                |
-| Problemas              | [Problemas do GitHub](https://github.com/CodesWhat/drydock/issues)                                                          |
-| Discussões             | [Discussões no GitHub](https://github.com/CodesWhat/drydock/discussions) - solicitações de recursos e ideias são bem-vindas |
-
-<hr>
-
-<a id="star-history"></a>
+<h2 align="center" id="star-history">História da estrela</h2>
 
 <div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
     <picture>
@@ -454,7 +453,7 @@ Apenas temas gerais; consulte [CHANGELOG.md](CHANGELOG.md) para detalhes de cada
 
 <div align="center">
 
-### Construído com
+<h2 align="center" id="built-with">Construído com</h2>
 
 [![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
 [![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
@@ -469,7 +468,7 @@ Apenas temas gerais; consulte [CHANGELOG.md](CHANGELOG.md) para detalhes de cada
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
 
-### Comunidade
+<h2 align="center" id="community-support">Comunidade e suporte</h2>
 
 Chat em tempo real e suporte antecipado: **[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
@@ -481,7 +480,7 @@ Obrigado aos usuários que ajudaram a testar os release candidate v1.4.0 e v1.5.
 
 [@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
 
-### Parte do ecossistema CodesWhat
+<h2 align="center" id="codeswhat-ecosystem">Parte do ecossistema CodesWhat</h2>
 
 <table>
   <tbody><tr><th>Ferramenta</th><th>Função</th></tr>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,25 +41,46 @@
 > [!WARNING]
 > **正在升级到 1.6.0-rc.3 或更高版本？** 更多安全强化措施会立即生效，没有宽限期。未配置身份验证，或已启用但尚未确认匿名身份验证的实例，在升级后会像新安装一样以故障关闭方式运行：容器保持运行，受保护的 API 请求返回 `401`，公共身份验证发现和状态路由仍可访问，`/health` 返回 `503`。SPA 外壳仍可能加载，但无法读取受保护的数据。升级前请设置 `DD_ANONYMOUS_AUTH_CONFIRM=true`，或配置 `DD_AUTH_BASIC_*`/OIDC。会话 cookie 从 `connect.sid` 更名为 `drydock.sid`，因此所有现有用户会被注销一次。HTTP 通知触发器、Hass webhook 和注册表图标获取现在通过受保护的 DNS 查询解析主机名，阻止云元数据和 link-local 目标，并且绝不跟随重定向。仅在确实需要时为特定 `DD_NOTIFICATION_HTTP_*` 触发器设置 `allowmetadata=true`。完整迁移说明请参阅 **[DEPRECATIONS.md](DEPRECATIONS.md#enforced-security-changes-no-deprecation-window)**。
 
-<h2 align="center">📑 内容</h2>
+<h2 align="center">内容</h2>
 
-- [📖 文档](#documentation)
-- [🚀 快速入门](#quick-start)
-- [🆕 最近更新](#recent-updates)
-- [📸 屏幕截图和现场演示](#screenshots)
-- [🤔 为什么是 Drydock](#why-drydock)
-- [✨ 特点](#features)
-- [🔌支持的集成](#supported-integrations)
-- [⚖️功能比较](#feature-comparison)
-- [🔄迁移](#migration)
-- [🗺️路线图](#roadmap)
-- [⭐ 星史](#star-history)
-- [🔧 技术栈](#技术栈)
-- [🤝 社区 QA](#社区质量检查)
+- [文档](#documentation)
+- [快速入门](#quick-start)
+- [最近更新](#recent-updates)
+- [屏幕截图和现场演示](#screenshots)
+- [为什么是 Drydock](#why-drydock)
+- [特点](#features)
+- [支持的集成](#supported-integrations)
+- [功能比较](#feature-comparison)
+- [迁移](#migration)
+- [路线图](#roadmap)
+- [星史](#star-history)
+- [技术栈](#built-with)
+- [社区与支持](#community-support)
+- [CodesWhat 生态系统](#codeswhat-ecosystem)
+
+<h2 align="center" id="documentation">文档</h2>
+
+| 资源           | 链接                                                                                 |
+| ------------ | ---------------------------------------------------------------------------------- |
+| 网站           | [getdrydock.com](https://getdrydock.com/)                           |
+| 现场演示         | [demo.getdrydock.com](https://demo.getdrydock.com) |
+| 文档           | [getdrydock.com/docs](https://getdrydock.com/docs)                 |
+| 配置           | [配置](https://getdrydock.com/docs/configuration)                                    |
+| 快速入门         | [快速入门](https://getdrydock.com/docs/quickstart)                                     |
+| 更新日志         | [`CHANGELOG.md`](CHANGELOG.md)                                                     |
+| 弃用           | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                               |
+| 路线图          | 请参阅上面的[路线图](#roadmap) 部分                                                           |
+| 贡献           | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                               |
+| 行为准则         | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                         |
+| 治理           | [`GOVERNANCE.md`](GOVERNANCE.md)                                                   |
+| 安全保证         | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                   |
+| 安全政策         | [`SECURITY.md`](SECURITY.md)                                                       |
+| 问题           | [GitHub 问题](https://github.com/CodesWhat/drydock/issues)                           |
+| 讨论           | [GitHub 讨论](https://github.com/CodesWhat/drydock/discussions) — 欢迎功能请求和想法          |
 
 <hr>
 
-<h2 align="center" id="quick-start">🚀 快速入门</h2>
+<h2 align="center" id="quick-start">快速入门</h2>
 
 **推荐：使用套接字代理**来限制哪些 Docker API 端点 Drydock 可以访问。这可以避免容器完全访问 Docker 套接字。
 
@@ -175,7 +196,7 @@ docker run -d \
 
 <hr>
 
-<h2 align="center" id="recent-updates">🆕 最近更新</h2>
+<h2 align="center" id="recent-updates">最近更新</h2>
 
 <details open><summary><strong>v1.7.0-rc.1 亮点</strong></summary>
 
@@ -250,7 +271,7 @@ docker run -d \
 
 <hr>
 
-<h2 align="center" id="screenshots">📸 屏幕截图和现场演示</h2>
+<h2 align="center" id="screenshots">屏幕截图和现场演示</h2>
 
 <p align="center">
   <img src="docs/assets/drydock-demo.gif" alt="Drydock detecting and applying a container update" width="880">
@@ -281,7 +302,7 @@ docker run -d \
 
 <hr>
 
-<h2 align="center" id="why-drydock">🤔 为什么是Drydock</h2>
+<h2 align="center" id="why-drydock">为什么是Drydock</h2>
 
 容器镜像悄然过时。基础镜像修补 CVE、应用程序剪切版本、标签移动。除非您手动监视每个注册表，否则正在运行的容器会落后，直到出现问题或被利用。
 
@@ -289,7 +310,7 @@ docker run -d \
 
 <hr>
 
-<h2 align="center" id="features">✨ 特点</h2>
+<h2 align="center" id="features">特点</h2>
 
 | |特色|描述 |
 | --- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -311,31 +332,31 @@ docker run -d \
 
 <hr>
 
-<h2 align="center" id="supported-integrations">🔌 支持的集成</h2>
+<h2 align="center" id="supported-integrations">支持的集成</h2>
 
-### 📦 注册表 (23)
+### 注册表 (23)
 
 Docker Hub · GHCR · ECR · ACR · GCR · GAR · GitLab · Quay · LSCR · Harbor · Artifactory · Nexus · Gitea · Forgejo · Codeberg · MAU · TrueForge · Custom · DOCR · DHI · IBM Cloud · Oracle Cloud · 阿里云
 
-### ⚡ 行动 (3)
+### 行动 (3)
 
 Docker·Docker Compose·命令
 
-### 🔔 通知 (17)
+### 通知 (17)
 
 Apprise · Discord · Google Chat · Gotify · HTTP · IFTTT · Kafka · Matrix · Mattermost · MQTT · MS Teams · NTFY · Pushover · Rocket.Chat · Slack · SMTP · Telegram
 
-### 🔐 身份验证
+### 身份验证
 
 匿名（通过 `DD_ANONYMOUS_AUTH_CONFIRM=true` 选择加入） · 基本（用户名 + 密码哈希） · OIDC（Authelia、Auth0、Authentik）。默认情况下，任何身份验证流程发生故障时都会拒绝访问（fail-closed）。
 
-### 🥊Update Bouncer
+### Update Bouncer
 
 Trivy 或 Grype 支持的漏洞扫描会在部署之前阻止不安全的更新。包括 Cosign 签名验证和 SBOM 生成（CycloneDX 和 SPDX）。
 
 <hr>
 
-<h2 align="center" id="feature-comparison">⚖️功能比较</h2>
+<h2 align="center" id="feature-comparison">功能比较</h2>
 
 <details><summary><strong>drydock 与其他容器更新工具相比如何？</strong></summary>
 
@@ -385,7 +406,7 @@ Trivy 或 Grype 支持的漏洞扫描会在部署之前阻止不安全的更新�
 
 <hr>
 
-<h2 align="center" id="migration">🔄 迁移</h2>
+<h2 align="center" id="migration">迁移</h2>
 
 <details><summary><strong>从 WUD 迁移（Docker 怎么样？）</strong></summary>
 
@@ -395,7 +416,7 @@ Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。�
 
 <hr>
 
-<h2 align="center" id="roadmap">🗺️路线图</h2>
+<h2 align="center" id="roadmap">路线图</h2>
 
 <details><summary><strong>版本主题及亮点</strong></summary>
 
@@ -418,29 +439,7 @@ Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。�
 
 <hr>
 
-<h2 align="center" id="documentation">📖 文档</h2>
-
-| 资源           | 链接                                                                                 |
-| ------------ | ---------------------------------------------------------------------------------- |
-| 网站           | [getdrydock.com](https://getdrydock.com/)                           |
-| 现场演示         | [demo.getdrydock.com](https://demo.getdrydock.com) |
-| 文档           | [getdrydock.com/docs](https://getdrydock.com/docs)                 |
-| 配置           | [配置](https://getdrydock.com/docs/configuration)                                    |
-| 快速入门         | [快速入门](https://getdrydock.com/docs/quickstart)                                     |
-| 更新日志         | [`CHANGELOG.md`](CHANGELOG.md)                                                     |
-| 弃用           | [`DEPRECATIONS.md`](DEPRECATIONS.md)                                               |
-| 路线图          | 请参阅上面的[路线图](#roadmap) 部分                                                           |
-| 贡献           | [`CONTRIBUTING.md`](CONTRIBUTING.md)                                               |
-| 行为准则         | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                         |
-| 治理           | [`GOVERNANCE.md`](GOVERNANCE.md)                                                   |
-| 安全保证         | [`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)                                   |
-| 安全政策         | [`SECURITY.md`](SECURITY.md)                                                       |
-| 问题           | [GitHub 问题](https://github.com/CodesWhat/drydock/issues)                           |
-| 讨论           | [GitHub 讨论](https://github.com/CodesWhat/drydock/discussions) — 欢迎功能请求和想法          |
-
-<hr>
-
-<a id="star-history"></a>
+<h2 align="center" id="star-history">星史</h2>
 
 <div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
     <picture>
@@ -454,7 +453,7 @@ Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。�
 
 <div align="center">
 
-### 技术栈
+<h2 align="center" id="built-with">技术栈</h2>
 
 [![TypeScript](https://img.shields.io/badge/TypeScript_6.0-3178C6?logo=typescript&logoColor=fff)](https://www.typescriptlang.org/)
 [![Vue 3](https://img.shields.io/badge/Vue_3-42b883?logo=vuedotjs&logoColor=fff)](https://vuejs.org/)
@@ -469,7 +468,7 @@ Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。�
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?logo=conventionalcommits&logoColor=fff)](https://www.conventionalcommits.org/)
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-E05735)](https://keepachangelog.com/)
 
-### 社区
+<h2 align="center" id="community-support">社区与支持</h2>
 
 实时聊天和早期支持：**[CodesWhat Discord](https://discord.gg/mWHCPJRzSx)**
 
@@ -481,7 +480,7 @@ Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。�
 
 [@RK62](https://github.com/RK62) &middot; [@flederohr](https://github.com/flederohr) &middot; [@rj10rd](https://github.com/rj10rd) &middot; [@larueli](https://github.com/larueli) &middot; [@Waler](https://github.com/Waler) &middot; [@ElVit](https://github.com/ElVit) &middot; [@nchieffo](https://github.com/nchieffo) &middot; [@begunfx](https://github.com/begunfx) &middot; [@Ra72xx](https://github.com/Ra72xx)
 
-### CodesWhat 生态系统的一部分
+<h2 align="center" id="codeswhat-ecosystem">CodesWhat 生态系统的一部分</h2>
 
 <table>
   <tbody><tr><th>工具</th><th>角色</th></tr>


### PR DESCRIPTION
## Summary

Closes #754, and item 5 of #759.

Investigating found `README.md` (English) was **already compliant** — no header/TOC emoji, Documentation positioned correctly, Community routing sentence present. It's untouched here.

The six translations had drifted from it structurally, not just cosmetically: emoji in every header and TOC entry, Documentation section misplaced, Star History missing a visible header, and Built With / Community / CodesWhat Ecosystem demoted to `h3`.

## Changes

- All six translated READMEs realigned to the English structure. All seven now have identical shape: 21 headings, 14 TOC entries, matching `id=` anchors.
- Emoji removed from every header and TOC entry across the six.
- Community routing sentence (issue #759 item 5, per ops `community.md`) verified present in all seven, each in its own locale's voice rather than English text dropped into a translated file.
- Badge wall untouched (qlty maintainability was already there, Codecov landed in #789).

## One non-README file

`.github/tests/readme-translations.test.ts` hard-coded the old drifted `### Built With` `h3` as a fixture contract. The shape migration intentionally promotes that to `h2`, so the six `builtWithHeading` fixtures were updated to the exact `<h2 align="center" id="built-with">…</h2>` form. This makes the assertion **more** specific, not weaker — it now pins the alignment and anchor id too. Committed separately as `test(readme): …`.

## Testing

- Regex scan confirms zero residual header/TOC emoji across all seven.
- `markdownlint-cli2`: no new issues (416 pre-existing MD060 findings unrelated to this change).
- Full lefthook pre-push pipeline passed, including 100% coverage and zizmor.

Fixes: #754