### PR TITLE
ci(quality): cap fleet-soak artifact retention at the repo ceiling

### DIFF
--- a/.github/workflows/quality-portwing-fleet-soak.yml
+++ b/.github/workflows/quality-portwing-fleet-soak.yml
@@ -148,7 +148,10 @@ jobs:
           name: portwing-fleet-soak-${{ github.run_id }}-${{ github.run_attempt }}
           path: artifacts/portwing-fleet-soak.json
           if-no-files-found: error
-          retention-days: 90
+          # 30 matches the repo-level artifact retention ceiling. A higher
+          # value here isn't honored, it's silently clamped, so the number
+          # would misreport how long the soak trend is actually kept.
+          retention-days: 30
 
       - name: Summarize
         if: always()


### PR DESCRIPTION
Follow-up to #783.

The repo-level artifact retention ceiling is 30 days. All 17 `upload-artifact` steps carry an explicit `retention-days`, so the repo setting is purely a ceiling and never an operative default. `quality-portwing-fleet-soak.yml` was the one value above it, asking for 90 and silently getting clamped to 30.

Set it to 30 so the file states what actually happens, with a comment explaining why a higher number here would misreport the retention.

No behavior change to what GitHub keeps. `npm run test:workflows` passes (175).

Refs: #783