### PR TITLE
docs(readme): replace the self-hosted star history chart with Warpchart

### DIFF
--- a/.github/tests/readme-translations.test.ts
+++ b/.github/tests/readme-translations.test.ts
@@ -254,8 +254,11 @@ describe.each(allReadmes)('%s star history', (readme) => {
 
   test('uses only the Warpchart growth chart', () => {
     expect(content).toContain('https://warpchart.dev/api/chart?repo=CodesWhat%2Fdrydock');
-    expect(content).not.toContain('api.star-history.com');
-    expect(content).not.toContain('star-history.com/#');
+    // Match the retired hosts, not particular URL shapes. `star-history.com/#`
+    // only caught the embed form, so a bare https://star-history.com/CodesWhat/
+    // drydock link would have walked straight back in. The host assertion also
+    // subsumes api.star-history.com.
+    expect(content).not.toContain('star-history.com');
     expect(content).not.toContain('getdrydock.com/api/star-history');
   });
 });

--- a/.github/tests/readme-translations.test.ts
+++ b/.github/tests/readme-translations.test.ts
@@ -181,9 +181,8 @@ const requiredFragments = [
   '[`GOVERNANCE.md`](GOVERNANCE.md)',
   '[`SECURITY-ASSURANCE.md`](SECURITY-ASSURANCE.md)',
   '[`SECURITY.md`](SECURITY.md)',
-  'https://github.com/CodesWhat/drydock/stargazers',
-  'https://getdrydock.com/api/star-history?theme=dark',
-  'https://getdrydock.com/api/star-history?theme=light',
+  'https://warpchart.dev/r/CodesWhat/drydock',
+  'https://warpchart.dev/api/chart?repo=CodesWhat%2Fdrydock',
 ];
 
 describe.each(translatedReadmes)('%s', (readme) => {
@@ -253,11 +252,11 @@ describe.each(translatedReadmes)('%s', (readme) => {
 describe.each(allReadmes)('%s star history', (readme) => {
   const content = readFileSync(`${repoRoot}/${readme}`, 'utf8');
 
-  test('uses only the canonical first-party tracker', () => {
-    expect(content).toContain('https://getdrydock.com/api/star-history?theme=dark');
-    expect(content).toContain('https://getdrydock.com/api/star-history?theme=light');
+  test('uses only the Warpchart growth chart', () => {
+    expect(content).toContain('https://warpchart.dev/api/chart?repo=CodesWhat%2Fdrydock');
     expect(content).not.toContain('api.star-history.com');
     expect(content).not.toContain('star-history.com/#');
+    expect(content).not.toContain('getdrydock.com/api/star-history');
   });
 });
 

--- a/README.de.md
+++ b/README.de.md
@@ -204,7 +204,6 @@ Weitere Informationen zu Docker Compose, Socket-Sicherheit, Reverse-Proxy und al
 - **Operator-UX** – installierbare PWA, anklickbare benannte Port-Links, Live-Container-Laufzeit, Tastenkürzel und entprellte Erkennung neu erschienener Container.
 - **Breaking-Änderung bei Triggern** – `DD_TRIGGER_*` verhindert jetzt den Start, und die alten Labels `dd.trigger.include` / `dd.trigger.exclude` leiten keine Arbeit mehr weiter. Verwenden Sie `DD_ACTION_*`, `DD_NOTIFICATION_*` und die zugehörigen bereichsspezifischen Labels.
 - **Abhängigkeitsbewusste Updates** – Labels oder Compose-Metadaten erzeugen einen validierten Abhängigkeitsgraphen, zeigen die genauen Update-Wellen in der Vorschau und führen Updates oder Neustarts von Abhängigkeiten in deterministischer Reihenfolge aus. Zyklen, Fehler und veraltete Vorschauen werden sicher behandelt. ([Diskussion #219](https://github.com/CodesWhat/drydock/discussions/219))
-- **First-Party-Star-History** – der Same-Origin-Provider `/api/star-history` stellt Diagramme für die freigegebenen Repositories Drydock, Sockguard und Portwing ohne Drittanbieter-Tracker bereit.
 
 Vollständige Versionshinweise in [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08-14).
 
@@ -441,11 +440,11 @@ Nur übergeordnete Themen; Details pro Version finden Sie in [CHANGELOG.md](CHAN
 
 <h2 align="center" id="star-history">Sterngeschichte</h2>
 
-<div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://getdrydock.com/api/star-history?theme=dark">
-      <img alt="Star History Chart" src="https://getdrydock.com/api/star-history?theme=light" />
-    </picture>
+<p align="center">Wachstumstrend via Warpchart:</p>
+
+<div align="center">
+  <a href="https://warpchart.dev/r/CodesWhat/drydock">
+    <img alt="Warpchart Growth Chart" src="https://warpchart.dev/api/chart?repo=CodesWhat%2Fdrydock" />
   </a>
 </div>
 

--- a/README.es.md
+++ b/README.es.md
@@ -204,7 +204,6 @@ Consulte la [guía de inicio rápido](https://getdrydock.com/docs/quickstart) pa
 - **Experiencia del operador**: PWA instalable, enlaces de puertos con nombre, tiempo de actividad del contenedor en vivo, atajos de teclado y detección con espera para contenedores recién descubiertos.
 - **Migración incompatible de disparadores**: `DD_TRIGGER_*` ahora impide el arranque y las etiquetas antiguas `dd.trigger.include` / `dd.trigger.exclude` ya no enrutan trabajo; use `DD_ACTION_*`, `DD_NOTIFICATION_*` y sus etiquetas con ámbito.
 - **Refuerzo de seguridad y ciclo de vida**: la autenticación, las solicitudes de agentes, los registros, WebSockets y las solicitudes a registros tienen límites explícitos; se ocultan valores sensibles de comandos y hooks; el descubrimiento de Home Assistant se resincroniza después del arranque y retira trabajo de proveedores sin publicaciones obsoletas. ([#708](https://github.com/CodesWhat/drydock/issues/708))
-- **Historial de estrellas propio**: el proveedor de mismo origen `/api/star-history` sirve gráficos de Drydock, Sockguard y Portwing mediante una lista permitida, sin depender de un rastreador externo.
 
 Notas completas en [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08-14).
 
@@ -441,11 +440,11 @@ Solo temas generales; consulte [CHANGELOG.md](CHANGELOG.md) para conocer el deta
 
 <h2 align="center" id="star-history">Historia de las estrellas</h2>
 
-<div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://getdrydock.com/api/star-history?theme=dark">
-      <img alt="Star History Chart" src="https://getdrydock.com/api/star-history?theme=light" />
-    </picture>
+<p align="center">Tendencia de crecimiento vía Warpchart:</p>
+
+<div align="center">
+  <a href="https://warpchart.dev/r/CodesWhat/drydock">
+    <img alt="Warpchart Growth Chart" src="https://warpchart.dev/api/chart?repo=CodesWhat%2Fdrydock" />
   </a>
 </div>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -204,7 +204,6 @@ Consultez le [Guide de démarrage rapide](https://getdrydock.com/docs/quickstart
 - **Expérience opérateur** : PWA installable, liens de ports nommés cliquables, durée d'exécution des conteneurs en direct, raccourcis clavier et détection temporisée des nouveaux conteneurs.
 - **Migration incompatible des déclencheurs** : `DD_TRIGGER_*` bloque désormais le démarrage et les anciens labels `dd.trigger.include` / `dd.trigger.exclude` n'acheminent plus de tâches ; utilisez `DD_ACTION_*`, `DD_NOTIFICATION_*` et leurs labels à portée dédiée.
 - **Renforcement de la sécurité et du cycle de vie** : l'authentification, les requêtes d'agents, les journaux, les WebSockets et les requêtes de registres sont explicitement bornés ; les valeurs sensibles de commandes et hooks sont masquées ; la découverte Home Assistant se resynchronise après le démarrage et retire les tâches des fournisseurs sans publication périmée. ([#708](https://github.com/CodesWhat/drydock/issues/708))
-- **Historique des étoiles propriétaire** : le fournisseur même origine `/api/star-history` sert les graphiques Drydock, Sockguard et Portwing autorisés sans dépendre d'un service tiers.
 
 Notes complètes dans [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08-14).
 
@@ -441,11 +440,11 @@ Thèmes généraux uniquement ; consultez [CHANGELOG.md](CHANGELOG.md) pour les
 
 <h2 align="center" id="star-history">Historique des étoiles</h2>
 
-<div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://getdrydock.com/api/star-history?theme=dark">
-      <img alt="Star History Chart" src="https://getdrydock.com/api/star-history?theme=light" />
-    </picture>
+<p align="center">Tendance de croissance via Warpchart :</p>
+
+<div align="center">
+  <a href="https://warpchart.dev/r/CodesWhat/drydock">
+    <img alt="Warpchart Growth Chart" src="https://warpchart.dev/api/chart?repo=CodesWhat%2Fdrydock" />
   </a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 - **Operator UX** — installable PWA support, clickable named port links, live container uptime, keyboard shortcuts, and debounced first-seen container discovery.
 - **Breaking trigger migration** — `DD_TRIGGER_*` now fails startup and legacy `dd.trigger.include` / `dd.trigger.exclude` labels no longer route work; use `DD_ACTION_*`, `DD_NOTIFICATION_*`, and their scoped labels.
 - **Security and lifecycle hardening** — bounded authentication, agent, log, WebSocket, and registry operations; sensitive command and hook values are redacted; Home Assistant discovery resynchronizes after startup and retires provider work without stale publishes. ([#708](https://github.com/CodesWhat/drydock/issues/708))
-- **First-party star history** — the same-origin `/api/star-history` provider now serves allowlisted Drydock, Sockguard, and Portwing charts without a third-party tracker dependency.
 
 Full release notes in [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08-14).
 
@@ -455,12 +454,11 @@ High-level themes only; see [CHANGELOG.md](CHANGELOG.md) for per-release detail.
 
 <h2 align="center" id="star-history">Star History</h2>
 
+<p align="center">Growth trend via Warpchart:</p>
+
 <div align="center">
-  <a href="https://github.com/CodesWhat/drydock/stargazers">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://getdrydock.com/api/star-history?theme=dark">
-      <img alt="Star History Chart" src="https://getdrydock.com/api/star-history?theme=light" />
-    </picture>
+  <a href="https://warpchart.dev/r/CodesWhat/drydock">
+    <img alt="Warpchart Growth Chart" src="https://warpchart.dev/api/chart?repo=CodesWhat%2Fdrydock" />
   </a>
 </div>
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -204,7 +204,6 @@ Zobacz [Przewodnik szybkiego startu](https://getdrydock.com/docs/quickstart) dla
 - **Wygoda operatora** — instalowalna aplikacja PWA, klikalne nazwane porty, bieżący czas działania kontenerów, skróty klawiaturowe i opóźnione wykrywanie nowych kontenerów.
 - **Niezgodna migracja wyzwalaczy** — `DD_TRIGGER_*` uniemożliwia teraz uruchomienie, a starsze etykiety `dd.trigger.include` / `dd.trigger.exclude` nie kierują już zadań. Należy użyć `DD_ACTION_*`, `DD_NOTIFICATION_*` i odpowiadających im etykiet zakresowych.
 - **Wzmocnienie bezpieczeństwa i cyklu życia** — uwierzytelnianie, żądania agentów, dzienniki, WebSockety i żądania do rejestrów mają jawne limity; poufne wartości poleceń i hooków są maskowane; wykrywanie Home Assistant ponownie synchronizuje się po starcie i wycofuje zadania dostawców bez publikowania nieaktualnych danych. ([#708](https://github.com/CodesWhat/drydock/issues/708))
-- **Własna historia gwiazdek** — dostawca same-origin `/api/star-history` udostępnia wykresy dla dozwolonych repozytoriów Drydock, Sockguard i Portwing bez zewnętrznego modułu śledzącego.
 
 Pełne informacje o wersji znajdują się w [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08-14).
 
@@ -441,11 +440,11 @@ Tylko motywy ogólne; szczegóły poszczególnych wersji zawiera [CHANGELOG.md](
 
 <h2 align="center" id="star-history">Historia gwiazd</h2>
 
-<div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://getdrydock.com/api/star-history?theme=dark">
-      <img alt="Star History Chart" src="https://getdrydock.com/api/star-history?theme=light" />
-    </picture>
+<p align="center">Trend wzrostu według Warpchart:</p>
+
+<div align="center">
+  <a href="https://warpchart.dev/r/CodesWhat/drydock">
+    <img alt="Warpchart Growth Chart" src="https://warpchart.dev/api/chart?repo=CodesWhat%2Fdrydock" />
   </a>
 </div>
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -204,7 +204,6 @@ Consulte o [Guia de início rápido](https://getdrydock.com/docs/quickstart) par
 - **Experiência do operador** — PWA instalável, links clicáveis para portas nomeadas, tempo de atividade dos contêineres em tempo real, atalhos de teclado e detecção com intervalo para novos contêineres.
 - **Migração incompatível de acionadores** — `DD_TRIGGER_*` agora impede a inicialização, e os rótulos antigos `dd.trigger.include` / `dd.trigger.exclude` não encaminham mais tarefas; use `DD_ACTION_*`, `DD_NOTIFICATION_*` e seus rótulos com escopo.
 - **Reforço de segurança e ciclo de vida** — autenticação, solicitações de agentes, logs, WebSockets e solicitações a registros têm limites explícitos; valores sensíveis de comandos e hooks são ocultados; a descoberta do Home Assistant sincroniza novamente após a inicialização e encerra o trabalho dos provedores sem publicações obsoletas. ([#708](https://github.com/CodesWhat/drydock/issues/708))
-- **Histórico de estrelas próprio** — o provedor de mesma origem `/api/star-history` serve gráficos permitidos de Drydock, Sockguard e Portwing sem depender de um rastreador de terceiros.
 
 Notas completas em [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08-14).
 
@@ -441,11 +440,11 @@ Apenas temas gerais; consulte [CHANGELOG.md](CHANGELOG.md) para detalhes de cada
 
 <h2 align="center" id="star-history">História da estrela</h2>
 
-<div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://getdrydock.com/api/star-history?theme=dark">
-      <img alt="Star History Chart" src="https://getdrydock.com/api/star-history?theme=light" />
-    </picture>
+<p align="center">Tendência de crescimento via Warpchart:</p>
+
+<div align="center">
+  <a href="https://warpchart.dev/r/CodesWhat/drydock">
+    <img alt="Warpchart Growth Chart" src="https://warpchart.dev/api/chart?repo=CodesWhat%2Fdrydock" />
   </a>
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -204,7 +204,6 @@ docker run -d \
 - **运维体验** — 可安装的 PWA、可点击的命名端口链接、实时容器运行时间、键盘快捷键，以及对新发现容器的防抖检测。
 - **不兼容的触发器迁移** — `DD_TRIGGER_*` 现在会阻止启动，旧的 `dd.trigger.include` / `dd.trigger.exclude` 标签也不再分派任务；请改用 `DD_ACTION_*`、`DD_NOTIFICATION_*` 及其作用域标签。
 - **安全与生命周期强化** — 身份验证、代理请求、日志、WebSocket 和镜像仓库请求均有明确的资源限制；敏感的命令和钩子值会被遮盖；Home Assistant 发现会在启动后重新同步，并在停用提供程序任务时避免发布过期数据。([#708](https://github.com/CodesWhat/drydock/issues/708))
-- **第一方 Star History** — 同源 `/api/star-history` 提供程序仅为允许的 Drydock、Sockguard 和 Portwing 仓库生成图表，不再依赖第三方跟踪服务。
 
 完整发行说明请参阅 [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08-14)。
 
@@ -441,11 +440,11 @@ Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。�
 
 <h2 align="center" id="star-history">星史</h2>
 
-<div align="center"><a href="https://github.com/CodesWhat/drydock/stargazers">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://getdrydock.com/api/star-history?theme=dark">
-      <img alt="Star History Chart" src="https://getdrydock.com/api/star-history?theme=light" />
-    </picture>
+<p align="center">通过 Warpchart 查看增长趋势：</p>
+
+<div align="center">
+  <a href="https://warpchart.dev/r/CodesWhat/drydock">
+    <img alt="Warpchart Growth Chart" src="https://warpchart.dev/api/chart?repo=CodesWhat%2Fdrydock" />
   </a>
 </div>
 


### PR DESCRIPTION
GitHub restricted stargazer API access, which broke the self-hosted
/api/star-history route the same way it broke the third-party embed
that route was built to replace. There's no first-party workaround,
so getdrydock.com/api/star-history now just serves a placeholder SVG.
Warpchart survives it because it accumulates its own time series
instead of depending on GitHub's stargazer API.

Drop the retired <picture> block from all seven READMEs and keep the
Warpchart block already added. Also drop the "First-party star
history" bullet from the open v1.7.0-rc.1 highlights, since the
feature it advertised no longer exists; the v1.6.0-rc.13 highlights
bullet describing the same route is left alone since it's a frozen
record of what that RC actually shipped.

All seven READMEs change together because the translation gate
asserts an exact URL multiset against README.md, so a source-only
change fails readme-translations.test.ts. Updated that gate to assert
the two Warpchart URLs instead of the retired getdrydock.com ones, and
extended the star-history negative-assertion block to permanently
forbid getdrydock.com/api/star-history alongside the two third-party
hosts it already blocked.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

✨ Added Warpchart growth charts to the Star History section in all seven README files.

🔧 Updated the translation gate to require both Warpchart URLs.

🔧 Extended negative URL assertions to reject `star-history.com` links, including bare and embed URLs, and `getdrydock.com/api/star-history`.

🗑️ Removed the v1.7.0-rc.1 release-note reference to the self-hosted Star History provider.

## Concerns

- Verify `npm run test:workflows` passes all tests.
- Verify all seven README files preserve heading parity and URL multiset parity.
- Verify the frozen v1.6.0-rc.13 record remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->