### PR TITLE
ci(i18n): mint an App token so the Crowdin sync can open its PR

### DIFF
--- a/.github/workflows/i18n-crowdin.yml
+++ b/.github/workflows/i18n-crowdin.yml
@@ -91,8 +91,10 @@ jobs:
         # branch fine, so translations landed on l10n_crowdin and stopped there.
         # The setting stays false (a workflow that can approve its own PRs
         # defeats the two-approver rule); the fix is a dedicated identity.
-        # An App installation token is minted per run and never expires, unlike
-        # a PAT that would silently re-break this sync a year from now.
+        # Chosen over a PAT for lifetime, not permissions. The App's stored
+        # credentials (id + private key) don't expire, so this can't silently
+        # re-break a year from now the way a PAT would. The token they mint is
+        # deliberately short-lived: fresh per run, dead in an hour.
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.CROWDIN_APP_ID }}

--- a/.github/workflows/i18n-crowdin.yml
+++ b/.github/workflows/i18n-crowdin.yml
@@ -82,6 +82,29 @@ jobs:
           git fetch origin "refs/heads/${BASE}:refs/remotes/origin/${BASE}"
           git checkout -B "${BASE}" "refs/remotes/origin/${BASE}"
 
+      - name: Mint an App installation token for the translation PR
+        id: app-token
+        # `can_approve_pull_request_reviews` is false org-wide and repo-wide, and
+        # that control blocks GITHUB_TOKEN from CREATING pull requests, not just
+        # approving them — the crowdin step 403'd with "GitHub Actions is not
+        # permitted to create or approve pull requests" while still pushing the
+        # branch fine, so translations landed on l10n_crowdin and stopped there.
+        # The setting stays false (a workflow that can approve its own PRs
+        # defeats the two-approver rule); the fix is a dedicated identity.
+        # An App installation token is minted per run and never expires, unlike
+        # a PAT that would silently re-break this sync a year from now.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          app-id: ${{ secrets.CROWDIN_APP_ID }}
+          private-key: ${{ secrets.CROWDIN_APP_PRIVATE_KEY }}
+          # Narrow at mint time, not just at the App's install grants. Without
+          # these the token carries whatever the installation happens to hold,
+          # so broadening the App later would silently widen this workflow too.
+          # These two are exactly what the crowdin step needs: push l10n_crowdin
+          # and open the PR.
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc  # v2.17.0
         with:
           user: auto
@@ -105,6 +128,6 @@ jobs:
           # git's global config at a mounted, writable file — GIT_CONFIG_GLOBAL
           # is honored independent of HOME (git >= 2.32).
           GIT_CONFIG_GLOBAL: /github/home/.gitconfig
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
The Crowdin sync has been unable to open its translation PR since 2026-08-14. Three separate causes were stacked, each masking the next; two are already fixed. This is the third.

## What this fixes

`can_approve_pull_request_reviews` is `false` at both org and repo level. That control blocks `GITHUB_TOKEN` from **creating** pull requests, not just approving them — the sync's last step 403'd with *"GitHub Actions is not permitted to create or approve pull requests"* while still pushing `l10n_crowdin` fine. So translations landed on the branch and stopped there.

The setting stays `false`. A workflow that can approve its own PRs defeats the two-approver rule, and the org standard mandates it. The fix is a dedicated identity instead.

## Why a GitHub App, not a PAT

A fine-grained PAT expires. When it does, this sync re-breaks silently a year after everyone stopped thinking about it — the same "looks fine until it doesn't" failure mode this integration has already hit twice. An App installation token is minted per run from a stored App ID and private key, so there's no expiry cliff. Crowdin's own docs recommend the App path for exactly this 403.

App `codeswhat-crowdin-sync` (id `4650361`) is installed on the org with exactly `contents: write`, `pull_requests: write`, `metadata: read`. Credentials are stored as the repo secrets `CROWDIN_APP_ID` and `CROWDIN_APP_PRIVATE_KEY`.

## Note on the permission inputs

zizmor flags a bare `create-github-app-token` as `dangerous use of GitHub App tokens` — without explicit `permission-*` inputs the minted token inherits whatever the installation happens to hold, so broadening the App later would silently widen this workflow too. The two inputs pin it to exactly what the crowdin step needs: push `l10n_crowdin`, open the PR.

## Verification

Not merged-and-hoped. Once this lands I'll dispatch the workflow against `dev/v1.7` and fetch the resulting PR URL to confirm it actually opened.

One thing the org API can't answer: the installation is `repository_selection: selected`, so whether drydock is in that selection is only provable by a run.

## Sequencing

This must merge **after** #798. `l10n_crowdin` regenerates from `dev/v1.7`, and until #798 lands the six translated READMEs still carry the retired star-history host — merging the translation PR before it would reintroduce the retired chart. (`readme-translations.test.ts` would catch it, but the right answer is ordering, not relying on the guard.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added GitHub App installation-token authentication to `.github/workflows/i18n-crowdin.yml`.
- 🔧 Changed the Crowdin action to use the App token for translation pushes and pull request creation.
- 🔒 Restricted token permissions to `contents: write`, `pull_requests: write`, and `metadata: read`.
- 🐛 Fixed pull request creation after `GITHUB_TOKEN` approval restrictions blocked the workflow.

## Concerns

- Merge after PR `#798` to prevent the retired star-history host from returning to translated READMEs.
- Configure `CROWDIN_APP_ID` and `CROWDIN_APP_PRIVATE_KEY` repository secrets.
- Dispatch the workflow for `dev/v1.7` and confirm that it opens a pull request.
- Confirm that the `codeswhat-crowdin-sync` App is installed on the target repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->