### PR TITLE
fix(i18n): disable Crowdin content segmentation on the README

### DIFF
--- a/.github/tests/crowdin-workflow.test.ts
+++ b/.github/tests/crowdin-workflow.test.ts
@@ -103,6 +103,14 @@ test('Crowdin sync manages the six translated READMEs independently of UI catalo
     },
     excluded_target_languages: ['ar', 'it', 'ja', 'ko', 'nl', 'ru', 'tr', 'uk', 'vi', 'zh-TW'],
     update_option: 'update_as_unapproved',
+    // Must stay 0. Crowdin's default is 1, which splits the README into
+    // sentence-level segments and routes the upload through what their docs
+    // call experimental ML — that reassembled the <details> release-history
+    // blocks out of order, broke HTML, and spliced English source into the
+    // German and zh-CN output (#801). The UI locale JSON was unaffected in the
+    // same sync because segmentation does not apply to JSON, which is what
+    // identified the cause. Deleting this key silently restores the default.
+    content_segmentation: 0,
   });
   expect(workflow.on?.push?.paths).toContain('README.md');
   expect(workflow.on?.push?.paths).not.toContain('README.*.md');

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -36,6 +36,17 @@ files:
     update_option: update_as_unapproved
   - source: /README.md
     translation: /README.%locale%.md
+    # Crowdin defaults content_segmentation to 1, which splits the README into
+    # sentence-level segments AND routes the translation upload through what
+    # their docs call "experimental machine learning technology". On this file
+    # that reassembled the <details>/<summary> release-history blocks in the
+    # wrong order, broke HTML tags, and spliced English source into the German
+    # and zh-CN output. The UI locale JSON was never affected because
+    # segmentation does not apply to JSON — which is what confirmed the cause.
+    # Turning it off took the file from 446 sentence segments to 382 block ones.
+    # Also set in the Crowdin UI (file 39, revision 7); this is the guard so a
+    # project re-create or a fresh upload cannot silently reintroduce it.
+    content_segmentation: 0
     languages_mapping:
       locale:
         de: de


### PR DESCRIPTION
Fixes the corruption that makes #801 unmergeable.

## Root cause

Crowdin defaults `content_segmentation` to `1`. On a Markdown file that splits the source into sentence-level segments and, per [Crowdin's own docs](https://support.crowdin.com/developer/configuration-file/), routes the translation upload through "experimental machine learning technology". Nobody enabled it — it was the default, applied to a README dense with inline HTML.

On `README.md` that produced:

- `<details>`/`<summary>` release-history blocks reassembled **out of order** — source `rc.13, rc.12, rc.11` came back `rc.12, rc.11, rc.13`
- broken HTML (stray `</summary>`, orphaned `</em>`) in zh-CN
- English source spliced into the German and zh-CN output while keeping mismatched links

## How it was identified

The UI locale JSON came through the *same sync* clean — **+256 lines, zero deletions, all 16 files valid JSON** — while the six READMEs churned **+169/−159**. Segmentation doesn't apply to JSON, so the damage split exactly along the boundary the setting predicts.

That also ruled out the translation-memory hypothesis the corruption first suggested: the release blocks were **reordered, not renumbered**. The full set `{rc.11, rc.12, rc.13}` was present and correctly spelled in both source and output, just in a different order. Stale TM produces wrong values; this produced right values in the wrong places, which is reassembly.

## What changed

- `crowdin.yml`: `content_segmentation: 0` on the README entry.
- `.github/tests/crowdin-workflow.test.ts`: the existing shape guard updated to pin the new key, with the reasoning inline so deleting it isn't a silent regression. That guard is why this PR needed a second push — it caught the config change immediately.
- Crowdin UI, file 39: segmentation off (**446 sentence segments → 382 block ones**, revision 6 → 7) and **Exclude code blocks** enabled, which had been off — fenced code was being sent out for translation.

The config entry is the guard, not the fix: it stops a project re-create or fresh upload from silently restoring the default.

## Not done yet

`l10n_crowdin` still holds the corrupt output. Next is re-uploading the known-good translations from `dev/v1.7` against the new segmentation, re-running the sync, and confirming `.github/tests/readme-translations.test.ts` goes **12 failed → 0**. **#801 must not merge as-is.**

Refs: #801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed `crowdin.yml` to set `content_segmentation: 0` for `README.md`.
- 🔧 Changed Crowdin UI settings to disable segmentation and exclude code blocks.
- ✨ Added a test requirement for `content_segmentation: 0`.
- 🐛 Fixed the configuration that caused corrupted translated READMEs.

## Concerns

- Replace the known-corrupt output in `l10n_crowdin`.
- Re-sync Crowdin translations after the configuration change.
- Rerun the README translation tests after re-sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->