### PR TITLE
fix(scripts): distinguish test failures from coverage gaps in pre-push

### DIFF
--- a/scripts/pre-push-coverage.sh
+++ b/scripts/pre-push-coverage.sh
@@ -63,11 +63,47 @@ run_coverage() {
 	local workspace=$1
 	local log_file="${ROOT_DIR}/.coverage-logs/${workspace}.log"
 	local gap_file="${ROOT_DIR}/.coverage-gaps.${workspace}.json"
+	local json_file="${ROOT_DIR}/.coverage-logs/${workspace}.json"
 
-	if (cd "${workspace}" && npx vitest run --coverage --reporter=dot >"${log_file}" 2>&1); then
-		rm -f "${gap_file}"
+	if (cd "${workspace}" && npx vitest run --coverage --reporter=dot --reporter=json --outputFile.json="${json_file}" >"${log_file}" 2>&1); then
+		rm -f "${gap_file}" "${json_file}"
 		echo "✅ ${workspace}: coverage met"
 		return 0
+	fi
+
+	# vitest exits non-zero for both failed tests and missed coverage
+	# thresholds. Distinguish them so we don't send an agent hunting for
+	# coverage gaps that don't exist. Prefer the JSON reporter's
+	# numFailedTests; fall back to parsing the vitest log summary line if
+	# the JSON report is missing or unparseable.
+	local failed_tests=""
+	if [ -s "${json_file}" ]; then
+		failed_tests=$(node -e '
+const fs = require("fs");
+try {
+  const report = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  process.stdout.write(String(report.numFailedTests ?? 0));
+} catch {
+  process.stdout.write("");
+}
+' "${json_file}" 2>/dev/null || true)
+	fi
+
+	if ! [[ ${failed_tests} =~ ^[0-9]+$ ]]; then
+		local summary_line
+		summary_line=$({ grep -E '^ *Tests +[0-9]+ failed' "${log_file}" || true; } | tail -1)
+		if [ -n "${summary_line}" ]; then
+			failed_tests=$(printf '%s\n' "${summary_line}" | grep -oE '[0-9]+' | head -1)
+		else
+			failed_tests=0
+		fi
+	fi
+
+	if [ "${failed_tests}" -gt 0 ]; then
+		echo "❌ ${workspace}: ${failed_tests} test(s) failed (not a coverage gap)"
+		echo "   vitest log: ${log_file}"
+		fail=1
+		return 1
 	fi
 
 	echo "❌ ${workspace}: coverage below threshold"


### PR DESCRIPTION
The pre-push coverage gate reports a failed test as a coverage gap, which sends you looking for uncovered lines that don't exist.

`run_coverage()` treats any non-zero exit from `vitest run --coverage` as a threshold failure and unconditionally runs `coverage-gaps.mjs`. But vitest exits non-zero for two unrelated reasons: failed tests, and missed thresholds. So a single failing test with 100% coverage still prints:

```
❌ ui: coverage below threshold
Coverage thresholds not met. Fix gaps before pushing.
Combined gaps: cat .coverage-gaps.json
```

...and `.coverage-gaps.json` is `[]`, because the gap script correctly found nothing. That happened today and cost real time before anyone thought to read the vitest log instead of hunting for gaps.

## The change

Adds `--reporter=json` alongside the existing `--reporter=dot`, writing to `.coverage-logs/${workspace}.json` (already gitignored). On failure it reads `numFailedTests`, and falls back to grepping the log for vitest's `Tests  N failed` summary line if the JSON is missing or unparseable. The grep is anchored so it doesn't match the `⎯⎯⎯ Failed Tests N ⎯⎯⎯` divider.

When tests failed, it prints `❌ ${workspace}: N test(s) failed (not a coverage gap)`, points at the vitest log, and skips gap generation entirely rather than emitting a misleading empty file. The test-failure check runs before the coverage path, so the both-at-once case reports the more actionable thing first.

The genuine coverage-threshold branch is untouched. That message is correct when it's true.

## Verified against real runs, not reasoning

Both cases run through the actual `./scripts/pre-push-coverage.sh app`, full 411-file / 13k-test suite, ~3m40s each.

**Failing test, coverage intact** (added `expect(1).toBe(2)` to `app/test/helpers.test.ts`):
```
❌ app: 1 test(s) failed (not a coverage gap)
   vitest log: .coverage-logs/app.log
```
No gap file generated.

**Genuine gap, tests pass** (added an uncalled function to `app/tag/index.ts`):
```
❌ app: coverage below threshold
  app/tag/index.ts
    lines: 96.05% (73/76), statements: 96.2% (76/79), branches: 95% (38/40), functions: 90% (9/10)
```
Gap file correctly populated. Identical to existing behavior.

Both deliberate breakages reverted, tree clean. Shellcheck compared pre- and post-edit: no new findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changelog

- ✨ Added Vitest JSON reporting at `.coverage-logs/${workspace}.json`.
- 🔧 Changed `run_coverage` to distinguish test failures from coverage-threshold failures.
- 🐛 Fixed test-failure handling so failed tests report their count, reference the Vitest log, and skip coverage-gap generation.
- 🔧 Added fallback parsing of the Vitest log when JSON reporting does not provide the failed-test count.
- 🗑️ Removed stale JSON and coverage-gap files after successful runs.

### Concerns

- Verify that stale `.coverage-logs` files are removed for every workspace and failure path.
- Verify that fallback log parsing handles changed Vitest summary formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->