### PR TITLE
style(i18n): match translated README details tag layout to source

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -119,7 +119,8 @@ services:
     restart: unless-stopped
 ```
 
-<details><summary>Alternativ: <a href="https://github.com/CodesWhat/sockguard">sockguard</a> Socket-Proxy</summary>
+<details>
+<summary>Alternativ: <a href="https://github.com/CodesWhat/sockguard">sockguard</a> Socket-Proxy</summary>
 
 [sockguard](https://github.com/CodesWhat/sockguard) ist ein standardmäßig verweigernder Docker-Socket-Filter aus demselben CodesWhat-Ökosystem mit einer für drydock erstellten Voreinstellung:
 
@@ -158,7 +159,8 @@ Siehe sockguards [`app/configs/portwing.yaml`](https://github.com/CodesWhat/sock
 
 </details>
 
-<details><summary>Alternative: Schnellstart mit direkter Steckdosenmontage</summary>
+<details>
+<summary>Alternative: Schnellstart mit direkter Steckdosenmontage</summary>
 
 ```bash
 docker run -d \
@@ -198,7 +200,8 @@ Weitere Informationen zu Docker Compose, Socket-Sicherheit, Reverse-Proxy und al
 
 <h2 align="center" id="recent-updates">Aktuelle Updates</h2>
 
-<details open><summary><strong>Highlights von v1.7.0-rc.1</strong></summary>
+<details open>
+<summary><strong>Highlights von v1.7.0-rc.1</strong></summary>
 
 - **Sicherheits- und Lifecycle-Härtung** – Authentifizierung, Agent-Anfragen, Protokolle, WebSockets und Registry-Anfragen sind explizit begrenzt; vertrauliche Befehls- und Hook-Werte werden redigiert; die Home-Assistant-Erkennung synchronisiert sich nach dem Start neu und beendet Provider-Arbeit ohne veraltete Veröffentlichungen. ([#708](https://github.com/CodesWhat/drydock/issues/708))
 - **Operator-UX** – installierbare PWA, anklickbare benannte Port-Links, Live-Container-Laufzeit, Tastenkürzel und entprellte Erkennung neu erschienener Container.
@@ -209,7 +212,8 @@ Vollständige Versionshinweise in [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08
 
 </details>
 
-<details><summary><strong>Highlights von v1.6.0</strong></summary>
+<details>
+<summary><strong>Highlights von v1.6.0</strong></summary>
 
 - **Portwing-Edge-/Agent-Transport ist ausgereift** – Controller-gesteuerte native Docker-Prüfungen und -Updates für Portwing 0.9.0+, kontinuierliches Edge-Log-Streaming, Ed25519-Anfragesignierung (v2) und agenteneigene Anzeigenamen, die an den Signaturschlüssel gebunden sind. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637))
 - **Deklarative Update-Richtlinie mit Reifegrad-Stabilisierung** – dreistufige `dd.updatePolicy.*`-Priorität, ein Live-Countdown bis zur Freigabe eines zurückgehaltenen Kandidaten und eine eigene `maturity-cleared`-Benachrichtigung. ([Diskussion #307](https://github.com/CodesWhat/drydock/discussions/307), [Diskussion #406](https://github.com/CodesWhat/drydock/discussions/406))
@@ -222,7 +226,8 @@ Vollständige Versionshinweise in [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11)
 
 </details>
 
-<details><summary><strong>Highlights von v1.6.0-rc.13</strong></summary>
+<details>
+<summary><strong>Highlights von v1.6.0-rc.13</strong></summary>
 
 - **Digest-Vergleiche verwenden passende Repository-Kandidaten** – `getOrderedRepoDigests` filtert die `RepoDigests` eines Containers nach dem Repository seiner Image-Referenz, statt einem beliebigen ersten Eintrag zu vertrauen; ein bereits fehlerhafter gespeicherter Anker repariert sich selbst. ([#670](https://github.com/CodesWhat/drydock/pull/670))
 - **`nanoid` ist in allen Workspaces auf 3.3.18 fixiert**, um CVE-2026-67213 und im E2E-Workspace CVE-2026-67214 zu beheben. ([#673](https://github.com/CodesWhat/drydock/pull/673))
@@ -232,7 +237,8 @@ Vollständige Versionshinweise in [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11)
 
 </details>
 
-<details><summary><strong>Highlights von v1.6.0-rc.12</strong></summary>
+<details>
+<summary><strong>Highlights von v1.6.0-rc.12</strong></summary>
 
 - **Aktualisierte Sicherheitsabhängigkeiten** – `brace-expansion` 5.0.9, `ip-address` 10.3.1 und `fast-uri` 4.1.2 beheben die zugehörigen CVEs. ([#659](https://github.com/CodesWhat/drydock/pull/659))
 - **Reifegrad-Uhr** – das Hot/Mature-Badge verwendet wie das Gate zuerst `updatePolicy.maturityMinAgeDays` des Containers und dann den globalen Grenzwert; Fehler beim Ermitteln des Veröffentlichungsdatums werden mit `warn` statt `debug` protokolliert. ([#604](https://github.com/CodesWhat/drydock/issues/604))
@@ -242,7 +248,8 @@ Vollständige Versionshinweise in [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11)
 
 </details>
 
-<details><summary><strong>Highlights von v1.6.0-rc.11</strong></summary>
+<details>
+<summary><strong>Highlights von v1.6.0-rc.11</strong></summary>
 
 - **Portwing-Transport** – Portwing 0.9.0 markiert mit `transport=docker-api`, `execution=controller`, `events=portwing` den nativen Transport für Registry-Prüfungen, Einzel-/Batch-Updates, Lebenszyklusaktionen, Vorschauen und Rollbacks über authentifiziertes Standard HTTP oder Edge. Portwing bleibt Ereignisquelle, und Rohinventar kann Controller-Ergebnisse nicht löschen. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637), [Portwing #76](https://github.com/CodesWhat/portwing/issues/76))
 - **Benachrichtigungen** – Titel- und Textvorlagen pro Regel/pro Anbieter mit Live-Vorschau sowie prüfungsgestützten In-App-Klingelkategorien und Schwellenwerten für den Aktualisierungsschweregrad.
@@ -256,7 +263,8 @@ Vollständige Migrationsanleitung in [DEPRECATIONS.md](./DEPRECATIONS.md).
 
 </details>
 
-<details><summary><strong>v1.5.2 Highlights</strong></summary>
+<details>
+<summary><strong>v1.5.2 Highlights</strong></summary>
 
 - **Erholungssichere Update-Richtlinie** – Reife-Gates, übersprungene Tags/Digests und Snoozes überleben jetzt die Container-Erstellung für lokale und Remote-Agent-Workloads.
 - **Zuverlässigkeit angehefteter Tags** – Vollständig angeheftete Tags erkennen Digest-Neuerstellungen mit demselben Tag erneut, während die Benutzeroberfläche ein nicht umsetzbares neueres Tag derselben Familie anzeigen kann, ohne das Aktualisierungs- oder Auslöseverhalten zu ändern.
@@ -357,7 +365,8 @@ Trivy- oder Grype-gestützte Schwachstellenscans blockieren unsichere Updates, b
 
 <h2 align="center" id="feature-comparison">Funktionsvergleich</h2>
 
-<details><summary><strong>Wie schneidet drydock im Vergleich zu anderen Container-Update-Tools ab?</strong></summary>
+<details>
+<summary><strong>Wie schneidet drydock im Vergleich zu anderen Container-Update-Tools ab?</strong></summary>
 
 > ✅ = unterstützt &nbsp; ❌ = nicht unterstützt &nbsp; ⚠️ = teilweise / begrenzt &nbsp; † = archiviert, nicht mehr gepflegt
 
@@ -407,7 +416,8 @@ Trivy- oder Grype-gestützte Schwachstellenscans blockieren unsichere Updates, b
 
 <h2 align="center" id="migration">Migration</h2>
 
-<details><summary><strong>Migration von WUD (What's Up Docker?)</strong></summary>
+<details>
+<summary><strong>Migration von WUD (What's Up Docker?)</strong></summary>
 
 Drydock v1.6 lädt zur Laufzeit keine `WUD_*`-Umgebungsvariablen oder `wud.*`-Labels mehr. Schreiben Sie sie neu, bevor Sie den aktualisierten Dienst starten. Der persistente Status wird weiterhin automatisch migriert. Verwenden Sie `docker exec -it drydock node dist/index.js config migrate --dry-run` für die Vorschau und dann `docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml`, um die Konfiguration in die Namen `DD_*` und `dd.*` umzuschreiben.
 
@@ -417,7 +427,8 @@ Drydock v1.6 lädt zur Laufzeit keine `WUD_*`-Umgebungsvariablen oder `wud.*`-La
 
 <h2 align="center" id="roadmap">Roadmap</h2>
 
-<details><summary><strong>Versionsthemen und Highlights</strong></summary>
+<details>
+<summary><strong>Versionsthemen und Highlights</strong></summary>
 
 Diese Planung deckt mindestens die nächsten zwölf Monate bis August 2027 ab.
 Nur übergeordnete Themen; Details pro Version finden Sie in [CHANGELOG.md](CHANGELOG.md).

--- a/README.es.md
+++ b/README.es.md
@@ -119,7 +119,8 @@ services:
     restart: unless-stopped
 ```
 
-<details><summary>Alternativa: <a href="https://github.com/CodesWhat/sockguard">sockguard</a> proxy de socket</summary>
+<details>
+<summary>Alternativa: <a href="https://github.com/CodesWhat/sockguard">sockguard</a> proxy de socket</summary>
 
 [sockguard](https://github.com/CodesWhat/sockguard) es un filtro de socket Docker de denegación predeterminado del mismo ecosistema CodesWhat, con un ajuste preestablecido creado para drydock:
 
@@ -158,7 +159,8 @@ Consulte el ajuste preestablecido [`app/configs/portwing.yaml`](https://github.c
 
 </details>
 
-<details><summary>Alternativa: inicio rápido con montaje directo en enchufe</summary>
+<details>
+<summary>Alternativa: inicio rápido con montaje directo en enchufe</summary>
 
 ```bash
 docker run -d \
@@ -198,7 +200,8 @@ Consulte la [guía de inicio rápido](https://getdrydock.com/docs/quickstart) pa
 
 <h2 align="center" id="recent-updates">Actualizaciones recientes</h2>
 
-<details open><summary><strong>Aspectos destacados de v1.7.0-rc.1</strong></summary>
+<details open>
+<summary><strong>Aspectos destacados de v1.7.0-rc.1</strong></summary>
 
 - **Actualizaciones conscientes de dependencias**: las etiquetas o los metadatos de Compose crean un grafo de dependencias validado, muestran las oleadas exactas en la vista previa y ejecutan actualizaciones o reinicios de dependientes en orden determinista, con manejo seguro de ciclos, fallos y vistas previas obsoletas. ([Discusión #219](https://github.com/CodesWhat/drydock/discussions/219))
 - **Experiencia del operador**: PWA instalable, enlaces de puertos con nombre, tiempo de actividad del contenedor en vivo, atajos de teclado y detección con espera para contenedores recién descubiertos.
@@ -209,7 +212,8 @@ Notas completas en [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08-14).
 
 </details>
 
-<details><summary><strong>Aspectos destacados de v1.6.0</strong></summary>
+<details>
+<summary><strong>Aspectos destacados de v1.6.0</strong></summary>
 
 - **El transporte de agentes/Edge de Portwing madura**: comprobaciones y actualizaciones nativas de Docker controladas por el controlador para Portwing 0.9.0+, transmisión continua de registros Edge, firma de solicitudes Ed25519 (v2) y nombres visibles propiedad del agente vinculados a su clave. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637))
 - **Política de actualización declarativa con estabilización de madurez**: precedencia `dd.updatePolicy.*` de tres niveles, cuenta atrás en vivo hasta liberar un candidato retenido y una notificación `maturity-cleared` dedicada. ([Discusión #307](https://github.com/CodesWhat/drydock/discussions/307), [Discusión #406](https://github.com/CodesWhat/drydock/discussions/406))
@@ -222,7 +226,8 @@ Notas completas en [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Aspectos destacados de v1.6.0-rc.13</strong></summary>
+<details>
+<summary><strong>Aspectos destacados de v1.6.0-rc.13</strong></summary>
 
 - **La comparación de digest parte de candidatos del mismo repositorio**: `getOrderedRepoDigests` filtra `RepoDigests` por el repositorio de la imagen en vez de confiar en el primer elemento; un ancla obsoleta ya guardada se repara sola. ([#670](https://github.com/CodesWhat/drydock/pull/670))
 - **`nanoid` fijado en 3.3.18** en todos los espacios de trabajo para CVE-2026-67213 y, en e2e, CVE-2026-67214. ([#673](https://github.com/CodesWhat/drydock/pull/673))
@@ -232,7 +237,8 @@ Notas completas en [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Aspectos destacados de v1.6.0-rc.12</strong></summary>
+<details>
+<summary><strong>Aspectos destacados de v1.6.0-rc.12</strong></summary>
 
 - **Renovación de dependencias de seguridad**: `brace-expansion` 5.0.9, `ip-address` 10.3.1 y `fast-uri` 4.1.2 corrigen sus CVE asociadas. ([#659](https://github.com/CodesWhat/drydock/pull/659))
 - **Reloj de madurez**: el distintivo hot/mature resuelve primero `updatePolicy.maturityMinAgeDays` por contenedor y luego el umbral global, igual que el bloqueo; los fallos de fecha de publicación se registran con `warn` en vez de `debug`. ([#604](https://github.com/CodesWhat/drydock/issues/604))
@@ -242,7 +248,8 @@ Notas completas en [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Aspectos destacados de v1.6.0-rc.11</strong></summary>
+<details>
+<summary><strong>Aspectos destacados de v1.6.0-rc.11</strong></summary>
 
 - **Transporte Portwing**: las marcas exactas `transport=docker-api`, `execution=controller`, `events=portwing` de Portwing 0.9.0 enrutan comprobaciones nativas, actualizaciones individuales/por lotes, acciones de ciclo de vida, vistas previas y restauraciones mediante Standard HTTP autenticado o Edge. Portwing sigue siendo la fuente de eventos y el inventario sin procesar no puede borrar resultados del controlador. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637), [Portwing #76](https://github.com/CodesWhat/portwing/issues/76))
 - **Notificaciones**: plantillas de cuerpo y título por regla/por proveedor con vista previa en vivo, además de categorías de campana en la aplicación respaldadas por auditorías y umbrales de gravedad de actualización.
@@ -256,7 +263,8 @@ Guía completa de migración en [DEPRECATIONS.md](./DEPRECATIONS.md).
 
 </details>
 
-<details><summary><strong>Aspectos destacados de v1.5.2</strong></summary>
+<details>
+<summary><strong>Aspectos destacados de v1.5.2</strong></summary>
 
 - **Política de actualización segura para la recreación**: las puertas de madurez, las etiquetas/resúmenes omitidos y las posposiciones ahora sobreviven a la recreación de contenedores para cargas de trabajo de agentes locales y remotos.
 - **Confiabilidad de etiquetas fijadas**: las etiquetas completamente fijadas detectan reconstrucciones de resúmenes de la misma etiqueta nuevamente, mientras que la interfaz de usuario puede mostrar una etiqueta de la misma familia más nueva y no procesable sin cambiar el comportamiento de actualización o activación.
@@ -357,7 +365,8 @@ El escaneo de vulnerabilidades impulsado por Trivy o Grype bloquea las actualiza
 
 <h2 align="center" id="feature-comparison">Comparación de funciones</h2>
 
-<details><summary><strong>¿Cómo se compara drydock con otras herramientas de actualización de contenedores?</strong></summary>
+<details>
+<summary><strong>¿Cómo se compara drydock con otras herramientas de actualización de contenedores?</strong></summary>
 
 > ✅ = compatible &nbsp; ❌ = no compatible &nbsp; ⚠️ = parcial/limitado &nbsp; † = archivado, ya no se mantiene
 
@@ -407,7 +416,8 @@ El escaneo de vulnerabilidades impulsado por Trivy o Grype bloquea las actualiza
 
 <h2 align="center" id="migration">Migración</h2>
 
-<details><summary><strong>Migrando desde WUD (¿Qué pasa Docker?)</strong></summary>
+<details>
+<summary><strong>Migrando desde WUD (¿Qué pasa Docker?)</strong></summary>
 
 Drydock v1.6 ya no carga variables de entorno `WUD_*` o etiquetas `wud.*` en tiempo de ejecución. Vuelva a escribirlos antes de iniciar el servicio actualizado; El estado persistente aún migra automáticamente. Utilice `docker exec -it drydock node dist/index.js config migrate --dry-run` para obtener una vista previa y luego `docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml` para reescribir la configuración con los nombres `DD_*` y `dd.*`.
 
@@ -417,7 +427,8 @@ Drydock v1.6 ya no carga variables de entorno `WUD_*` o etiquetas `wud.*` en tie
 
 <h2 align="center" id="roadmap">Hoja de ruta</h2>
 
-<details><summary><strong>Temas y aspectos destacados de la versión</strong></summary>
+<details>
+<summary><strong>Temas y aspectos destacados de la versión</strong></summary>
 
 Esta dirección cubre al menos los próximos doce meses, hasta agosto de 2027.
 Solo temas generales; consulte [CHANGELOG.md](CHANGELOG.md) para conocer el detalle de cada versión.

--- a/README.fr.md
+++ b/README.fr.md
@@ -119,7 +119,8 @@ services:
     restart: unless-stopped
 ```
 
-<details><summary>Alternative : <a href="https://github.com/CodesWhat/sockguard">sockguard</a> proxy de socket</summary>
+<details>
+<summary>Alternative : <a href="https://github.com/CodesWhat/sockguard">sockguard</a> proxy de socket</summary>
 
 [sockguard](https://github.com/CodesWhat/sockguard) est un filtre de socket Docker à refus par défaut du même écosystème CodesWhat, avec un préréglage conçu pour drydock :
 
@@ -158,7 +159,8 @@ Voir le préréglage [`app/configs/portwing.yaml`](https://github.com/CodesWhat/
 
 </details>
 
-<details><summary>Alternative : démarrage rapide avec montage direct sur prise</summary>
+<details>
+<summary>Alternative : démarrage rapide avec montage direct sur prise</summary>
 
 ```bash
 docker run -d \
@@ -198,7 +200,8 @@ Consultez le [Guide de démarrage rapide](https://getdrydock.com/docs/quickstart
 
 <h2 align="center" id="recent-updates">Mises à jour récentes</h2>
 
-<details open><summary><strong>Points forts de la v1.7.0-rc.1</strong></summary>
+<details open>
+<summary><strong>Points forts de la v1.7.0-rc.1</strong></summary>
 
 - **Mises à jour tenant compte des dépendances** : les labels ou métadonnées Compose construisent un graphe de dépendances validé, prévisualisent les vagues exactes et exécutent les mises à jour ou redémarrages des dépendants dans un ordre déterministe, avec gestion sûre des cycles, échecs et aperçus périmés. ([Discussion #219](https://github.com/CodesWhat/drydock/discussions/219))
 - **Expérience opérateur** : PWA installable, liens de ports nommés cliquables, durée d'exécution des conteneurs en direct, raccourcis clavier et détection temporisée des nouveaux conteneurs.
@@ -209,7 +212,8 @@ Notes complètes dans [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08-14).
 
 </details>
 
-<details><summary><strong>Points forts de la v1.6.0</strong></summary>
+<details>
+<summary><strong>Points forts de la v1.6.0</strong></summary>
 
 - **Le transport Edge/agent Portwing arrive à maturité** avec les vérifications et mises à jour Docker natives pilotées par le contrôleur pour Portwing 0.9.0+, les journaux Edge continus, la signature Ed25519 v2 et les noms d'affichage liés à la clé de l'agent. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637))
 - **Politique de mise à jour déclarative avec stabilisation de maturité** : priorité `dd.updatePolicy.*` à trois niveaux, compte à rebours et notification `maturity-cleared`. ([Discussion #307](https://github.com/CodesWhat/drydock/discussions/307), [Discussion #406](https://github.com/CodesWhat/drydock/discussions/406))
@@ -222,7 +226,8 @@ Notes complètes dans [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Points forts de la v1.6.0-rc.13</strong></summary>
+<details>
+<summary><strong>Points forts de la v1.6.0-rc.13</strong></summary>
 
 - **Comparaison des digests par dépôts correspondants** : `getOrderedRepoDigests` filtre les `RepoDigests` et répare automatiquement les ancres obsolètes. ([#670](https://github.com/CodesWhat/drydock/pull/670))
 - **`nanoid` fixé à 3.3.18** dans tous les espaces de travail pour CVE-2026-67213 et CVE-2026-67214. ([#673](https://github.com/CodesWhat/drydock/pull/673))
@@ -232,7 +237,8 @@ Notes complètes dans [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Points forts de la v1.6.0-rc.12</strong></summary>
+<details>
+<summary><strong>Points forts de la v1.6.0-rc.12</strong></summary>
 
 - **Dépendances de sécurité actualisées** : `brace-expansion` 5.0.9, `ip-address` 10.3.1 et `fast-uri` 4.1.2. ([#659](https://github.com/CodesWhat/drydock/pull/659))
 - **Horloge de maturité cohérente** : l'affichage et le blocage utilisent `updatePolicy.maturityMinAgeDays`, et les erreurs de date passent de `debug` à `warn`. ([#604](https://github.com/CodesWhat/drydock/issues/604))
@@ -242,7 +248,8 @@ Notes complètes dans [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Points forts de la v1.6.0-rc.11</strong></summary>
+<details>
+<summary><strong>Points forts de la v1.6.0-rc.11</strong></summary>
 
 - **Transport Portwing** : les marqueurs `transport=docker-api`, `execution=controller`, `events=portwing` activent Standard HTTP ou Edge authentifié pour les vérifications, mises à jour, actions de cycle de vie, aperçus et restaurations pilotés par le contrôleur. Portwing reste la source des événements de cycle de vie, et l'inventaire brut ne peut pas effacer les résultats de mise à jour enrichis par le contrôleur. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637), [Portwing #76](https://github.com/CodesWhat/portwing/issues/76))
 - **Notifications** — Modèles de titre et de corps par règle/par fournisseur avec aperçu en direct, ainsi que des catégories de cloches dans l'application basées sur un audit et des seuils de gravité de mise à jour.
@@ -256,7 +263,8 @@ Conseils de migration complets dans [DEPRECATIONS.md](./DEPRECATIONS.md).
 
 </details>
 
-<details><summary><strong>Points forts de la v1.5.2</strong></summary>
+<details>
+<summary><strong>Points forts de la v1.5.2</strong></summary>
 
 - **Politique de mise à jour sécurisée pour les loisirs** — Les portes de maturité, les balises/récapitulatifs ignorés et les répétitions survivent désormais à la récréation des conteneurs pour les charges de travail des agents locaux et distants.
 - **Fiabilité des balises épinglées** — Les balises entièrement épinglées détectent à nouveau les reconstructions de résumé de même balise, tandis que l'interface utilisateur peut afficher une balise de même famille plus récente et non exploitable sans modifier le comportement de mise à jour ou de déclenchement.
@@ -357,7 +365,8 @@ L'analyse des vulnérabilités basée sur Trivy ou Grype bloque les mises à jou
 
 <h2 align="center" id="feature-comparison">Comparaison des fonctionnalités</h2>
 
-<details><summary><strong>Comment drydock se compare-t-il aux autres outils de mise à jour de conteneurs ?</strong></summary>
+<details>
+<summary><strong>Comment drydock se compare-t-il aux autres outils de mise à jour de conteneurs ?</strong></summary>
 
 > ✅ = pris en charge &nbsp; ❌ = non pris en charge &nbsp; ⚠️ = partiel / limité &nbsp; † = archivé, n'est plus conservé
 
@@ -407,7 +416,8 @@ L'analyse des vulnérabilités basée sur Trivy ou Grype bloque les mises à jou
 
 <h2 align="center" id="migration">Migration</h2>
 
-<details><summary><strong>Migration depuis WUD (What's Up Docker ?)</strong></summary>
+<details>
+<summary><strong>Migration depuis WUD (What's Up Docker ?)</strong></summary>
 
 Drydock v1.6 ne charge plus les variables d'environnement `WUD_*` ou les étiquettes `wud.*` au moment de l'exécution. Réécrivez-les avant de démarrer le service mis à niveau ; l'état persistant migre toujours automatiquement. Utilisez `docker exec -it drydock node dist/index.js config migrate --dry-run` pour prévisualiser, puis `docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml` pour réécrire la configuration en dénomination `DD_*` et `dd.*`.
 
@@ -417,7 +427,8 @@ Drydock v1.6 ne charge plus les variables d'environnement `WUD_*` ou les étique
 
 <h2 align="center" id="roadmap">Feuille de route</h2>
 
-<details><summary><strong>Thèmes et faits saillants de la version</strong></summary>
+<details>
+<summary><strong>Thèmes et faits saillants de la version</strong></summary>
 
 Cette orientation couvre au moins les douze prochains mois, jusqu'en août 2027.
 Thèmes généraux uniquement ; consultez [CHANGELOG.md](CHANGELOG.md) pour les détails de chaque version.

--- a/README.pl.md
+++ b/README.pl.md
@@ -119,7 +119,8 @@ services:
     restart: unless-stopped
 ```
 
-<details><summary>Alternatywa: <a href="https://github.com/CodesWhat/sockguard">sockguard</a> proxy gniazda</summary>
+<details>
+<summary>Alternatywa: <a href="https://github.com/CodesWhat/sockguard">sockguard</a> proxy gniazda</summary>
 
 [sockguard](https://github.com/CodesWhat/sockguard) to filtr gniazda Docker z domyślną odmową z tego samego ekosystemu CodesWhat, z ustawieniem wstępnym zbudowanym dla drydock:
 
@@ -158,7 +159,8 @@ Zobacz ustawienie wstępne sockguard [`app/configs/portwing.yaml`](https://githu
 
 </details>
 
-<details><summary>Alternatywa: szybki start z bezpośrednim montażem na gnieździe</summary>
+<details>
+<summary>Alternatywa: szybki start z bezpośrednim montażem na gnieździe</summary>
 
 ```bash
 docker run -d \
@@ -198,7 +200,8 @@ Zobacz [Przewodnik szybkiego startu](https://getdrydock.com/docs/quickstart) dla
 
 <h2 align="center" id="recent-updates">Ostatnie aktualizacje</h2>
 
-<details open><summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.1</strong></summary>
+<details open>
+<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.1</strong></summary>
 
 - **Aktualizacje uwzględniające zależności** — etykiety lub metadane Compose tworzą zweryfikowany graf zależności, pokazują dokładne fale aktualizacji i uruchamiają aktualizacje albo ponowne uruchomienia elementów zależnych w deterministycznej kolejności, bezpiecznie obsługując cykle, błędy i nieaktualne podglądy. ([Dyskusja #219](https://github.com/CodesWhat/drydock/discussions/219))
 - **Wygoda operatora** — instalowalna aplikacja PWA, klikalne nazwane porty, bieżący czas działania kontenerów, skróty klawiaturowe i opóźnione wykrywanie nowych kontenerów.
@@ -209,7 +212,8 @@ Pełne informacje o wersji znajdują się w [CHANGELOG.md](./CHANGELOG.md#170-rc
 
 </details>
 
-<details><summary><strong>Najważniejsze informacje w wersji v1.6.0</strong></summary>
+<details>
+<summary><strong>Najważniejsze informacje w wersji v1.6.0</strong></summary>
 
 - **Transport Edge/agent Portwing osiąga dojrzałość**: natywne kontrole i aktualizacje Dockera sterowane przez kontroler dla Portwing 0.9.0+, ciągłe logi Edge, podpisy Ed25519 v2 i nazwy agentów powiązane z kluczem. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637))
 - **Deklaratywna polityka aktualizacji z bramką dojrzałości**: trójpoziomowy priorytet `dd.updatePolicy.*`, licznik odblokowania i powiadomienie `maturity-cleared`. ([Dyskusja #307](https://github.com/CodesWhat/drydock/discussions/307), [Dyskusja #406](https://github.com/CodesWhat/drydock/discussions/406))
@@ -222,7 +226,8 @@ Pełne informacje w [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Najważniejsze informacje w wersji v1.6.0-rc.13</strong></summary>
+<details>
+<summary><strong>Najważniejsze informacje w wersji v1.6.0-rc.13</strong></summary>
 
 - **Porównanie digestów korzysta z pasujących repozytoriów**: `getOrderedRepoDigests` filtruje `RepoDigests` i samoczynnie naprawia stare kotwice. ([#670](https://github.com/CodesWhat/drydock/pull/670))
 - **`nanoid` przypięto do 3.3.18** we wszystkich przestrzeniach roboczych dla CVE-2026-67213 i CVE-2026-67214. ([#673](https://github.com/CodesWhat/drydock/pull/673))
@@ -232,7 +237,8 @@ Pełne informacje w [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Najważniejsze informacje w wersji v1.6.0-rc.12</strong></summary>
+<details>
+<summary><strong>Najważniejsze informacje w wersji v1.6.0-rc.12</strong></summary>
 
 - **Odświeżono zależności bezpieczeństwa**: `brace-expansion` 5.0.9, `ip-address` 10.3.1 i `fast-uri` 4.1.2. ([#659](https://github.com/CodesWhat/drydock/pull/659))
 - **Zegar dojrzałości** wspólnie używa `updatePolicy.maturityMinAgeDays` w widoku i bramce, a błędy daty przechodzą z `debug` do `warn`. ([#604](https://github.com/CodesWhat/drydock/issues/604))
@@ -242,7 +248,8 @@ Pełne informacje w [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Najważniejsze informacje w wersji v1.6.0-rc.11</strong></summary>
+<details>
+<summary><strong>Najważniejsze informacje w wersji v1.6.0-rc.11</strong></summary>
 
 - **Transport Portwing**: znaczniki `transport=docker-api`, `execution=controller`, `events=portwing` włączają uwierzytelniony Standard HTTP lub Edge dla sterowanych przez kontroler kontroli, aktualizacji, działań cyklu życia, podglądów i przywracania. Portwing pozostaje źródłem zdarzeń cyklu życia, a surowy spis nie może usunąć wyników aktualizacji wzbogaconych przez kontroler. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637), [Portwing #76](https://github.com/CodesWhat/portwing/issues/76))
 - **Powiadomienia** — szablony tytułów i treści dla poszczególnych reguł/dostawców z podglądem na żywo oraz wspierane audytem kategorie dzwonków w aplikacji i progi ważności aktualizacji.
@@ -256,7 +263,8 @@ Pełne wskazówki dotyczące migracji znajdują się w [DEPRECATIONS.md](./DEPRE
 
 </details>
 
-<details><summary><strong>Najważniejsze informacje w wersji 1.5.2</strong></summary>
+<details>
+<summary><strong>Najważniejsze informacje w wersji 1.5.2</strong></summary>
 
 - **Zasady aktualizacji bezpiecznej dla rozrywki** — Bramy dojrzałości, pominięte tagi/streszczenia i drzemki teraz przetrwają odtwarzanie kontenera w przypadku obciążeń lokalnych i zdalnych agentów.
 - **Niezawodność przypiętego tagu** — Całkowicie przypięte tagi wykrywają ponowne przebudowanie podsumowania tego samego tagu, podczas gdy interfejs użytkownika może wyświetlać niewykonalny nowszy tag tej samej rodziny bez zmiany zachowania aktualizacji lub wyzwalacza.
@@ -357,7 +365,8 @@ Skanowanie pod kątem luk w zabezpieczeniach oparte na Trivy lub Grype blokuje n
 
 <h2 align="center" id="feature-comparison">Porównanie funkcji</h2>
 
-<details><summary><strong>Jak drydock wypada w porównaniu z innymi narzędziami do aktualizacji kontenerów?</strong></summary>
+<details>
+<summary><strong>Jak drydock wypada w porównaniu z innymi narzędziami do aktualizacji kontenerów?</strong></summary>
 
 > ✅ = obsługiwane &nbsp; ❌ = nieobsługiwane &nbsp; ⚠️ = częściowy / ograniczony &nbsp; † = zarchiwizowane, nie jest już obsługiwane
 
@@ -407,7 +416,8 @@ Skanowanie pod kątem luk w zabezpieczeniach oparte na Trivy lub Grype blokuje n
 
 <h2 align="center" id="migration">Migracja</h2>
 
-<details><summary><strong>Migracja z WUD (Co słychać w oknie dokowanym?)</strong></summary>
+<details>
+<summary><strong>Migracja z WUD (Co słychać w oknie dokowanym?)</strong></summary>
 
 Drydock v1.6 nie ładuje już zmiennych środowiskowych `WUD_*` ani etykiet `wud.*` w czasie wykonywania. Przepisz je przed uruchomieniem uaktualnionej usługi; stan utrwalony nadal migruje automatycznie. Użyj `docker exec -it drydock node dist/index.js config migrate --dry-run`, aby wyświetlić podgląd, a następnie `docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml`, aby przepisać konfigurację na nazewnictwo `DD_*` i `dd.*`.
 
@@ -417,7 +427,8 @@ Drydock v1.6 nie ładuje już zmiennych środowiskowych `WUD_*` ani etykiet `wud
 
 <h2 align="center" id="roadmap">Roadmap</h2>
 
-<details><summary><strong>Motywy i najważniejsze wersje wersji</strong></summary>
+<details>
+<summary><strong>Motywy i najważniejsze wersje wersji</strong></summary>
 
 Ten kierunek obejmuje co najmniej następne dwanaście miesięcy, do sierpnia 2027 r.
 Tylko motywy ogólne; szczegóły poszczególnych wersji zawiera [CHANGELOG.md](CHANGELOG.md).

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -119,7 +119,8 @@ services:
     restart: unless-stopped
 ```
 
-<details><summary>Alternativa: <a href="https://github.com/CodesWhat/sockguard">sockguard</a> proxy de soquete</summary>
+<details>
+<summary>Alternativa: <a href="https://github.com/CodesWhat/sockguard">sockguard</a> proxy de soquete</summary>
 
 [sockguard](https://github.com/CodesWhat/sockguard) é um filtro de soquete Docker de negação padrão do mesmo ecossistema CodesWhat, com uma predefinição criada para drydock:
 
@@ -158,7 +159,8 @@ Consulte a [predefinição sockguard de `app/configs/portwing.yaml`](https://git
 
 </details>
 
-<details><summary>Alternativa: início rápido com montagem direta em soquete</summary>
+<details>
+<summary>Alternativa: início rápido com montagem direta em soquete</summary>
 
 ```bash
 docker run -d \
@@ -198,7 +200,8 @@ Consulte o [Guia de início rápido](https://getdrydock.com/docs/quickstart) par
 
 <h2 align="center" id="recent-updates">Atualizações recentes</h2>
 
-<details open><summary><strong>Destaques da v1.7.0-rc.1</strong></summary>
+<details open>
+<summary><strong>Destaques da v1.7.0-rc.1</strong></summary>
 
 - **Atualizações com reconhecimento de dependências** — rótulos ou metadados do Compose criam um grafo de dependências validado, mostram as ondas exatas na prévia e executam atualizações ou reinicializações de dependentes em ordem determinística, com tratamento seguro de ciclos, falhas e prévias obsoletas. ([Discussão #219](https://github.com/CodesWhat/drydock/discussions/219))
 - **Experiência do operador** — PWA instalável, links clicáveis para portas nomeadas, tempo de atividade dos contêineres em tempo real, atalhos de teclado e detecção com intervalo para novos contêineres.
@@ -209,7 +212,8 @@ Notas completas em [CHANGELOG.md](./CHANGELOG.md#170-rc1--2026-08-14).
 
 </details>
 
-<details><summary><strong>Destaques da v1.6.0</strong></summary>
+<details>
+<summary><strong>Destaques da v1.6.0</strong></summary>
 
 - **O transporte Edge/agente do Portwing amadurece** com verificações e atualizações nativas do Docker controladas pelo controlador para Portwing 0.9.0+, logs Edge contínuos, assinatura Ed25519 v2 e nomes de exibição vinculados à chave do agente. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637))
 - **Política declarativa de atualização com estabilização de maturidade**: precedência `dd.updatePolicy.*` em três níveis, contagem regressiva e notificação `maturity-cleared`. ([Discussão #307](https://github.com/CodesWhat/drydock/discussions/307), [Discussão #406](https://github.com/CodesWhat/drydock/discussions/406))
@@ -222,7 +226,8 @@ Notas completas em [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Destaques da v1.6.0-rc.13</strong></summary>
+<details>
+<summary><strong>Destaques da v1.6.0-rc.13</strong></summary>
 
 - **Comparação de digests usa candidatos do mesmo repositório**: `getOrderedRepoDigests` filtra `RepoDigests` e corrige âncoras antigas automaticamente. ([#670](https://github.com/CodesWhat/drydock/pull/670))
 - **`nanoid` fixado em 3.3.18** em todos os workspaces para CVE-2026-67213 e CVE-2026-67214. ([#673](https://github.com/CodesWhat/drydock/pull/673))
@@ -232,7 +237,8 @@ Notas completas em [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Destaques da v1.6.0-rc.12</strong></summary>
+<details>
+<summary><strong>Destaques da v1.6.0-rc.12</strong></summary>
 
 - **Dependências de segurança atualizadas**: `brace-expansion` 5.0.9, `ip-address` 10.3.1 e `fast-uri` 4.1.2. ([#659](https://github.com/CodesWhat/drydock/pull/659))
 - **Relógio de maturidade** compartilha `updatePolicy.maturityMinAgeDays` entre exibição e bloqueio, e falhas de data passam de `debug` para `warn`. ([#604](https://github.com/CodesWhat/drydock/issues/604))
@@ -242,7 +248,8 @@ Notas completas em [CHANGELOG.md](./CHANGELOG.md#160--2026-08-11).
 
 </details>
 
-<details><summary><strong>Destaques da v1.6.0-rc.11</strong></summary>
+<details>
+<summary><strong>Destaques da v1.6.0-rc.11</strong></summary>
 
 - **Transporte Portwing**: os marcadores `transport=docker-api`, `execution=controller`, `events=portwing` ativam Standard HTTP ou Edge autenticado para verificações, atualizações, ações de ciclo de vida, prévias e restaurações controladas pelo controlador. O Portwing continua sendo a fonte de eventos de ciclo de vida, e o inventário bruto não pode apagar resultados de atualização enriquecidos pelo controlador. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637), [Portwing #76](https://github.com/CodesWhat/portwing/issues/76))
 - **Notificações** — Título e modelos de corpo por regra/por provedor com visualização ao vivo, além de categorias de sino no aplicativo apoiadas por auditoria e limites de gravidade de atualização.
@@ -256,7 +263,8 @@ Orientação completa sobre migração em [DEPRECATIONS.md](./DEPRECATIONS.md).
 
 </details>
 
-<details><summary><strong>Destaques da v1.5.2</strong></summary>
+<details>
+<summary><strong>Destaques da v1.5.2</strong></summary>
 
 - **Política de atualização segura para recreação** — Portões de maturidade, tags/resumos ignorados e adiamentos agora sobrevivem à recriação de contêineres para cargas de trabalho de agentes locais e remotos.
 - **Confiabilidade da tag fixada** — Tags totalmente fixadas detectam recriações de resumo da mesma tag novamente, enquanto a IU pode mostrar uma tag da mesma família mais recente e não acionável sem alterar a atualização ou o comportamento do acionador.
@@ -357,7 +365,8 @@ A verificação de vulnerabilidades com tecnologia Trivy ou Grype bloqueia atual
 
 <h2 align="center" id="feature-comparison">Comparação de recursos</h2>
 
-<details><summary><strong>Como o drydock se compara a outras ferramentas de atualização de contêiner?</strong></summary>
+<details>
+<summary><strong>Como o drydock se compara a outras ferramentas de atualização de contêiner?</strong></summary>
 
 > ✅ = suportado &nbsp; ❌ = não suportado &nbsp; ⚠️ = parcial/limitado † = arquivado, não é mais mantido
 
@@ -407,7 +416,8 @@ A verificação de vulnerabilidades com tecnologia Trivy ou Grype bloqueia atual
 
 <h2 align="center" id="migration">Migração</h2>
 
-<details><summary><strong>Migrando do WUD (E aí, Docker?)</strong></summary>
+<details>
+<summary><strong>Migrando do WUD (E aí, Docker?)</strong></summary>
 
 Drydock v1.6 não carrega mais variáveis ​​de ambiente `WUD_*` ou rótulos `wud.*` em tempo de execução. Reescreva-os antes de iniciar o serviço atualizado; o estado persistido ainda migra automaticamente. Use `docker exec -it drydock node dist/index.js config migrate --dry-run` para visualizar e, em seguida, `docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml` para reescrever a configuração para a nomenclatura `DD_*` e `dd.*`.
 
@@ -417,7 +427,8 @@ Drydock v1.6 não carrega mais variáveis ​​de ambiente `WUD_*` ou rótulos 
 
 <h2 align="center" id="roadmap">Roadmap</h2>
 
-<details><summary><strong>Temas e destaques da versão</strong></summary>
+<details>
+<summary><strong>Temas e destaques da versão</strong></summary>
 
 Esta direção cobre pelo menos os próximos doze meses, até agosto de 2027.
 Apenas temas gerais; consulte [CHANGELOG.md](CHANGELOG.md) para detalhes de cada versão.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,7 +119,8 @@ services:
     restart: unless-stopped
 ```
 
-<details><summary>替代方案：<a href="https://github.com/CodesWhat/sockguard">sockguard</a>套接字代理</summary>
+<details>
+<summary>替代方案：<a href="https://github.com/CodesWhat/sockguard">sockguard</a>套接字代理</summary>
 
 [sockguard](https://github.com/CodesWhat/sockguard) 是来自同一 CodesWhat 生态系统的默认拒绝 Docker 套接字过滤器，具有为 drydock 构建的预设：
 
@@ -158,7 +159,8 @@ services:
 
 </details>
 
-<details><summary>替代方案：通过直接挂载套接字快速启动</summary>
+<details>
+<summary>替代方案：通过直接挂载套接字快速启动</summary>
 
 ```bash
 docker run -d \
@@ -198,7 +200,8 @@ docker run -d \
 
 <h2 align="center" id="recent-updates">最近更新</h2>
 
-<details open><summary><strong>v1.7.0-rc.1 亮点</strong></summary>
+<details open>
+<summary><strong>v1.7.0-rc.1 亮点</strong></summary>
 
 - **依赖感知更新** — 通过标签或 Compose 元数据构建经过验证的依赖关系图，预览准确的更新波次，并按确定的顺序执行更新或重启依赖项，同时安全处理循环依赖、失败和过期预览。([讨论 #219](https://github.com/CodesWhat/drydock/discussions/219))
 - **运维体验** — 可安装的 PWA、可点击的命名端口链接、实时容器运行时间、键盘快捷键，以及对新发现容器的防抖检测。
@@ -209,7 +212,8 @@ docker run -d \
 
 </details>
 
-<details><summary><strong>v1.6.0 亮点</strong></summary>
+<details>
+<summary><strong>v1.6.0 亮点</strong></summary>
 
 - **Portwing Edge/代理传输趋于成熟**：Portwing 0.9.0+ 支持由控制器执行原生 Docker 检查和更新、连续 Edge 日志、Ed25519 v2 请求签名，以及与签名密钥绑定的代理显示名称。([#632](https://github.com/CodesWhat/drydock/issues/632)、[#637](https://github.com/CodesWhat/drydock/issues/637))
 - **带成熟度稳定门的声明式更新策略**：三级 `dd.updatePolicy.*` 优先级、候选解锁倒计时和专用 `maturity-cleared` 通知。([讨论 #307](https://github.com/CodesWhat/drydock/discussions/307)、[讨论 #406](https://github.com/CodesWhat/drydock/discussions/406))
@@ -222,7 +226,8 @@ docker run -d \
 
 </details>
 
-<details><summary><strong>v1.6.0-rc.13 亮点</strong></summary>
+<details>
+<summary><strong>v1.6.0-rc.13 亮点</strong></summary>
 
 - **摘要比较仅使用匹配仓库的候选项**：`getOrderedRepoDigests` 会筛选 `RepoDigests`，并可自动修复过期锚点。([#670](https://github.com/CodesWhat/drydock/pull/670))
 - **所有工作区将 `nanoid` 固定为 3.3.18**，修复 CVE-2026-67213 和 CVE-2026-67214。([#673](https://github.com/CodesWhat/drydock/pull/673))
@@ -232,7 +237,8 @@ docker run -d \
 
 </details>
 
-<details><summary><strong>v1.6.0-rc.12 亮点</strong></summary>
+<details>
+<summary><strong>v1.6.0-rc.12 亮点</strong></summary>
 
 - **安全依赖更新**：`brace-expansion` 5.0.9、`ip-address` 10.3.1 和 `fast-uri` 4.1.2。([#659](https://github.com/CodesWhat/drydock/pull/659))
 - **成熟度时钟**在显示和阻止逻辑中共同使用 `updatePolicy.maturityMinAgeDays`，日期错误从 `debug` 提升为 `warn`。([#604](https://github.com/CodesWhat/drydock/issues/604))
@@ -242,7 +248,8 @@ docker run -d \
 
 </details>
 
-<details><summary><strong>v1.6.0-rc.11 亮点</strong></summary>
+<details>
+<summary><strong>v1.6.0-rc.11 亮点</strong></summary>
 
 - **Portwing 传输**：`transport=docker-api`、`execution=controller`、`events=portwing` 标记启用经过身份验证的 Standard HTTP 或 Edge，以承载由控制器执行的检查、更新、生命周期操作、预览和回滚。Portwing 仍是生命周期事件源，原始清单无法抹除控制器增强的更新结果。([#632](https://github.com/CodesWhat/drydock/issues/632)、[#637](https://github.com/CodesWhat/drydock/issues/637)、[Portwing #76](https://github.com/CodesWhat/portwing/issues/76))
 - **通知** — 每个规则/每个提供商的标题和正文模板，带有实时预览，加上审计支持的应用内响铃类别和更新严重性阈值。
@@ -256,7 +263,8 @@ docker run -d \
 
 </details>
 
-<details><summary><strong>v1.5.2亮点</strong></summary>
+<details>
+<summary><strong>v1.5.2亮点</strong></summary>
 
 - **重新创建安全的更新策略** - 成熟度门、跳过的标签/摘要和暂停现在可以在本地和远程代理工作负载的容器重新创建中继续存在。
 - **固定标签可靠性** — 完全固定标签再次检测相同标签摘要重建，而 UI 可以显示不可操作的较新同系列标签，而无需更改更新或触发行为。
@@ -357,7 +365,8 @@ Trivy 或 Grype 支持的漏洞扫描会在部署之前阻止不安全的更新�
 
 <h2 align="center" id="feature-comparison">功能比较</h2>
 
-<details><summary><strong>drydock 与其他容器更新工具相比如何？</strong></summary>
+<details>
+<summary><strong>drydock 与其他容器更新工具相比如何？</strong></summary>
 
 > ✅ = 支持 &nbsp; ❌ = 不支持 &nbsp; ⚠️ = 部分/有限 &nbsp; † = 已存档，不再维护
 
@@ -407,7 +416,8 @@ Trivy 或 Grype 支持的漏洞扫描会在部署之前阻止不安全的更新�
 
 <h2 align="center" id="migration">迁移</h2>
 
-<details><summary><strong>从 WUD 迁移（Docker 怎么样？）</strong></summary>
+<details>
+<summary><strong>从 WUD 迁移（Docker 怎么样？）</strong></summary>
 
 Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。在启动升级服务之前重写它们；持久状态仍然会自动迁移。使用`docker exec -it drydock node dist/index.js config migrate --dry-run`进行预览，然后使用`docker exec -it drydock node dist/index.js config migrate --file .env --file compose.yaml`将配置重写为`DD_*`和`dd.*`命名。
 
@@ -417,7 +427,8 @@ Drydock v1.6 不再在运行时加载 `WUD_*` 环境变量或 `wud.*` 标签。�
 
 <h2 align="center" id="roadmap">路线图</h2>
 
-<details><summary><strong>版本主题及亮点</strong></summary>
+<details>
+<summary><strong>版本主题及亮点</strong></summary>
 
 此方向至少覆盖未来十二个月，直至 2027 年 8 月。
 此处仅列出高级主题；各版本详情请参阅 [CHANGELOG.md](CHANGELOG.md)。


### PR DESCRIPTION
Prep for the Crowdin README purge. Pure formatting, no translated text touched.

The six translated READMEs have `<details><summary>` collapsed onto one line. The English source has `<details>` on its own line with `<summary>...</summary>` on the next. This drift is pre-existing and came in via an earlier sync; the original translation commit `6d2b7710` (#562) had them split, so split is the original form.

## Why it matters now

GitHub renders both forms identically, so this has never been a visible bug. But Crowdin's file-based translation upload may align segments by parsing the target file's own block structure, and the source is now a 382-segment file after the segmentation fix in #804. A target whose HTML block boundaries differ from the source can misalign on upload, independently of the stale-translation problem the purge is meant to fix.

If that happened we'd spend a one-shot destructive purge and reproduce corruption on the very next sync. Cheap to rule out, so ruling it out first.

## The change

Insert a newline between `<details...>` and `<summary>`. Nothing else.

Tag counts are identical across the source and all six translations: 11 `<details>` (one of them `<details open>`, for the v1.7.0-rc.1 block), 11 `</details>`, 11 `<summary>`, 11 `</summary>`. No file diverged, which would have meant a content problem rather than a formatting one.

## Verification

Every removed line was compared byte-for-byte against the concatenation of its two replacement lines. All 66 changed lines across the six files matched exactly, so there is no possibility of a translated word, punctuation mark, or ordering having shifted. Line endings stayed LF and trailing newlines are preserved.

`npm run test:workflows` passes, 175 tests. That includes `readme-translations.test.ts`'s 76 tests and specifically its `balances $name tags` suite, which checks opening/closing tag parity per file, which is the check most relevant to the alignment risk above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

🔧 **Changed**
- Reformatted six translated README files.
- Placed each `<details>` tag and `<summary>` element on separate lines.
- Preserved translated content, tag counts, ordering, line endings, and trailing newlines.
- Verified all 66 changed lines byte-for-byte.
- Preserved README block alignment for Crowdin uploads.
- Workflow tests pass, including 175 tests and translated README tag-balance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->