### PR TITLE
docs(agent): record WUD_AGENT_SECRET removal in 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Scoped the Grype image gate around CVE-2026-14456 (openssl/libssl3/libcrypto3, Alpine 3.24) pending an upstream fix.** `ci-verify.yml`'s `grype-image` job started failing `--fail-on high` after this CVE (CWE-770, unbounded memory growth in OpenSSL's QUIC *server* incoming-channel-queue handling) entered the Grype DB; the packages are pinned at `3.5.7-r0` and no Alpine branch — 3.24-stable or edge — has repackaged the upstream 3.5.8 fix yet. Drydock links these libs only as a TLS client (curl, the `openssl` CLI) for registry queries and the healthcheck, never as a QUIC/HTTP3 server, so the vulnerable path isn't reachable; OpenSSL's own advisory rates the flaw Low, versus the generic CVSS 7.5 the gate scores. Added a CVE-scoped (not location-scoped) `.grype.yaml` ignore entry for exactly this CVE on these three package names, so a different HIGH/CRITICAL finding in openssl still fails the gate. Two removal triggers: bump the Dockerfile's pinned `openssl=` version once Alpine ships >= 3.5.8 for 3.24, or 2026-11-17 (90 days out) regardless.
 
+### Documentation
+
+- **Retroactively documented the `WUD_AGENT_SECRET`/`WUD_AGENT_SECRET_FILE` removal.** v1.6.0-rc.1 silently dropped agent mode's `DD_AGENT_SECRET ?? WUD_AGENT_SECRET` fallback (and the `_FILE` equivalent) with no deprecation period, and it was never recorded in the v1.6.0 changelog entry or `DEPRECATIONS.md` at the time. An agent configured with only the legacy `WUD_AGENT_SECRET` went from authenticating to a startup failure whose message doesn't name the variable actually set. See the new `DEPRECATIONS.md` entry.
+
 ## [1.7.0-rc.1] — 2026-08-14
 
 ### Added

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -147,6 +147,20 @@ The migration CLI intentionally retains knowledge of the removed WUD names so it
 
 ---
 
+### Agent-mode `WUD_AGENT_SECRET` / `WUD_AGENT_SECRET_FILE` fallback
+
+| | |
+| --- | --- |
+| **Deprecated in** | Never — removed directly, no deprecation period |
+| **Removed in** | v1.6.0-rc.1 |
+| **Affects** | Agent-mode deployments (`app/agent/api/index.ts`) configured with only `WUD_AGENT_SECRET` / `WUD_AGENT_SECRET_FILE`, no `DD_AGENT_SECRET` / `DD_AGENT_SECRET_FILE` |
+
+This is a separate, undocumented removal from the general `WUD_*` table above. Unlike the general configuration loader — which never read `WUD_*` variables at all — agent mode's secret lookup carried its own explicit fallback through v1.5.2: `process.env.DD_AGENT_SECRET ?? process.env.WUD_AGENT_SECRET` (and the equivalent for `_FILE`). v1.6.0-rc.1 dropped both fallbacks with no warning release first. An agent that had only `WUD_AGENT_SECRET` set went straight from authenticating successfully to `init()` throwing `Agent mode requires DD_AGENT_SECRET or DD_AGENT_SECRET_FILE` at startup — an error message that never mentions the `WUD_` variable the operator actually configured. This entry was never recorded at the time of the v1.6.0 release; it is added here retroactively.
+
+**Migration:** Rename `WUD_AGENT_SECRET` to `DD_AGENT_SECRET` and `WUD_AGENT_SECRET_FILE` to `DD_AGENT_SECRET_FILE`.
+
+---
+
 ### Legacy aggregate container stats endpoint
 
 | | |


### PR DESCRIPTION
v1.6.0-rc.1 dropped agent mode's `DD_AGENT_SECRET ?? WUD_AGENT_SECRET` fallback,
and the `_FILE` equivalent with it. No deprecation period, no changelog entry, no
`DEPRECATIONS.md` record.

For anyone still configured on the legacy variable, the agent went from
authenticating to failing at startup — and the error names `DD_AGENT_SECRET`, the
variable they *haven't* set, rather than the one they have. There's no thread to
pull from the message back to what changed.

This doesn't restore the fallback. Removing it was the right call and reverting it
now would be a second unannounced behavior change. It records what happened: a
`DEPRECATIONS.md` entry and a v1.6.0 changelog note, so the next person hitting
that startup failure can search the variable name and find the answer.

Found while investigating #802, ruled out as its cause, kept because it's a real
documentation gap independent of that.
