### PR TITLE
🔧 chore(release): prepare v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Demo site favicon now matches the refreshed branding.** The v1.5.1 brand refresh (#439) moved the website to the cropped whale "headshot" icon and the app UI followed, but demo.getdrydock.com kept showing the old full-body whale: its stale `favicon.svg` — which modern browsers preferred over the PNGs — was never replaced. The demo now ships the same headshot icon set as the website and app UI, the `favicon.svg` is removed, and the icon links carry a `?v=2` cache-buster so browsers re-fetch instead of serving the aggressively cached old icon. (#689)
+
+## [1.6.1] — 2026-08-20
+
+### Fixed
+
 - **Drydock no longer reports "Up to date" when an update check failed.** A registry error while verifying a candidate's digest discarded the newer tag that had already been found, and the UI presented the result as a confirmed "no update available." A check that could not complete now surfaces as an explicitly unknown status instead of a negative answer. This also covers transient registry failures reported separately. ([#814](https://github.com/CodesWhat/drydock/issues/814), [#808](https://github.com/CodesWhat/drydock/issues/808))
 - **Nested OCI image indexes now resolve to the real image manifest.** An image whose per-platform entry is itself an index, which is what Buildx produces when SBOM or provenance attestations are enabled, failed with `Unexpected error; no manifest found` and left the container unable to complete a digest check. Drydock now follows the nested index to the platform's actual manifest, bounded to three levels, and correctly ignores the attestation manifest alongside it. ([#814](https://github.com/CodesWhat/drydock/issues/814))
 - **A single malformed container no longer zeroes out an entire agent inventory sync.** `AgentClient.processAuthoritativeContainers()` — the loop driving both the standard-mode handshake (`_doHandshake()`, every initial load and reconnect) and edge-mode `handleContainerSync()` (every `dd:container_sync` frame) — had no per-container error isolation, unlike the sibling SSE watcher-snapshot path. One container that threw while building its report (for example, during controller-side SBOM document offload) aborted the whole batch before any container reached the store, so a single bad container could make an otherwise-healthy fleet's inventory sync silently report zero containers. Each container in the batch is now processed independently, matching the existing isolation pattern in `handleWatcherSnapshotEvent()`: a failure is logged with the container id and the batch continues with the rest. A batch where every container fails now also logs a single proportionate warning, since a silently empty result was what let this go unnoticed for a release cycle. Found while investigating [#802](https://github.com/CodesWhat/drydock/issues/802); this closes the isolation gap but does not confirm the SBOM path as that issue's trigger — Portwing does not currently send `security.sbom` on its container wire format, so #802 remains open pending its actual root cause.
@@ -2403,7 +2408,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/CodesWhat/drydock/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.13...v1.6.0
 [1.6.0-rc.13]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.12...v1.6.0-rc.13
 [1.6.0-rc.12]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.11...v1.6.0-rc.12

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.0-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,6 +179,17 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.6.1 highlights</strong></summary>
+
+- **Drydock no longer reports "Up to date" when an update check failed** — a registry error during digest verification now surfaces as an explicit unknown status instead of a false negative. ([#814](https://github.com/CodesWhat/drydock/issues/814), [#808](https://github.com/CodesWhat/drydock/issues/808))
+- **Nested OCI image indexes now resolve to the real image manifest** — images built with Buildx SBOM/provenance attestations no longer fail digest checks with `Unexpected error; no manifest found`. ([#814](https://github.com/CodesWhat/drydock/issues/814))
+- **A single malformed container no longer zeroes out an entire agent inventory sync** — per-container error isolation now matches the existing watcher-snapshot path. ([#802](https://github.com/CodesWhat/drydock/issues/802))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161--2026-08-20).
+
+</details>
+
+<details>
 <summary><strong>v1.6.0 highlights</strong></summary>
 
 - **Portwing edge/agent transport matures** — controller-owned native Docker checks/updates for Portwing 0.9.0+, continuous edge log streaming, Ed25519 request signing (v2), and agent-owned display names bound to their signing key. ([#632](https://github.com/CodesWhat/drydock/issues/632), [#637](https://github.com/CodesWhat/drydock/issues/637))

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-app",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-app",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@aws-sdk/client-ecr": "3.1096.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "drydock-app",
-  "version": "1.6.0",
-  "description": "Drydock backend \u2014 Docker container update manager",
+  "version": "1.6.1",
+  "description": "Drydock backend — Docker container update manager",
   "engines": {
     "node": ">=24.0.0"
   },

--- a/apps/demo/package-lock.json
+++ b/apps/demo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-demo",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-demo",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "^5.2.7",
         "iconify-icon": "^3.0.2",

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-demo",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.0',
+    version: '1.6.1',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.0 started',
+    details: 'Drydock v1.6.1 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.0',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.0',
+    tag: '1.6.1',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.0',
+  version: '1.6.1',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.0',
+      version: '1.6.1',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.0', mode: 'demo' },
+        server: { version: '1.6.1', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.0",
+  version: "1.6.1",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.0",
+    version: "v1.6.1",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.0",
+      "version": "1.6.1",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.0",
+    "version": "1.6.1",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.0"
+  "version":"1.6.1"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.0",
+      "drydockVersion": "1.6.1",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.0` | Immutable exact GA release; best for reproducible deployments |
+| `1.6.1` | Immutable exact GA release; best for reproducible deployments |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.0-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,15 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.6.1 Highlights — August 20, 2026
+
+Three bug fixes: nested OCI image indexes (produced by Buildx SBOM/provenance
+attestations) now resolve to the real image manifest instead of failing digest
+checks; a failed update check no longer reports a container as falsely
+"Up to date"; and a single malformed container report no longer zeroes out an
+entire agent's inventory sync. See [CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161--2026-08-20)
+for the full release notes.
+
 ## v1.6.0 Highlights — August 11, 2026
 
 Consolidates the `1.6.0-rc.1` … `1.6.0-rc.13` prereleases into one GA release. The

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-e2e",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-e2e",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@cucumber/cucumber": "12.9.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-e2e",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "drydock - e2e",
   "engines": {
     "node": ">=24.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "dd-nanoid",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "devDependencies": {
         "@biomejs/biome": "2.5.6",
         "@types/node": "25.9.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "1.6.1",
   "scripts": {
     "prepare": "lefthook install",
     "release:precheck": "node scripts/release-precut-check.mjs",

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -53,10 +53,11 @@ test('every linked changelog heading has exactly one link definition', () => {
   );
 });
 
-test('v1.6.0 GA and v1.5.2 GA have a complete chronological comparison-link chain', () => {
+test('v1.6.1 GA, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.0...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1...HEAD`],
+    ['1.6.1', `${repositoryUrl}/compare/v1.6.0...v1.6.1`],
     ['1.6.0', `${repositoryUrl}/compare/v1.6.0-rc.13...v1.6.0`],
     ['1.6.0-rc.13', `${repositoryUrl}/compare/v1.6.0-rc.12...v1.6.0-rc.13`],
     ['1.6.0-rc.12', `${repositoryUrl}/compare/v1.6.0-rc.11...v1.6.0-rc.12`],
@@ -152,5 +153,24 @@ test('real changelog exposes nonempty v1.6.0 GA release notes', () => {
     'Anonymous access fails closed',
   ]) {
     assert.ok(entry.includes(marker), `v1.6.0 GA notes must include: ${marker}`);
+  }
+});
+
+test('real changelog exposes nonempty v1.6.1 GA release notes', () => {
+  const entry = extractChangelogEntry(changelog, 'v1.6.1');
+
+  assert.match(entry, /^## \[1\.6\.1\] [–—-] \d{4}-\d{2}-\d{2}$/mu);
+  assert.match(entry, /^### Fixed$/mu);
+  // v1.6.1 is a direct patch cut straight to GA (no rc series to roll up), unlike
+  // v1.6.0/v1.5.2 above — the entry is the release notes verbatim, not a synthesis.
+  assert.doesNotMatch(entry, /^## \[1\.6\.0\]/mu);
+  assert.match(changelog, /^## \[1\.6\.0\]/mu);
+
+  for (const marker of [
+    'Drydock no longer reports "Up to date" when an update check failed',
+    'Nested OCI image indexes now resolve to the real image manifest',
+    'A single malformed container no longer zeroes out an entire agent inventory sync',
+  ]) {
+    assert.ok(entry.includes(marker), `v1.6.1 GA notes must include: ${marker}`);
   }
 });

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.0';
-const PREV_RC_VERSION = '1.6.0-rc.13';
-const RC_DATE = '2026-08-11';
-const RC_DISPLAY_DATE = 'August 11, 2026';
+const RC_VERSION = '1.6.1';
+const PREV_RC_VERSION = '1.6.0';
+const RC_DATE = '2026-08-20';
+const RC_DISPLAY_DATE = 'August 20, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const BASE_VERSION = '1.6.0';
-const RC_VERSION = '1.6.0';
+const BASE_VERSION = '1.6.1';
+const RC_VERSION = '1.6.1';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drydock-ui",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drydock-ui",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@fontsource/ibm-plex-mono": "5.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drydock-ui",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Drydock dashboard — Vue 3 + Tailwind CSS 4 SPA",
   "repository": "CodesWhat/drydock",
   "engines": {


### PR DESCRIPTION
Release-prep for the v1.6.1 maintenance patch, mirroring the v1.6.0 GA prep commit (daf12292) file-for-file.

- CHANGELOG: new `[1.6.1] — 2026-08-20` section carrying the three shipped fixes (failed-check status reporting, nested OCI index resolution, agent inventory ingest isolation); link chain extended and the new GA-notes test added to changelog-links.
- Version stamps to 1.6.1 across the five release-locked workspaces (root, app, ui, e2e, apps/demo + demo mocks), site-config/site-content, API doc examples, quickstart tag matrix, updates highlights, README badge + highlights block.
- release-identity and release-docs-identity test constants rolled forward.

`npm run release:precheck -- v1.6.1` exits 0. Full verification in the branch: 142/142 script tests, 87/87 workflow tests, app/ui/apps-web builds clean.

After this merges, the cut needs: manual `workflow_dispatch` of ci-verify.yml and e2e-playwright.yml on dev/v1.6 (green), then release-cut.yml dispatched from main with `release_tag=v1.6.1` and `source_ref=dev/v1.6` — which requires the rc.2 dev→main sync to land #824's release-cut changes on main first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

### ✨ Added
- Added the `v1.6.1` changelog and site release highlights.
- Added GA release-note and comparison-link test coverage.

### 🔧 Changed
- Updated release versions from `1.6.0` to `1.6.1` across packages, manifests, mocks, site content, documentation, README content, and release tests.
- Updated release identity and documentation test constants.
- Updated changelog comparison links.

### 🐛 Fixed
- Documented failed update checks as `unknown` instead of `Up to date`.
- Documented nested OCI image-index resolution for digest checks.
- Documented per-container error isolation during agent inventory sync.

## Concerns

- Dispatch the required workflows on `dev/v1.6`.
- Run `release-cut.yml` from `main` with `release_tag=v1.6.1` and `source_ref=dev/v1.6`.
- Wait for `#824` to land and complete the required synchronization before cutting the release.
- `npm run release:precheck -- v1.6.1` passes, along with 142 script tests, 87 workflow tests, and app/UI/apps-web builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->