### PR TITLE
ci(web): schedule the committed star-history chart refresh

### DIFF
--- a/.github/tests/reusable-ci-config.test.ts
+++ b/.github/tests/reusable-ci-config.test.ts
@@ -27,7 +27,10 @@ const goCiUses = `CodesWhat/.github/.github/workflows/go-ci.yml@${frozenGoCiSha}
 const frozenGreptileSummonSha = 'bbc181dc4d462f673dac2dff5f88a8408dd9c763';
 const greptileSummonUses = `CodesWhat/.github/.github/workflows/greptile-summon.yml@${frozenGreptileSummonSha}`;
 
-const frozenReusableWorkflowUses = [goCiUses, greptileSummonUses];
+const frozenStarchartRefreshSha = '96e2765052a5d01ad9db2dffa355636d9e9bde88';
+const starchartRefreshUses = `CodesWhat/.github/.github/workflows/starchart-refresh.yml@${frozenStarchartRefreshSha}`;
+
+const frozenReusableWorkflowUses = [goCiUses, greptileSummonUses, starchartRefreshUses];
 
 const workflowsDir = fileURLToPath(new URL('../workflows', import.meta.url));
 

--- a/.github/workflows/starchart.yml
+++ b/.github/workflows/starchart.yml
@@ -1,0 +1,24 @@
+# Refreshes the committed star-history chart at docs/assets/star-history.svg.
+#
+# The chart is a committed artifact on purpose: the retired /api/star-history
+# route read a runtime credential that was never set in production and served a
+# placeholder at HTTP 200 forever, and the Warpchart embed that briefly
+# replaced it was reversed. A committed SVG cannot fail silently — stale is
+# visible in git, missing is a broken image. This caller only regenerates it on
+# a weekly cadence; the shared workflow owns the generation logic.
+name: Starchart Refresh
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  starchart:
+    permissions:
+      contents: write
+    uses: CodesWhat/.github/.github/workflows/starchart-refresh.yml@96e2765052a5d01ad9db2dffa355636d9e9bde88  # main 2026-08-20
+    with:
+      branch: dev/v1.7


### PR DESCRIPTION
Weekly caller of the shared `starchart-refresh` workflow to regenerate `docs/assets/star-history.svg`, completing the arc from #823: route retired, Warpchart reversed, committed SVG is the one chart, and this keeps it fresh.

- Pinned to a frozen SHA of `CodesWhat/.github` like the repo's other reusable-workflow callers, and registered in the frozen-SHA allowlist test.
- `permissions: {}` at workflow level; `contents: write` scoped to the single job so the shared workflow can commit the regenerated SVG to `dev/v1.7`.
- Monday 06:17 UTC cron plus manual dispatch. No PAT anywhere; the shared workflow runs on the default job credential.

zizmor: no findings. Workflow tests: 208/208.