### PR TITLE
chore(release): prepare v1.7.0-rc.2

### DIFF
--- a/.github/tests/readme-translations.test.ts
+++ b/.github/tests/readme-translations.test.ts
@@ -66,68 +66,68 @@ const localizedSurfaceFragments: Record<
     featureTableHeader: '| | Funktion | Beschreibung |',
     builtWithHeading: '<h2 align="center" id="built-with">Gebaut mit</h2>',
     communityQaHeading: '### Community-QA',
-    releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.1</strong></summary>',
+    releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.2</strong></summary>',
   },
   'README.es.md': {
     featureTableHeader: '| | Característica | Descripción |',
     builtWithHeading: '<h2 align="center" id="built-with">Construido con</h2>',
     communityQaHeading: '### Control de calidad de la comunidad',
-    releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.1</strong></summary>',
+    releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.2</strong></summary>',
   },
   'README.fr.md': {
     featureTableHeader: '| | Fonctionnalité | Descriptif |',
     builtWithHeading: '<h2 align="center" id="built-with">Construit avec</h2>',
     communityQaHeading: '### Contrôle qualité de la communauté',
-    releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.1</strong></summary>',
+    releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.2</strong></summary>',
   },
   'README.pl.md': {
     featureTableHeader: '| | Funkcja | Opis |',
     builtWithHeading: '<h2 align="center" id="built-with">Zbudowany z</h2>',
     communityQaHeading: '### Kontrola jakości społeczności',
     releaseHeading:
-      '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.1</strong></summary>',
+      '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.2</strong></summary>',
   },
   'README.pt-BR.md': {
     featureTableHeader: '| | Recurso | Descrição |',
     builtWithHeading: '<h2 align="center" id="built-with">Construído com</h2>',
     communityQaHeading: '### Controle de qualidade da comunidade',
-    releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.1</strong></summary>',
+    releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.2</strong></summary>',
   },
   'README.zh-CN.md': {
     featureTableHeader: '| |特色|描述 |',
     builtWithHeading: '<h2 align="center" id="built-with">技术栈</h2>',
     communityQaHeading: '### 社区质量检查',
-    releaseHeading: '<summary><strong>v1.7.0-rc.1 亮点</strong></summary>',
+    releaseHeading: '<summary><strong>v1.7.0-rc.2 亮点</strong></summary>',
   },
 };
 
 const localizedReleaseFragments: Record<
   string,
-  { dependencyAware: string; securityHardening: string }
+  { updateCheckFixes: string; securityHardening: string }
 > = {
   'README.de.md': {
-    dependencyAware: '**Abhängigkeitsbewusste Updates**',
-    securityHardening: '**Sicherheits- und Lifecycle-Härtung**',
+    updateCheckFixes: '**Korrekturen bei der Update-Prüfung**',
+    securityHardening: '**Sicherheit**',
   },
   'README.es.md': {
-    dependencyAware: '**Actualizaciones conscientes de dependencias**',
-    securityHardening: '**Refuerzo de seguridad y ciclo de vida**',
+    updateCheckFixes: '**Correcciones de exactitud en la comprobación de actualizaciones**',
+    securityHardening: '**Seguridad**',
   },
   'README.fr.md': {
-    dependencyAware: '**Mises à jour tenant compte des dépendances**',
-    securityHardening: '**Renforcement de la sécurité et du cycle de vie**',
+    updateCheckFixes: '**Corrections de justesse des vérifications de mise à jour**',
+    securityHardening: '**Sécurité**',
   },
   'README.pl.md': {
-    dependencyAware: '**Aktualizacje uwzględniające zależności**',
-    securityHardening: '**Wzmocnienie bezpieczeństwa i cyklu życia**',
+    updateCheckFixes: '**Poprawki poprawności sprawdzania aktualizacji**',
+    securityHardening: '**Bezpieczeństwo**',
   },
   'README.pt-BR.md': {
-    dependencyAware: '**Atualizações com reconhecimento de dependências**',
-    securityHardening: '**Reforço de segurança e ciclo de vida**',
+    updateCheckFixes: '**Correções de exatidão na verificação de atualizações**',
+    securityHardening: '**Segurança**',
   },
   'README.zh-CN.md': {
-    dependencyAware: '**依赖感知更新**',
-    securityHardening: '**安全与生命周期强化**',
+    updateCheckFixes: '**更新检查正确性修复**',
+    securityHardening: '**安全**',
   },
 };
 
@@ -163,7 +163,7 @@ const forbiddenSourceEnglishProse = [
 ];
 
 const requiredFragments = [
-  'version-1.7.0--rc.1-blue',
+  'version-1.7.0--rc.2-blue',
   'https://www.bestpractices.dev/projects/11915',
   '`drydock.sid`',
   '`allowmetadata=true`',
@@ -174,6 +174,7 @@ const requiredFragments = [
   'v1.6.0-rc.11',
   './CHANGELOG.md#160--2026-08-11',
   './CHANGELOG.md#170-rc1--2026-08-14',
+  './CHANGELOG.md#170-rc2--2026-08-20',
   'Portwing 0.9.0+',
   'Standard HTTP',
   '`DD_EXPERIMENTAL_PORTWING=false`',
@@ -226,15 +227,13 @@ describe.each(translatedReadmes)('%s', (readme) => {
     const surface = localizedSurfaceFragments[readme];
     const release = localizedReleaseFragments[readme];
     const releaseBlock = getReleaseBlock(content, surface.releaseHeading);
-    const dependencyBullet = getBullet(releaseBlock, release.dependencyAware);
+    const updateCheckBullet = getBullet(releaseBlock, release.updateCheckFixes);
     const securityBullet = getBullet(releaseBlock, release.securityHardening);
     const getUrls = (bullet: string | undefined) =>
       [...(bullet ?? '').matchAll(/https?:\/\/[^)<>"\s]+/g)].map(([url]) => url);
 
-    expect(getUrls(dependencyBullet)).toEqual([
-      'https://github.com/CodesWhat/drydock/discussions/219',
-    ]);
-    expect(getUrls(securityBullet)).toEqual(['https://github.com/CodesWhat/drydock/issues/708']);
+    expect(getUrls(updateCheckBullet)).toEqual(['https://github.com/CodesWhat/drydock/issues/814']);
+    expect(getUrls(securityBullet)).toEqual(['https://github.com/CodesWhat/drydock/pull/750']);
   });
 
   test('preserves the exact source URL multiset', () => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0-rc.2] — 2026-08-20
+
 ### Added
 
 - **Action-policy resolution is surfaced on the API and UI (spec-6.0.1-action-policy.md, slice 5).** `GET /api/v1/containers` and SSE container payloads now include an `actionPolicy` object (`state`: `blocked`/`manual`/`auto`, plus `triggerId` and, when blocked, `reason`) on `updateEligibility`, reflecting the winning action trigger's resolved verdict for that container independent of whether it produced a blocker. `GET /api/v1/containers/{id}/triggers` gains a per-trigger `resolvedState` field with the same three values, so every candidate action trigger's individual verdict is visible, not just the winner. The container list/detail UI shows a new **Auto** badge (Update Status panel, full-page Actions tab, side panel trigger rows) wherever a container's or trigger's resolved state is `auto`, with tooltips explaining the blocked/manual/auto states. New `dd.action.auto` container label and `onauto` `AUTO` mode: under `AUTO=onauto`, `dd.action.include` keeps granting manual access but automatic dispatch additionally requires a `dd.action.auto` match, letting a container opt into manual-only access without picking up automatic execution. Drydock now logs a startup `WARN` for any action trigger left on `AUTO=oninclude` that has `dd.action.include`-matching containers with no corresponding `dd.action.auto` label (would silently drop to manual-only if switched to `onauto`), and a second `WARN` when a trigger is on `AUTO=none` but a container carries an inert `dd.action.auto` label for it. Docs: new `dd.action.auto` label and `onauto` value are documented on the labels reference, triggers configuration, and update-eligibility pages, including a callout on all three clarifying that `AUTO=none`/`AUTO=all` also set the baseline **access** default (not just automatic execution) — `AUTO=none` still opens manual access to every container, `AUTO=all` opens both.
@@ -2484,7 +2486,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.1...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.2...HEAD
+[1.7.0-rc.2]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.1...v1.7.0-rc.2
 [1.7.0-rc.1]: https://github.com/CodesWhat/drydock/compare/v1.6.0...v1.7.0-rc.1
 [1.6.0]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.13...v1.6.0
 [1.6.0-rc.13]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.12...v1.6.0-rc.13

--- a/README.de.md
+++ b/README.de.md
@@ -14,7 +14,7 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.1-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -201,6 +201,19 @@ Weitere Informationen zu Docker Compose, Socket-Sicherheit, Reverse-Proxy und al
 <h2 align="center" id="recent-updates">Aktuelle Updates</h2>
 
 <details open>
+<summary><strong>Highlights von v1.7.0-rc.2</strong></summary>
+
+- **Pro-Container-Richtlinienauflösung für Aktionen** – API und UI zeigen jetzt den aufgelösten Status (blocked/manual/auto) und den entscheidenden Trigger für jeden Container an, plus ein neues Label `dd.action.auto` und der Modus `AUTO=onauto` für reinen manuellen Zugriff ohne automatische Ausführung.
+- **Breaking Changes in diesem Zyklus** – `DD_TRIGGER_*`/`dd.trigger.*` sind vollständig entfernt, `trigger-excluded`/`trigger-not-included` werden zu harten Update-Blockern, das MQTT-Themenlayout von Home Assistant erhält standardmäßig ein `agent/<name>`-Segment, `GET /api/auth/methods` liefert jetzt 410, und `curl` ist nicht mehr im Image enthalten.
+- **Korrekturen bei der Update-Prüfung** – ein Registry-Fehler während der Prüfung meldet nicht mehr fälschlich „Up to date“, ein fehlerhafter Container leert nicht mehr die gesamte Agenten-Inventarsynchronisierung, und verschachtelte OCI-Image-Indizes werden jetzt korrekt auf das eigentliche Manifest aufgelöst. ([#814](https://github.com/CodesWhat/drydock/issues/814))
+- **Abhängigkeits- und Selbst-Update-Korrekturen** – ein abgelehntes Abhängigkeitsmitglied behält seinen Neustart-Kontext, Compose-Aktualisierungen übernehmen keine veralteten, aus dem Image geerbten Umgebungsvariablen mehr, und Update-Richtlinien-Überschreibungen überstehen jetzt das eigene Self-Update von Drydock. ([#718](https://github.com/CodesWhat/drydock/pull/718), [#736](https://github.com/CodesWhat/drydock/pull/736), [#743](https://github.com/CodesWhat/drydock/pull/743))
+- **Sicherheit** – ein Pfad für „Remote Property Injection“ in der URL-Abfragesynchronisierung der Container-Liste wurde geschlossen, und das Grype-Image-Gate wurde gezielt um eine CVE eingegrenzt, für die Alpine noch keinen Fix veröffentlicht hat. ([#750](https://github.com/CodesWhat/drydock/pull/750))
+
+Vollständige Versionshinweise in [CHANGELOG.md](./CHANGELOG.md#170-rc2--2026-08-20).
+
+</details>
+
+<details>
 <summary><strong>Highlights von v1.7.0-rc.1</strong></summary>
 
 - **Sicherheits- und Lifecycle-Härtung** – Authentifizierung, Agent-Anfragen, Protokolle, WebSockets und Registry-Anfragen sind explizit begrenzt; vertrauliche Befehls- und Hook-Werte werden redigiert; die Home-Assistant-Erkennung synchronisiert sich nach dem Start neu und beendet Provider-Arbeit ohne veraltete Veröffentlichungen. ([#708](https://github.com/CodesWhat/drydock/issues/708))

--- a/README.es.md
+++ b/README.es.md
@@ -14,7 +14,7 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.1-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -201,6 +201,19 @@ Consulte la [guía de inicio rápido](https://getdrydock.com/docs/quickstart) pa
 <h2 align="center" id="recent-updates">Actualizaciones recientes</h2>
 
 <details open>
+<summary><strong>Aspectos destacados de v1.7.0-rc.2</strong></summary>
+
+- **Resolución de política de acción por contenedor**: la API y la interfaz ahora muestran el estado resuelto (blocked/manual/auto) y el disparador ganador de cada contenedor, además de una nueva etiqueta `dd.action.auto` y el modo `AUTO=onauto` para acceso solo manual sin despacho automático.
+- **Cambios incompatibles en este ciclo**: `DD_TRIGGER_*`/`dd.trigger.*` se eliminan por completo, `trigger-excluded`/`trigger-not-included` pasan a ser bloqueos duros de actualización, el esquema de temas MQTT de Home Assistant añade un segmento `agent/<name>` por defecto, `GET /api/auth/methods` devuelve 410, y `curl` desaparece de la imagen.
+- **Correcciones de exactitud en la comprobación de actualizaciones**: un error de registro durante la comprobación ya no informa «Up to date», un contenedor con errores ya no anula toda la sincronización del inventario del agente, y los índices de imagen OCI anidados ahora se resuelven al manifiesto real. ([#814](https://github.com/CodesWhat/drydock/issues/814))
+- **Correcciones de dependencias y autoactualización**: un miembro de dependencia rechazado conserva su contexto de reinicio, las actualizaciones de Compose ya no arrastran valores de entorno obsoletos heredados de la imagen, y las anulaciones de política de actualización ahora sobreviven a la autoactualización de drydock. ([#718](https://github.com/CodesWhat/drydock/pull/718), [#736](https://github.com/CodesWhat/drydock/pull/736), [#743](https://github.com/CodesWhat/drydock/pull/743))
+- **Seguridad**: se cerró una vía de inyección de propiedades remota en la sincronización de consultas de URL de la lista de contenedores, y se acotó la puerta de Grype para la imagen en torno a un CVE de Alpine pendiente de corrección. ([#750](https://github.com/CodesWhat/drydock/pull/750))
+
+Notas completas en [CHANGELOG.md](./CHANGELOG.md#170-rc2--2026-08-20).
+
+</details>
+
+<details>
 <summary><strong>Aspectos destacados de v1.7.0-rc.1</strong></summary>
 
 - **Actualizaciones conscientes de dependencias**: las etiquetas o los metadatos de Compose crean un grafo de dependencias validado, muestran las oleadas exactas en la vista previa y ejecutan actualizaciones o reinicios de dependientes en orden determinista, con manejo seguro de ciclos, fallos y vistas previas obsoletas. ([Discusión #219](https://github.com/CodesWhat/drydock/discussions/219))

--- a/README.fr.md
+++ b/README.fr.md
@@ -14,7 +14,7 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.1-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -201,6 +201,19 @@ Consultez le [Guide de démarrage rapide](https://getdrydock.com/docs/quickstart
 <h2 align="center" id="recent-updates">Mises à jour récentes</h2>
 
 <details open>
+<summary><strong>Points forts de la v1.7.0-rc.2</strong></summary>
+
+- **Résolution de la politique d'action par conteneur** : l'API et l'interface exposent désormais l'état résolu (blocked/manual/auto) et le déclencheur gagnant pour chaque conteneur, ainsi qu'un nouveau label `dd.action.auto` et le mode `AUTO=onauto` pour un accès manuel uniquement, sans déclenchement automatique.
+- **Changements incompatibles ce cycle** : `DD_TRIGGER_*`/`dd.trigger.*` sont totalement supprimés, `trigger-excluded`/`trigger-not-included` deviennent des blocages de mise à jour définitifs, la disposition des sujets MQTT de Home Assistant inclut désormais un segment `agent/<name>` par défaut, `GET /api/auth/methods` renvoie 410, et `curl` a disparu de l'image.
+- **Corrections de justesse des vérifications de mise à jour** : une erreur de registre en cours de vérification n'indique plus à tort « Up to date », un conteneur malformé n'annule plus toute la synchronisation d'inventaire d'un agent, et les index d'image OCI imbriqués se résolvent désormais vers le manifeste réel. ([#814](https://github.com/CodesWhat/drydock/issues/814))
+- **Corrections de dépendances et d'auto-mise à jour** : un membre de dépendance rejeté conserve son contexte de redémarrage, les rafraîchissements Compose ne reportent plus de valeurs d'environnement obsolètes héritées de l'image, et les substitutions de politique de mise à jour survivent désormais à l'auto-mise à jour de drydock. ([#718](https://github.com/CodesWhat/drydock/pull/718), [#736](https://github.com/CodesWhat/drydock/pull/736), [#743](https://github.com/CodesWhat/drydock/pull/743))
+- **Sécurité** : fermeture d'une voie d'injection de propriété distante dans la synchronisation des requêtes d'URL de la liste des conteneurs, et restriction de la porte Grype pour l'image autour d'un CVE Alpine en attente de correctif amont. ([#750](https://github.com/CodesWhat/drydock/pull/750))
+
+Notes complètes dans [CHANGELOG.md](./CHANGELOG.md#170-rc2--2026-08-20).
+
+</details>
+
+<details>
 <summary><strong>Points forts de la v1.7.0-rc.1</strong></summary>
 
 - **Mises à jour tenant compte des dépendances** : les labels ou métadonnées Compose construisent un graphe de dépendances validé, prévisualisent les vagues exactes et exécutent les mises à jour ou redémarrages des dépendants dans un ordre déterministe, avec gestion sûre des cycles, échecs et aperçus périmés. ([Discussion #219](https://github.com/CodesWhat/drydock/discussions/219))

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.1-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -204,6 +204,19 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.7.0-rc.2 highlights</strong></summary>
+
+- **Per-container action-policy resolution** — the API and UI surface the resolved blocked/manual/auto state and winning trigger for every container, plus a new `dd.action.auto` label and `AUTO=onauto` mode for manual-only access without automatic dispatch.
+- **Breaking changes land this cycle** — `DD_TRIGGER_*`/`dd.trigger.*` are fully removed, `trigger-excluded`/`trigger-not-included` become hard update blockers, the Home Assistant MQTT topic layout gains an `agent/<name>` segment by default, `GET /api/auth/methods` returns 410, and `curl` is gone from the image.
+- **Update-check correctness fixes** — a registry error mid-check no longer reports "Up to date," a malformed container no longer zeroes out an entire agent inventory sync, and nested OCI image indexes now resolve to the real manifest. ([#814](https://github.com/CodesWhat/drydock/issues/814))
+- **Dependency and self-update fixes** — a rejected dependency member keeps its restart context, Compose refreshes no longer carry forward stale environment defaults, and update-policy overrides now survive drydock's own self-update. ([#718](https://github.com/CodesWhat/drydock/pull/718), [#736](https://github.com/CodesWhat/drydock/pull/736), [#743](https://github.com/CodesWhat/drydock/pull/743))
+- **Security** — closed a remote-property-injection path in the container list's URL query sync, and scoped the Grype image gate around a pending-upstream-fix Alpine CVE. ([#750](https://github.com/CodesWhat/drydock/pull/750))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#170-rc2--2026-08-20).
+
+</details>
+
+<details>
 <summary><strong>v1.7.0-rc.1 highlights</strong></summary>
 
 - **Dependency-aware updates** — labels or Compose metadata build a validated dependency graph, preview exact update waves, and run updates or dependent restarts in deterministic order with cycle, failure, and stale-preview handling. ([Discussion #219](https://github.com/CodesWhat/drydock/discussions/219))

--- a/README.pl.md
+++ b/README.pl.md
@@ -14,7 +14,7 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.1-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -201,6 +201,19 @@ Zobacz [Przewodnik szybkiego startu](https://getdrydock.com/docs/quickstart) dla
 <h2 align="center" id="recent-updates">Ostatnie aktualizacje</h2>
 
 <details open>
+<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.2</strong></summary>
+
+- **Rozstrzyganie polityki akcji dla poszczególnych kontenerów** — API i interfejs użytkownika pokazują teraz rozstrzygnięty stan (blocked/manual/auto) oraz zwycięski wyzwalacz dla każdego kontenera, a także nową etykietę `dd.action.auto` i tryb `AUTO=onauto` umożliwiający wyłącznie ręczny dostęp bez automatycznego wywoływania.
+- **Niezgodne zmiany w tym cyklu** — `DD_TRIGGER_*`/`dd.trigger.*` zostały całkowicie usunięte, `trigger-excluded`/`trigger-not-included` stają się twardymi blokadami aktualizacji, układ tematów MQTT Home Assistant domyślnie zyskuje segment `agent/<name>`, `GET /api/auth/methods` zwraca teraz 410, a `curl` zniknął z obrazu.
+- **Poprawki poprawności sprawdzania aktualizacji** — błąd rejestru w trakcie sprawdzania nie zgłasza już fałszywie „Up to date”, uszkodzony kontener nie zeruje już całej synchronizacji inwentarza agenta, a zagnieżdżone indeksy obrazów OCI są teraz poprawnie rozwiązywane do właściwego manifestu. ([#814](https://github.com/CodesWhat/drydock/issues/814))
+- **Poprawki zależności i samoaktualizacji** — odrzucony element zależności zachowuje teraz swój kontekst ponownego uruchomienia, odświeżenia Compose nie przenoszą już nieaktualnych wartości środowiskowych odziedziczonych z obrazu, a nadpisania polityki aktualizacji przetrwają teraz własną samoaktualizację drydock. ([#718](https://github.com/CodesWhat/drydock/pull/718), [#736](https://github.com/CodesWhat/drydock/pull/736), [#743](https://github.com/CodesWhat/drydock/pull/743))
+- **Bezpieczeństwo** — zamknięto ścieżkę wstrzykiwania zdalnych właściwości w synchronizacji zapytań URL listy kontenerów oraz zawężono bramkę obrazu Grype wokół CVE dla Alpine oczekującego na poprawkę u dostawcy. ([#750](https://github.com/CodesWhat/drydock/pull/750))
+
+Pełne informacje o wersji znajdują się w [CHANGELOG.md](./CHANGELOG.md#170-rc2--2026-08-20).
+
+</details>
+
+<details>
 <summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.1</strong></summary>
 
 - **Aktualizacje uwzględniające zależności** — etykiety lub metadane Compose tworzą zweryfikowany graf zależności, pokazują dokładne fale aktualizacji i uruchamiają aktualizacje albo ponowne uruchomienia elementów zależnych w deterministycznej kolejności, bezpiecznie obsługując cykle, błędy i nieaktualne podglądy. ([Dyskusja #219](https://github.com/CodesWhat/drydock/discussions/219))

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -14,7 +14,7 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.1-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -201,6 +201,19 @@ Consulte o [Guia de início rápido](https://getdrydock.com/docs/quickstart) par
 <h2 align="center" id="recent-updates">Atualizações recentes</h2>
 
 <details open>
+<summary><strong>Destaques da v1.7.0-rc.2</strong></summary>
+
+- **Resolução de política de ação por contêiner** — a API e a interface agora expõem o estado resolvido (blocked/manual/auto) e o acionador vencedor de cada contêiner, além de um novo rótulo `dd.action.auto` e o modo `AUTO=onauto` para acesso somente manual sem disparo automático.
+- **Mudanças incompatíveis neste ciclo** — `DD_TRIGGER_*`/`dd.trigger.*` foram totalmente removidos, `trigger-excluded`/`trigger-not-included` passam a ser bloqueios definitivos de atualização, o layout de tópicos MQTT do Home Assistant ganha um segmento `agent/<name>` por padrão, `GET /api/auth/methods` agora retorna 410, e o `curl` foi removido da imagem.
+- **Correções de exatidão na verificação de atualizações** — um erro de registry durante a verificação não relata mais “Up to date” indevidamente, um contêiner malformado não zera mais toda a sincronização de inventário de um agente, e índices de imagem OCI aninhados agora são resolvidos para o manifesto real. ([#814](https://github.com/CodesWhat/drydock/issues/814))
+- **Correções de dependências e autoatualização** — um membro de dependência rejeitado mantém seu contexto de reinicialização, as atualizações do Compose não arrastam mais valores de ambiente obsoletos herdados da imagem, e substituições de política de atualização agora sobrevivem à própria autoatualização do drydock. ([#718](https://github.com/CodesWhat/drydock/pull/718), [#736](https://github.com/CodesWhat/drydock/pull/736), [#743](https://github.com/CodesWhat/drydock/pull/743))
+- **Segurança** — foi fechado um caminho de injeção de propriedade remota na sincronização de consultas de URL da lista de contêineres, e o gate de imagem do Grype foi restrito a um CVE do Alpine ainda sem correção upstream. ([#750](https://github.com/CodesWhat/drydock/pull/750))
+
+Notas completas em [CHANGELOG.md](./CHANGELOG.md#170-rc2--2026-08-20).
+
+</details>
+
+<details>
 <summary><strong>Destaques da v1.7.0-rc.1</strong></summary>
 
 - **Atualizações com reconhecimento de dependências** — rótulos ou metadados do Compose criam um grafo de dependências validado, mostram as ondas exatas na prévia e executam atualizações ou reinicializações de dependentes em ordem determinística, com tratamento seguro de ciclos, falhas e prévias obsoletas. ([Discussão #219](https://github.com/CodesWhat/drydock/discussions/219))

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.1-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -201,6 +201,19 @@ docker run -d \
 <h2 align="center" id="recent-updates">最近更新</h2>
 
 <details open>
+<summary><strong>v1.7.0-rc.2 亮点</strong></summary>
+
+- **按容器解析操作策略** — API 和界面现在会显示每个容器已解析的状态（blocked/manual/auto）以及胜出的触发器，并新增 `dd.action.auto` 标签和 `AUTO=onauto` 模式，可实现仅手动访问而不自动派发。
+- **本周期的不兼容变更** — `DD_TRIGGER_*`/`dd.trigger.*` 已被彻底移除，`trigger-excluded`/`trigger-not-included` 现在会硬性阻止更新，Home Assistant 的 MQTT 主题布局默认新增 `agent/<name>` 段，`GET /api/auth/methods` 现在返回 410，且镜像中已移除 `curl`。
+- **更新检查正确性修复** — 检查过程中的注册表错误不再误报为"Up to date"，格式错误的容器不再清空整个代理清单同步，嵌套的 OCI 镜像索引现在能正确解析到实际清单。([#814](https://github.com/CodesWhat/drydock/issues/814))
+- **依赖关系与自我更新修复** — 被拒绝的依赖成员现在会保留其重启上下文，Compose 刷新不再带入镜像继承的过期环境变量默认值，更新策略覆盖设置现在能在 drydock 自我更新后保留。([#718](https://github.com/CodesWhat/drydock/pull/718)、[#736](https://github.com/CodesWhat/drydock/pull/736)、[#743](https://github.com/CodesWhat/drydock/pull/743))
+- **安全** — 修复了容器列表 URL 查询同步中的远程属性注入路径，并将 Grype 镜像门限收窄到一个尚待上游修复的 Alpine CVE。([#750](https://github.com/CodesWhat/drydock/pull/750))
+
+完整发行说明请参阅 [CHANGELOG.md](./CHANGELOG.md#170-rc2--2026-08-20)。
+
+</details>
+
+<details>
 <summary><strong>v1.7.0-rc.1 亮点</strong></summary>
 
 - **依赖感知更新** — 通过标签或 Compose 元数据构建经过验证的依赖关系图，预览准确的更新波次，并按确定的顺序执行更新或重启依赖项，同时安全处理循环依赖、失败和过期预览。([讨论 #219](https://github.com/CodesWhat/drydock/discussions/219))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.7.0-rc.1',
+    version: '1.7.0-rc.2',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-08-12T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.7.0-rc.1 started',
+    details: 'Drydock v1.7.0-rc.2 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-08-05T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.7.0-rc.1',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.7.0-rc.2',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.7.0-rc.1',
+    tag: '1.7.0-rc.2',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.7.0-rc.1',
+  version: '1.7.0-rc.2',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.7.0-rc.1',
+      version: '1.7.0-rc.2',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.7.0-rc.1', mode: 'demo' },
+        server: { version: '1.7.0-rc.2', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.7.0-rc.1",
+  version: "1.7.0-rc.2",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -294,7 +294,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.7.0-rc.1",
+    version: "v1.7.0-rc.2",
     title: "Smart Updates & UX",
     emoji: "\u{1F680}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.7.0-rc.1",
+      "version": "1.7.0-rc.2",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.7.0-rc.1",
+    "version": "1.7.0-rc.2",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.7.0-rc.1"
+  "version":"1.7.0-rc.2"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.7.0-rc.1",
+    "version": "1.7.0-rc.2",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.7.0-rc.1",
+      "drydockVersion": "1.7.0-rc.2",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.7.0-rc.1` | Immutable release candidate; best for reproducible testing |
+| `1.7.0-rc.2` | Immutable release candidate; best for reproducible testing |
 | `1.7-rc` | Rolling release-candidate channel; moves to the newest `1.7.0-rc.N` |
 | `1.6.0` | Immutable exact GA release; best for reproducible deployments |
 | `1.6` | Rolling stable minor channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,16 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.7.0-rc.2 Highlights — August 20, 2026
+
+- **Per-container action-policy resolution** — the API and UI now surface the resolved `blocked`/`manual`/`auto` state and winning trigger for every container and candidate action trigger, plus a new `dd.action.auto` label and `AUTO=onauto` mode so a container can opt into manual-only access without picking up automatic dispatch (spec-6.0.1-action-policy.md, slice 5).
+- **BREAKING changes take effect this cycle** — the legacy `DD_TRIGGER_*` prefix and `dd.trigger.*` labels are fully removed, `trigger-excluded`/`trigger-not-included` become hard update blockers ending the v1.5.0–v1.6.x soft-severity grace period, the Home Assistant MQTT topic layout now scopes multi-agent deployments under an `agent/<name>` segment by default, `GET /api/auth/methods` returns 410, and `curl` is gone from the Docker image in favor of the compiled healthcheck binary.
+- **Dependency-graph and admission fixes** — a rejected dependency member no longer loses its restart context in wave 0, and Docker Compose refreshes no longer carry forward a stale image-inherited environment default ([#718](https://github.com/CodesWhat/drydock/pull/718), [#736](https://github.com/CodesWhat/drydock/pull/736)).
+- **Self-update state survives itself** — the `updatePolicyRetentionCache` that lets a recreated container inherit its predecessor's policy overrides now persists write-through to the store instead of being silently dropped on drydock's own self-update restart ([#743](https://github.com/CodesWhat/drydock/pull/743)).
+- **Update checks stop reporting false confidence** — a registry error mid-check no longer reports "Up to date," a single malformed container no longer zeroes out an entire agent inventory sync, and nested OCI image indexes (Buildx SBOM/provenance builds) now resolve to the real manifest instead of erroring ([#814](https://github.com/CodesWhat/drydock/issues/814)).
+- **Security** — closed a remote-property-injection path in the container list's URL query sync, and scoped the Grype image gate around CVE-2026-14456 pending an upstream Alpine fix ([#750](https://github.com/CodesWhat/drydock/pull/750)).
+- **Everything else** — Greptile second-opinion review is available behind a label, `release-cut.yml` can cut a maintenance patch from a retired dev branch, the container SBOM attestation is now documented in the verification guide, the trivy qlty plugin gave way to Grype, the login screen's oversized logo asset was fixed, and the star-history chart moved to a committed SVG.
+
 ## v1.7.0-rc.1 Highlights — August 14, 2026
 
 - **Dependency-aware updates** — labels or Compose metadata resolve into deterministic update waves, with preview-bound confirmation, restart-only dependents, cycle handling, and explicit skipped-dependency results ([Discussion #219](https://github.com/CodesWhat/drydock/discussions/219)).

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.7 RC and prior releases have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.7.0-rc.1...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.7.0-rc.2...HEAD`],
+    ['1.7.0-rc.2', `${repositoryUrl}/compare/v1.7.0-rc.1...v1.7.0-rc.2`],
     ['1.7.0-rc.1', `${repositoryUrl}/compare/v1.6.0...v1.7.0-rc.1`],
     ['1.6.0', `${repositoryUrl}/compare/v1.6.0-rc.13...v1.6.0`],
     ['1.6.0-rc.13', `${repositoryUrl}/compare/v1.6.0-rc.12...v1.6.0-rc.13`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.7.0-rc.1';
-const PREV_RC_VERSION = '1.6.0';
-const RC_DATE = '2026-08-14';
-const RC_DISPLAY_DATE = 'August 14, 2026';
+const RC_VERSION = '1.7.0-rc.2';
+const PREV_RC_VERSION = '1.7.0-rc.1';
+const RC_DATE = '2026-08-20';
+const RC_DISPLAY_DATE = 'August 20, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.6', 'content/docs/v1.5'];
 const RELEASE_REDIRECT_STATUSES = [301, 302, 303, 307, 308];
 const BROAD_401_CLAIM =
@@ -24,12 +24,6 @@ function extractMarkdownSection(document, heading) {
   assert.notEqual(sectionStart, -1, `missing Markdown section: ${heading}`);
   const nextSectionStart = document.indexOf('\n## ', sectionStart + heading.length + 1);
   return document.slice(sectionStart, nextSectionStart === -1 ? undefined : nextSectionStart);
-}
-
-function extractMarkdownListItem(section, marker) {
-  const item = section.split('\n').find((line) => line.startsWith('- ') && line.includes(marker));
-  assert.ok(item, `missing Markdown list item containing: ${marker}`);
-  return item;
 }
 
 function assertReleaseRedirectAllowlist(name, section) {
@@ -141,37 +135,26 @@ test('release candidate notes cover the post-promotion fixes', () => {
     `## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`,
   );
 
-  for (const issue of [606, 635, 687, 688]) {
+  for (const issue of [718, 736, 743, 814]) {
     const issueLink = `https://github.com/CodesWhat/drydock/issues/${issue}`;
-    assert.ok(changelog.includes(issueLink), `CHANGELOG.md must link issue #${issue}`);
-    assert.ok(updates.includes(issueLink), `updates page must link issue #${issue}`);
+    const pullLink = `https://github.com/CodesWhat/drydock/pull/${issue}`;
+    assert.ok(
+      changelog.includes(issueLink) || changelog.includes(pullLink),
+      `CHANGELOG.md must link issue/PR #${issue}`,
+    );
+    assert.ok(
+      updates.includes(issueLink) || updates.includes(pullLink),
+      `updates page must link issue/PR #${issue}`,
+    );
   }
 
-  const manifestIssueLink = 'https://github.com/CodesWhat/drydock/issues/606';
-  assertReleaseRedirectAllowlist(
-    'CHANGELOG.md manifest metadata note',
-    extractMarkdownListItem(changelog, manifestIssueLink),
-  );
-  assertReleaseRedirectAllowlist(
-    'updates page manifest metadata note',
-    extractMarkdownListItem(updates, manifestIssueLink),
-  );
   for (const fragment of [
-    '`DD_PORTWING_POLL_INTERVAL`',
-    '`exec_end.reason`',
-    "controller's configured registry identity",
-    '4xx, 5xx, network, and non-object failures',
+    '`dd.action.auto`',
+    'updatePolicyRetentionCache',
+    'OCI image indexes',
+    'remote-property-injection',
   ]) {
     assert.ok(changelog.includes(fragment), `CHANGELOG.md must include ${fragment}`);
-  }
-
-  for (const fragment of [
-    '`DD_PORTWING_POLL_INTERVAL`',
-    '`exec_end.reason`',
-    'normalize against configured registries',
-    '301, 302, 303, 307, or 308',
-    '4xx, 5xx, network, and non-object failures',
-  ]) {
     assert.ok(updates.includes(fragment), `updates page must include ${fragment}`);
   }
 });

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.7.0';
-const RC_VERSION = '1.7.0-rc.1';
+const RC_VERSION = '1.7.0-rc.2';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',

--- a/scripts/release-precut-check.test.mjs
+++ b/scripts/release-precut-check.test.mjs
@@ -348,7 +348,7 @@ test('cli exits 1 and reports pending discussion when strict RC check has an unc
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.1'],
+    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.2'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -365,7 +365,7 @@ test('cli exits 0 when --force is set even with pending replies', () => {
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', '--force', 'v1.7.0-rc.1'],
+    [scriptPath, '--tracker', trackerPath, '--strict', '--force', 'v1.7.0-rc.2'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -380,7 +380,7 @@ test('cli exits 0 with warning when tracker file does not exist', () => {
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.1'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.2'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -397,7 +397,7 @@ test('cli exits 0 for prerelease tags with pending replies (informational only)'
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.1'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.2'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -413,7 +413,7 @@ test('cli exits 1 for prerelease tags with --strict and pending replies', () => 
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.1'],
+    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.2'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -429,7 +429,7 @@ test('cli exits 0 and prints success when tracker has no pending replies', () =>
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.1'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.2'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',


### PR DESCRIPTION
Release-prep for v1.7.0-rc.2, mirroring the rc.1 prep shape. `npm run release:precheck -- v1.7.0-rc.2` exits 0.

- CHANGELOG: `[Unreleased]` rolled into `[1.7.0-rc.2] — 2026-08-20` with the compare-link chain extended. Covers the three breaking deprecation executions (HA MQTT topic-segment default, trigger include/exclude hard blockers, `DD_TRIGGER_*` removal), curl and `GET /api/auth/methods` removals, the #814/#808 update-check correctness fixes, the committed star-history chart, maintenance-cut release support, and the security items.
- Version stamps: README badge + rc.2 highlights across all seven READMEs (translation parity held), site-config/content, quickstart matrix, API doc examples, demo mocks, updates highlights.
- Release-identity/docs-identity/changelog test constants rolled to rc.2. No package.json changes: the 1.7.0 base is fixed for the whole rc line.

Verification: 166/166 script tests, 208/208 workflow tests, 66/66 web script tests, app/ui/web/demo builds clean.

After merge: sync dev/v1.7 → main, then dispatch `release-cut.yml --ref main -f release_tag=v1.7.0-rc.2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

✨ **Added**
- Added `v1.7.0-rc.2` release highlights to all README translations and site updates.
- Added release identity fixtures for `v1.7.0-rc.2`.
- Added updated API, quickstart, and demo release examples.

🔧 **Changed**
- Promoted `[Unreleased]` changelog content to `[1.7.0-rc.2]`.
- Extended changelog comparison links.
- Updated release references from `1.7.0-rc.1` to `1.7.0-rc.2` across documentation, site content, demo mocks, and tests.
- Kept `package.json` and lockfile versions at `1.7.0`.
- Updated release and translation test expectations.

🐛 **Fixed**
- Updated tests for update-check fixes, dependency fixes, security fixes, and release links.
- Confirmed `npm run release:precheck -- v1.7.0-rc.2` succeeds.
- Verified script, workflow, web, application, UI, and demo builds and tests.

⚠️ **Breaking**
- Documented rc.2 breaking changes in release highlights.

🔒 **Security**
- Documented rc.2 security fixes across release highlights and test fixtures.

## Concerns

- Sync `dev/v1.7` into `main` after merge.
- Dispatch `release-cut.yml` with `release_tag=v1.7.0-rc.2`.
- Confirm the August 20, 2026 release date is correct before promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->