### PR TITLE
fix(deps): revert e2e js-yaml override to v3 for artillery compatibility

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -2575,13 +2575,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/arrivals": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/arrivals/-/arrivals-2.1.2.tgz",
@@ -3001,6 +2994,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/artillery/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/artillery/node_modules/filtrex": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/filtrex/-/filtrex-2.2.3.tgz",
@@ -3021,6 +3024,20 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/artillery/node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/artillery/node_modules/playwright": {
@@ -5161,29 +5178,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
-      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.mjs"
-      }
-    },
     "node_modules/jsep": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
@@ -6591,6 +6585,13 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/sqs-consumer": {
       "version": "6.0.2",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -38,7 +38,7 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
-    "js-yaml": "5.3.0",
+    "js-yaml": "3.15.1",
     "fast-xml-parser": "5.10.1",
     "joi": "18.2.3",
     "minimatch": "10.2.6",

--- a/e2e/tests/artillery-startup.test.js
+++ b/e2e/tests/artillery-startup.test.js
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const { join } = require('node:path');
+const test = require('node:test');
+
+// The Artillery load-test jobs only run on main pushes and
+// workflow_dispatch, never on PRs, so a dependency change that breaks
+// Artillery at module load merges green and detonates after the fact
+// (js-yaml v5 override, main push run 32444352693). This runs on every
+// PR via test:support: parse the real CI scenario and execute one VU
+// against a dead target, which exercises Artillery's full startup path
+// including its YAML loader. ECONNREFUSED is the expected outcome; a
+// loader crash never reaches the phase log.
+test('artillery starts up and parses the ci load-test scenario', () => {
+  const scenario = join(__dirname, '../../test/test.yml');
+  const artillery = join(__dirname, '../node_modules/.bin/artillery');
+  const overrides = JSON.stringify({
+    config: { phases: [{ duration: 1, arrivalCount: 1 }] },
+  });
+
+  let output;
+  try {
+    output = execFileSync(
+      artillery,
+      ['run', scenario, '-e', 'ci', '--target', 'http://127.0.0.1:9', '--overrides', overrides],
+      { encoding: 'utf8', timeout: 120_000 },
+    );
+  } catch (error) {
+    // Artillery exits non-zero when VUs fail; the startup path still ran.
+    output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+
+  assert.doesNotMatch(output, /SyntaxError|Cannot find module|ERR_MODULE_NOT_FOUND/);
+  assert.match(output, /Phase started/);
+});

--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
       "enabled": false
     },
     {
-      "description": "js-yaml in e2e is a global npm override consumed by artillery's internals, which use a default import; js-yaml v5 is ESM-only with named exports, so a major bump breaks the Artillery load-test jobs at module load. Those jobs only run on main pushes and workflow_dispatch, never on PRs, so the break lands after merge (main push run 32444352693, 2026-08-21). Re-enable once artillery imports js-yaml by named export.",
+      "description": "js-yaml in e2e is a global npm override consumed by artillery's internals, which use a default import and safeLoad; js-yaml v4 removed safeLoad and v5 is ESM-only with named exports, so any major bump past 3.x breaks the Artillery load-test jobs at module load. Those jobs only run on main pushes and workflow_dispatch, never on PRs, so the break lands after merge (main push run 32444352693, 2026-08-21). e2e/tests/artillery-startup.test.js is the PR-time backstop. Re-enable once artillery migrates to the js-yaml v4+ API.",
       "matchPackageNames": ["js-yaml"],
       "matchFileNames": ["e2e/package.json"],
       "matchUpdateTypes": ["major"],

--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,13 @@
       "matchPackageNames": ["@babel/core"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "js-yaml in e2e is a global npm override consumed by artillery's internals, which use a default import; js-yaml v5 is ESM-only with named exports, so a major bump breaks the Artillery load-test jobs at module load. Those jobs only run on main pushes and workflow_dispatch, never on PRs, so the break lands after merge (main push run 32444352693, 2026-08-21). Re-enable once artillery imports js-yaml by named export.",
+      "matchPackageNames": ["js-yaml"],
+      "matchFileNames": ["e2e/package.json"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## What

The rc.2 release cut (run 32444361346) failed because main's push-triggered CI Verify run (32444352693) died in both Artillery load-test jobs:

```
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
```

#771 bumped the `js-yaml` npm **override** in `e2e/package.json` from 3.15.1 to 5.3.0. Overrides are global, so that forced ESM-only js-yaml 5 onto artillery's internals, which use a default import and `safeLoad` (both gone in v4+/v5). The load-test jobs only run on main pushes and workflow_dispatch, never on PRs, so #771 merged green and the break surfaced on the promotion push.

## Changes

- Revert the override to 3.15.1 (artillery's own range is `^3.15.1`).
- Renovate exception scoped to `e2e/package.json` only: no major js-yaml bumps until artillery adopts the v4+ API. apps/web stays on js-yaml 5, which its build handles fine.
- New PR-gating regression test `e2e/tests/artillery-startup.test.js` (runs in the Cucumber job's `test:support`): one VU of the real ci scenario against a dead target, exercising artillery's full startup path. Verified **red** on the js-yaml 5 override, **green** on v3.

## Verification

- `npx artillery run test/test.yml -e ci` with a 1-VU phase: parses and executes, only ECONNREFUSED from the dead target.
- Codex review: two findings, both addressed (regression test added; renovate description completed). Lockfile/scoping checks passed.

After merge: dispatch ci-verify.yml on dev/v1.7 (dispatch runs the load-test jobs) to confirm green, then re-promote to main and re-dispatch the rc.2 cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed Artillery compatibility by pinning `e2e/package.json` to `js-yaml` `3.15.1`.
- 🔧 Changed Renovate rules to block major `js-yaml` updates only for `e2e/package.json`.
- ✨ Added a regression test for Artillery startup and YAML loading.

## Concerns

- Confirm the new test is included in the PR-gating test command.
- Verify that the test asserts the expected Artillery phase log and rejects module-loading or syntax errors.
- Keep `apps/web` on `js-yaml` `5.x`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->