### PR TITLE
🔧 chore(release): roll release identity forward to v1.6.1-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Demo site favicon now matches the refreshed branding.** The v1.5.1 brand refresh (#439) moved the website to the cropped whale "headshot" icon and the app UI followed, but demo.getdrydock.com kept showing the old full-body whale: its stale `favicon.svg` — which modern browsers preferred over the PNGs — was never replaced. The demo now ships the same headshot icon set as the website and app UI, the `favicon.svg` is removed, and the icon links carry a `?v=2` cache-buster so browsers re-fetch instead of serving the aggressively cached old icon. (#689)
 
-## [1.6.1] — 2026-08-20
+## [1.6.1-rc.1] — 2026-08-21
 
 ### Fixed
 
@@ -2408,8 +2408,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1...HEAD
-[1.6.1]: https://github.com/CodesWhat/drydock/compare/v1.6.0...v1.6.1
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.1...HEAD
+[1.6.1-rc.1]: https://github.com/CodesWhat/drydock/compare/v1.6.0...v1.6.1-rc.1
 [1.6.0]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.13...v1.6.0
 [1.6.0-rc.13]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.12...v1.6.0-rc.13
 [1.6.0-rc.12]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.11...v1.6.0-rc.12

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.1-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,13 +179,13 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
-<summary><strong>v1.6.1 highlights</strong></summary>
+<summary><strong>v1.6.1-rc.1 highlights</strong></summary>
 
 - **Drydock no longer reports "Up to date" when an update check failed** — a registry error during digest verification now surfaces as an explicit unknown status instead of a false negative. ([#814](https://github.com/CodesWhat/drydock/issues/814), [#808](https://github.com/CodesWhat/drydock/issues/808))
 - **Nested OCI image indexes now resolve to the real image manifest** — images built with Buildx SBOM/provenance attestations no longer fail digest checks with `Unexpected error; no manifest found`. ([#814](https://github.com/CodesWhat/drydock/issues/814))
 - **A single malformed container no longer zeroes out an entire agent inventory sync** — per-container error isolation now matches the existing watcher-snapshot path. ([#802](https://github.com/CodesWhat/drydock/issues/802))
 
-Full release notes in [CHANGELOG.md](./CHANGELOG.md#161--2026-08-20).
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc1--2026-08-21).
 
 </details>
 

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1',
+    version: '1.6.1-rc.1',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1 started',
+    details: 'Drydock v1.6.1-rc.1 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.1',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1',
+    tag: '1.6.1-rc.1',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1',
+  version: '1.6.1-rc.1',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1',
+      version: '1.6.1-rc.1',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1', mode: 'demo' },
+        server: { version: '1.6.1-rc.1', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1",
+  version: "1.6.1-rc.1",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1",
+    version: "v1.6.1-rc.1",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1",
+      "version": "1.6.1-rc.1",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1",
+    "version": "1.6.1-rc.1",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1"
+  "version":"1.6.1-rc.1"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1",
+    "version": "1.6.1-rc.1",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1",
+      "drydockVersion": "1.6.1-rc.1",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,8 +108,8 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1` | Immutable exact GA release; best for reproducible deployments |
-| `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.0-rc.N` |
+| `1.6.1-rc.1` | Immutable release candidate; best for reproducible testing |
+| `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |
 | `latest` | Newest GA release; never points at a prerelease |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,13 +5,13 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
-## v1.6.1 Highlights — August 20, 2026
+## v1.6.1-rc.1 Highlights — August 21, 2026
 
 Three bug fixes: nested OCI image indexes (produced by Buildx SBOM/provenance
 attestations) now resolve to the real image manifest instead of failing digest
 checks; a failed update check no longer reports a container as falsely
 "Up to date"; and a single malformed container report no longer zeroes out an
-entire agent's inventory sync. See [CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161--2026-08-20)
+entire agent's inventory sync. See [CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc1--2026-08-21)
 for the full release notes.
 
 ## v1.6.0 Highlights — August 11, 2026

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -53,11 +53,11 @@ test('every linked changelog heading has exactly one link definition', () => {
   );
 });
 
-test('v1.6.1 GA, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
+test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1...HEAD`],
-    ['1.6.1', `${repositoryUrl}/compare/v1.6.0...v1.6.1`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.1...HEAD`],
+    ['1.6.1-rc.1', `${repositoryUrl}/compare/v1.6.0...v1.6.1-rc.1`],
     ['1.6.0', `${repositoryUrl}/compare/v1.6.0-rc.13...v1.6.0`],
     ['1.6.0-rc.13', `${repositoryUrl}/compare/v1.6.0-rc.12...v1.6.0-rc.13`],
     ['1.6.0-rc.12', `${repositoryUrl}/compare/v1.6.0-rc.11...v1.6.0-rc.12`],
@@ -153,24 +153,5 @@ test('real changelog exposes nonempty v1.6.0 GA release notes', () => {
     'Anonymous access fails closed',
   ]) {
     assert.ok(entry.includes(marker), `v1.6.0 GA notes must include: ${marker}`);
-  }
-});
-
-test('real changelog exposes nonempty v1.6.1 GA release notes', () => {
-  const entry = extractChangelogEntry(changelog, 'v1.6.1');
-
-  assert.match(entry, /^## \[1\.6\.1\] [–—-] \d{4}-\d{2}-\d{2}$/mu);
-  assert.match(entry, /^### Fixed$/mu);
-  // v1.6.1 is a direct patch cut straight to GA (no rc series to roll up), unlike
-  // v1.6.0/v1.5.2 above — the entry is the release notes verbatim, not a synthesis.
-  assert.doesNotMatch(entry, /^## \[1\.6\.0\]/mu);
-  assert.match(changelog, /^## \[1\.6\.0\]/mu);
-
-  for (const marker of [
-    'Drydock no longer reports "Up to date" when an update check failed',
-    'Nested OCI image indexes now resolve to the real image manifest',
-    'A single malformed container no longer zeroes out an entire agent inventory sync',
-  ]) {
-    assert.ok(entry.includes(marker), `v1.6.1 GA notes must include: ${marker}`);
   }
 });

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1';
+const RC_VERSION = '1.6.1-rc.1';
 const PREV_RC_VERSION = '1.6.0';
-const RC_DATE = '2026-08-20';
-const RC_DISPLAY_DATE = 'August 20, 2026';
+const RC_DATE = '2026-08-21';
+const RC_DISPLAY_DATE = 'August 21, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1';
+const RC_VERSION = '1.6.1-rc.1';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
The v1.6.1 maintenance cut (run 32455088508) failed on release-cut's GA gate: GA tags can only promote an existing `vX.Y.Z-rc.N` candidate (candidate_tag + candidate_digest + soak). There's no direct-GA path, so v1.6.1 ships as rc.1 first.

17-file identity roll mirroring the b98808e7 (rc.13) precedent: CHANGELOG section renamed `[1.6.1]` → `[1.6.1-rc.1]` (2026-08-21) with compare links rotated, README badge/highlights/anchor, demo mocks, site config/content, docs API pages, quickstart tag matrix (now correctly says "Immutable release candidate"), updates highlights, identity-test constants. package.json versions stay 1.6.1 (rc preps never touch them).

Verified: `release:precheck -- v1.6.1-rc.1` exit 0, scripts suites 141/141, apps/web scripts 57/57.

After merge: dispatch ci-verify + e2e-playwright on the new dev/v1.6 tip (CI evidence is per-SHA), then `release-cut.yml --ref main -f release_tag=v1.6.1-rc.1 -f source_ref=dev/v1.6`. rc.1 soaks alongside v1.7.0-rc.2 for a ~Aug 28 GA pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

### 🔧 Changed
- Rolled the release identity from `v1.6.1` to `v1.6.1-rc.1` across README, changelog, demo mocks, site content, API documentation, quickstart documentation, updates, and release tests.
- Updated changelog links, release dates, highlights, and comparison-link expectations for the RC release.
- Updated quickstart tags to use `1.6.1-rc.1` and `1.6.1-rc.N`.
- Kept `package.json` and `package-lock.json` at `1.6.1`.
- Verified `release:precheck -- v1.6.1-rc.1`, 141/141 script tests, and 57/57 web script tests.

### 🗑️ Removed
- Removed the v1.6.1 GA release-notes test and immutable GA quickstart tag entry.

## Concerns
- Run CI verification and Playwright workflows on the new `dev/v1.6` tip before dispatching the `v1.6.1-rc.1` release cut.
- Confirm that `1.6.1-rc.1` is the intended release identity in all generated or external release references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->