### PR TITLE
fix(e2e): raise flaky Playwright wait ceilings past the app's own budgets

### DIFF
--- a/.github/tests/e2e-playwright-workflow.test.ts
+++ b/.github/tests/e2e-playwright-workflow.test.ts
@@ -97,8 +97,8 @@ test('Playwright waits for one complete QA scan before browser tests and parks b
   expect(authSetup).toContain('/api/v1/containers?limit=100');
   expect(authSetup).not.toContain('/api/v1/containers/watch');
   expect(authSetup).toContain('page.request.get');
-  expect(authSetup).toContain('180_000');
-  expect(authSetup).toContain('setup.setTimeout(240_000)');
+  expect(authSetup).toContain('240_000');
+  expect(authSetup).toContain('setup.setTimeout(300_000)');
   expect(authSetup).toContain('Nginx (Hooked)');
   expect(authSetup).toContain("container.labels?.['dd.group'] === 'web-stack'");
   expect(authSetup).toContain('container.result');

--- a/e2e/playwright/auth.setup.ts
+++ b/e2e/playwright/auth.setup.ts
@@ -46,7 +46,20 @@ function hasCompleteQaFixtureSnapshot(payload: unknown): boolean {
   );
 }
 
-setup.setTimeout(240_000);
+// qa-compose.yml watches 31 containers (37 services minus unwatched infra
+// like dex, mosquitto, and trivy-server) across every registry provider the
+// suite exercises (docker hub, ghcr, mirror.gcr.io, ...). initWatcher() runs
+// one full scan across all of them at boot before the cron schedule takes
+// over (DD_WATCHER_LOCAL_CRON is parked at Feb 29 specifically so no second
+// scan can race this one) — there's no per-container event to hook, only the
+// aggregate snapshot this poll already checks for. Under CI load that
+// full-fleet scan can outrun a short ceiling even though nothing is actually
+// stuck: this is the exact race that flaked issue #832's fixture-snapshot
+// check on the rc.2 promotion run, which shares runner/network capacity with
+// whatever else is running during a release cut. 300s/240s (up from
+// 240s/180s) keeps the same 60s gap between the outer test timeout and the
+// poll ceiling for login + storageState overhead.
+setup.setTimeout(300_000);
 
 setup('authenticate', async ({ page, request, baseURL }) => {
   const availability = await checkServerAvailability(request, baseURL);
@@ -72,7 +85,7 @@ setup('authenticate', async ({ page, request, baseURL }) => {
       },
       {
         message: 'Drydock startup watcher scans did not produce the complete QA fixture snapshot',
-        timeout: 180_000,
+        timeout: 240_000,
         intervals: [2_000],
       },
     )

--- a/e2e/playwright/dashboard.spec.ts
+++ b/e2e/playwright/dashboard.spec.ts
@@ -106,7 +106,18 @@ test.describe('Dashboard', () => {
     // this test now polls the backend until the triggered update operation
     // reaches a terminal state, which involves a real image pull + container
     // recreate against the QA stack (issue #763).
-    test.setTimeout(90_000);
+    //
+    // 200s, not 90s: the operation walks queued -> pulling -> prepare ->
+    // ... -> health-gate -> succeeded (the security scan/SBOM phases are
+    // skipped here since qa-compose.yml leaves DD_SECURITY_SCANNER unset),
+    // and a container with a Docker HEALTHCHECK goes through
+    // waitForContainerHealthy(), whose own budget is
+    // NON_SELF_UPDATE_HEALTH_TIMEOUT_MS = 120_000ms
+    // (app/triggers/providers/docker/Docker.ts). The old 90s test timeout
+    // (60s poll + 15s in-flight wait) was already tighter than that single
+    // phase's allowed budget, so it raced the app's own state machine under
+    // CI load rather than a fixed image-pull duration (issue #832).
+    test.setTimeout(200_000);
 
     const widget = page.locator('[aria-label="Updates Available widget"]');
     const updateButtons = widget.locator('[data-test="dashboard-update-btn"]');
@@ -178,7 +189,11 @@ test.describe('Dashboard', () => {
         },
         {
           message: `update operation ${operationId} should reach a terminal status`,
-          timeout: 60_000,
+          // Must clear the app's own health-gate budget (120_000ms, see
+          // test.setTimeout comment above) plus room for pull/scan/hook
+          // phases ahead of it, or this poll times out before the operation
+          // it's watching is even allowed to fail.
+          timeout: 150_000,
         },
       )
       .toBe(true);


### PR DESCRIPTION
Fixes #832. Both flakes were waits budgeted tighter than the backend operations they cover, so under CI load the test raced the app's own state machine:

- **auth.setup.ts** fixture-snapshot poll: 180s ceiling vs one full startup scan across the 31 watched qa-compose containers. Now 240s poll / 300s setup timeout (same 60s buffer as before). This is the flake that failed the rc.2 promotion's main-push run and cost a cut cycle.
- **dashboard.spec.ts** terminal-status poll: 60s budget vs a pipeline whose health-gate phase alone is allowed `NON_SELF_UPDATE_HEALTH_TIMEOUT_MS` = 120s. Now 150s poll / 200s test timeout. (QA runs without the security scanner, so the scan/SBOM phases don't apply; the comment says so.)

Each number is justified inline from the app constant it must outlast, not padded blindly. The e2e-playwright-workflow guard test that pins the auth.setup constants is updated in the same commit (it correctly rejected the first push). Workflow-verified: an adversarial review pass caught two inaccurate justification comments (container count, phase narration), corrected here. `playwright test --list` parses all 34 tests; e2e lint clean; workflow tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed `auth.setup.ts`:
  - Increased fixture-snapshot polling from 180s to 240s.
  - Increased setup timeout from 240s to 300s.
  - Updated timeout rationale comments.
- 🔧 Changed `dashboard.spec.ts`:
  - Increased terminal-status polling from 60s to 150s.
  - Increased test timeout from 90s to 200s.
  - Updated timeout rationale comments.
- 🔧 Changed `.github/tests/e2e-playwright-workflow.test.ts`:
  - Updated expected authentication timeout constants.
- ✨ Added coverage for QA container startup scans and the 120s health-gate budget.

## Concerns

- Verify that the dashboard timeout change from 90s to 200s matches the intended 200s test budget.
- Confirm that timeout constants remain synchronized between `auth.setup.ts` and the workflow guard test.
- Confirm that all 34 Playwright tests parse, e2e lint passes, and workflow tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->