### PR TITLE
fix(security): fail-closed on ZAP warnings and zizmor skip

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -951,7 +951,6 @@ jobs:
           rules_file_name: .zap/rules.tsv
           allow_issue_writing: false
           fail_action: true
-          cmd_options: '-I'
 
       - name: Convert ZAP JSON report to SARIF
         if: always() && hashFiles('report_json.json') != ''

--- a/.github/workflows/security-dast-web.yml
+++ b/.github/workflows/security-dast-web.yml
@@ -60,7 +60,6 @@ jobs:
           rules_file_name: .zap/rules.tsv
           allow_issue_writing: false
           fail_action: true
-          cmd_options: '-I'
 
       - name: Convert ZAP JSON report to SARIF
         if: always() && hashFiles('report_json.json') != ''
@@ -339,7 +338,6 @@ jobs:
           rules_file_name: .zap/rules.tsv
           allow_issue_writing: false
           fail_action: true
-          cmd_options: '-I'
 
       - name: Convert ZAP JSON report to SARIF
         if: always() && hashFiles('report_json.json') != ''

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -153,10 +153,16 @@ pre-push:
       fail_text: "Docker QA build failed — fix Dockerfile before push"
 
     # ── Zizmor: GitHub Actions security scanner (blocking) ───────────
+    # Hard-fails with an install hint when the binary is missing, rather
+    # than skipping silently — a missing zizmor must not let a
+    # workflow-security regression through the gate unnoticed.
     zizmor:
       glob: '.github/workflows/*.yml'
-      run: zizmor .github/workflows/
-      skip:
-        - run: '! command -v zizmor >/dev/null 2>&1'
+      run: |
+        if ! command -v zizmor >/dev/null 2>&1; then
+          echo "zizmor not installed — install it (brew install zizmor) or the workflow-security gate cannot run" >&2
+          exit 1
+        fi
+        zizmor .github/workflows/
       priority: 14
       timeout: 30s


### PR DESCRIPTION
Two house-audit findings, both the same shape: a gate that silently passes when its tool doesn't run.

- Removed `cmd_options: '-I'` from all three ZAP jobs (ci-verify's dast-zap-baseline, security-dast-web's full scan and demo baseline). `-I` told ZAP to ignore warnings entirely, so the scans could never fail on findings. `.zap/rules.tsv` already exists for targeted suppressions (one IGNORE entry today), which is the right mechanism — suppress named findings, not the whole signal.
- Lefthook's pre-push zizmor step now fails with an install hint when the binary is missing instead of silently skipping. Same shape sockguard already uses.

Workflow tests: 208/208 pass. Ran the new zizmor command locally: no findings, exit 0. If ZAP surfaces real warnings on this PR's DAST runs, they're triaged as findings, not re-suppressed wholesale.