### PR TITLE
chore(audit): align qlty, renovate, coderabbit, and site badges with house shapes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -34,7 +34,7 @@ reviews:
   assess_linked_issues: true
   related_issues: true
   related_prs: true
-  suggested_labels: false
+  suggested_labels: true
   auto_apply_labels: true
   labeling_instructions:
     - label: "second-opinion"

--- a/apps/web/src/components/github-badges.tsx
+++ b/apps/web/src/components/github-badges.tsx
@@ -44,14 +44,24 @@ const quality: Badge[] = [
     alt: "OpenSSF Scorecard",
   },
   {
+    href: "https://www.bestpractices.dev/projects/11915",
+    src: "https://www.bestpractices.dev/projects/11915/badge",
+    alt: "OpenSSF Best Practices",
+  },
+  {
     href: "https://qlty.sh/gh/CodesWhat/projects/drydock",
-    src: "https://qlty.sh/gh/CodesWhat/projects/drydock/test_coverage.svg",
-    alt: "Test coverage",
+    src: "https://qlty.sh/gh/CodesWhat/projects/drydock/maintainability.svg",
+    alt: "Maintainability",
   },
   {
     href: `https://dashboard.stryker-mutator.io/reports/github.com/${REPO_SLUG}/main`,
     src: `https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2F${encodeURIComponent(REPO_SLUG)}%2Fmain`,
     alt: "Mutation score",
+  },
+  {
+    href: `https://codecov.io/gh/${REPO_SLUG}`,
+    src: `https://codecov.io/gh/${REPO_SLUG}/graph/badge.svg`,
+    alt: "Coverage",
   },
 ];
 

--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
       "groupSlug": "playwright"
     },
     {
-      "description": "@babel/core is only present as an unscoped override consumed by @stryker-mutator/instrumenter, which requires ~7.29.0 with matching 7.x sibling plugins; npm overrides are global, so a core@8 bump forces an unsupported mix under the instrumenter and breaks the monthly mutation-testing workflow. Re-enable once Stryker supports Babel 8.",
+      "description": "@babel/core is only present as an unscoped override consumed by @stryker-mutator/instrumenter, which requires ~7.29.0 with matching 7.x sibling plugins; npm overrides are global, so a core@8 bump forces an unsupported mix under the instrumenter and breaks the monthly mutation-testing workflow. Re-enable once Stryker supports Babel 8 (recorded 2026-08-13; re-check at each Stryker major).",
       "matchPackageNames": ["@babel/core"],
       "matchUpdateTypes": ["major"],
       "enabled": false


### PR DESCRIPTION
House-audit alignment batch, all config-level:

- `renovate.json`: dated the @babel/core major-block rule (recorded 2026-08-13; re-check at each Stryker major) so the exception carries its own recheck trigger.
- `.coderabbit.yaml`: `suggested_labels: false` with `auto_apply_labels: true` was a dead pair — auto-apply applies suggested labels, so labeling never fired and the second-opinion Greptile summon could only be triggered by hand. Now `true`/`true`, matching sockguard and careerrat.
- `apps/web/src/components/github-badges.tsx`: badge wall synced to the README's — retired qlty test_coverage badge replaced with maintainability, added OpenSSF Best Practices and Codecov, same order as the README.
- `.qlty/qlty.toml` needed nothing: the trivy plugin was already removed in 924bd1f6.

Workflow tests 208/208 green; no apps/web test references the badge component.