### PR TITLE
ci(starchart): dispatch the chart refresh from the release cut

### DIFF
--- a/.github/tests/release-cut-starchart-dispatch.test.ts
+++ b/.github/tests/release-cut-starchart-dispatch.test.ts
@@ -1,0 +1,80 @@
+import { fileURLToPath } from 'node:url';
+
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
+
+// starchart.yml's `release: types: [published]` trigger can never fire:
+// release-cut.yml creates the GitHub release with `GH_TOKEN: ${{ github.token
+// }}`, and GitHub suppresses workflow runs for events caused by GITHUB_TOKEN.
+// workflow_dispatch is one of the two documented exceptions (the other is
+// repository_dispatch), so release-cut.yml dispatches the refresh explicitly
+// after publishing the release. These tests pin that shape so a future edit
+// can't silently regress either half of the fix.
+const releaseCutPath = fileURLToPath(new URL('../workflows/release-cut.yml', import.meta.url));
+const starchartPath = fileURLToPath(new URL('../workflows/starchart.yml', import.meta.url));
+
+const DISPATCH_STEP_NAME = 'Dispatch starchart refresh';
+
+function releaseSteps(): WorkflowStep[] {
+  return loadWorkflow(releaseCutPath).jobs?.release?.steps ?? [];
+}
+
+function dispatchStep(): WorkflowStep | undefined {
+  return releaseSteps().find((step) => step.name === DISPATCH_STEP_NAME);
+}
+
+test('release-cut grants actions: write for the starchart dispatch', () => {
+  const permissions = loadWorkflow(releaseCutPath).jobs?.release?.permissions as
+    | Record<string, string>
+    | undefined;
+
+  expect(permissions?.actions).toBe('write');
+});
+
+test('release-cut dispatches the starchart refresh after publishing the release', () => {
+  const step = dispatchStep();
+  expect(step).toBeDefined();
+  expect(step?.env?.GH_TOKEN).toBe('${{ github.token }}');
+  expect(step?.env?.RELEASE_TAG).toBe('${{ steps.next.outputs.release_tag }}');
+
+  const run = step?.run ?? '';
+  expect(run).toContain('dev_branch="dev/v${minor}"');
+  expect(run).toContain('gh workflow run starchart.yml --ref "${dev_branch}"');
+  // No `|| true`: a failed dispatch has to redden the run so a human notices —
+  // the release itself has already published by this point.
+  expect(run).not.toContain('|| true');
+
+  const names = releaseSteps().map((step) => step.name);
+  const indexOf = (name: string) => {
+    const index = names.indexOf(name);
+    expect(index, `release-cut has no step named "${name}"`).toBeGreaterThanOrEqual(0);
+    return index;
+  };
+  expect(indexOf(DISPATCH_STEP_NAME)).toBeGreaterThan(indexOf('Publish GitHub Release'));
+  expect(indexOf(DISPATCH_STEP_NAME)).toBeLessThan(indexOf('Release summary'));
+});
+
+test('the starchart dispatch is skipped on a maintenance cut', () => {
+  // A maintenance dev/vX.Y branch doesn't carry starchart.yml (dispatching there
+  // would fail on a missing workflow and redden an otherwise-good maintenance GA),
+  // and a maintenance line never owns the published README anyway since GitHub
+  // renders main's, so a refresh there would update a page nobody sees.
+  const step = dispatchStep();
+  expect(step?.if).toBe("steps.source_ref.outputs.is_maintenance_cut != 'true'");
+});
+
+test('starchart.yml only accepts workflow_dispatch, not a release event', () => {
+  const on = loadWorkflow(starchartPath).on as
+    | { release?: unknown; workflow_dispatch?: unknown }
+    | undefined;
+
+  expect(on?.workflow_dispatch).toBeDefined();
+  expect(on?.release).toBeUndefined();
+});
+
+test('starchart.yml derives its target branch from the dispatch ref, not a hardcoded value', () => {
+  const job = loadWorkflow(starchartPath).jobs?.starchart as
+    | { with?: Record<string, unknown> }
+    | undefined;
+
+  expect(job?.with?.branch).toBe('${{ github.ref_name }}');
+});

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -67,7 +67,7 @@ jobs:
       packages: write      # ghcr push
       id-token: write      # cosign keyless signing
       attestations: write  # attest-build-provenance + OCI attestation storage
-      actions: read        # wait-for-successful-branch-ci queries workflow runs
+      actions: write       # wait-for-successful-branch-ci queries workflow runs; also dispatch starchart refresh (write implies read)
 
     steps:
       - name: Harden Runner
@@ -1504,6 +1504,31 @@ jobs:
               echo "::error::Release ${RELEASE_TAG} is still a draft after publish."
               exit 1
             fi
+
+      - name: Dispatch starchart refresh
+        if: steps.source_ref.outputs.is_maintenance_cut != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.next.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          # starchart.yml's release: published trigger can never fire: this job creates
+          # the release with GH_TOKEN (github.token), and GitHub suppresses workflow runs
+          # for events caused by GITHUB_TOKEN — the same suppression that keeps the
+          # pushed release tag above from re-triggering anything itself. workflow_dispatch
+          # is one of the two documented exceptions (repository_dispatch is the other),
+          # so the cut dispatches the chart refresh explicitly instead of relying on the
+          # release event.
+          #
+          # Mainline cuts only (see the `if:` above): a maintenance dev/vX.Y branch
+          # doesn't carry starchart.yml, so dispatching there would fail on a missing
+          # workflow and redden an otherwise-good maintenance GA; and a maintenance line
+          # never owns the published README anyway — GitHub renders main's README, and
+          # maintenance cuts never promote to main, so a chart refresh there would update
+          # a page nobody sees.
+          minor="$(printf '%s' "${RELEASE_TAG}" | sed -E 's/^v?([0-9]+)\.([0-9]+)\..*/\1.\2/')"
+          dev_branch="dev/v${minor}"
+          gh workflow run starchart.yml --ref "${dev_branch}"
 
       - name: Release summary
         env:

--- a/.github/workflows/starchart.yml
+++ b/.github/workflows/starchart.yml
@@ -5,17 +5,23 @@
 # route read a runtime credential that was never set in production and served a
 # placeholder at HTTP 200 forever, and the Warpchart embed that briefly
 # replaced it was reversed. A committed SVG cannot fail silently — stale is
-# visible in git, missing is a broken image. This caller regenerates the chart
-# when a release publishes, not on a cron: a committed artifact refreshed on a
-# schedule mutates underneath a tag, which is exactly what "main is the
-# released version" forbids. The shared workflow owns the generation logic and
-# now emits a light/dark pair so the README's <picture> block can follow
-# GitHub's theme toggle.
+# visible in git, missing is a broken image. The shared workflow owns the
+# generation logic and emits a light/dark pair so the README's <picture> block
+# can follow GitHub's theme toggle.
+#
+# Refreshed by the "Dispatch starchart refresh" step in release-cut.yml after
+# each release is published — tying the committed artifact to the release cut,
+# not wall-clock time, the way "main is the released version" requires. There
+# used to be a `release: types: [published]` trigger here too, but it was
+# removed: release-cut.yml creates releases with `GH_TOKEN: ${{ github.token
+# }}`, and GitHub suppresses workflow runs for events caused by GITHUB_TOKEN,
+# so that trigger could never fire. workflow_dispatch is one of the two
+# documented exceptions to that suppression (the other is
+# repository_dispatch), which is why release-cut.yml dispatches this workflow
+# explicitly instead of relying on the release event.
 name: Starchart Refresh
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions: {}
@@ -26,5 +32,12 @@ jobs:
       contents: write
     uses: CodesWhat/.github/.github/workflows/starchart-refresh.yml@a66a777304d657a90161a8859dbc0dfa7d5020f7  # main 2026-08-21
     with:
-      branch: dev/v1.7
+      # Only ever dispatched (see header) on the dev branch this cut is
+      # rotating the chart for — deriving branch from ref_name instead of a
+      # hardcoded dev/vX.Y kills a second rotate-at-branch-cut chore (renovate.json
+      # already has one). This is only safe because the release: trigger above
+      # is gone: on a release event, github.ref_name would have been the TAG
+      # name, not the dev branch, so removing that trigger and deriving the
+      # branch this way have to travel together.
+      branch: ${{ github.ref_name }}
       accent: "#49bcfb"


### PR DESCRIPTION
Fixes a dead trigger shipped in #844: `release: [published]` never fires here, because release-cut.yml creates releases with `github.token` and GitHub suppresses workflow runs for events caused by that credential. The chart would have looked correctly wired and silently never refreshed.

- release-cut.yml now dispatches the refresh explicitly after the release publishes. `workflow_dispatch` is one of the suppression's two documented exceptions, so `github.token` works and no new credential is involved. The step fails loud on purpose — the release is already out at that point, so a red run is the alarm, not a rollback. Maintenance cuts skip it: maintenance branches don't carry starchart.yml and never own the README anyone renders.
- starchart.yml drops the dead trigger and derives its branch input from `github.ref_name`, removing a rotate-at-branch-cut chore. The two changes travel together: with a release trigger present, `ref_name` would be the tag name.
- New guard test pins the step's placement, the maintenance skip, the `actions: write` permission, and the caller's trigger shape.

Workflow tests 213/213.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changelog

- ✨ Added explicit `workflow_dispatch` from `release-cut.yml` to refresh Starchart after release publication.
- 🔧 Changed release permissions to `actions: write`.
- 🔧 Derived the Starchart branch from `github.ref_name`.
- 🔧 Skipped Starchart dispatches for maintenance branches.
- 🐛 Propagated dispatch failures.
- 🗑️ Removed the unused `release: [published]` trigger from `starchart.yml`.
- ✨ Added regression tests for dispatch ordering, permissions, credentials, failure handling, maintenance skipping, and trigger configuration.
- ✅ Workflow tests pass: 213/213.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->