### PR TITLE
ci(deps): re-pin shared starchart and main-is-released workflows

### DIFF
--- a/.github/tests/reusable-ci-config.test.ts
+++ b/.github/tests/reusable-ci-config.test.ts
@@ -27,10 +27,10 @@ const goCiUses = `CodesWhat/.github/.github/workflows/go-ci.yml@${frozenGoCiSha}
 const frozenGreptileSummonSha = 'bbc181dc4d462f673dac2dff5f88a8408dd9c763';
 const greptileSummonUses = `CodesWhat/.github/.github/workflows/greptile-summon.yml@${frozenGreptileSummonSha}`;
 
-const frozenStarchartRefreshSha = 'a66a777304d657a90161a8859dbc0dfa7d5020f7';
+const frozenStarchartRefreshSha = '11004e42d7d19e86eb3b7777c467ec9522b784e1';
 const starchartRefreshUses = `CodesWhat/.github/.github/workflows/starchart-refresh.yml@${frozenStarchartRefreshSha}`;
 
-const frozenMainIsReleasedSha = 'a66a777304d657a90161a8859dbc0dfa7d5020f7';
+const frozenMainIsReleasedSha = '11004e42d7d19e86eb3b7777c467ec9522b784e1';
 const mainIsReleasedUses = `CodesWhat/.github/.github/workflows/main-is-released.yml@${frozenMainIsReleasedSha}`;
 
 const frozenReusableWorkflowUses = [

--- a/.github/workflows/main-is-released.yml
+++ b/.github/workflows/main-is-released.yml
@@ -27,4 +27,4 @@ jobs:
   released:
     permissions:
       contents: read
-    uses: CodesWhat/.github/.github/workflows/main-is-released.yml@a66a777304d657a90161a8859dbc0dfa7d5020f7  # main 2026-08-21
+    uses: CodesWhat/.github/.github/workflows/main-is-released.yml@11004e42d7d19e86eb3b7777c467ec9522b784e1  # main 2026-08-21

--- a/.github/workflows/starchart.yml
+++ b/.github/workflows/starchart.yml
@@ -30,7 +30,7 @@ jobs:
   starchart:
     permissions:
       contents: write
-    uses: CodesWhat/.github/.github/workflows/starchart-refresh.yml@a66a777304d657a90161a8859dbc0dfa7d5020f7  # main 2026-08-21
+    uses: CodesWhat/.github/.github/workflows/starchart-refresh.yml@11004e42d7d19e86eb3b7777c467ec9522b784e1  # main 2026-08-21
     with:
       # Only ever dispatched (see header) on the dev branch this cut is
       # rotating the chart for — deriving branch from ref_name instead of a


### PR DESCRIPTION
Moves both callers and the frozen-SHA guard constants from a66a7773 to 11004e42, the CodesWhat/.github main promoted this evening. Input surfaces verified byte-identical at the new SHA before pinning, so nothing but the pin moves.

What the new pin carries:
- starchart-refresh.yml's doc comment now documents the workflow_dispatch-from-the-cut trigger (the release: [published] one never fires for GITHUB_TOKEN-created releases — drydock's caller already adopted the dispatch model in #847).
- main-is-released.yml now requires a release-shaped version tag instead of any exact tag (a main sitting on `snapshot` used to pass), fixes prerelease detection, and retries with refetch so a scheduled run landing between a promotion merge and its tag push no longer reads as false drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed shared `starchart` and `main-is-released` workflow pins from `a66a7773` to `11004e42`.
- 🔧 Changed frozen-SHA guard constants to `11004e42`.
- ✨ Added `workflow_dispatch`-from-cut documentation to `starchart-refresh.yml`.
- 🐛 Fixed `main-is-released.yml` tag validation, prerelease detection, and promotion timing retries.

## Concerns

- Confirm workflow tests pass with the new pinned revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->