### PR TITLE
docs(readme): swap static badges for live shields endpoints

### DIFF
--- a/.github/tests/readme-translations.test.ts
+++ b/.github/tests/readme-translations.test.ts
@@ -163,7 +163,10 @@ const forbiddenSourceEnglishProse = [
 ];
 
 const requiredFragments = [
-  'version-1.7.0--rc.2-blue',
+  'img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases',
+  'img.shields.io/github/license/CodesWhat/drydock',
+  'img.shields.io/docker/pulls/codeswhat/drydock',
+  'img.shields.io/github/stars/CodesWhat/drydock',
   'https://www.bestpractices.dev/projects/11915',
   '`drydock.sid`',
   '`allowmetadata=true`',
@@ -203,7 +206,8 @@ describe.each(translatedReadmes)('%s', (readme) => {
   });
 
   test('does not retain superseded release or star-history markup', () => {
-    expect(content).not.toContain('version-1.6.0--rc.2-blue');
+    expect(content).not.toContain('img.shields.io/badge/version-');
+    expect(content).not.toContain('GHCR-150K%2B_pulls');
     expect(content).not.toContain('https://api.star-history.com/svg');
     expect(content).not.toContain('https://star-history.com/#');
   });

--- a/README.de.md
+++ b/README.de.md
@@ -14,9 +14,9 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases&label=release" alt="Release"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/CodesWhat/drydock" alt="License"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
@@ -25,7 +25,8 @@
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
-  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://hub.docker.com/r/codeswhat/drydock"><img src="https://img.shields.io/docker/pulls/codeswhat/drydock?logo=docker&logoColor=white&label=Docker+Hub" alt="Docker Hub pulls"></a>
+  <a href="https://github.com/CodesWhat/drydock/stargazers"><img src="https://img.shields.io/github/stars/CodesWhat/drydock?style=flat" alt="Stars"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
   <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>

--- a/README.es.md
+++ b/README.es.md
@@ -14,9 +14,9 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases&label=release" alt="Release"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/CodesWhat/drydock" alt="License"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
@@ -25,7 +25,8 @@
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
-  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://hub.docker.com/r/codeswhat/drydock"><img src="https://img.shields.io/docker/pulls/codeswhat/drydock?logo=docker&logoColor=white&label=Docker+Hub" alt="Docker Hub pulls"></a>
+  <a href="https://github.com/CodesWhat/drydock/stargazers"><img src="https://img.shields.io/github/stars/CodesWhat/drydock?style=flat" alt="Stars"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
   <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>

--- a/README.fr.md
+++ b/README.fr.md
@@ -14,9 +14,9 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases&label=release" alt="Release"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/CodesWhat/drydock" alt="License"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
@@ -25,7 +25,8 @@
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
-  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://hub.docker.com/r/codeswhat/drydock"><img src="https://img.shields.io/docker/pulls/codeswhat/drydock?logo=docker&logoColor=white&label=Docker+Hub" alt="Docker Hub pulls"></a>
+  <a href="https://github.com/CodesWhat/drydock/stargazers"><img src="https://img.shields.io/github/stars/CodesWhat/drydock?style=flat" alt="Stars"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
   <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases&label=release" alt="Release"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/CodesWhat/drydock" alt="License"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
@@ -26,7 +26,8 @@
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
-  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://hub.docker.com/r/codeswhat/drydock"><img src="https://img.shields.io/docker/pulls/codeswhat/drydock?logo=docker&logoColor=white&label=Docker+Hub" alt="Docker Hub pulls"></a>
+  <a href="https://github.com/CodesWhat/drydock/stargazers"><img src="https://img.shields.io/github/stars/CodesWhat/drydock?style=flat" alt="Stars"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
   <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>

--- a/README.pl.md
+++ b/README.pl.md
@@ -14,9 +14,9 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases&label=release" alt="Release"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/CodesWhat/drydock" alt="License"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
@@ -25,7 +25,8 @@
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
-  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://hub.docker.com/r/codeswhat/drydock"><img src="https://img.shields.io/docker/pulls/codeswhat/drydock?logo=docker&logoColor=white&label=Docker+Hub" alt="Docker Hub pulls"></a>
+  <a href="https://github.com/CodesWhat/drydock/stargazers"><img src="https://img.shields.io/github/stars/CodesWhat/drydock?style=flat" alt="Stars"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
   <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -14,9 +14,9 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases&label=release" alt="Release"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/CodesWhat/drydock" alt="License"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
@@ -25,7 +25,8 @@
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
-  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://hub.docker.com/r/codeswhat/drydock"><img src="https://img.shields.io/docker/pulls/codeswhat/drydock?logo=docker&logoColor=white&label=Docker+Hub" alt="Docker Hub pulls"></a>
+  <a href="https://github.com/CodesWhat/drydock/stargazers"><img src="https://img.shields.io/github/stars/CodesWhat/drydock?style=flat" alt="Stars"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
   <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,9 +14,9 @@
 
 </div>
 
-<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.7.0--rc.2-blue" alt="Version"></a>
+<p align="center"><a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases&label=release" alt="Release"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/CodesWhat/drydock" alt="License"></a>
   <br>
   <a href="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml"><img src="https://github.com/CodesWhat/drydock/actions/workflows/ci-verify.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/CodesWhat/drydock"><img src="https://img.shields.io/ossf-scorecard/github.com/CodesWhat/drydock?label=openssf+scorecard&style=flat" alt="OpenSSF Scorecard"></a>
@@ -25,7 +25,8 @@
   <a href="https://dashboard.stryker-mutator.io/reports/github.com/CodesWhat/drydock/main"><img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FCodesWhat%2Fdrydock%2Fmain" alt="Mutation testing"></a>
   <a href="https://codecov.io/gh/CodesWhat/drydock"><img src="https://codecov.io/gh/CodesWhat/drydock/graph/badge.svg" alt="Coverage"></a>
   <br>
-  <a href="https://github.com/CodesWhat/drydock/pkgs/container/drydock"><img src="https://img.shields.io/badge/GHCR-150K%2B_pulls-2ea44f?logo=github&logoColor=white" alt="GHCR pulls"></a>
+  <a href="https://hub.docker.com/r/codeswhat/drydock"><img src="https://img.shields.io/docker/pulls/codeswhat/drydock?logo=docker&logoColor=white&label=Docker+Hub" alt="Docker Hub pulls"></a>
+  <a href="https://github.com/CodesWhat/drydock/stargazers"><img src="https://img.shields.io/github/stars/CodesWhat/drydock?style=flat" alt="Stars"></a>
   <a href="https://github.com/veggiemonk/awesome-docker#container-management"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Docker"></a>
   <a href="https://crowdin.com/project/drydock"><img src="https://badges.crowdin.net/drydock/localized.svg" alt="Crowdin localization"></a>
   <a href="https://github.com/sponsors/CodesWhat"><img src="https://img.shields.io/badge/Sponsor-ea4aaa?logo=githubsponsors&logoColor=white" alt="Sponsor"></a>

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -55,7 +55,14 @@ test('public release surfaces identify the v1.7 release candidate', () => {
   const rcSuffixMatch = /^(.*-rc\.)(\d+)$/u.exec(RC_VERSION);
 
   // The README version badge reads live from shields' github/v/release endpoint,
-  // so there is no static badge string to assert against RC_VERSION.
+  // so there is no static badge string to assert against RC_VERSION — but the
+  // live badge itself must be present.
+  assert.ok(
+    readme.includes(
+      'https://img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases',
+    ),
+    'README must carry the live release badge',
+  );
   assert.match(readme, new RegExp(`v${escapedRcVersion} highlights`, 'u'));
   assert.match(siteConfig, new RegExp(`version: "${escapedRcVersion}"`, 'u'));
   assert.ok(updates.includes(`## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`));
@@ -215,7 +222,10 @@ test('v1.6.0 is released and public release routing advances to v1.7', () => {
 
 test('README reads the pull count live from Docker Hub instead of a typed figure', () => {
   const readme = read('README.md');
-  assert.match(readme, /img\.shields\.io\/docker\/pulls\/codeswhat\/drydock/u);
+  assert.ok(
+    readme.includes('https://img.shields.io/docker/pulls/codeswhat/drydock'),
+    'README must carry the live Docker Hub pulls badge',
+  );
   assert.doesNotMatch(readme, /GHCR-150K%2B_pulls/u);
 });
 

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -54,10 +54,8 @@ test('public release surfaces identify the v1.7 release candidate', () => {
   // constant — no shape-specific literal is hand-maintained, and no shape throws.
   const rcSuffixMatch = /^(.*-rc\.)(\d+)$/u.exec(RC_VERSION);
 
-  assert.match(
-    readme,
-    new RegExp(`version-${escapeRegExp(RC_VERSION.replaceAll('-', '--'))}-blue`, 'u'),
-  );
+  // The README version badge reads live from shields' github/v/release endpoint,
+  // so there is no static badge string to assert against RC_VERSION.
   assert.match(readme, new RegExp(`v${escapedRcVersion} highlights`, 'u'));
   assert.match(siteConfig, new RegExp(`version: "${escapedRcVersion}"`, 'u'));
   assert.ok(updates.includes(`## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`));
@@ -215,8 +213,10 @@ test('v1.6.0 is released and public release routing advances to v1.7', () => {
   }
 });
 
-test('README retains the published 150K+ pull count', () => {
-  assert.match(read('README.md'), /GHCR-150K%2B_pulls/u);
+test('README reads the pull count live from Docker Hub instead of a typed figure', () => {
+  const readme = read('README.md');
+  assert.match(readme, /img\.shields\.io\/docker\/pulls\/codeswhat\/drydock/u);
+  assert.doesNotMatch(readme, /GHCR-150K%2B_pulls/u);
 });
 
 test('current and archived docs prevent unsafe copy-paste configuration', () => {

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -56,10 +56,12 @@ test('public release surfaces identify the v1.7 release candidate', () => {
 
   // The README version badge reads live from shields' github/v/release endpoint,
   // so there is no static badge string to assert against RC_VERSION — but the
-  // live badge itself must be present.
+  // live badge itself must be present, compared as a whole URL rather than a
+  // substring so the scanner can't mistake this for URL sanitization.
+  const badgeUrls = [...readme.matchAll(/<img src="([^"]+)"/gu)].map((m) => m[1]);
   assert.ok(
-    readme.includes(
-      'https://img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases',
+    badgeUrls.includes(
+      'https://img.shields.io/github/v/release/CodesWhat/drydock?include_prereleases&label=release',
     ),
     'README must carry the live release badge',
   );
@@ -222,8 +224,11 @@ test('v1.6.0 is released and public release routing advances to v1.7', () => {
 
 test('README reads the pull count live from Docker Hub instead of a typed figure', () => {
   const readme = read('README.md');
+  const badgeUrls = [...readme.matchAll(/<img src="([^"]+)"/gu)].map((m) => m[1]);
   assert.ok(
-    readme.includes('https://img.shields.io/docker/pulls/codeswhat/drydock'),
+    badgeUrls.includes(
+      'https://img.shields.io/docker/pulls/codeswhat/drydock?logo=docker&logoColor=white&label=Docker+Hub',
+    ),
     'README must carry the live Docker Hub pulls badge',
   );
   assert.doesNotMatch(readme, /GHCR-150K%2B_pulls/u);

--- a/scripts/release-precut-check.mjs
+++ b/scripts/release-precut-check.mjs
@@ -77,14 +77,10 @@ export function validateReleaseMetadata(root, tag) {
     problems.push(`CHANGELOG.md has no non-empty [${version}] entry`);
   }
 
+  // README version badges read live from shields' github/v/release endpoint,
+  // so there is no static badge string to bump or validate per cut.
   const publicChecks = [
-    ['README.md', [`version-${version.replaceAll('-', '--')}-blue`, `v${version} highlights`]],
-    ['README.de.md', [`version-${version.replaceAll('-', '--')}-blue`]],
-    ['README.es.md', [`version-${version.replaceAll('-', '--')}-blue`]],
-    ['README.fr.md', [`version-${version.replaceAll('-', '--')}-blue`]],
-    ['README.pl.md', [`version-${version.replaceAll('-', '--')}-blue`]],
-    ['README.pt-BR.md', [`version-${version.replaceAll('-', '--')}-blue`]],
-    ['README.zh-CN.md', [`version-${version.replaceAll('-', '--')}-blue`]],
+    ['README.md', [`v${version} highlights`]],
     ['apps/web/src/lib/site-config.ts', [`version: "${version}"`]],
     [
       'apps/web/scripts/docs-versions.mjs',

--- a/scripts/release-precut-check.test.mjs
+++ b/scripts/release-precut-check.test.mjs
@@ -129,13 +129,7 @@ function makeReleaseFixture(overrides = {}) {
     'apps/demo/package-lock.json': '{"version":"1.7.0","packages":{"":{"version":"1.7.0"}}}',
     'CHANGELOG.md':
       '# Changelog\n\n## [Unreleased]\n\n## [1.7.0-rc.1] — 2026-08-13\n\n### Added\n\n- release work\n',
-    'README.md': 'version-1.7.0--rc.1-blue\nv1.7.0-rc.1 highlights\n',
-    'README.de.md': 'version-1.7.0--rc.1-blue\n',
-    'README.es.md': 'version-1.7.0--rc.1-blue\n',
-    'README.fr.md': 'version-1.7.0--rc.1-blue\n',
-    'README.pl.md': 'version-1.7.0--rc.1-blue\n',
-    'README.pt-BR.md': 'version-1.7.0--rc.1-blue\n',
-    'README.zh-CN.md': 'version-1.7.0--rc.1-blue\n',
+    'README.md': 'v1.7.0-rc.1 highlights\n',
     'apps/web/scripts/docs-versions.mjs': '{ slug: "v1.7", source: "current", title: "v1.7" }',
     'apps/web/src/lib/site-config.ts': 'version: "1.7.0-rc.1"',
     'content/docs/current/updates/index.mdx':
@@ -163,13 +157,7 @@ test('release metadata validation accepts the GA quickstart label for a stable t
   const root = makeReleaseFixture({
     'CHANGELOG.md':
       '# Changelog\n\n## [Unreleased]\n\n## [1.7.0] — 2026-08-13\n\n### Added\n\n- release work\n',
-    'README.md': 'version-1.7.0-blue\nv1.7.0 highlights\n',
-    'README.de.md': 'version-1.7.0-blue\n',
-    'README.es.md': 'version-1.7.0-blue\n',
-    'README.fr.md': 'version-1.7.0-blue\n',
-    'README.pl.md': 'version-1.7.0-blue\n',
-    'README.pt-BR.md': 'version-1.7.0-blue\n',
-    'README.zh-CN.md': 'version-1.7.0-blue\n',
+    'README.md': 'v1.7.0 highlights\n',
     'apps/web/src/lib/site-config.ts': 'version: "1.7.0"',
     'content/docs/current/updates/index.mdx':
       '## Unreleased\n\n## v1.7.0 Highlights — August 13, 2026\n',
@@ -208,18 +196,10 @@ test('release metadata validation rejects a stale lockfile workspace version', (
   );
 });
 
-test('release metadata validation rejects a stale translated README badge', () => {
-  const root = makeReleaseFixture({ 'README.fr.md': 'version-1.6.0-blue\n' });
-  assert.throws(
-    () => releasePrecheck.validateReleaseMetadata(root, 'v1.7.0-rc.1'),
-    /README\.fr\.md is missing version-1\.7\.0--rc\.1-blue/u,
-  );
-});
-
 test('release metadata validation rejects missing exact changelog and public RC identity', () => {
   const root = makeReleaseFixture({
     'CHANGELOG.md': '# Changelog\n\n## [Unreleased]\n',
-    'README.md': 'version-1.6.0-blue\nv1.6.0 highlights\n',
+    'README.md': 'v1.6.0 highlights\n',
   });
   assert.throws(
     () => releasePrecheck.validateReleaseMetadata(root, 'v1.7.0-rc.1'),


### PR DESCRIPTION
New house rule (ops standards/readme-shape.md): a badge may be static only when the fact changes when we change it. Version, license, pull count, and stars all change without anyone touching the repo, so they now read live in the English README and all six translations:

- version badge -> `github/v/release` with `include_prereleases`, renders v1.7.0-rc.2 today, and stops being a thing to remember at every cut
- license badge -> `github/license`, renders AGPL-3.0
- typed "GHCR 150K+ pulls" -> live Docker Hub pulls. GitHub Packages publishes no public pull count so shields has no GHCR endpoint; Docker Hub does (renders 211k), and sockguard already reads it live. A typed count only ever gets more wrong.
- new stars badge (`github/stars`, renders 239), matching sockguard's styling. drydock was the only repo in the org with real social proof not showing it.

The release tooling asserted the static version badge in all seven READMEs, so it changes with the swap: `release-precut-check.mjs` drops the badge checks (a live badge can't drift, nothing to bump per cut), and the precut fixtures, docs-identity, and readme-translations tests now require the live endpoints and reject the retired static/typed forms. All rendered badge text verified by fetching the shields SVGs, and the full pre-push gate passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added live Shields.io badges for GitHub releases, license, Docker Hub pulls, and GitHub stars in the English README and six translations.
- 🔧 Updated release and translation tests to require exact live badge URLs.
- 🔧 Simplified release metadata validation to check release highlights instead of static README version badges.
- 🗑️ Removed static version badges, typed GHCR pull-count badges, obsolete fixtures, and stale-badge test coverage.

## Concerns

- Confirm all README badge URLs use consistent repository and Docker image identifiers.
- Verify translated README tests cover every supported translation.
- Run release and README validation tests after the endpoint changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->