### PR TITLE
feat(portwing-ws): negotiate non-JSON edge response bodies via base64

### DIFF
--- a/app/agent/AgentClient.test.ts
+++ b/app/agent/AgentClient.test.ts
@@ -8874,6 +8874,46 @@ describe('AgentClient', () => {
       expect(text).toEqual({ statusCode: 200, headers: {}, body: Buffer.from('plain-text') });
     });
 
+    // edge-response-body-b64: when the capability is negotiated, portwing sends
+    // the raw response bytes as standard base64 in `bodyBase64` and omits the
+    // legacy `body` field. This lets a non-JSON Docker response (e.g. the
+    // literal "OK" from /_ping) survive the tunnel without breaking JSON
+    // framing. Reverting the bodyBase64 check in AgentClient's decode would
+    // make this fail because normalizeDockerProxyBody(record.body) would run
+    // on `undefined` and return an empty buffer instead of "OK".
+    test('edge mode decodes bodyBase64 to the exact original non-JSON bytes', async () => {
+      const sendRequest = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        headers: { 'content-type': 'text/plain' },
+        bodyBase64: Buffer.from('OK').toString('base64'),
+      });
+      client.edgeAdapter = { sendRequest, sendStreamRequest: vi.fn() } as never;
+
+      const response = await client.requestDockerApi('GET', '/_ping');
+
+      expect(response.body).toEqual(Buffer.from('OK'));
+      expect(response.body.toString()).toBe('OK');
+    });
+
+    // Regression guard: a legacy response frame (no bodyBase64, negotiated or
+    // not) must keep decoding a bare `body` string as literal UTF-8 bytes,
+    // exactly as before this feature. If normalizeDockerProxyBody's
+    // bare-string handling ever changed, or the new bodyBase64 check
+    // accidentally consumed the legacy path, this would fail.
+    test('edge mode still decodes a legacy bare-string body as literal bytes when bodyBase64 is absent', async () => {
+      const sendRequest = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        headers: { 'content-type': 'text/plain' },
+        body: 'OK',
+      });
+      client.edgeAdapter = { sendRequest, sendStreamRequest: vi.fn() } as never;
+
+      const response = await client.requestDockerApi('GET', '/_ping');
+
+      expect(response.body).toEqual(Buffer.from('OK'));
+      expect(response.body.toString()).toBe('OK');
+    });
+
     test.each([
       ['null response', null],
       ['primitive response', 'invalid'],

--- a/app/agent/AgentClient.ts
+++ b/app/agent/AgentClient.ts
@@ -148,6 +148,20 @@ function normalizeDockerProxyBody(body: unknown): Buffer {
   return Buffer.from(JSON.stringify(body));
 }
 
+// Decodes a Docker API proxy response body from an edge agent response frame.
+// When the edge-response-body-b64 capability was negotiated for the
+// connection, the agent carries the raw response bytes as standard base64 in
+// `bodyBase64` (e.g. so a non-JSON body like the literal "OK" from /_ping
+// survives the tunnel). If `bodyBase64` is absent, this falls through to the
+// existing legacy `body` handling unchanged — a bare string there still means
+// literal UTF-8 bytes, exactly as before.
+function decodeDockerProxyResponseBody(record: Record<string, unknown>): Buffer {
+  if (typeof record.bodyBase64 === 'string') {
+    return Buffer.from(record.bodyBase64, 'base64');
+  }
+  return normalizeDockerProxyBody(record.body);
+}
+
 function normalizeDockerProxyHeaders(headers: unknown): Record<string, string> {
   if (!headers || typeof headers !== 'object' || Array.isArray(headers)) {
     return {};
@@ -572,7 +586,7 @@ export class AgentClient {
       return {
         statusCode: Number(record.statusCode),
         headers: normalizeDockerProxyHeaders(record.headers),
-        body: normalizeDockerProxyBody(record.body),
+        body: decodeDockerProxyResponseBody(record),
       };
     }
 

--- a/app/api/portwing-ws.test.ts
+++ b/app/api/portwing-ws.test.ts
@@ -973,6 +973,89 @@ describe('hello verification — happy path', () => {
     expect(welcome.data.config.supportedProtocols).toBe('portwing/1.0');
   });
 
+  // edge-response-body-b64: the welcome frame must advertise this exact
+  // capability token so a new portwing agent knows it can send a non-JSON
+  // response body as base64. If the token is dropped, renamed, or the
+  // `capabilities` field removed from welcome, portwing silently falls back
+  // to the legacy body path forever on this controller — this test fails if
+  // that additive field regresses.
+  test('welcome advertises the edge-response-body-b64 capability', async () => {
+    const { privateKey, pubkeyBase64, keyId } = generateKeyPair();
+    const ts = Math.floor(Date.now() / 1000);
+    const nonce = 'f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
+    const sig = signHello(privateKey, ts, nonce);
+
+    const record: AgentKeyRecord = {
+      keyId,
+      pubkey: pubkeyBase64,
+      label: 'test',
+      createdAt: new Date().toISOString(),
+      revokedAt: null,
+    };
+
+    const { gateway, getUpgradedWs } = createGateway(record);
+    gateway.handleUpgrade(
+      createRequest('/api/portwing/ws'),
+      createMockSocket() as unknown as Socket,
+      Buffer.alloc(0),
+    );
+    const ws = getUpgradedWs()!;
+
+    sendMessageToGateway(ws, buildHello(keyId, ts, nonce, sig));
+    await vi.waitFor(() => {
+      expect(ws.sentMessages.length).toBeGreaterThan(0);
+    });
+
+    const welcome = JSON.parse(ws.sentMessages[0]) as {
+      type: string;
+      data: { capabilities: string[] };
+    };
+    expect(welcome.type).toBe('welcome');
+    expect(welcome.data.capabilities).toContain('edge-response-body-b64');
+  });
+
+  // A hello frame from an old portwing agent has no `capabilities` field at
+  // all (it predates the field being read on this side). The handshake must
+  // still complete with a welcome — no protocol-mismatch, no compat
+  // regression — since this is an additive, capability-gated negotiation,
+  // not a protocol version bump.
+  test('an old-shaped hello with no capabilities field still completes the handshake', async () => {
+    const { privateKey, pubkeyBase64, keyId } = generateKeyPair();
+    const ts = Math.floor(Date.now() / 1000);
+    const nonce = 'f2b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6';
+    const sig = signHello(privateKey, ts, nonce);
+
+    const record: AgentKeyRecord = {
+      keyId,
+      pubkey: pubkeyBase64,
+      label: 'test',
+      createdAt: new Date().toISOString(),
+      revokedAt: null,
+    };
+
+    const { gateway, getUpgradedWs } = createGateway(record);
+    gateway.handleUpgrade(
+      createRequest('/api/portwing/ws'),
+      createMockSocket() as unknown as Socket,
+      Buffer.alloc(0),
+    );
+    const ws = getUpgradedWs()!;
+
+    // capabilities: undefined drops the key entirely on JSON.stringify,
+    // reproducing the exact shape of a pre-capabilities hello frame.
+    sendMessageToGateway(ws, buildHello(keyId, ts, nonce, sig, { capabilities: undefined }));
+    await vi.waitFor(() => {
+      expect(ws.sentMessages.length).toBeGreaterThan(0);
+    });
+
+    const welcome = JSON.parse(ws.sentMessages[0]) as {
+      type: string;
+      data: { capabilities: string[] };
+    };
+    expect(welcome.type).toBe('welcome');
+    expect(welcome.data.capabilities).toContain('edge-response-body-b64');
+  });
+
   test('uses the controller-configured poll interval in the welcome and agent metadata', async () => {
     mockGetPortwingPollInterval.mockReturnValueOnce(5);
     const { privateKey, pubkeyBase64, keyId } = generateKeyPair();

--- a/app/api/portwing-ws.ts
+++ b/app/api/portwing-ws.ts
@@ -43,6 +43,18 @@ export const PORTWING_WS_ROUTE_PATTERN = /^\/api(?:\/v1)?\/portwing\/ws$/;
 
 const PROTOCOL_STRING = 'portwing/1.0';
 const SERVER_COMPAT_LEVEL = '1.4.0';
+// Capability tokens this controller advertises in the welcome frame's
+// `capabilities` array. Additive and capability-gated — NOT a protocol
+// version bump — so an agent that doesn't recognize a token simply ignores
+// it and keeps today's behavior. Exact string, byte-for-byte match required
+// on the agent side; see portwing's edge tunnel wire contract.
+//
+// edge-response-body-b64: this controller decodes a response frame's
+// `bodyBase64` field (standard base64) when present, letting the agent carry
+// a non-JSON Docker response body (e.g. a bare "OK" from /_ping) across the
+// tunnel without breaking JSON framing.
+const EDGE_RESPONSE_BODY_B64_CAPABILITY = 'edge-response-body-b64';
+const WELCOME_CAPABILITIES: readonly string[] = [EDGE_RESPONSE_BODY_B64_CAPABILITY];
 const HELLO_TIMEOUT_MS = 30_000;
 const NONCE_PATTERN = /^[0-9a-f]{32}$/;
 // Key IDs are hex(SHA-256(raw32Bytes)[:8]) → exactly 16 lowercase hex chars.
@@ -807,6 +819,7 @@ async function processHello(
         supportedProtocols: PROTOCOL_STRING,
         serverCompatLevel: SERVER_COMPAT_LEVEL,
       },
+      capabilities: WELCOME_CAPABILITIES,
     },
   };
   try {


### PR DESCRIPTION
The drydock (controller) half of a coordinated edge-protocol change with portwing (agent PR: CodesWhat/portwing #206). Fixes the audit finding that a non-JSON Docker response body (e.g. `GET /_ping`'s "OK") can't cross the edge tunnel.

## How (additive, capability-gated, no protocol-version bump)
- `app/api/portwing-ws.ts`: the welcome frame now advertises a `capabilities` array including the exact token `edge-response-body-b64`. No `ProtocolString`/`SERVER_COMPAT_LEVEL` change.
- `app/agent/AgentClient.ts`: response decode checks `record.bodyBase64` first (`Buffer.from(bodyBase64, 'base64')`); absent, it falls through to the existing `normalizeDockerProxyBody(record.body)` path unchanged, so legacy agents are unaffected.

Portwing only emits `bodyBase64` when it sees this capability in the welcome, so an old agent + new controller (and new agent + old controller) both keep exactly today's behavior.

Full app suite green (13086 tests, 100%), tsc and biome clean; each new test verified to fail on revert. Does not touch `main` or the v1.7.0-rc line, and does not implement request-body streaming (tracked separately on portwing as issue #205).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added `edge-response-body-b64` to the WebSocket welcome capabilities.
- ✨ Added standard Base64 decoding for `bodyBase64` responses in `AgentClient`.
- 🔧 Preserved legacy bare-string `body` decoding when `bodyBase64` is absent.
- 🐛 Added tests for Docker non-JSON responses and older hello messages without `capabilities`.
- ⚠️ No protocol version changes. Request-body streaming remains unsupported.

## Concerns

- Verify controller and agent capability negotiation remains compatible with mixed-version deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->