### PR TITLE
ci(security): suppress the two accepted ZAP baseline alerts

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,1 +1,3 @@
 10049	IGNORE	Storable and Cacheable Content (informational) - content-hashed static assets are intentionally cacheable
+10055	IGNORE	CSP style-src unsafe-inline - accepted: vendor libraries (iconify-icon, Vue Transition) set element.style programmatically; documented in the CSP directives in app/api/index.ts. Stays visible in code scanning (not in IGNORED_ZAP_PLUGIN_IDS).
+10109	IGNORE	Modern Web Application (informational) - SPA detection notice, not a finding; recurs on every scan.

--- a/scripts/zap-json-to-sarif.mjs
+++ b/scripts/zap-json-to-sarif.mjs
@@ -12,8 +12,12 @@ const ZAP_INFORMATION_URI = 'https://www.zaproxy.org/';
 // fires on every content-hashed static asset (e.g. /assets/*-<hash>.js).
 // Those assets are immutable and intentionally cacheable and hold no
 // sensitive data, so the alert is a false positive that otherwise recurs
-// under a new hash on every build.
-export const IGNORED_ZAP_PLUGIN_IDS = new Set(['10049']);
+// under a new hash on every build. 10109 ("Modern Web Application") is a
+// pure SPA-detection notice, not a finding, and recurs on every scan.
+// Accepted real risks (e.g. 10055 CSP style-src unsafe-inline) stay OUT of
+// this set so they remain visible in code scanning; they are gate-suppressed
+// in .zap/rules.tsv instead.
+export const IGNORED_ZAP_PLUGIN_IDS = new Set(['10049', '10109']);
 
 function asArray(value) {
   if (Array.isArray(value)) {

--- a/scripts/zap-json-to-sarif.test.mjs
+++ b/scripts/zap-json-to-sarif.test.mjs
@@ -275,6 +275,39 @@ describe('zap-json-to-sarif', () => {
     assert.ok(IGNORED_ZAP_PLUGIN_IDS.has('10049'));
   });
 
+  test('IGNORED_ZAP_PLUGIN_IDS contains plugin 10109', () => {
+    assert.ok(IGNORED_ZAP_PLUGIN_IDS.has('10109'));
+  });
+
+  test('keeps plugin 10055 out of IGNORED_ZAP_PLUGIN_IDS so the accepted risk stays visible', () => {
+    assert.ok(!IGNORED_ZAP_PLUGIN_IDS.has('10055'));
+  });
+
+  test('drops plugin 10109 alerts from rules and results entirely', () => {
+    const sarif = convertZapJsonToSarif({
+      site: [
+        {
+          '@name': 'http://localhost:3333',
+          alerts: [
+            {
+              pluginid: '10109',
+              alertRef: '10109',
+              alert: 'Modern Web Application',
+              name: 'Modern Web Application',
+              riskcode: '0',
+              instances: [{ uri: 'http://localhost:3333/', method: 'GET' }],
+            },
+          ],
+        },
+      ],
+    });
+    assert.ok(
+      !sarif.runs[0].tool.driver.rules.some((r) => r.id.startsWith('10109')),
+      'rule 10109 must be excluded',
+    );
+    assert.equal(sarif.runs[0].results.length, 0);
+  });
+
   test('drops plugin 10049 alerts from rules and results entirely', () => {
     const sarif = convertZapJsonToSarif({
       site: [


### PR DESCRIPTION
The first main push after #842's fail-closed change surfaced the two warnings `-I` had been swallowing, failing CI Verify on main (run 32647734823) and aborting the v1.7.0-rc.3 release cut (run 32647743423).

- **10055 CSP style-src unsafe-inline** — accepted risk, documented in the CSP directives in `app/api/index.ts`: iconify-icon and Vue Transition set `element.style` programmatically. Gate-suppressed in `.zap/rules.tsv`, deliberately kept visible in code scanning (not added to `IGNORED_ZAP_PLUGIN_IDS`).
- **10109 Modern Web Application** — informational SPA-detection notice, not a finding. Suppressed in `rules.tsv` and dropped from the SARIF surface alongside 10049.

This is the suppress-named-findings mechanism #842 itself prescribed. Tests cover the new set membership and the 10109 SARIF drop; the existing test already pins that 10055 stays in SARIF output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added tests for ZAP plugin IDs `10109` and `10055`.
- 🔧 Changed SARIF generation to ignore plugin `10109`.
- 🐛 Fixed SARIF output for accepted ZAP alerts.
- 🔒 Preserved visibility of plugin `10055` in code scanning.

## Concerns

- Confirm `.zap/rules.tsv` suppresses plugins `10055` and `10109`.
- Confirm `app/api/index.ts` documents the `10055` risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->