### PR TITLE
fix(security): let upload-sarif set the ZAP SARIF category

### DIFF
--- a/scripts/zap-json-to-sarif.mjs
+++ b/scripts/zap-json-to-sarif.mjs
@@ -274,9 +274,6 @@ export function convertZapJsonToSarif(zapReport) {
             rules: [...ruleMap.values()],
           },
         },
-        automationDetails: {
-          id: 'zap-baseline',
-        },
         ...(originalUriBaseIds ? { originalUriBaseIds } : {}),
         results: cleanResults,
       },

--- a/scripts/zap-json-to-sarif.test.mjs
+++ b/scripts/zap-json-to-sarif.test.mjs
@@ -90,6 +90,14 @@ describe('zap-json-to-sarif', () => {
       TARGET: { uri: 'http://localhost:3333/' },
     });
     assert.match(sarif.runs[0].results[0].message.text, /Evidence:/);
+    // automationDetails.id must stay absent so upload-sarif's `category:` input
+    // is the only thing that sets the run's code-scanning category. GitHub
+    // derives the category from runAutomationDetails.id up to the final slash
+    // and does not let `category:` override an id already present in the
+    // SARIF, so a hardcoded slashless id here collapses every ZAP scan
+    // (app baseline, zap-web-getdrydock, zap-web-demo-baseline) into one
+    // empty-category configuration that clobbers the others' alerts.
+    assert.equal('automationDetails' in sarif.runs[0], false);
   });
 
   test('maps non-medium ZAP risk codes to SARIF levels and security severities', () => {


### PR DESCRIPTION
The ZAP JSON-to-SARIF converter hardcoded `automationDetails.id` to `zap-baseline` on every run it produced. GitHub derives the code-scanning category from `runAutomationDetails.id` up to the final slash, and the upload-sarif action's `category:` input doesn't override an id already present in the SARIF. With a slashless id the derived category is empty, so all three ZAP scans (ci-verify's app baseline, security-dast-web's getdrydock and demo scans) collapsed into one empty-category configuration and clobbered each other's alerts. This is half of the 'Code scanning configuration error' banner; the other half is the retired zizmor configuration, being cleared by analysis deletion.

Fix: drop the hardcoded `automationDetails` block so each workflow's own `category:` input takes effect, and pin the regression with a test asserting the field stays absent.

Verified: `node --test scripts/zap-json-to-sarif.test.mjs` 17/17 (the new assertion was confirmed red against the unfixed converter first), `npm run test:workflows` 213/213, biome clean, full pre-push gate green.

After this lands and each scan next runs, the three named categories appear and the stale empty-category configuration can be deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🗑️ Removed hardcoded `automationDetails` from the ZAP JSON-to-SARIF converter.
- ✨ Added a regression test to verify that converted SARIF runs omit `automationDetails`.
- 🐛 Fixed category collisions caused by ZAP scans using one empty-category configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->