### PR TITLE
fix(api): trust proxy headers over local socket TLS state in websocket origin check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **WebSocket log-stream connections behind a TLS-terminating proxy no longer 403 when `X-Forwarded-Proto` is absent.** With trust proxy enabled, `isOriginAllowed` fell back to the local socket's `encrypted` flag whenever the proxy omitted `X-Forwarded-Proto`, which is plain HTTP on a backend behind TLS termination, so a browser's `https://` Origin never matched and every WebSocket upgrade was rejected while REST traffic worked fine. The protocol is now treated as unknown (and skipped from the comparison) in that case instead of being inferred from the local socket; host validation is unaffected. ([#867](https://github.com/CodesWhat/drydock/issues/867))
+
 ## [1.7.0-rc.3] — 2026-08-23
 
 ### Added

--- a/app/api/ws-upgrade-utils.test.ts
+++ b/app/api/ws-upgrade-utils.test.ts
@@ -1,3 +1,18 @@
+// Hoisted so tests can assert on log calls — the module-level `log` in
+// ws-upgrade-utils.ts is `logger.child(...)`, called once at import time, so
+// it always returns this same singleton.
+const mockLogChild = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+vi.mock('../log/index.js', () => ({
+  default: {
+    child: vi.fn(() => mockLogChild),
+  },
+}));
+
 import {
   applySessionMiddleware,
   createFixedWindowRateLimiter,
@@ -202,6 +217,16 @@ describe('ws-upgrade-utils', () => {
         } as any;
         expect(isOriginAllowed(request, noProxy)).toBe(true);
       });
+
+      test('rejects an https Origin against an unencrypted local socket, unchanged from today', () => {
+        // Trust proxy off: the local socket's TLS state is still the source of
+        // truth for the effective protocol, and behavior here must not change.
+        const request = {
+          headers: { origin: 'https://drydock.example.com', host: 'drydock.example.com' },
+          socket: { encrypted: false },
+        } as any;
+        expect(isOriginAllowed(request, noProxy)).toBe(false);
+      });
     });
 
     describe('trust proxy enabled', () => {
@@ -270,6 +295,81 @@ describe('ws-upgrade-utils', () => {
         } as any;
         expect(isOriginAllowed(request, withProxy)).toBe(false);
       });
+
+      test('allows a matching origin when X-Forwarded-Proto is absent and the local socket is unencrypted (TLS-terminating proxy)', () => {
+        // Reporter's deployment shape (#867): trust proxy is on, the proxy
+        // terminates TLS and sends X-Forwarded-Host but not X-Forwarded-Proto,
+        // and the backend socket itself is plain HTTP. The local socket's
+        // encrypted=false must not be used as a stand-in for the client-facing
+        // protocol.
+        const request = {
+          headers: {
+            origin: 'https://drydock.example.com',
+            host: '10.0.0.1:3000',
+            'x-forwarded-host': 'drydock.example.com',
+          },
+          socket: { encrypted: false },
+        } as any;
+        expect(isOriginAllowed(request, withProxy)).toBe(true);
+      });
+
+      test('still allows a matching origin when X-Forwarded-Proto is present alongside an unencrypted local socket', () => {
+        const request = {
+          headers: {
+            origin: 'https://drydock.example.com',
+            host: '10.0.0.1:3000',
+            'x-forwarded-host': 'drydock.example.com',
+            'x-forwarded-proto': 'https',
+          },
+          socket: { encrypted: false },
+        } as any;
+        expect(isOriginAllowed(request, withProxy)).toBe(true);
+      });
+
+      test('still rejects a mismatched X-Forwarded-Host when X-Forwarded-Proto is absent and the local socket is unencrypted', () => {
+        // Protocol being unknown must not weaken the host check.
+        const request = {
+          headers: {
+            origin: 'https://evil.com',
+            host: '10.0.0.1:3000',
+            'x-forwarded-host': 'drydock.example.com',
+          },
+          socket: { encrypted: false },
+        } as any;
+        expect(isOriginAllowed(request, withProxy)).toBe(false);
+      });
+    });
+
+    test('logs a debug message with the mismatch details on rejection', () => {
+      const request = {
+        headers: {
+          origin: 'https://evil.com',
+          host: '10.0.0.1:3000',
+          'x-forwarded-host': 'drydock.example.com',
+          'x-forwarded-proto': 'https',
+        },
+        socket: { encrypted: false },
+      } as any;
+
+      expect(isOriginAllowed(request, { trustproxy: 1 })).toBe(false);
+
+      expect(mockLogChild.debug).toHaveBeenCalledTimes(1);
+      const [message] = mockLogChild.debug.mock.calls[0];
+      expect(message).toContain('origin=https://evil.com');
+      expect(message).toContain('effectiveHost=drydock.example.com');
+      expect(message).toContain('effectiveProtocol=https:');
+      expect(message).toContain('trustProxy=true');
+      expect(message).toContain('x-forwarded-host=drydock.example.com');
+      expect(message).toContain('x-forwarded-proto=https');
+    });
+
+    test('does not log when the origin is allowed', () => {
+      const request = {
+        headers: { origin: 'http://localhost:3000', host: 'localhost:3000' },
+      } as any;
+
+      expect(isOriginAllowed(request)).toBe(true);
+      expect(mockLogChild.debug).not.toHaveBeenCalled();
     });
   });
 

--- a/app/api/ws-upgrade-utils.ts
+++ b/app/api/ws-upgrade-utils.ts
@@ -1,10 +1,13 @@
 import { type IncomingMessage, ServerResponse } from 'node:http';
 import type { Socket } from 'node:net';
+import logger from '../log/index.js';
 import {
   getAuthenticatedRouteRateLimitKey,
   type IdentityAwareRateLimitRequestLike,
   isIdentityAwareRateLimitKeyingEnabled,
 } from './rate-limit-key.js';
+
+const log = logger.child({ component: 'ws-upgrade-utils' });
 
 export type SessionMiddleware = (
   request: IncomingMessage,
@@ -85,39 +88,60 @@ export function isOriginAllowed(
     (trustProxy ? getFirstForwardedValue(request.headers['x-forwarded-host']) : undefined) ??
     request.headers.host;
 
-  if (!effectiveHost) {
-    return false;
-  }
-
   const forwardedProtocol = trustProxy
     ? getFirstForwardedValue(request.headers['x-forwarded-proto'])
     : undefined;
   let effectiveProtocol: 'http:' | 'https:' | undefined;
-  if (forwardedProtocol !== undefined) {
+  let allowed = true;
+
+  if (!effectiveHost) {
+    allowed = false;
+  } else if (forwardedProtocol !== undefined) {
     const normalizedProtocol = `${forwardedProtocol.toLowerCase()}:`;
     if (normalizedProtocol !== 'http:' && normalizedProtocol !== 'https:') {
-      return false;
+      allowed = false;
+    } else {
+      effectiveProtocol = normalizedProtocol;
     }
-    effectiveProtocol = normalizedProtocol;
   } else {
-    effectiveProtocol = getSocketOriginProtocol(request);
+    // When trust proxy is enabled but X-Forwarded-Proto is absent, the local
+    // socket's TLS state does not reflect the client-facing protocol behind a
+    // TLS-terminating proxy (the backend socket is typically plain HTTP).
+    // Treat the protocol as unknown rather than falling back to the socket,
+    // which would otherwise reject a same-origin request purely because the
+    // proxy stripped the protocol header (see #867).
+    effectiveProtocol = trustProxy ? undefined : getSocketOriginProtocol(request);
   }
 
-  let parsedOrigin: URL;
-  try {
-    parsedOrigin = new URL(origin);
-  } catch {
-    return false;
+  let parsedOrigin: URL | undefined;
+  if (allowed) {
+    try {
+      parsedOrigin = new URL(origin);
+    } catch {
+      allowed = false;
+    }
   }
 
-  if (parsedOrigin.protocol !== 'http:' && parsedOrigin.protocol !== 'https:') {
-    return false;
+  if (allowed && parsedOrigin !== undefined) {
+    if (parsedOrigin.protocol !== 'http:' && parsedOrigin.protocol !== 'https:') {
+      allowed = false;
+    } else {
+      allowed =
+        parsedOrigin.host === effectiveHost &&
+        (effectiveProtocol === undefined || parsedOrigin.protocol === effectiveProtocol);
+    }
   }
 
-  return (
-    parsedOrigin.host === effectiveHost &&
-    (effectiveProtocol === undefined || parsedOrigin.protocol === effectiveProtocol)
-  );
+  if (!allowed) {
+    log.debug(
+      `WebSocket origin rejected: origin=${origin} effectiveHost=${effectiveHost ?? 'unknown'} ` +
+        `effectiveProtocol=${effectiveProtocol ?? 'unknown'} trustProxy=${trustProxy} ` +
+        `x-forwarded-host=${request.headers['x-forwarded-host'] ?? 'absent'} ` +
+        `x-forwarded-proto=${request.headers['x-forwarded-proto'] ?? 'absent'}`,
+    );
+  }
+
+  return allowed;
 }
 
 export function writeUpgradeError(socket: Socket, statusCode: number, message: string): void {


### PR DESCRIPTION
Fixes #867.

With DD_SERVER_TRUSTPROXY enabled but X-Forwarded-Proto absent on a websocket upgrade, `isOriginAllowed` fell back to the local socket's `encrypted` flag. Behind a TLS-terminating proxy (Traefik in the report) the backend socket is plain HTTP, so a browser's https:// Origin never matched and every upgrade got a hard 403 while REST kept working (Express's own trust-proxy machinery resolves `req.protocol` there). Not auth-specific; the reporter's OIDC-only setup just made it look that way. The trust-proxy-enabled test block never exercised a realistic socket, so the branch was untested.

Fix: when trust proxy is on and the forwarded protocol header is absent, treat the protocol as unknown and skip that comparison (matching Express trust-proxy semantics); host validation keeps its teeth, trust-proxy-off behavior is untouched. Also adds a debug log on every rejection with the origin/host/protocol and raw forwarded-header values so the next 403 explains itself.

Verified: six new tests including the reporter's exact deployment shape (TDD, new tests confirmed red against the unfixed code), full app suite 412 files / 13,092 tests green at 100% coverage, biome clean, full pre-push gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed WebSocket origin checks when `DD_SERVER_TRUSTPROXY` is enabled and `X-Forwarded-Proto` is absent.
- 🔒 Preserved host validation and trust-proxy-disabled behavior.
- ✨ Added debug logging for rejected WebSocket origins.
- ✨ Added six tests for trusted TLS-terminating proxy scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->