### PR TITLE
test(scripts): opt fleet-soak agents into portwing's plaintext edge URL gate

### DIFF
--- a/scripts/portwing-fleet-soak.mjs
+++ b/scripts/portwing-fleet-soak.mjs
@@ -313,6 +313,9 @@ function spawnAgent(index) {
       DD_POLL_INTERVAL: '2',
       DOCKER_SOCKET: socketPath,
       DRYDOCK_URL: `http://127.0.0.1:${controllerAddress.port}`,
+      // portwing v0.9.9+ refuses plaintext controller URLs in edge mode unless
+      // this opt-in is set; the soak dials loopback over http by design.
+      ALLOW_INSECURE_EDGE_URL: 'true',
       LOG_LEVEL: 'warn',
       MAX_RECONNECT_DELAY: '2',
       NO_COLOR: '1',

--- a/scripts/portwing-fleet-soak.test.mjs
+++ b/scripts/portwing-fleet-soak.test.mjs
@@ -52,3 +52,19 @@ test('continues closing agents after one component cleanup fails', async () => {
   assert.deepEqual(removed, ['fleet-agent-0', 'fleet-agent-1']);
   assert.deepEqual(errors, ['fleet-agent-0:cleanup failed']);
 });
+
+test('spawned agents opt into the plaintext loopback controller URL', async () => {
+  // portwing v0.9.9 (PR CodesWhat/portwing#201) fails closed on http:// or
+  // ws:// controller URLs in edge mode unless ALLOW_INSECURE_EDGE_URL=true.
+  // The soak dials http://127.0.0.1 by design, so dropping this opt-in makes
+  // every spawned agent exit at config load and the soak time out at 0/8
+  // registered. Guard the env wiring at the source level.
+  const { readFile } = await import('node:fs/promises');
+  const source = await readFile(new URL('./portwing-fleet-soak.mjs', import.meta.url), 'utf8');
+  assert.match(source, /ALLOW_INSECURE_EDGE_URL: 'true'/);
+  const envBlock = source.slice(source.indexOf('DRYDOCK_URL:'));
+  assert.ok(
+    envBlock.indexOf("ALLOW_INSECURE_EDGE_URL: 'true'") > -1,
+    'ALLOW_INSECURE_EDGE_URL must be set alongside the plaintext DRYDOCK_URL',
+  );
+});


### PR DESCRIPTION
The scheduled Portwing fleet soak has been failing deterministically at 0/8 agents registered since portwing v0.9.9. Root cause: portwing PR CodesWhat/portwing#201 (correct, intentional hardening) fails closed on http:// and ws:// controller URLs in edge mode unless ALLOW_INSECURE_EDGE_URL=true. The soak spawns agents against http://127.0.0.1 by design, so every agent exited at config load before dialing the controller. Bisection: soak runs against portwing 0a57a91 (v0.9.8) passed; runs against edf7394 (v0.9.9) fail identically. Verified directly by building portwing at edf7394 and running it with the soak's exact env, with and without the opt-in.

Fix: set ALLOW_INSECURE_EDGE_URL in spawnAgent's env with a comment, plus a source-level regression test so the opt-in can't be dropped silently. Not a product defect in drydock; nothing in the rc.3 line is implicated and this doesn't gate the GA cut.

Verified: script tests green, biome clean, full pre-push gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed fleet-soak agents exiting when Portwing rejects plaintext loopback controller URLs.
- 🔧 Changed `spawnAgent` to set `ALLOW_INSECURE_EDGE_URL: 'true'`.
- ✨ Added a source-level regression test for the environment configuration.

## Validation

- Script tests passed.
- Biome passed.
- Full pre-push gate passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->