### PR TITLE
fix(api): trust proxy headers over local socket TLS state in websocket origin check (v1.6 backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **WebSocket log-stream connections behind a TLS-terminating proxy no longer 403 when `X-Forwarded-Proto` is absent.** With trust proxy enabled, `isOriginAllowed` fell back to the local socket's `encrypted` flag whenever the proxy omitted `X-Forwarded-Proto`, which is plain HTTP on a backend behind TLS termination, so a browser's `https://` Origin never matched and every WebSocket upgrade was rejected while REST traffic worked fine. The protocol is now treated as unknown (and skipped from the comparison) in that case instead of being inferred from the local socket; host validation is unaffected. ([#867](https://github.com/CodesWhat/drydock/issues/867))
 - **Demo site favicon now matches the refreshed branding.** The v1.5.1 brand refresh (#439) moved the website to the cropped whale "headshot" icon and the app UI followed, but demo.getdrydock.com kept showing the old full-body whale: its stale `favicon.svg` — which modern browsers preferred over the PNGs — was never replaced. The demo now ships the same headshot icon set as the website and app UI, the `favicon.svg` is removed, and the icon links carry a `?v=2` cache-buster so browsers re-fetch instead of serving the aggressively cached old icon. (#689)
 
 ## [1.6.1-rc.1] — 2026-08-21

--- a/app/api/ws-upgrade-utils.test.ts
+++ b/app/api/ws-upgrade-utils.test.ts
@@ -1,3 +1,18 @@
+// Hoisted so tests can assert on log calls — the module-level `log` in
+// ws-upgrade-utils.ts is `logger.child(...)`, called once at import time, so
+// it always returns this same singleton.
+const mockLogChild = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+vi.mock('../log/index.js', () => ({
+  default: {
+    child: vi.fn(() => mockLogChild),
+  },
+}));
+
 import {
   applySessionMiddleware,
   createFixedWindowRateLimiter,
@@ -202,6 +217,16 @@ describe('ws-upgrade-utils', () => {
         } as any;
         expect(isOriginAllowed(request, noProxy)).toBe(true);
       });
+
+      test('rejects an https Origin against an unencrypted local socket, unchanged from today', () => {
+        // Trust proxy off: the local socket's TLS state is still the source of
+        // truth for the effective protocol, and behavior here must not change.
+        const request = {
+          headers: { origin: 'https://drydock.example.com', host: 'drydock.example.com' },
+          socket: { encrypted: false },
+        } as any;
+        expect(isOriginAllowed(request, noProxy)).toBe(false);
+      });
     });
 
     describe('trust proxy enabled', () => {
@@ -270,6 +295,81 @@ describe('ws-upgrade-utils', () => {
         } as any;
         expect(isOriginAllowed(request, withProxy)).toBe(false);
       });
+
+      test('allows a matching origin when X-Forwarded-Proto is absent and the local socket is unencrypted (TLS-terminating proxy)', () => {
+        // Reporter's deployment shape (#867): trust proxy is on, the proxy
+        // terminates TLS and sends X-Forwarded-Host but not X-Forwarded-Proto,
+        // and the backend socket itself is plain HTTP. The local socket's
+        // encrypted=false must not be used as a stand-in for the client-facing
+        // protocol.
+        const request = {
+          headers: {
+            origin: 'https://drydock.example.com',
+            host: '10.0.0.1:3000',
+            'x-forwarded-host': 'drydock.example.com',
+          },
+          socket: { encrypted: false },
+        } as any;
+        expect(isOriginAllowed(request, withProxy)).toBe(true);
+      });
+
+      test('still allows a matching origin when X-Forwarded-Proto is present alongside an unencrypted local socket', () => {
+        const request = {
+          headers: {
+            origin: 'https://drydock.example.com',
+            host: '10.0.0.1:3000',
+            'x-forwarded-host': 'drydock.example.com',
+            'x-forwarded-proto': 'https',
+          },
+          socket: { encrypted: false },
+        } as any;
+        expect(isOriginAllowed(request, withProxy)).toBe(true);
+      });
+
+      test('still rejects a mismatched X-Forwarded-Host when X-Forwarded-Proto is absent and the local socket is unencrypted', () => {
+        // Protocol being unknown must not weaken the host check.
+        const request = {
+          headers: {
+            origin: 'https://evil.com',
+            host: '10.0.0.1:3000',
+            'x-forwarded-host': 'drydock.example.com',
+          },
+          socket: { encrypted: false },
+        } as any;
+        expect(isOriginAllowed(request, withProxy)).toBe(false);
+      });
+    });
+
+    test('logs a debug message with the mismatch details on rejection', () => {
+      const request = {
+        headers: {
+          origin: 'https://evil.com',
+          host: '10.0.0.1:3000',
+          'x-forwarded-host': 'drydock.example.com',
+          'x-forwarded-proto': 'https',
+        },
+        socket: { encrypted: false },
+      } as any;
+
+      expect(isOriginAllowed(request, { trustproxy: 1 })).toBe(false);
+
+      expect(mockLogChild.debug).toHaveBeenCalledTimes(1);
+      const [message] = mockLogChild.debug.mock.calls[0];
+      expect(message).toContain('origin=https://evil.com');
+      expect(message).toContain('effectiveHost=drydock.example.com');
+      expect(message).toContain('effectiveProtocol=https:');
+      expect(message).toContain('trustProxy=true');
+      expect(message).toContain('x-forwarded-host=drydock.example.com');
+      expect(message).toContain('x-forwarded-proto=https');
+    });
+
+    test('does not log when the origin is allowed', () => {
+      const request = {
+        headers: { origin: 'http://localhost:3000', host: 'localhost:3000' },
+      } as any;
+
+      expect(isOriginAllowed(request)).toBe(true);
+      expect(mockLogChild.debug).not.toHaveBeenCalled();
     });
   });
 

--- a/app/api/ws-upgrade-utils.ts
+++ b/app/api/ws-upgrade-utils.ts
@@ -1,10 +1,13 @@
 import { type IncomingMessage, ServerResponse } from 'node:http';
 import type { Socket } from 'node:net';
+import logger from '../log/index.js';
 import {
   getAuthenticatedRouteRateLimitKey,
   type IdentityAwareRateLimitRequestLike,
   isIdentityAwareRateLimitKeyingEnabled,
 } from './rate-limit-key.js';
+
+const log = logger.child({ component: 'ws-upgrade-utils' });
 
 export type SessionMiddleware = (
   request: IncomingMessage,
@@ -85,39 +88,60 @@ export function isOriginAllowed(
     (trustProxy ? getFirstForwardedValue(request.headers['x-forwarded-host']) : undefined) ??
     request.headers.host;
 
-  if (!effectiveHost) {
-    return false;
-  }
-
   const forwardedProtocol = trustProxy
     ? getFirstForwardedValue(request.headers['x-forwarded-proto'])
     : undefined;
   let effectiveProtocol: 'http:' | 'https:' | undefined;
-  if (forwardedProtocol !== undefined) {
+  let allowed = true;
+
+  if (!effectiveHost) {
+    allowed = false;
+  } else if (forwardedProtocol !== undefined) {
     const normalizedProtocol = `${forwardedProtocol.toLowerCase()}:`;
     if (normalizedProtocol !== 'http:' && normalizedProtocol !== 'https:') {
-      return false;
+      allowed = false;
+    } else {
+      effectiveProtocol = normalizedProtocol;
     }
-    effectiveProtocol = normalizedProtocol;
   } else {
-    effectiveProtocol = getSocketOriginProtocol(request);
+    // When trust proxy is enabled but X-Forwarded-Proto is absent, the local
+    // socket's TLS state does not reflect the client-facing protocol behind a
+    // TLS-terminating proxy (the backend socket is typically plain HTTP).
+    // Treat the protocol as unknown rather than falling back to the socket,
+    // which would otherwise reject a same-origin request purely because the
+    // proxy stripped the protocol header (see #867).
+    effectiveProtocol = trustProxy ? undefined : getSocketOriginProtocol(request);
   }
 
-  let parsedOrigin: URL;
-  try {
-    parsedOrigin = new URL(origin);
-  } catch {
-    return false;
+  let parsedOrigin: URL | undefined;
+  if (allowed) {
+    try {
+      parsedOrigin = new URL(origin);
+    } catch {
+      allowed = false;
+    }
   }
 
-  if (parsedOrigin.protocol !== 'http:' && parsedOrigin.protocol !== 'https:') {
-    return false;
+  if (allowed && parsedOrigin !== undefined) {
+    if (parsedOrigin.protocol !== 'http:' && parsedOrigin.protocol !== 'https:') {
+      allowed = false;
+    } else {
+      allowed =
+        parsedOrigin.host === effectiveHost &&
+        (effectiveProtocol === undefined || parsedOrigin.protocol === effectiveProtocol);
+    }
   }
 
-  return (
-    parsedOrigin.host === effectiveHost &&
-    (effectiveProtocol === undefined || parsedOrigin.protocol === effectiveProtocol)
-  );
+  if (!allowed) {
+    log.debug(
+      `WebSocket origin rejected: origin=${origin} effectiveHost=${effectiveHost ?? 'unknown'} ` +
+        `effectiveProtocol=${effectiveProtocol ?? 'unknown'} trustProxy=${trustProxy} ` +
+        `x-forwarded-host=${request.headers['x-forwarded-host'] ?? 'absent'} ` +
+        `x-forwarded-proto=${request.headers['x-forwarded-proto'] ?? 'absent'}`,
+    );
+  }
+
+  return allowed;
 }
 
 export function writeUpgradeError(socket: Socket, statusCode: number, message: string): void {


### PR DESCRIPTION
Backport of #868 (dev/v1.7, squash 85df047b) to the 1.6 line for v1.6.1. The reporter of #867 runs 1.6.

With trust proxy enabled and X-Forwarded-Proto absent on the websocket upgrade request, isOriginAllowed fell back to the local socket's TLS state, which is plain HTTP behind a TLS-terminating proxy, so every https origin mismatched and the upgrade 403'd while REST worked. The protocol is now treated as unknown and skipped from the comparison in that case; host validation is unchanged. Also adds a debug log of the exact mismatch inputs on rejection.

Clean cherry-pick, only the CHANGELOG needed manual resolution (entry added under Unreleased on this line). 77 ws-upgrade-utils tests pass; full pre-push gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed WebSocket origin validation behind TLS-terminating trusted proxies.
- 🔧 Treated absent `X-Forwarded-Proto` as unknown instead of using local socket TLS state.
- 🔧 Added debug logs with origin, host, and protocol values for rejected requests.
- ✨ Added tests for proxy, socket, and rejection-logging scenarios.
- 🔧 Preserved host validation behavior.
- 🔧 Resolved the CHANGELOG conflict.

## Validation

- 77 WebSocket upgrade utility tests passed.
- Full pre-push gate passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->