### PR TITLE
chore(release): roll release identity forward to v1.6.1-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1-rc.2] — 2026-08-25
+
 ### Fixed
 
 - **WebSocket log-stream connections behind a TLS-terminating proxy no longer 403 when `X-Forwarded-Proto` is absent.** With trust proxy enabled, `isOriginAllowed` fell back to the local socket's `encrypted` flag whenever the proxy omitted `X-Forwarded-Proto`, which is plain HTTP on a backend behind TLS termination, so a browser's `https://` Origin never matched and every WebSocket upgrade was rejected while REST traffic worked fine. The protocol is now treated as unknown (and skipped from the comparison) in that case instead of being inferred from the local socket; host validation is unaffected. ([#867](https://github.com/CodesWhat/drydock/issues/867))
@@ -2409,7 +2411,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.1...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.2...HEAD
+[1.6.1-rc.2]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.1...v1.6.1-rc.2
 [1.6.1-rc.1]: https://github.com/CodesWhat/drydock/compare/v1.6.0...v1.6.1-rc.1
 [1.6.0]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.13...v1.6.0
 [1.6.0-rc.13]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.12...v1.6.0-rc.13

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.1-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.2-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,13 +179,13 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
-<summary><strong>v1.6.1-rc.1 highlights</strong></summary>
+<summary><strong>v1.6.1-rc.2 highlights</strong></summary>
 
 - **Drydock no longer reports "Up to date" when an update check failed** — a registry error during digest verification now surfaces as an explicit unknown status instead of a false negative. ([#814](https://github.com/CodesWhat/drydock/issues/814), [#808](https://github.com/CodesWhat/drydock/issues/808))
 - **Nested OCI image indexes now resolve to the real image manifest** — images built with Buildx SBOM/provenance attestations no longer fail digest checks with `Unexpected error; no manifest found`. ([#814](https://github.com/CodesWhat/drydock/issues/814))
 - **A single malformed container no longer zeroes out an entire agent inventory sync** — per-container error isolation now matches the existing watcher-snapshot path. ([#802](https://github.com/CodesWhat/drydock/issues/802))
 
-Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc1--2026-08-21).
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc2--2026-08-25).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -181,11 +181,21 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <details open>
 <summary><strong>v1.6.1-rc.2 highlights</strong></summary>
 
+- **WebSocket log streams behind a TLS-terminating proxy no longer 403** — with trust proxy enabled and `X-Forwarded-Proto` absent on the upgrade request, the origin check no longer falls back to the local socket's TLS state; the protocol is treated as unknown and host validation keeps working. ([#867](https://github.com/CodesWhat/drydock/issues/867))
+- **Demo site favicon matches the refreshed branding** — the stale full-body whale `favicon.svg` is replaced by the same headshot icon set as the website and app UI. ([#689](https://github.com/CodesWhat/drydock/issues/689))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc2--2026-08-25).
+
+</details>
+
+<details>
+<summary><strong>v1.6.1-rc.1 highlights</strong></summary>
+
 - **Drydock no longer reports "Up to date" when an update check failed** — a registry error during digest verification now surfaces as an explicit unknown status instead of a false negative. ([#814](https://github.com/CodesWhat/drydock/issues/814), [#808](https://github.com/CodesWhat/drydock/issues/808))
 - **Nested OCI image indexes now resolve to the real image manifest** — images built with Buildx SBOM/provenance attestations no longer fail digest checks with `Unexpected error; no manifest found`. ([#814](https://github.com/CodesWhat/drydock/issues/814))
 - **A single malformed container no longer zeroes out an entire agent inventory sync** — per-container error isolation now matches the existing watcher-snapshot path. ([#802](https://github.com/CodesWhat/drydock/issues/802))
 
-Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc2--2026-08-25).
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc1--2026-08-21).
 
 </details>
 

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1-rc.1',
+    version: '1.6.1-rc.2',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1-rc.1 started',
+    details: 'Drydock v1.6.1-rc.2 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.1',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.2',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1-rc.1',
+    tag: '1.6.1-rc.2',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1-rc.1',
+  version: '1.6.1-rc.2',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1-rc.1',
+      version: '1.6.1-rc.2',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1-rc.1', mode: 'demo' },
+        server: { version: '1.6.1-rc.2', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1-rc.1",
+  version: "1.6.1-rc.2",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1-rc.1",
+    version: "v1.6.1-rc.2",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1-rc.1",
+      "version": "1.6.1-rc.2",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1-rc.1",
+    "version": "1.6.1-rc.2",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1-rc.1"
+  "version":"1.6.1-rc.2"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1-rc.1",
+    "version": "1.6.1-rc.2",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1-rc.1",
+      "drydockVersion": "1.6.1-rc.2",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1-rc.1` | Immutable release candidate; best for reproducible testing |
+| `1.6.1-rc.2` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,7 +5,16 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
-## v1.6.1-rc.2 Highlights — August 21, 2026
+## v1.6.1-rc.2 Highlights — August 25, 2026
+
+Two bug fixes: WebSocket log-stream connections behind a TLS-terminating proxy
+no longer 403 when the proxy omits `X-Forwarded-Proto` on the upgrade request
+(with trust proxy enabled, the local socket's TLS state is no longer treated as
+the client-facing protocol); and the demo site favicon now matches the
+refreshed branding. See [CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc2--2026-08-25)
+for the full release notes.
+
+## v1.6.1-rc.1 Highlights — August 21, 2026
 
 Three bug fixes: nested OCI image indexes (produced by Buildx SBOM/provenance
 attestations) now resolve to the real image manifest instead of failing digest

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,7 +5,7 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
-## v1.6.1-rc.1 Highlights — August 21, 2026
+## v1.6.1-rc.2 Highlights — August 21, 2026
 
 Three bug fixes: nested OCI image indexes (produced by Buildx SBOM/provenance
 attestations) now resolve to the real image manifest instead of failing digest

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.1...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.2...HEAD`],
+    ['1.6.1-rc.2', `${repositoryUrl}/compare/v1.6.1-rc.1...v1.6.1-rc.2`],
     ['1.6.1-rc.1', `${repositoryUrl}/compare/v1.6.0...v1.6.1-rc.1`],
     ['1.6.0', `${repositoryUrl}/compare/v1.6.0-rc.13...v1.6.0`],
     ['1.6.0-rc.13', `${repositoryUrl}/compare/v1.6.0-rc.12...v1.6.0-rc.13`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -5,7 +5,7 @@ import test from 'node:test';
 const RC_VERSION = '1.6.1-rc.2';
 const PREV_RC_VERSION = '1.6.1-rc.1';
 const RC_DATE = '2026-08-25';
-const RC_DISPLAY_DATE = 'August 21, 2026';
+const RC_DISPLAY_DATE = 'August 25, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1-rc.1';
-const PREV_RC_VERSION = '1.6.0';
-const RC_DATE = '2026-08-21';
+const RC_VERSION = '1.6.1-rc.2';
+const PREV_RC_VERSION = '1.6.1-rc.1';
+const RC_DATE = '2026-08-25';
 const RC_DISPLAY_DATE = 'August 21, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1-rc.1';
+const RC_VERSION = '1.6.1-rc.2';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Same shape as #833's roll to rc.1. The rc.2 cut (run 32873962793) failed CHANGELOG validation because the identity still said rc.1.

CHANGELOG gains the `## [1.6.1-rc.2] — 2026-08-25` heading absorbing the Unreleased entries (#872 ws-origin backport + demo favicon), with link refs rolled. README badge/highlights anchor, demo mocks, site config/content, and the current-docs version strings all roll `1.6.1-rc.1 -> 1.6.1-rc.2`. Identity tests updated (RC_VERSION, RC_DATE, PREV_RC_VERSION now the rc.1 tag, changelog-links gains the rc.2 row); all 19 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

🔧 **Changed**
- Rolled release identity from `1.6.1-rc.1` to `1.6.1-rc.2`.
- Added the `1.6.1-rc.2` CHANGELOG heading dated `2026-08-25`.
- Updated CHANGELOG comparison links.
- Updated README, demo mocks, site content, and current documentation version strings.
- Updated release identity tests for the new version, date, previous RC tag, and links.
- Confirmed 19 identity tests pass.

## Concerns

- Verify that `content/docs/current/updates/index.mdx` retains the `August 21, 2026` date for `v1.6.1-rc.1`.
- Confirm that all remaining `1.6.1-rc.1` references are intentional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->