### PR TITLE
feat(analytics): capture $pageleave and send $pathname

### DIFF
--- a/apps/web/scripts/analytics-client.test.mjs
+++ b/apps/web/scripts/analytics-client.test.mjs
@@ -22,7 +22,7 @@ test("PostHog options pin the privacy posture and cookieless web vitals", () => 
       autocapture: false,
       rageclick: false,
       capture_pageview: false,
-      capture_pageleave: false,
+      capture_pageleave: true,
       disable_session_recording: true,
       capture_heatmaps: false,
       capture_dead_clicks: false,

--- a/apps/web/scripts/analytics-contract.test.mjs
+++ b/apps/web/scripts/analytics-contract.test.mjs
@@ -161,9 +161,84 @@ test("pageviews are rebuilt from the canonical production URL and a minimal enve
       surface: "marketing",
       path: "/compare",
       $current_url: `${PRODUCTION_ORIGIN}/compare`,
+      $pathname: "/compare",
       ...COOKIELESS_HASH_PROPERTIES,
     },
   });
+});
+
+test("pageleaves are rebuilt from posthog-js's own envelope onto the canonical contract", () => {
+  // posthog-js emits $pageleave itself once capture_pageleave is true, so it
+  // reaches before_send carrying PostHog's own properties ($current_url,
+  // $raw_user_agent, $host, token, $cookieless_mode,
+  // $process_person_profile) rather than ours. before_send has to rebuild it
+  // from that envelope like any other event; before this branch existed the
+  // fallthrough `return null` dropped every $pageleave silently, which is
+  // why flipping capture_pageleave alone does nothing.
+  const timestamp = new Date("2026-08-14T12:05:00.000Z");
+  const beforeSend = createBeforeSend("phc_public-token_123", ROUTES);
+  const result = beforeSend({
+    uuid: "018f0000-0000-7000-8000-000000000008",
+    event: "$pageleave",
+    timestamp,
+    properties: {
+      ...COOKIELESS_HASH_PROPERTIES,
+      $current_url: "https://getdrydock.com/compare/?utm_source=secret#secret",
+      token: "phc_public-token_123",
+      $cookieless_mode: true,
+      $process_person_profile: false,
+      $referrer: "https://secret.example",
+      title: "Private title",
+    },
+  });
+
+  assert.deepEqual(result, {
+    uuid: "018f0000-0000-7000-8000-000000000008",
+    event: "$pageleave",
+    timestamp,
+    properties: {
+      token: "phc_public-token_123",
+      $cookieless_mode: true,
+      $process_person_profile: false,
+      schema_version: 1,
+      site: "drydock",
+      surface: "marketing",
+      path: "/compare",
+      $current_url: `${PRODUCTION_ORIGIN}/compare`,
+      $pathname: "/compare",
+      ...COOKIELESS_HASH_PROPERTIES,
+    },
+  });
+});
+
+test("$pathname always equals the canonicalized path and never leaks an unlisted route", () => {
+  // $pathname exists purely so PostHog's Web analytics Page / Entry page /
+  // Exit page tables resolve at all; they read that property and nothing
+  // else. It must stay bound to the already-canonicalized `path`: if it ever
+  // carried the raw pathname instead, every unlisted route would start
+  // leaking into the analytics project, which is exactly what the route
+  // allowlist exists to prevent.
+  const beforeSend = createBeforeSend("phc_public-token_123", ROUTES);
+  for (const event of ["$pageview", "$pageleave"]) {
+    for (const rawPath of ["/", "/compare", "/private/customer-secret", "/docs/v1.7/unknown"]) {
+      const result = beforeSend({
+        uuid: "018f0000-0000-7000-8000-000000000009",
+        event,
+        properties: {
+          ...COOKIELESS_HASH_PROPERTIES,
+          path: rawPath,
+          token: "phc_public-token_123",
+        },
+      });
+      assert.ok(result, `${event} for ${rawPath} must not be dropped`);
+      assert.equal(result.properties.$pathname, result.properties.path);
+      assert.equal(
+        String(result.properties.$pathname).includes("customer-secret"),
+        false,
+        `unlisted route leaked into $pathname for ${event} ${rawPath}`,
+      );
+    }
+  }
 });
 
 test("before_send requires and forwards the cookieless server-hash fields", () => {

--- a/apps/web/src/lib/analytics-client.ts
+++ b/apps/web/src/lib/analytics-client.ts
@@ -23,7 +23,7 @@ type PostHogOptions = {
   autocapture: false;
   rageclick: false;
   capture_pageview: false;
-  capture_pageleave: false;
+  capture_pageleave: true;
   disable_session_recording: true;
   capture_heatmaps: false;
   capture_dead_clicks: false;
@@ -69,7 +69,7 @@ export function createPostHogOptions(token: string, routes: ReadonlySet<string>)
     autocapture: false,
     rageclick: false,
     capture_pageview: false,
-    capture_pageleave: false,
+    capture_pageleave: true,
     disable_session_recording: true,
     capture_heatmaps: false,
     capture_dead_clicks: false,

--- a/apps/web/src/lib/analytics-contract.ts
+++ b/apps/web/src/lib/analytics-contract.ts
@@ -219,8 +219,15 @@ export function createBeforeSend(token: string, routes: ReadonlySet<string>) {
     properties.$raw_user_agent = rawUserAgent;
     properties.$host = host;
 
-    if (input.event === "$pageview") {
+    if (input.event === "$pageview" || input.event === "$pageleave") {
+      // PostHog's Web analytics Page / Entry page / Exit page tables key off
+      // $pathname, so without it those tables return no rows at all. Send
+      // the already-canonicalized `path` rather than the raw pathname:
+      // `path` has already been reduced to the known-route allowlist with
+      // OTHER_PATH as the catch-all, so $pathname carries nothing the event
+      // was not already sending and can never leak an unlisted route.
       properties.$current_url = `${PRODUCTION_ORIGIN}${properties.path}`;
+      properties.$pathname = properties.path;
       return createCaptureResult(input, properties);
     }
 


### PR DESCRIPTION
Two properties the analytics contract never sent, both costing real data and neither changing the privacy posture. Same change as portwing #214, adapted to drydock's contract shape.

## What's wrong today

`capture_pageleave` was `false`, so a session's last recorded timestamp is its last pageview. A five minute read of one page scores as zero seconds, and PostHog's Web analytics Page, Entry page, and Exit page tables return zero rows: they key off `$pathname`, which the contract never sent.

## Why flipping the option alone doesn't work

posthog-js gates the event on `capture_pageleave === true || ('if_capture_pageview' && capture_pageview)`. Since `capture_pageview` is `false` here and pageviews are captured by hand, the option has to be an explicit `true`.

That alone would have fixed nothing quietly: `createBeforeSend`'s event switch only had branches for `$pageview`, `cta activated`, and `$web_vitals`. Any `$pageleave` envelope posthog-js emitted would fall through to the trailing `return null` and get dropped with no error, no ingestion warning, nothing. This widens the existing `$pageview` branch to also handle `$pageleave`, mirroring the same `$current_url` synthesis from `PRODUCTION_ORIGIN + path`, and adds `$pathname` to both.

## Privacy

Nothing opens up. `cookieless_mode`, `person_profiles`, `persistence`, `disable_persistence`, `respect_dnt`, `save_referrer`, and `save_campaign_params` are all untouched.

`$pathname` is set to the already-canonicalized `path`, never the raw pathname, so it can't carry a route outside the known-route allowlist (`/_other` catch-all) and adds no information the event wasn't already sending. A regression test asserts the two never diverge, including for an unlisted route.

## Tests

`npm run test:scripts` in `apps/web`: 68 passed (66 baseline + 2 new). New cases:
- `$pageleave` rebuilt from posthog-js's own envelope (`$current_url`, `$raw_user_agent`, `$host`, `token`, `$cookieless_mode`, `$process_person_profile`) onto the canonical contract, through `before_send`.
- `$pathname` always equals `path` for both `$pageview` and `$pageleave`, and an unlisted route still collapses to `/_other` rather than leaking.

Also updated the exact-options assertion in `analytics-client.test.mjs` for `capture_pageleave: true`. `npm run type-check` and biome both clean. Full pre-push pipeline (knip, qlty, coverage, build) passed.

No CHANGELOG entry: this repo's feature PRs only touch it at release prep, not per PR (checked the last several feature commits into `dev/v1.7`).

Part of X16 in the ops execution plan. Same change already up for portwing (#214); careerrat, sockguard, and codeswhat.com still to come.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added `$pathname` to `$pageview` and `$pageleave` events.
- ✨ Added regression tests for pageleave reconstruction and route canonicalization.
- 🔧 Changed analytics processing to handle `$pageleave` in `before_send`.
- 🔧 Changed `$pathname` and `$current_url` derivation to use canonicalized paths.
- 🔧 Enabled explicit `capture_pageleave` in PostHog options.
- 🔒 Preserved existing privacy options and `/_other` handling for unlisted routes.

## Concerns

- Verify that `$pageleave` processing uses the same privacy and canonicalization utilities as `$pageview`.
- Confirm that enabling automatic pageleave capture does not create duplicate events for existing manual capture flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->