### PR TITLE
ci(monitor): allow prerelease tags on main until the dual GA lands

### DIFF
--- a/.github/workflows/main-is-released.yml
+++ b/.github/workflows/main-is-released.yml
@@ -5,10 +5,11 @@
 # merge landing and the tag being cut, which happens before every RC and GA.
 # Scott chose scheduled-daily over that.
 #
-# allow-prerelease stays at its default (false) per the org ruling of
-# 2026-08-21: prerelease tags live on the dev branch (release-cut.yml's
-# source_ref path), and main carries only GA tags — an rc on main is the
-# exact drift this check exists to catch.
+# Drydock promotes dev to main before every cut including RCs, so main
+# carries the rc tag through each soak window by design. allow-prerelease is
+# set to true to match that: the override stays true until v1.7.0/v1.6.1 GA
+# land, then reverts to the default false as part of the post-GA per-line
+# signing-identity work, where that reversal is already scheduled.
 #
 # This is an invariant monitor, deliberately NOT a required status check:
 # requiring it would deadlock every promotion, because a promotion PR's merge
@@ -28,3 +29,5 @@ jobs:
     permissions:
       contents: read
     uses: CodesWhat/.github/.github/workflows/main-is-released.yml@11004e42d7d19e86eb3b7777c467ec9522b784e1  # main 2026-08-21
+    with:
+      allow-prerelease: true


### PR DESCRIPTION
## Summary

Drydock promotes dev to main before every cut, including RCs, so main sits on an rc tag through each soak window by design. The main-is-released monitor caller (`.github/workflows/main-is-released.yml`) was still running the reusable workflow at its default `allow-prerelease: false`, so the daily scheduled run reds out during every soak window even though nothing is actually wrong.

This sets `allow-prerelease: true` on the `uses:` job, matching the drydock-specific decision recorded 2026-08-21 to run this monitor with prerelease acceptance during the pre-GA transitional window. It also rewrites the caller's comment block, which previously attributed default-false to "the org ruling of 2026-08-21" as if that ruling bound this cycle. It doesn't: the org ruling is the reusable workflow's own default behavior, and drydock's soak-window design is a documented deliberate override on top of it.

The override is meant to be temporary. Per the comment, it stays `true` until v1.7.0/v1.6.1 GA land, then reverts to the default `false` as part of the already-scheduled post-GA per-line signing-identity work.

No changes to the pinned SHA on the reusable workflow call.

## Test plan

- [x] `actionlint .github/workflows/main-is-released.yml` — clean
- [x] `npm run test:workflows` — 20 files / 213 tests passed
- [x] Full pre-push hook (lint, knip, qlty, scripts-test, workflow-tests, typecheck-ui, coverage, build, zizmor) — all green
- [ ] GitHub Actions is in a major outage right now, so PR checks may not run; noting it here rather than waiting on them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added `allow-prerelease: true` to the reusable release-check workflow.

🔧 Changed workflow comments to document the Drydock RC-tag override and its planned removal after v1.7.0 and v1.6.1 reach GA.

- Revert `allow-prerelease` to `false` after both releases reach GA.
- Preserve the reusable workflow’s pinned SHA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->