### PR TITLE
fix(security): send the missing security headers on the demo surface

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,3 +1,5 @@
 10049	IGNORE	Storable and Cacheable Content (informational) - content-hashed static assets are intentionally cacheable
 10055	IGNORE	CSP style-src unsafe-inline - accepted: vendor libraries (iconify-icon, Vue Transition) set element.style programmatically; documented in the CSP directives in app/api/index.ts. Stays visible in code scanning (not in IGNORED_ZAP_PLUGIN_IDS).
 10109	IGNORE	Modern Web Application (informational) - SPA detection notice, not a finding; recurs on every scan.
+10015	IGNORE	Re-examine Cache-control Directives - demo.getdrydock.com (apps/demo/vercel.json) is a 100% static SPA serving mock data only, no auth, no per-user or sensitive responses; Vercel's CDN caches the shell and assets by design, same rationale as 10049. The dynamic getdrydock.com surface sends `Cache-Control: private, no-cache, no-store` on its documents, so this stays a no-op there.
+10050	IGNORE	Retrieved from Cache - same static/CDN-cached-by-design rationale as 10015 and 10049; demo.getdrydock.com has nothing dynamic or per-user to be served stale.

--- a/apps/demo/vercel.json
+++ b/apps/demo/vercel.json
@@ -11,6 +11,19 @@
         {
           "key": "Content-Security-Policy",
           "value": "frame-ancestors 'self' https://getdrydock.com https://*.vercel.app"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "credentialless"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "https://demo.getdrydock.com"
         }
       ]
     }


### PR DESCRIPTION
The weekly ZAP baseline scan against demo.getdrydock.com started failing (run 32948622205, 2026-08-26 08:36 UTC) with FAIL-NEW: 0, WARN-NEW: 6. The zaproxy action exits nonzero on any alert, so the job stays red until each one is fixed or explicitly ruled. This addresses all six.

Each warning and its disposition:

- **X-Content-Type-Options Header Missing [10021] x5** — fixed. Added `X-Content-Type-Options: nosniff` to `apps/demo/vercel.json`, matching the value already set on the production surface (`apps/web/vercel.json`).

- **Permissions Policy Header Not Set [10063] x4** — fixed. Added `Permissions-Policy: camera=(), microphone=(), geolocation=()` to `apps/demo/vercel.json`, same value production already sends.

- **Cross-Origin-Embedder-Policy Header Missing or Invalid [90004] x6** — fixed, with `credentialless` rather than `require-corp`. The demo fetches real icons and fonts from `cdn.jsdelivr.net` through MSW handlers (`apps/demo/src/mocks/handlers/icons.ts`, `fonts.ts`) that proxy-fetch server-side in the service worker and hand the page a same-origin response, so `require-corp` shouldn't break anything in the intercepted path. `credentialless` is the safer choice anyway for any request that lands outside MSW's scope — it strips credentials from cross-origin loads instead of blocking them, and jsDelivr doesn't need credentials, so nothing should break either way.

- **Cross-Domain Misconfiguration [10098] x5** — fixed. Vercel's static file CDN sends `Access-Control-Allow-Origin: *` by default on every response for this app (confirmed live on `demo.getdrydock.com`, and the same thing happens on getdrydock.com's own static assets, e.g. `/favicon.ico`). Production's dynamic document responses don't carry this header at all, and nothing in the demo needs cross-origin XHR/fetch access to its own assets (checked: `apps/web` only references `demo.getdrydock.com` for the iframe `frame-src`/`frame-ancestors` CSP, never a fetch). Locked `Access-Control-Allow-Origin` to `https://demo.getdrydock.com` in `apps/demo/vercel.json` to match production's posture without changing behavior.

- **Re-examine Cache-control Directives [10015] x4** and **Retrieved from Cache [10050] x5** — ruled, not fixed. `.zap/rules.tsv` gets two new IGNORE entries. demo.getdrydock.com is a 100% static SPA with no auth and no per-user data; Vercel's CDN caching the shell and assets is the intended behavior, same rationale as the existing 10049 rule for content-hashed static assets. Production's document responses are explicitly `Cache-Control: private, no-cache, no-store`, so these two rules stay a no-op there — nothing on the dynamic surface gets more permissive.

Deliberately not touched: `X-Frame-Options`. Production sends `DENY`, but demo's own CSP (`frame-ancestors 'self' https://getdrydock.com https://*.vercel.app`) exists specifically so getdrydock.com can iframe the demo — copying `DENY` from production would break that embed. It wasn't one of the six warnings, so left alone.

Note: GitHub Actions is in the middle of a platform-wide outage as of this PR, so checks may not run or may sit pending — that's not a signal about this diff.

## Test plan

- [x] `npx lefthook run pre-push` clean in the worktree (biome, knip, qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, coverage at 100%, build) before pushing
- [x] `git push` re-ran the same pre-push hook via the repo's git hook, also clean
- [x] `apps/demo/vercel.json` validated as parseable JSON
- [ ] Confirm the next scheduled/manual `security-dast-web.yml` run against demo.getdrydock.com comes back green once this deploys