### PR TITLE
build(docker): roll base image digests to pick up OpenSSL 3.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Base images bumped to clear six HIGH OpenSSL CVEs.** The `node:24-alpine` and `alpine:3.24` digest pins are rolled to the current upstream rebuilds, moving the shipped OpenSSL from 3.5.7-r0 (flagged by Grype for CVE-2026-14457, CVE-2026-18798, CVE-2026-54874, CVE-2026-63072, CVE-2026-63075, and CVE-2026-63076) to 3.5.8-r0.
+
 ### Fixed
 
 - **WebSocket log-stream connections behind a TLS-terminating proxy no longer 403 when `X-Forwarded-Proto` is absent.** With trust proxy enabled, `isOriginAllowed` fell back to the local socket's `encrypted` flag whenever the proxy omitted `X-Forwarded-Proto`, which is plain HTTP on a backend behind TLS termination, so a browser's `https://` Origin never matched and every WebSocket upgrade was rejected while REST traffic worked fine. The protocol is now treated as unknown (and skipped from the comparison) in that case instead of being inferred from the local socket; host validation is unaffected. ([#867](https://github.com/CodesWhat/drydock/issues/867))

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM aquasec/trivy@sha256:7cced7cae583819fc7806d4cbc0dbbc7cad18b99f7d3e235192e6da8c091045c AS trivy-bin
 
 # Common Stage
-FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS base
+FROM node:24-alpine@sha256:2a49bdf71e9fd965a58c1703fd9ddd205b34e5782b692a72dd1d248abb0beb43 AS base
 WORKDIR /home/node/app
 
 LABEL maintainer="CodesWhat"
@@ -33,7 +33,7 @@ RUN apk add --no-cache \
     && mkdir -m 0700 /store && chown node:node /store
 
 # Build stage for healthcheck binary (~65KB static binary)
-FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS healthcheck-build
+FROM alpine:3.24@sha256:79ff19e9084a00eece421b2523fb93e22d730e2c0e525905de047e848e56d95f AS healthcheck-build
 RUN apk add --no-cache gcc=15.2.0-r5 musl-dev=1.2.6-r2
 COPY healthcheck.c /src/healthcheck.c
 RUN gcc -Os -static -s -o /bin/healthcheck /src/healthcheck.c

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache \
     bash=5.3.9-r1 \
     git=2.54.0-r0 \
     jq=1.8.1-r0 \
-    openssl=3.5.7-r0 \
+    openssl=3.5.8-r0 \
     su-exec=0.3-r0 \
     tini=0.19.0-r3 \
     tzdata=2026c-r0 \

--- a/app/configuration/dockerfile-defaults.test.ts
+++ b/app/configuration/dockerfile-defaults.test.ts
@@ -11,7 +11,7 @@ describe('Dockerfile release defaults', () => {
     const dockerfile = fs.readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
 
     expect(dockerfile).toContain(
-      'FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS base',
+      'FROM node:24-alpine@sha256:2a49bdf71e9fd965a58c1703fd9ddd205b34e5782b692a72dd1d248abb0beb43 AS base',
     );
   });
 


### PR DESCRIPTION
Grype started failing every image-scanning PR (first seen on #862) on six HIGH OpenSSL CVEs (CVE-2026-14457, CVE-2026-18798, CVE-2026-54874, CVE-2026-63072, CVE-2026-63075, CVE-2026-63076) in openssl/libssl3/libcrypto3 3.5.7-r0, which comes from the pinned node:24-alpine and alpine:3.24 digests. Not related to any dependency bump; rc.3's published image carries the same packages.

This rolls both digest pins (and the Dockerfile defaults test) to the current upstream rebuilds, which carry openssl 3.5.8-r0. This PR's own Grype image scan is the verification that the new bases clear the findings.