### PR TITLE
chore(release): prepare v1.7.0-rc.4

### DIFF
--- a/.github/tests/readme-translations.test.ts
+++ b/.github/tests/readme-translations.test.ts
@@ -66,71 +66,69 @@ const localizedSurfaceFragments: Record<
     featureTableHeader: '| | Funktion | Beschreibung |',
     builtWithHeading: '<h2 align="center" id="built-with">Gebaut mit</h2>',
     communityQaHeading: '### Community-QA',
-    releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.3</strong></summary>',
+    releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.4</strong></summary>',
   },
   'README.es.md': {
     featureTableHeader: '| | Característica | Descripción |',
     builtWithHeading: '<h2 align="center" id="built-with">Construido con</h2>',
     communityQaHeading: '### Control de calidad de la comunidad',
-    releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.3</strong></summary>',
+    releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.4</strong></summary>',
   },
   'README.fr.md': {
     featureTableHeader: '| | Fonctionnalité | Descriptif |',
     builtWithHeading: '<h2 align="center" id="built-with">Construit avec</h2>',
     communityQaHeading: '### Contrôle qualité de la communauté',
-    releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.3</strong></summary>',
+    releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.4</strong></summary>',
   },
   'README.pl.md': {
     featureTableHeader: '| | Funkcja | Opis |',
     builtWithHeading: '<h2 align="center" id="built-with">Zbudowany z</h2>',
     communityQaHeading: '### Kontrola jakości społeczności',
     releaseHeading:
-      '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.3</strong></summary>',
+      '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.4</strong></summary>',
   },
   'README.pt-BR.md': {
     featureTableHeader: '| | Recurso | Descrição |',
     builtWithHeading: '<h2 align="center" id="built-with">Construído com</h2>',
     communityQaHeading: '### Controle de qualidade da comunidade',
-    releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.3</strong></summary>',
+    releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.4</strong></summary>',
   },
   'README.zh-CN.md': {
     featureTableHeader: '| |特色|描述 |',
     builtWithHeading: '<h2 align="center" id="built-with">技术栈</h2>',
     communityQaHeading: '### 社区质量检查',
-    releaseHeading: '<summary><strong>v1.7.0-rc.3 亮点</strong></summary>',
+    releaseHeading: '<summary><strong>v1.7.0-rc.4 亮点</strong></summary>',
   },
 };
 
-const localizedReleaseFragments: Record<
-  string,
-  { portwingEdgeBodies: string; mainIsReleasedMonitor: string }
-> = {
+const localizedReleaseFragments: Record<string, { wsProxyFix: string; bareIntegerTags: string }> = {
   'README.de.md': {
-    portwingEdgeBodies: '**Portwing-Edge-Tunnel übertragen jetzt Nicht-JSON-Antworten**',
-    mainIsReleasedMonitor: '**Ein täglicher Monitor prüft, dass `main` einen Release-Tag trägt**',
+    wsProxyFix: '**WebSocket-Log-Streams funktionieren jetzt hinter TLS-terminierenden Proxys**',
+    bareIntegerTags: '**Reine Ganzzahl-Tags überholen keine gepunkteten Versionen mehr**',
   },
   'README.es.md': {
-    portwingEdgeBodies:
-      '**Los túneles de borde de Portwing ahora transportan cuerpos que no son JSON**',
-    mainIsReleasedMonitor:
-      '**Un monitor diario verifica que `main` lleve una etiqueta de versión**',
+    wsProxyFix:
+      '**Los flujos de logs por WebSocket funcionan ahora detrás de proxies con terminación TLS**',
+    bareIntegerTags:
+      '**Las etiquetas de enteros simples ya no superan a las versiones con puntos**',
   },
   'README.fr.md': {
-    portwingEdgeBodies: '**Les tunnels Portwing edge transportent désormais des corps non JSON**',
-    mainIsReleasedMonitor:
-      '**Un contrôle quotidien vérifie que `main` porte une étiquette de version**',
+    wsProxyFix:
+      '**Les flux de logs WebSocket fonctionnent désormais derrière des proxys à terminaison TLS**',
+    bareIntegerTags: '**Les tags entiers nus ne dépassent plus les versions à points**',
   },
   'README.pl.md': {
-    portwingEdgeBodies: '**Tunele brzegowe Portwing przenoszą teraz treści inne niż JSON**',
-    mainIsReleasedMonitor: '**Codzienny monitor sprawdza, czy `main` ma tag wydania**',
+    wsProxyFix: '**Strumienie logów WebSocket działają teraz za proxy z terminacją TLS**',
+    bareIntegerTags: '**Nagie tagi liczbowe nie wyprzedzają już wersji z kropkami**',
   },
   'README.pt-BR.md': {
-    portwingEdgeBodies: '**Túneis de borda do Portwing agora carregam corpos que não são JSON**',
-    mainIsReleasedMonitor: '**Um monitor diário verifica se `main` carrega uma tag de versão**',
+    wsProxyFix:
+      '**Fluxos de logs via WebSocket agora funcionam atrás de proxies com terminação TLS**',
+    bareIntegerTags: '**Tags de inteiros simples não superam mais versões com pontos**',
   },
   'README.zh-CN.md': {
-    portwingEdgeBodies: '**Portwing 边缘隧道现在可传输非 JSON 响应体**',
-    mainIsReleasedMonitor: '**每日监控确认 `main` 携带发布标签**',
+    wsProxyFix: '**WebSocket 日志流现在可在 TLS 终止代理后正常工作**',
+    bareIntegerTags: '**纯数字标签不再超过带点号的版本号**',
   },
 };
 
@@ -182,6 +180,7 @@ const requiredFragments = [
   './CHANGELOG.md#170-rc1--2026-08-14',
   './CHANGELOG.md#170-rc2--2026-08-20',
   './CHANGELOG.md#170-rc3--2026-08-23',
+  './CHANGELOG.md#170-rc4--2026-08-26',
   'Portwing 0.9.0+',
   'Standard HTTP',
   '`DD_EXPERIMENTAL_PORTWING=false`',
@@ -235,13 +234,19 @@ describe.each(translatedReadmes)('%s', (readme) => {
     const surface = localizedSurfaceFragments[readme];
     const release = localizedReleaseFragments[readme];
     const releaseBlock = getReleaseBlock(content, surface.releaseHeading);
-    const portwingEdgeBullet = getBullet(releaseBlock, release.portwingEdgeBodies);
-    const mainMonitorBullet = getBullet(releaseBlock, release.mainIsReleasedMonitor);
+    const wsProxyBullet = getBullet(releaseBlock, release.wsProxyFix);
+    const bareIntegerBullet = getBullet(releaseBlock, release.bareIntegerTags);
     const getUrls = (bullet: string | undefined) =>
       [...(bullet ?? '').matchAll(/https?:\/\/[^)<>"\s]+/g)].map(([url]) => url);
 
-    expect(getUrls(portwingEdgeBullet)).toEqual(['https://github.com/CodesWhat/drydock/pull/852']);
-    expect(getUrls(mainMonitorBullet)).toEqual(['https://github.com/CodesWhat/drydock/pull/846']);
+    expect(getUrls(wsProxyBullet)).toEqual([
+      'https://github.com/CodesWhat/drydock/issues/867',
+      'https://github.com/CodesWhat/drydock/pull/868',
+    ]);
+    expect(getUrls(bareIntegerBullet)).toEqual([
+      'https://github.com/CodesWhat/drydock/issues/859',
+      'https://github.com/CodesWhat/drydock/pull/871',
+    ]);
   });
 
   test('preserves the exact source URL multiset', () => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0-rc.4] — 2026-08-26
+
 ### Security
 
-- **Base images bumped to clear six HIGH OpenSSL CVEs.** The `node:24-alpine` and `alpine:3.24` digest pins are rolled to the current upstream rebuilds, moving the shipped OpenSSL from 3.5.7-r0 (flagged by Grype for CVE-2026-14457, CVE-2026-18798, CVE-2026-54874, CVE-2026-63072, CVE-2026-63075, and CVE-2026-63076) to 3.5.8-r0.
+- **Base images bumped to clear six HIGH OpenSSL CVEs.** The `node:24-alpine` and `alpine:3.24` digest pins are rolled to the current upstream rebuilds, moving the shipped OpenSSL from 3.5.7-r0 (flagged by Grype for CVE-2026-14457, CVE-2026-18798, CVE-2026-54874, CVE-2026-63072, CVE-2026-63075, and CVE-2026-63076) to 3.5.8-r0. ([#881](https://github.com/CodesWhat/drydock/pull/881))
+- **The demo site sends the full security-header set.** `demo.getdrydock.com` was failing the weekly ZAP baseline scan with six WARN-NEW alerts. `apps/demo/vercel.json` now sends `X-Content-Type-Options`, `Permissions-Policy`, a credentialless `Cross-Origin-Embedder-Policy`, and a same-origin `Access-Control-Allow-Origin`; the two cache-control alerts are allowlisted in `.zap/rules.tsv` under the same static-SPA rationale as the existing 10049 entry. ([#878](https://github.com/CodesWhat/drydock/pull/878))
 
 ### Fixed
 
-- **WebSocket log-stream connections behind a TLS-terminating proxy no longer 403 when `X-Forwarded-Proto` is absent.** With trust proxy enabled, `isOriginAllowed` fell back to the local socket's `encrypted` flag whenever the proxy omitted `X-Forwarded-Proto`, which is plain HTTP on a backend behind TLS termination, so a browser's `https://` Origin never matched and every WebSocket upgrade was rejected while REST traffic worked fine. The protocol is now treated as unknown (and skipped from the comparison) in that case instead of being inferred from the local socket; host validation is unaffected. ([#867](https://github.com/CodesWhat/drydock/issues/867))
-- **Tag suggestion no longer ranks a bare integer build-number tag above a real dotted version.** A bare integer tag (e.g. `168`) coerces via `semver.coerce()` into a fake `168.0.0`, which previously outranked a real release like `1.43.3` — for `linuxserver/plex`, this meant the suggested-tag badge and, with a permissive `dd.tag.include` filter, the actionable update candidate itself could point at a destructive downgrade. Bare integer tags are now only ever ranked among themselves (never against a real dotted version, and never at all when the population contains any other non-integer version signal, such as a prerelease-only or coercion-lossy tag), sorted numerically rather than lexically. The rule is shared between the suggested-tag badge (`tag/suggest.ts`) and the actionable non-semver/`includeTags` recovery path (`watchers/providers/docker/tag-candidates.ts`) via a new `tag/version-population.ts` module so the two paths can't drift apart again. ([#859](https://github.com/CodesWhat/drydock/issues/859))
+- **WebSocket log-stream connections behind a TLS-terminating proxy no longer 403 when `X-Forwarded-Proto` is absent.** With trust proxy enabled, `isOriginAllowed` fell back to the local socket's `encrypted` flag whenever the proxy omitted `X-Forwarded-Proto`, which is plain HTTP on a backend behind TLS termination, so a browser's `https://` Origin never matched and every WebSocket upgrade was rejected while REST traffic worked fine. The protocol is now treated as unknown (and skipped from the comparison) in that case instead of being inferred from the local socket; host validation is unaffected. ([#867](https://github.com/CodesWhat/drydock/issues/867), [#868](https://github.com/CodesWhat/drydock/pull/868))
+- **Tag suggestion no longer ranks a bare integer build-number tag above a real dotted version.** A bare integer tag (e.g. `168`) coerces via `semver.coerce()` into a fake `168.0.0`, which previously outranked a real release like `1.43.3` — for `linuxserver/plex`, this meant the suggested-tag badge and, with a permissive `dd.tag.include` filter, the actionable update candidate itself could point at a destructive downgrade. Bare integer tags are now only ever ranked among themselves (never against a real dotted version, and never at all when the population contains any other non-integer version signal, such as a prerelease-only or coercion-lossy tag), sorted numerically rather than lexically. The rule is shared between the suggested-tag badge (`tag/suggest.ts`) and the actionable non-semver/`includeTags` recovery path (`watchers/providers/docker/tag-candidates.ts`) via a new `tag/version-population.ts` module so the two paths can't drift apart again. ([#859](https://github.com/CodesWhat/drydock/issues/859), [#871](https://github.com/CodesWhat/drydock/pull/871))
 
 ## [1.7.0-rc.3] — 2026-08-23
 
@@ -2512,7 +2515,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.3...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.4...HEAD
+[1.7.0-rc.4]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.3...v1.7.0-rc.4
 [1.7.0-rc.3]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.2...v1.7.0-rc.3
 [1.7.0-rc.2]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.1...v1.7.0-rc.2
 [1.7.0-rc.1]: https://github.com/CodesWhat/drydock/compare/v1.6.0...v1.7.0-rc.1

--- a/README.de.md
+++ b/README.de.md
@@ -202,6 +202,18 @@ Weitere Informationen zu Docker Compose, Socket-Sicherheit, Reverse-Proxy und al
 <h2 align="center" id="recent-updates">Aktuelle Updates</h2>
 
 <details open>
+<summary><strong>Highlights von v1.7.0-rc.4</strong></summary>
+
+- **WebSocket-Log-Streams funktionieren jetzt hinter TLS-terminierenden Proxys** – wenn Trust Proxy aktiviert ist und `X-Forwarded-Proto` beim Upgrade-Request fehlt, fällt die Origin-Prüfung nicht mehr auf den TLS-Status des lokalen Sockets zurück (reines HTTP hinter TLS-Terminierung, wodurch jede Browser-Verbindung mit 403 abgelehnt wurde); das Protokoll gilt jetzt als unbekannt, die Host-Validierung bleibt unverändert. ([#867](https://github.com/CodesWhat/drydock/issues/867), [#868](https://github.com/CodesWhat/drydock/pull/868))
+- **Reine Ganzzahl-Tags überholen keine gepunkteten Versionen mehr** – ein Build-Zähler-Tag wie `168` wird nicht mehr zu einem fiktiven `168.0.0` aufgewertet, das eine echte Version wie `1.43.3` schlägt; sowohl das vorgeschlagene Tag-Badge als auch der handlungsrelevante `includeTags`-Wiederherstellungspfad teilen sich jetzt eine gemeinsame Partitionierungsregel, damit sie nicht mehr auseinanderdriften können. ([#859](https://github.com/CodesWhat/drydock/issues/859), [#871](https://github.com/CodesWhat/drydock/pull/871))
+- **Basis-Images beheben sechs HIGH-OpenSSL-CVEs** – die Digest-Pins von `node:24-alpine` und `alpine:3.24` sowie der `openssl`-apk-Pin werden auf OpenSSL 3.5.8-r0 vorgezogen. ([#881](https://github.com/CodesWhat/drydock/pull/881))
+- **Die Demo-Seite sendet jetzt den vollständigen Satz an Sicherheits-Headern** – die von DAST als fehlend markierten Header auf der Demo-Oberfläche werden jetzt gesendet. ([#878](https://github.com/CodesWhat/drydock/pull/878))
+
+Vollständige Versionshinweise in [CHANGELOG.md](./CHANGELOG.md#170-rc4--2026-08-26).
+
+</details>
+
+<details>
 <summary><strong>Highlights von v1.7.0-rc.3</strong></summary>
 
 - **Portwing-Edge-Tunnel übertragen jetzt Nicht-JSON-Antworten** – der Willkommens-Frame des Controllers kündigt jetzt die Capability `edge-response-body-b64` an und dekodiert base64-kodierte Docker-Antwortkörper (zum Beispiel die reine Textantwort „OK" von `_ping`) von Agenten, die dies unterstützen; additiv und capability-gated. ([#852](https://github.com/CodesWhat/drydock/pull/852))

--- a/README.es.md
+++ b/README.es.md
@@ -202,6 +202,18 @@ Consulte la [guía de inicio rápido](https://getdrydock.com/docs/quickstart) pa
 <h2 align="center" id="recent-updates">Actualizaciones recientes</h2>
 
 <details open>
+<summary><strong>Aspectos destacados de v1.7.0-rc.4</strong></summary>
+
+- **Los flujos de logs por WebSocket funcionan ahora detrás de proxies con terminación TLS**: con el proxy de confianza habilitado y sin `X-Forwarded-Proto` en la solicitud de upgrade, la comprobación de origen ya no recurre al estado TLS del socket local (HTTP simple detrás de la terminación TLS, lo que provocaba que cada conexión del navegador recibiera un 403); el protocolo se trata ahora como desconocido y la validación de host no cambia. ([#867](https://github.com/CodesWhat/drydock/issues/867), [#868](https://github.com/CodesWhat/drydock/pull/868))
+- **Las etiquetas de enteros simples ya no superan a las versiones con puntos**: una etiqueta de contador de compilación como `168` ya no se convierte en un falso `168.0.0` que supera a una versión real como `1.43.3`, tanto en el badge de etiqueta sugerida como en la ruta de recuperación accionable `includeTags`, que ahora comparten una única regla de partición para no volver a divergir. ([#859](https://github.com/CodesWhat/drydock/issues/859), [#871](https://github.com/CodesWhat/drydock/pull/871))
+- **Las imágenes base eliminan seis CVE HIGH de OpenSSL**: los pines de digest de `node:24-alpine` y `alpine:3.24`, y el pin de apk de `openssl`, avanzan a OpenSSL 3.5.8-r0. ([#881](https://github.com/CodesWhat/drydock/pull/881))
+- **El sitio de demostración envía el conjunto completo de cabeceras de seguridad**: las cabeceras que DAST marcaba como ausentes en la superficie de demostración ahora se envían. ([#878](https://github.com/CodesWhat/drydock/pull/878))
+
+Notas completas en [CHANGELOG.md](./CHANGELOG.md#170-rc4--2026-08-26).
+
+</details>
+
+<details>
 <summary><strong>Aspectos destacados de v1.7.0-rc.3</strong></summary>
 
 - **Los túneles de borde de Portwing ahora transportan cuerpos que no son JSON**: el frame de bienvenida del controlador ahora anuncia la capacidad `edge-response-body-b64` y decodifica cuerpos de respuesta de Docker negociados en base64 (por ejemplo, la respuesta de texto plano «OK» de `_ping`) de los agentes que la admiten; aditivo y controlado por capacidad. ([#852](https://github.com/CodesWhat/drydock/pull/852))

--- a/README.fr.md
+++ b/README.fr.md
@@ -202,6 +202,18 @@ Consultez le [Guide de démarrage rapide](https://getdrydock.com/docs/quickstart
 <h2 align="center" id="recent-updates">Mises à jour récentes</h2>
 
 <details open>
+<summary><strong>Points forts de la v1.7.0-rc.4</strong></summary>
+
+- **Les flux de logs WebSocket fonctionnent désormais derrière des proxys à terminaison TLS** : avec le trust proxy activé et `X-Forwarded-Proto` absent de la requête d'upgrade, la vérification d'origine ne se rabat plus sur l'état TLS du socket local (HTTP en clair derrière la terminaison TLS, ce qui faisait échouer chaque connexion navigateur avec un 403) ; le protocole est désormais traité comme inconnu et la validation de l'hôte reste inchangée. ([#867](https://github.com/CodesWhat/drydock/issues/867), [#868](https://github.com/CodesWhat/drydock/pull/868))
+- **Les tags entiers nus ne dépassent plus les versions à points** : un tag de compteur de build comme `168` ne se convertit plus en un faux `168.0.0` qui dépasserait une vraie version comme `1.43.3`, à la fois dans le badge de tag suggéré et dans le chemin de récupération actionnable `includeTags`, qui partagent désormais une seule règle de partition afin de ne plus diverger. ([#859](https://github.com/CodesWhat/drydock/issues/859), [#871](https://github.com/CodesWhat/drydock/pull/871))
+- **Les images de base éliminent six CVE HIGH d'OpenSSL** : les pins de digest de `node:24-alpine` et `alpine:3.24`, ainsi que le pin apk d'`openssl`, avancent vers OpenSSL 3.5.8-r0. ([#881](https://github.com/CodesWhat/drydock/pull/881))
+- **Le site de démonstration envoie désormais l'ensemble complet des en-têtes de sécurité** : les en-têtes signalés comme manquants par DAST sur la surface de démonstration sont désormais envoyés. ([#878](https://github.com/CodesWhat/drydock/pull/878))
+
+Notes complètes dans [CHANGELOG.md](./CHANGELOG.md#170-rc4--2026-08-26).
+
+</details>
+
+<details>
 <summary><strong>Points forts de la v1.7.0-rc.3</strong></summary>
 
 - **Les tunnels Portwing edge transportent désormais des corps non JSON** : la trame de bienvenue du contrôleur annonce désormais la capacité `edge-response-body-b64` et décode les corps de réponse Docker négociés en base64 (par exemple la réponse texte brut « OK » de `_ping`) provenant des agents qui la prennent en charge ; additif et conditionné par la capacité. ([#852](https://github.com/CodesWhat/drydock/pull/852))

--- a/README.md
+++ b/README.md
@@ -205,6 +205,18 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.7.0-rc.4 highlights</strong></summary>
+
+- **WebSocket log streams work behind TLS-terminating proxies** — with trust proxy enabled and `X-Forwarded-Proto` absent on the upgrade request, the origin check no longer falls back to the local socket's TLS state (plain HTTP behind TLS termination, so every browser connection 403'd); the protocol is treated as unknown and host validation is unchanged. ([#867](https://github.com/CodesWhat/drydock/issues/867), [#868](https://github.com/CodesWhat/drydock/pull/868))
+- **Bare integer tags no longer outrank dotted versions** — a build-counter tag like `168` no longer coerces into a fake `168.0.0` that beats a real `1.43.3`, in both the suggested-tag badge and the actionable `includeTags` recovery path, which now share one partition rule so they can't drift apart. ([#859](https://github.com/CodesWhat/drydock/issues/859), [#871](https://github.com/CodesWhat/drydock/pull/871))
+- **Base images clear six HIGH OpenSSL CVEs** — the `node:24-alpine` and `alpine:3.24` digest pins and the `openssl` apk pin roll forward to OpenSSL 3.5.8-r0. ([#881](https://github.com/CodesWhat/drydock/pull/881))
+- **The demo site sends the full security-header set** — the headers DAST flagged as missing on the demo surface are now sent. ([#878](https://github.com/CodesWhat/drydock/pull/878))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#170-rc4--2026-08-26).
+
+</details>
+
+<details>
 <summary><strong>v1.7.0-rc.3 highlights</strong></summary>
 
 - **Portwing edge tunnels carry non-JSON bodies** — the controller's welcome frame advertises an `edge-response-body-b64` capability and decodes base64-negotiated Docker response bodies (for example `_ping`'s plain-text `OK`) from agents that support it, additive and capability-gated. ([#852](https://github.com/CodesWhat/drydock/pull/852))

--- a/README.pl.md
+++ b/README.pl.md
@@ -202,6 +202,18 @@ Zobacz [Przewodnik szybkiego startu](https://getdrydock.com/docs/quickstart) dla
 <h2 align="center" id="recent-updates">Ostatnie aktualizacje</h2>
 
 <details open>
+<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.4</strong></summary>
+
+- **Strumienie logów WebSocket działają teraz za proxy z terminacją TLS** — gdy trust proxy jest włączone, a `X-Forwarded-Proto` jest nieobecne w żądaniu upgrade, sprawdzanie originu nie wraca już do stanu TLS lokalnego socketu (zwykły HTTP za terminacją TLS, przez co każde połączenie z przeglądarki kończyło się błędem 403); protokół jest teraz traktowany jako nieznany, a walidacja hosta pozostaje bez zmian. ([#867](https://github.com/CodesWhat/drydock/issues/867), [#868](https://github.com/CodesWhat/drydock/pull/868))
+- **Nagie tagi liczbowe nie wyprzedzają już wersji z kropkami** — tag licznika builda, taki jak `168`, nie jest już konwertowany na fikcyjny `168.0.0`, który wyprzedzałby prawdziwą wersję `1.43.3`; zarówno odznaka sugerowanego tagu, jak i ścieżka odzyskiwania `includeTags` korzystają teraz z jednej wspólnej reguły podziału, dzięki czemu nie mogą już się rozjechać. ([#859](https://github.com/CodesWhat/drydock/issues/859), [#871](https://github.com/CodesWhat/drydock/pull/871))
+- **Obrazy bazowe usuwają sześć luk OpenSSL o wysokim priorytecie (HIGH)** — pinowania digestów `node:24-alpine` i `alpine:3.24` oraz pinowanie pakietu apk `openssl` są przesuwane do OpenSSL 3.5.8-r0. ([#881](https://github.com/CodesWhat/drydock/pull/881))
+- **Strona demo wysyła teraz pełny zestaw nagłówków bezpieczeństwa** — nagłówki, których brak zgłaszał DAST na powierzchni demo, są teraz wysyłane. ([#878](https://github.com/CodesWhat/drydock/pull/878))
+
+Pełne informacje o wersji znajdują się w [CHANGELOG.md](./CHANGELOG.md#170-rc4--2026-08-26).
+
+</details>
+
+<details>
 <summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.3</strong></summary>
 
 - **Tunele brzegowe Portwing przenoszą teraz treści inne niż JSON** — ramka powitalna kontrolera ogłasza teraz możliwość `edge-response-body-b64` i dekoduje treści odpowiedzi Dockera negocjowane w base64 (na przykład zwykłą tekstową odpowiedź „OK" z `_ping`) od agentów, którzy to obsługują; addytywnie i w zależności od możliwości. ([#852](https://github.com/CodesWhat/drydock/pull/852))

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -202,6 +202,18 @@ Consulte o [Guia de início rápido](https://getdrydock.com/docs/quickstart) par
 <h2 align="center" id="recent-updates">Atualizações recentes</h2>
 
 <details open>
+<summary><strong>Destaques da v1.7.0-rc.4</strong></summary>
+
+- **Fluxos de logs via WebSocket agora funcionam atrás de proxies com terminação TLS** — com o trust proxy habilitado e `X-Forwarded-Proto` ausente na solicitação de upgrade, a verificação de origem não recorre mais ao estado TLS do socket local (HTTP puro atrás da terminação TLS, o que fazia toda conexão do navegador retornar 403); o protocolo agora é tratado como desconhecido e a validação do host permanece inalterada. ([#867](https://github.com/CodesWhat/drydock/issues/867), [#868](https://github.com/CodesWhat/drydock/pull/868))
+- **Tags de inteiros simples não superam mais versões com pontos** — uma tag de contador de build como `168` não é mais convertida em um falso `168.0.0` que supera uma versão real como `1.43.3`, tanto no selo de tag sugerida quanto no caminho de recuperação acionável `includeTags`, que agora compartilham uma única regra de partição para não voltarem a divergir. ([#859](https://github.com/CodesWhat/drydock/issues/859), [#871](https://github.com/CodesWhat/drydock/pull/871))
+- **As imagens base eliminam seis CVEs HIGH do OpenSSL** — os pins de digest de `node:24-alpine` e `alpine:3.24`, e o pin de apk do `openssl`, avançam para o OpenSSL 3.5.8-r0. ([#881](https://github.com/CodesWhat/drydock/pull/881))
+- **O site de demonstração agora envia o conjunto completo de cabeçalhos de segurança** — os cabeçalhos que o DAST sinalizava como ausentes na superfície de demonstração agora são enviados. ([#878](https://github.com/CodesWhat/drydock/pull/878))
+
+Notas completas em [CHANGELOG.md](./CHANGELOG.md#170-rc4--2026-08-26).
+
+</details>
+
+<details>
 <summary><strong>Destaques da v1.7.0-rc.3</strong></summary>
 
 - **Túneis de borda do Portwing agora carregam corpos que não são JSON** — o frame de boas-vindas do controlador agora anuncia a capacidade `edge-response-body-b64` e decodifica corpos de resposta do Docker negociados em base64 (por exemplo, a resposta em texto simples "OK" do `_ping`) de agentes que oferecem suporte a isso; aditivo e controlado por capacidade. ([#852](https://github.com/CodesWhat/drydock/pull/852))

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -202,6 +202,18 @@ docker run -d \
 <h2 align="center" id="recent-updates">最近更新</h2>
 
 <details open>
+<summary><strong>v1.7.0-rc.4 亮点</strong></summary>
+
+- **WebSocket 日志流现在可在 TLS 终止代理后正常工作** — 当启用 trust proxy 且升级请求中缺少 `X-Forwarded-Proto` 时，来源检查不再回退到本地 socket 的 TLS 状态（TLS 终止后端为纯 HTTP，导致每个浏览器连接都被 403 拒绝）；协议现在被视为未知，主机校验保持不变。([#867](https://github.com/CodesWhat/drydock/issues/867)、[#868](https://github.com/CodesWhat/drydock/pull/868))
+- **纯数字标签不再超过带点号的版本号** — 像 `168` 这样的构建计数器标签不再被强制转换为虚假的 `168.0.0` 从而超过真实版本 `1.43.3`；建议标签徽章和可操作的 `includeTags` 恢复路径现在共享同一条分区规则，因此二者不会再出现分歧。([#859](https://github.com/CodesWhat/drydock/issues/859)、[#871](https://github.com/CodesWhat/drydock/pull/871))
+- **基础镜像清除了六个高危 OpenSSL CVE** — `node:24-alpine` 与 `alpine:3.24` 的摘要固定版本以及 `openssl` 的 apk 固定版本均升级至 OpenSSL 3.5.8-r0。([#881](https://github.com/CodesWhat/drydock/pull/881))
+- **演示站点现在发送完整的安全响应头集合** — DAST 标记为缺失的响应头现在已在演示环境中发送。([#878](https://github.com/CodesWhat/drydock/pull/878))
+
+完整发行说明请参阅 [CHANGELOG.md](./CHANGELOG.md#170-rc4--2026-08-26)。
+
+</details>
+
+<details>
 <summary><strong>v1.7.0-rc.3 亮点</strong></summary>
 
 - **Portwing 边缘隧道现在可传输非 JSON 响应体** — 控制器的欢迎帧现在会宣告 `edge-response-body-b64` 能力，并为支持该能力的代理解码经 base64 协商的 Docker 响应体（例如 `_ping` 的纯文本响应 "OK"）；此变更是增量式的，并受能力协商门控。([#852](https://github.com/CodesWhat/drydock/pull/852))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.7.0-rc.3',
+    version: '1.7.0-rc.4',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-08-12T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.7.0-rc.3 started',
+    details: 'Drydock v1.7.0-rc.4 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-08-05T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.7.0-rc.3',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.7.0-rc.4',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.7.0-rc.3',
+    tag: '1.7.0-rc.4',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.7.0-rc.3',
+  version: '1.7.0-rc.4',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.7.0-rc.3',
+      version: '1.7.0-rc.4',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.7.0-rc.3', mode: 'demo' },
+        server: { version: '1.7.0-rc.4', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.7.0-rc.3",
+  version: "1.7.0-rc.4",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -294,7 +294,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.7.0-rc.3",
+    version: "v1.7.0-rc.4",
     title: "Smart Updates & UX",
     emoji: "\u{1F680}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.7.0-rc.3",
+      "version": "1.7.0-rc.4",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.7.0-rc.3",
+    "version": "1.7.0-rc.4",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.7.0-rc.3"
+  "version":"1.7.0-rc.4"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.7.0-rc.3",
+    "version": "1.7.0-rc.4",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.7.0-rc.3",
+      "drydockVersion": "1.7.0-rc.4",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.7.0-rc.3` | Immutable release candidate; best for reproducible testing |
+| `1.7.0-rc.4` | Immutable release candidate; best for reproducible testing |
 | `1.7-rc` | Rolling release-candidate channel; moves to the newest `1.7.0-rc.N` |
 | `1.6.0` | Immutable exact GA release; best for reproducible deployments |
 | `1.6` | Rolling stable minor channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,13 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.7.0-rc.4 Highlights — August 26, 2026
+
+- **WebSocket log streams work behind TLS-terminating proxies** — with trust proxy enabled and `X-Forwarded-Proto` absent on the upgrade request, the origin check no longer falls back to the local socket's TLS state (plain HTTP behind TLS termination, so every browser connection 403'd); the protocol is treated as unknown and host validation is unchanged ([#867](https://github.com/CodesWhat/drydock/issues/867), [#868](https://github.com/CodesWhat/drydock/pull/868)).
+- **Bare integer tags no longer outrank dotted versions** — a build-counter tag like `168` no longer coerces into a fake `168.0.0` that beats a real `1.43.3`, in both the suggested-tag badge and the actionable `includeTags` recovery path, which now share one partition rule so they can't drift apart ([#859](https://github.com/CodesWhat/drydock/issues/859), [#871](https://github.com/CodesWhat/drydock/pull/871)).
+- **Base images clear six HIGH OpenSSL CVEs** — the `node:24-alpine` and `alpine:3.24` digest pins and the `openssl` apk pin roll forward to OpenSSL 3.5.8-r0 ([#881](https://github.com/CodesWhat/drydock/pull/881)).
+- **The demo site sends the full security-header set** — the headers DAST flagged as missing on the demo surface are now sent ([#878](https://github.com/CodesWhat/drydock/pull/878)).
+
 ## v1.7.0-rc.3 Highlights — August 23, 2026
 
 - **Portwing edge tunnels carry non-JSON Docker response bodies** — the controller's welcome frame now advertises an `edge-response-body-b64` capability and decodes base64-negotiated response bodies (for example `GET /_ping`'s plain-text `OK`) from agents that support it, falling back to the existing path otherwise. Additive and capability-gated, no protocol-version bump ([#852](https://github.com/CodesWhat/drydock/pull/852)).

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.7 RC and prior releases have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.7.0-rc.3...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.7.0-rc.4...HEAD`],
+    ['1.7.0-rc.4', `${repositoryUrl}/compare/v1.7.0-rc.3...v1.7.0-rc.4`],
     ['1.7.0-rc.3', `${repositoryUrl}/compare/v1.7.0-rc.2...v1.7.0-rc.3`],
     ['1.7.0-rc.2', `${repositoryUrl}/compare/v1.7.0-rc.1...v1.7.0-rc.2`],
     ['1.7.0-rc.1', `${repositoryUrl}/compare/v1.6.0...v1.7.0-rc.1`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.7.0-rc.3';
-const PREV_RC_VERSION = '1.7.0-rc.2';
-const RC_DATE = '2026-08-23';
-const RC_DISPLAY_DATE = 'August 23, 2026';
+const RC_VERSION = '1.7.0-rc.4';
+const PREV_RC_VERSION = '1.7.0-rc.3';
+const RC_DATE = '2026-08-26';
+const RC_DISPLAY_DATE = 'August 26, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.6', 'content/docs/v1.5'];
 const RELEASE_REDIRECT_STATUSES = [301, 302, 303, 307, 308];
 const BROAD_401_CLAIM =
@@ -142,7 +142,7 @@ test('release candidate notes cover the post-promotion fixes', () => {
     `## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`,
   );
 
-  for (const issue of [829, 832, 836]) {
+  for (const issue of [867, 859, 878, 881]) {
     const issueLink = `https://github.com/CodesWhat/drydock/issues/${issue}`;
     const pullLink = `https://github.com/CodesWhat/drydock/pull/${issue}`;
     assert.ok(
@@ -155,7 +155,7 @@ test('release candidate notes cover the post-promotion fixes', () => {
     );
   }
 
-  for (const fragment of ['`edge-response-body-b64`', 'shields.io', 'zizmor', 'js-yaml']) {
+  for (const fragment of ['`X-Forwarded-Proto`', '168.0.0', '3.5.8-r0', 'security-header set']) {
     assert.ok(changelog.includes(fragment), `CHANGELOG.md must include ${fragment}`);
     assert.ok(updates.includes(fragment), `updates page must include ${fragment}`);
   }

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.7.0';
-const RC_VERSION = '1.7.0-rc.3';
+const RC_VERSION = '1.7.0-rc.4';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',

--- a/scripts/release-precut-check.test.mjs
+++ b/scripts/release-precut-check.test.mjs
@@ -328,7 +328,7 @@ test('cli exits 1 and reports pending discussion when strict RC check has an unc
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.3'],
+    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.4'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -345,7 +345,7 @@ test('cli exits 0 when --force is set even with pending replies', () => {
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', '--force', 'v1.7.0-rc.3'],
+    [scriptPath, '--tracker', trackerPath, '--strict', '--force', 'v1.7.0-rc.4'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -360,7 +360,7 @@ test('cli exits 0 with warning when tracker file does not exist', () => {
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.3'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.4'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -377,7 +377,7 @@ test('cli exits 0 for prerelease tags with pending replies (informational only)'
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.3'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.4'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -393,7 +393,7 @@ test('cli exits 1 for prerelease tags with --strict and pending replies', () => 
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.3'],
+    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.4'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -409,7 +409,7 @@ test('cli exits 0 and prints success when tracker has no pending replies', () =>
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.3'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.4'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',


### PR DESCRIPTION
Same shape as #854's rc.3 prep. Rolls the release identity to v1.7.0-rc.4 (2026-08-26): CHANGELOG heading absorbing the Unreleased entries with link refs, README + all six translations get a translated rc.4 highlights block (rc.3 blocks collapse), updates page section, demo mocks / site config / docs version strings, and the identity + translation test fixtures.

rc.4 supersedes rc.3 as the GA candidate: rc.3 predates the ws-origin 403 fix (#868), the bare-integer tag ranking fix (#871), the OpenSSL base-image bump clearing six HIGH CVEs (#881), and the demo security headers (#878). Also authors the missing CHANGELOG entry for #878 and adds shipping-PR links to the existing Unreleased bullets.

Verification: 55/55 identity/link tests, 213/213 workflow tests, full pre-push gate green (one DashboardGrid flake retry, the known #807 pattern).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added v1.7.0-rc.4 highlights to README translations and release documentation.
- 🔧 Changed changelog links, release metadata, site configuration, roadmap, API examples, quickstart tags, demo mocks, and test fixtures from rc.3 to rc.4.
- 🐛 Fixed release documentation and translation tests for rc.4 links and content.
- 🔒 Documented OpenSSL base-image updates for six HIGH CVEs.
- 🔒 Documented complete security headers for the demo site.
- 🐛 Documented WebSocket log streaming fixes behind TLS proxies.
- 🐛 Documented numeric tag ranking and fallback partitioning fixes.

- Confirm all rc.4 issue, pull-request, and changelog reference URLs resolve.
- Check that all release-facing version references use `1.7.0-rc.4` consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->