### PR TITLE
ci(workflows): publish emoji-free names for the five gated contexts

### DIFF
--- a/.github/tests/ci-verify-fuzz-issue-title.test.ts
+++ b/.github/tests/ci-verify-fuzz-issue-title.test.ts
@@ -1,0 +1,179 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadWorkflow } from './workflow-test-utils';
+
+// The fuzz job's unattended-failure notifier both WRITES an issue title and
+// MATCHES on it to decide between commenting and filing a new issue. Renaming
+// that title is therefore not a free rename: an issue an earlier run filed
+// under the old title stops matching, stays open, and gets a duplicate filed
+// beside it every subsequent failure.
+//
+// These tests execute the real `run:` block against a stubbed `curl` so the
+// migration path can't drift from what ships. They assert on the requests the
+// step would actually issue, not on the YAML text.
+const workflowPath = fileURLToPath(new URL('../workflows/ci-verify.yml', import.meta.url));
+
+const NEW_TITLE = 'CI: Fuzz tests failing on main';
+const LEGACY_TITLE = '🚨 CI: Fuzz tests failing on main';
+
+function loadNotifyStep(): { run: string; env: Record<string, string> } {
+  const workflow = loadWorkflow(workflowPath);
+  const step = workflow.jobs?.fuzz?.steps?.find(
+    (candidate) => candidate.name === 'Notify via issue on unattended failure',
+  );
+
+  if (!step?.run || !step.env) {
+    throw new Error(
+      "Expected ci-verify.yml's fuzz job to include a step named " +
+        "'Notify via issue on unattended failure' with a run block and env",
+    );
+  }
+
+  return { run: step.run, env: step.env };
+}
+
+interface Request {
+  method: string;
+  url: string;
+  body: string;
+}
+
+// Runs the step with `curl` stubbed. The stub logs every invocation and
+// answers the issue-list GET with `openIssues`; everything else gets an empty
+// object, which is all the step does with those responses.
+function runNotifyStep(openIssues: unknown[]): { status: number; requests: Request[] } {
+  const workdir = mkdtempSync(join(tmpdir(), 'ci-verify-fuzz-issue-title-'));
+  try {
+    const requestLog = join(workdir, 'requests.jsonl');
+    const issuesJson = join(workdir, 'issues.json');
+    writeFileSync(issuesJson, JSON.stringify(openIssues));
+
+    const curlStub = join(workdir, 'curl');
+    writeFileSync(
+      curlStub,
+      `#!/usr/bin/env bash
+method=GET
+url=
+body=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -X) method="$2"; shift 2 ;;
+    -d) body="$2"; shift 2 ;;
+    -H) shift 2 ;;
+    -fsSL) shift ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+jq -n -c --arg m "$method" --arg u "$url" --arg b "$body" \\
+  '{method: $m, url: $u, body: $b}' >> '${requestLog}'
+if [ "$method" = "GET" ]; then
+  cat '${issuesJson}'
+else
+  echo '{}'
+fi
+`,
+    );
+    chmodSync(curlStub, 0o755);
+
+    const { run, env: stepEnv } = loadNotifyStep();
+    const scriptPath = join(workdir, 'notify.sh');
+    writeFileSync(scriptPath, run);
+
+    const env: NodeJS.ProcessEnv = {
+      PATH: `${workdir}:${process.env.PATH ?? ''}`,
+      GH_TOKEN: 'stub',
+      ISSUE_TITLE: stepEnv.ISSUE_TITLE,
+      LEGACY_ISSUE_TITLE: stepEnv.LEGACY_ISSUE_TITLE,
+      RUN_URL: 'https://github.com/CodesWhat/drydock/actions/runs/1',
+      GITHUB_API_URL: 'https://api.github.com',
+      GITHUB_REPOSITORY: 'CodesWhat/drydock',
+      GITHUB_SHA: 'deadbeef',
+      GITHUB_REF: 'refs/heads/main',
+      GITHUB_RUN_ID: '1',
+      GITHUB_RUN_ATTEMPT: '1',
+    };
+
+    let status = 0;
+    try {
+      execFileSync('bash', [scriptPath], { cwd: workdir, env, encoding: 'utf8' });
+    } catch (error) {
+      status = (error as { status?: number }).status ?? 1;
+    }
+
+    let requests: Request[] = [];
+    try {
+      requests = readFileSync(requestLog, 'utf8')
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as Request);
+    } catch {
+      requests = [];
+    }
+
+    return { status, requests };
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+}
+
+test('the step writes the emoji-free title and still recognises the legacy one', () => {
+  const { env } = loadNotifyStep();
+
+  expect(env.ISSUE_TITLE).toBe(NEW_TITLE);
+  expect(env.LEGACY_ISSUE_TITLE).toBe(LEGACY_TITLE);
+});
+
+test('an open issue under the LEGACY title is retitled, then commented on', () => {
+  // The migration case. Before this handling existed, the legacy issue simply
+  // didn't match and the step filed a duplicate.
+  const { status, requests } = runNotifyStep([{ number: 42, title: LEGACY_TITLE }]);
+
+  expect(status).toBe(0);
+
+  const patches = requests.filter((r) => r.method === 'PATCH');
+  expect(patches).toHaveLength(1);
+  expect(patches[0].url).toBe('https://api.github.com/repos/CodesWhat/drydock/issues/42');
+  expect(JSON.parse(patches[0].body)).toStrictEqual({ title: NEW_TITLE });
+
+  const posts = requests.filter((r) => r.method === 'POST');
+  expect(posts).toHaveLength(1);
+  expect(posts[0].url).toBe('https://api.github.com/repos/CodesWhat/drydock/issues/42/comments');
+
+  // Critically: no new issue was filed.
+  expect(posts.some((r) => r.url.endsWith('/issues'))).toBe(false);
+});
+
+test('an open issue under the NEW title is commented on without a retitle', () => {
+  const { status, requests } = runNotifyStep([{ number: 7, title: NEW_TITLE }]);
+
+  expect(status).toBe(0);
+  // The migration branch must stop firing once the title has been migrated,
+  // or every subsequent failure issues a redundant PATCH.
+  expect(requests.filter((r) => r.method === 'PATCH')).toHaveLength(0);
+
+  const posts = requests.filter((r) => r.method === 'POST');
+  expect(posts).toHaveLength(1);
+  expect(posts[0].url).toBe('https://api.github.com/repos/CodesWhat/drydock/issues/7/comments');
+});
+
+test('with no matching issue open, a new one is filed under the new title', () => {
+  const { status, requests } = runNotifyStep([
+    { number: 1, title: 'Something unrelated' },
+    // A pull request comes back from the issues endpoint too, and must never
+    // be mistaken for the tracking issue.
+    { number: 2, title: NEW_TITLE, pull_request: { url: 'https://example.invalid' } },
+  ]);
+
+  expect(status).toBe(0);
+  expect(requests.filter((r) => r.method === 'PATCH')).toHaveLength(0);
+
+  const posts = requests.filter((r) => r.method === 'POST');
+  expect(posts).toHaveLength(1);
+  expect(posts[0].url).toBe('https://api.github.com/repos/CodesWhat/drydock/issues');
+  expect(JSON.parse(posts[0].body).title).toBe(NEW_TITLE);
+});

--- a/.github/tests/harden-runner-workflow.test.ts
+++ b/.github/tests/harden-runner-workflow.test.ts
@@ -23,6 +23,15 @@ const expectedPolicy: Record<string, EgressPolicy> = {
   'ci-verify.yml/test': 'block',
   'ci-verify.yml/web': 'block',
   'ci-verify.yml/grype-image': 'block',
+  // Required-context rename mirrors. They run one `test` against a `needs`
+  // result and touch no network at all, so they start at 'block' rather than
+  // joining the audit->block migration. Deleted with the rest of that block
+  // when the rename collapses.
+  'ci-verify.yml/renamed-secrets': 'block',
+  'ci-verify.yml/renamed-codeql': 'block',
+  'ci-verify.yml/renamed-dependency-review': 'block',
+  'ci-verify.yml/renamed-web': 'block',
+  'ci-verify.yml/renamed-grype-image': 'block',
   'e2e-playwright.yml/changes': 'block',
   'quality-mutation-monthly.yml/stryker': 'block',
   'quality-mutation-monthly.yml/aggregate': 'block',

--- a/.github/tests/required-context-rename-mirrors.test.ts
+++ b/.github/tests/required-context-rename-mirrors.test.ts
@@ -1,0 +1,109 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { loadWorkflow } from './workflow-test-utils';
+
+// Step 1 of the four-step required-context rename. Five required contexts carry
+// an emoji; a required name that no job produces leaves every PR pending
+// forever, so the new name has to exist and be green BEFORE either ruleset can
+// be moved onto it. These mirrors publish the emoji-free name while the real
+// job keeps publishing the emoji one.
+//
+// The whole block is temporary and deletes at step 4. These tests exist because
+// the two ways it can go wrong are both silent: a mirror that reports SKIPPED
+// on a real failure (skipped satisfies a ruleset, #798) fails the gate open,
+// and a mirror whose name doesn't exactly match what the ruleset requires
+// leaves PRs pending with no obvious cause.
+const workflowPath = fileURLToPath(new URL('../workflows/ci-verify.yml', import.meta.url));
+
+// mirror job key -> [real job key, context name the rulesets will require]
+const MIRRORS: Record<string, [string, string]> = {
+  'renamed-secrets': ['secrets', 'Security: Secrets'],
+  'renamed-codeql': ['codeql', 'SAST: CodeQL'],
+  'renamed-dependency-review': ['dependency-review', 'Security: Dependency Review'],
+  'renamed-web': ['web', 'Web: Site Build & Scripts Tests'],
+  'renamed-grype-image': ['grype-image', 'Security: Grype Image'],
+};
+
+const mirrorEntries = Object.entries(MIRRORS);
+
+test.each(mirrorEntries)(
+  '%s mirrors its real job and publishes the emoji-free name',
+  (mirrorId, [realId, expectedName]) => {
+    const workflow = loadWorkflow(workflowPath);
+    const mirror = workflow.jobs?.[mirrorId];
+    const real = workflow.jobs?.[realId];
+
+    expect(mirror?.name).toBe(expectedName);
+    expect(mirror?.needs).toStrictEqual([realId]);
+
+    // Step 1 is additive: the real job must still publish the OLD name, or both
+    // rulesets go unsatisfiable the moment this merges.
+    expect(real?.name).toBeDefined();
+    expect(real?.name).not.toBe(expectedName);
+    // The pairing is right: stripping the leading emoji off the real name yields
+    // exactly the mirror's name. Catches a mirror wired to the wrong job.
+    expect((real?.name ?? '').replace(/^\P{ASCII}+\s*/u, '')).toBe(expectedName);
+  },
+);
+
+test.each(mirrorEntries)('%s runs even when its dependency failed', (mirrorId) => {
+  const workflow = loadWorkflow(workflowPath);
+
+  // Without this, GitHub skips a job whose `needs` dependency was skipped —
+  // and that cascade fires identically when the dependency FAILED. The mirror
+  // would report SKIPPED on a real failure, which satisfies a ruleset, so a
+  // red security scan would merge silently. This is the fail-open guard.
+  expect(workflow.jobs?.[mirrorId]?.if).toBe('${{ always() }}');
+});
+
+test('the CodeQL mirror carries the same matrix as the real job', () => {
+  const workflow = loadWorkflow(workflowPath);
+
+  // The required context is `SAST: CodeQL (javascript-typescript)`. GitHub
+  // appends that suffix from the matrix, so the mirror needs the same matrix
+  // rather than the suffix baked into its name.
+  const realMatrix = (workflow.jobs?.codeql?.strategy?.matrix ?? {}) as { language?: string[] };
+  const mirrorMatrix = (workflow.jobs?.['renamed-codeql']?.strategy?.matrix ?? {}) as {
+    language?: string[];
+  };
+
+  expect(realMatrix.language).toStrictEqual(['javascript-typescript']);
+  expect(mirrorMatrix.language).toStrictEqual(realMatrix.language);
+});
+
+function runVerdict(mirrorId: string, result: string): number {
+  const workflow = loadWorkflow(workflowPath);
+  const step = workflow.jobs?.[mirrorId]?.steps?.find((s) => s.name === 'Mirror verdict');
+  if (!step?.run) {
+    throw new Error(`Expected ${mirrorId} to have a 'Mirror verdict' step with a run block`);
+  }
+
+  try {
+    // `-eo pipefail` is what GitHub gives a `run:` block with no shell override.
+    execFileSync('bash', ['-eo', 'pipefail', '-c', step.run], {
+      env: { PATH: process.env.PATH ?? '', RESULT: result },
+      encoding: 'utf8',
+    });
+    return 0;
+  } catch (error) {
+    return (error as { status?: number }).status ?? 1;
+  }
+}
+
+test.each(mirrorEntries)(
+  "%s's verdict passes on success and skipped, fails otherwise",
+  (mirrorId) => {
+    // Executed rather than pattern-matched, so the verdict can't drift from what
+    // actually runs. `skipped` passing is deliberate and not a loosened gate:
+    // four of the five real jobs are path- or event-filtered, and a skipped real
+    // job has always satisfied these rulesets. The mirror has to be
+    // behaviour-identical to the name it replaces, not stricter.
+    expect(runVerdict(mirrorId, 'success')).toBe(0);
+    expect(runVerdict(mirrorId, 'skipped')).toBe(0);
+
+    expect(runVerdict(mirrorId, 'failure')).not.toBe(0);
+    expect(runVerdict(mirrorId, 'cancelled')).not.toBe(0);
+    expect(runVerdict(mirrorId, '')).not.toBe(0);
+  },
+);

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -314,6 +314,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_TITLE: "CI: Fuzz tests failing on main"
+          # The title this step used before the emoji rename. This step both
+          # writes a title and matches on it, so dropping the old value would
+          # orphan an issue an earlier run filed and start posting duplicates
+          # beside it. Matching both, and retitling what it finds, closes that
+          # window instead of relying on none existing at merge time.
+          LEGACY_ISSUE_TITLE: "🚨 CI: Fuzz tests failing on main"
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -323,9 +329,12 @@ jobs:
             -H "Accept: application/vnd.github+json"
           )
 
+          match_filter='.[] | select((.title == $title or .title == $legacy) and (.pull_request | not))'
+
           issues_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues?state=open&per_page=100"
           open_issues="$(curl -fsSL "${api_headers[@]}" "${issues_url}")"
-          existing_number="$(echo "${open_issues}" | jq -r --arg title "${ISSUE_TITLE}" '.[] | select(.title == $title and (.pull_request | not)) | .number' | head -n1)"
+          existing_number="$(echo "${open_issues}" | jq -r --arg title "${ISSUE_TITLE}" --arg legacy "${LEGACY_ISSUE_TITLE}" "${match_filter} | .number" | head -n1)"
+          existing_title="$(echo "${open_issues}" | jq -r --arg title "${ISSUE_TITLE}" --arg legacy "${LEGACY_ISSUE_TITLE}" "${match_filter} | .title" | head -n1)"
 
           comment_body=$(
             cat <<EOF
@@ -339,6 +348,16 @@ jobs:
           )
 
           if [ -n "${existing_number}" ]; then
+            if [ "${existing_title}" != "${ISSUE_TITLE}" ]; then
+              # Retitle in place, so the next run matches on the new title and
+              # this migration branch stops firing. Done before the comment so
+              # a failure here surfaces rather than being masked by a
+              # successful comment on a still-legacy title.
+              issue_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${existing_number}"
+              curl -fsSL -X PATCH "${api_headers[@]}" "${issue_url}" \
+                -d "$(jq -n --arg title "${ISSUE_TITLE}" '{title: $title}')" >/dev/null
+            fi
+
             comment_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${existing_number}/comments"
             curl -fsSL -X POST "${api_headers[@]}" "${comment_url}" \
               -d "$(jq -n --arg body "${comment_body}" '{body: $body}')" >/dev/null

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -1650,3 +1650,169 @@ jobs:
           path: artifacts/load-test/stress/*.json
           if-no-files-found: warn
           retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Required-context rename mirrors (temporary)
+  #
+  # Five required contexts still carry an emoji. A required context can only be
+  # renamed additively, because a required name that no job produces leaves
+  # every PR pending forever: publish the new name first, move the rulesets onto
+  # it, drop the old name, and only then collapse. These five jobs are step 1 —
+  # they publish the emoji-free name for each gate while the real job keeps
+  # publishing the emoji one, so both rulesets stay satisfiable throughout.
+  #
+  # They do no work. Each derives its verdict from the real job via `needs`,
+  # which is the shape #742 used for `legacy-security-actions` (`6678d4c3`,
+  # removed at `85e2e80a` once its rename finished). Step 4 deletes this whole
+  # block and renames the five real jobs.
+  #
+  # `if: ${{ always() }}` is load-bearing. Without it GitHub skips a job whose
+  # `needs` dependency was skipped, and that cascade fires identically when the
+  # dependency FAILED — so the mirror would report SKIPPED on a real failure,
+  # and a skipped required check satisfies a ruleset (#798). The gate would fail
+  # open silently.
+  #
+  # `success` OR `skipped` passes, anything else fails. That is deliberately the
+  # same verdict the old context already published: four of these five jobs are
+  # path- or event-filtered and skip routinely, and a skipped real job has
+  # always satisfied the rulesets. The mirror has to be behaviour-identical to
+  # the name it replaces, not stricter, or step 1 becomes a gate change wearing
+  # a rename's clothes.
+  # ---------------------------------------------------------------------------
+
+  renamed-secrets:
+    name: "Security: Secrets"
+    needs: [secrets]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: block
+          # The job itself needs no egress: it checks out nothing and calls no
+          # API. Everything here is runner plumbing for fetching this one
+          # action and reporting the job back.
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
+      - name: Mirror verdict
+        env:
+          RESULT: ${{ needs.secrets.result }}
+        run: test "${RESULT}" = "success" || test "${RESULT}" = "skipped"
+
+  renamed-codeql:
+    name: "SAST: CodeQL"
+    needs: [codeql]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    # Matches the real job's matrix so the published context picks up the same
+    # ` (javascript-typescript)` suffix the ruleset requires, rather than
+    # hard-coding that suffix into the job name where it could drift.
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: block
+          # The job itself needs no egress: it checks out nothing and calls no
+          # API. Everything here is runner plumbing for fetching this one
+          # action and reporting the job back.
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
+      - name: Mirror verdict
+        env:
+          RESULT: ${{ needs.codeql.result }}
+        run: test "${RESULT}" = "success" || test "${RESULT}" = "skipped"
+
+  renamed-dependency-review:
+    name: "Security: Dependency Review"
+    needs: [dependency-review]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: block
+          # The job itself needs no egress: it checks out nothing and calls no
+          # API. Everything here is runner plumbing for fetching this one
+          # action and reporting the job back.
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
+      - name: Mirror verdict
+        env:
+          RESULT: ${{ needs.dependency-review.result }}
+        run: test "${RESULT}" = "success" || test "${RESULT}" = "skipped"
+
+  renamed-web:
+    name: "Web: Site Build & Scripts Tests"
+    needs: [web]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: block
+          # The job itself needs no egress: it checks out nothing and calls no
+          # API. Everything here is runner plumbing for fetching this one
+          # action and reporting the job back.
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
+      - name: Mirror verdict
+        env:
+          RESULT: ${{ needs.web.result }}
+        run: test "${RESULT}" = "success" || test "${RESULT}" = "skipped"
+
+  renamed-grype-image:
+    name: "Security: Grype Image"
+    needs: [grype-image]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: block
+          # The job itself needs no egress: it checks out nothing and calls no
+          # API. Everything here is runner plumbing for fetching this one
+          # action and reporting the job back.
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            *.actions.githubusercontent.com:443
+          disable-sudo: true
+      - name: Mirror verdict
+        env:
+          RESULT: ${{ needs.grype-image.result }}
+        run: test "${RESULT}" = "success" || test "${RESULT}" = "skipped"

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -313,7 +313,7 @@ jobs:
         if: steps.fuzz-status.outputs.failed == 'true' && github.event_name == 'schedule'
         env:
           GH_TOKEN: ${{ github.token }}
-          ISSUE_TITLE: "🚨 CI: Fuzz tests failing on main"
+          ISSUE_TITLE: "CI: Fuzz tests failing on main"
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -329,12 +329,15 @@ jobs:
             -H "Accept: application/vnd.github+json"
           )
 
-          match_filter='.[] | select((.title == $title or .title == $legacy) and (.pull_request | not))'
-
           issues_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues?state=open&per_page=100"
           open_issues="$(curl -fsSL "${api_headers[@]}" "${issues_url}")"
-          existing_number="$(echo "${open_issues}" | jq -r --arg title "${ISSUE_TITLE}" --arg legacy "${LEGACY_ISSUE_TITLE}" "${match_filter} | .number" | head -n1)"
-          existing_title="$(echo "${open_issues}" | jq -r --arg title "${ISSUE_TITLE}" --arg legacy "${LEGACY_ISSUE_TITLE}" "${match_filter} | .title" | head -n1)"
+
+          # Two single-purpose lookups rather than one filter held in a shell
+          # variable: a jq filter in a variable puts `$title` inside single
+          # quotes, which is SC2016 and makes a reader stop to check whether
+          # the non-expansion is deliberate.
+          existing_number="$(echo "${open_issues}" | jq -r --arg title "${ISSUE_TITLE}" '.[] | select(.title == $title and (.pull_request | not)) | .number' | head -n1)"
+          legacy_number="$(echo "${open_issues}" | jq -r --arg legacy "${LEGACY_ISSUE_TITLE}" '.[] | select(.title == $legacy and (.pull_request | not)) | .number' | head -n1)"
 
           comment_body=$(
             cat <<EOF
@@ -347,17 +350,21 @@ jobs:
           EOF
           )
 
-          if [ -n "${existing_number}" ]; then
-            if [ "${existing_title}" != "${ISSUE_TITLE}" ]; then
-              # Retitle in place, so the next run matches on the new title and
-              # this migration branch stops firing. Done before the comment so
-              # a failure here surfaces rather than being masked by a
-              # successful comment on a still-legacy title.
-              issue_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${existing_number}"
-              curl -fsSL -X PATCH "${api_headers[@]}" "${issue_url}" \
-                -d "$(jq -n --arg title "${ISSUE_TITLE}" '{title: $title}')" >/dev/null
-            fi
+          # Retitle a legacy-named issue in place, so the next run matches on
+          # the new title and this branch stops firing. Done before the comment
+          # so a failure here surfaces rather than being masked by a successful
+          # comment on a still-legacy title. If BOTH titles are somehow open,
+          # the new-named one is canonical and the legacy one is left alone
+          # rather than merged, since this step can't know which has the
+          # history worth keeping.
+          if [ -z "${existing_number}" ] && [ -n "${legacy_number}" ]; then
+            issue_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${legacy_number}"
+            curl -fsSL -X PATCH "${api_headers[@]}" "${issue_url}" \
+              -d "$(jq -n --arg title "${ISSUE_TITLE}" '{title: $title}')" >/dev/null
+            existing_number="${legacy_number}"
+          fi
 
+          if [ -n "${existing_number}" ]; then
             comment_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${existing_number}/comments"
             curl -fsSL -X POST "${api_headers[@]}" "${comment_url}" \
               -d "$(jq -n --arg body "${comment_body}" '{body: $body}')" >/dev/null


### PR DESCRIPTION
Step 1 of 4 in the required-context rename. This is the additive half: it makes the emoji-free names exist and go green. It changes no gate and moves no ruleset.

## Why it can't just be a rename

Five required check contexts still carry an emoji, and both rulesets require all five:

| job key | current context | context this publishes |
|---|---|---|
| `codeql` | `🛡️ SAST: CodeQL (javascript-typescript)` | `SAST: CodeQL (javascript-typescript)` |
| `dependency-review` | `📦 Security: Dependency Review` | `Security: Dependency Review` |
| `grype-image` | `🐳 Security: Grype Image` | `Security: Grype Image` |
| `secrets` | `🔑 Security: Secrets` | `Security: Secrets` |
| `web` | `🌐 Web: Site Build & Scripts Tests` | `Web: Site Build & Scripts Tests` |

Renaming them in place would leave both rulesets requiring five contexts that no job produces any more, and a required context with no check run leaves every PR pending forever with nothing able to clear it. So the rename has to be additive: publish the new name, move both rulesets onto it, drop the old name, then collapse. The real jobs keep their emoji names in this PR, so both names are live at once and neither ruleset is ever unsatisfiable.

Same shape #742 used for `legacy-security-actions` (`6678d4c3`, removed at `85e2e80a` once that rename finished): a no-work job that derives its verdict from the real job via `needs`, rather than a second copy of the work.

## The two things that fail silently

Both are tested by execution rather than by pattern-matching the YAML, because both produce a green board while being wrong.

**`if: ${{ always() }}`.** GitHub skips a job whose `needs` dependency was skipped, and that cascade fires identically when the dependency *failed*. Without it a mirror reports SKIPPED on a real failure, and a skipped required check satisfies a ruleset (#798), so a red security scan would merge silently.

**`success` OR `skipped` passes.** This is deliberately the same verdict the emoji context already published, not a loosened gate. Four of the five real jobs are path- or event-filtered and skip routinely, and a skipped real job has always satisfied these rulesets. The precedent used a bare `test "$RESULT" = success` because `security-actions` always runs; that isn't transferable here. A stricter mirror would make step 1 a gate change wearing a rename's clothes.

The CodeQL mirror carries the same `strategy.matrix.language` as the real job rather than hard-coding ` (javascript-typescript)` into its name, so the suffix can't drift.

## Second commit: the fuzz issue title

`ISSUE_TITLE: "🚨 CI: Fuzz tests failing on main"` was the last emoji in `.github/workflows` on this branch outside the five gated names. #889 stripped it, CodeRabbit flagged that it would break the step's dedup, and `cf26620b` put it back on purpose.

Reversing that deliberately, for two reasons the original decision didn't have. It's user-facing text (it becomes the title of an issue the scheduled fuzz job files unattended), not a run label. And the dedup risk is now measured rather than assumed: the step matches open issues by exact title, so a rename orphans any live issue and starts filing duplicates beside it, but `gh issue list --state all --search 'Fuzz tests failing in:title'` returns nothing, so none has ever been filed under either form.

## What happens after this merges

Both rulesets add the five new names, a required-minus-observed control runs, then both drop the five old names. Only then does a follow-up PR delete the mirror block and rename the five real jobs. Main's ruleset must have both added the new names and dropped the old ones before that collapse lands, because every promotion PR after it reports only the new names.

## Test plan

- [x] `npm run test:workflows` — 22 files / 235 tests. New `.github/tests/required-context-rename-mirrors.test.ts` executes each mirror's verdict script against `success`/`skipped`/`failure`/`cancelled`/empty rather than grepping the YAML, asserts `if: ${{ always() }}` on all five, and asserts the emoji-stripped real name equals the mirror name so a mirror wired to the wrong job fails.
- [x] `zizmor` — no findings (51 suppressed).
- [x] Full pre-push chain green: clean-tree, ts-nocheck, biome, knip, qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, coverage, build, zizmor.
- [x] Emoji re-audit of `.github/workflows` over the full emoji codepoint ranges (not just `name:` lines, since a multi-line `run-name: >-` block hides them on continuation lines) returns exactly the five gated job names this sequence removes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
✨ Added
- Added emoji-free mirror contexts for CodeQL, Dependency Review, Grype Image, Secrets, and Web.
- Added tests for mirror dependencies, verdicts, names, `always()`, and CodeQL matrix parity.
- Added Harden Runner policies for the mirror jobs.
- Added end-to-end tests for fuzz-failure issue-title migration.

🔧 Changed
- Mirrors pass when the source job result is `success` or `skipped`.
- Migrated legacy emoji-prefixed fuzz-failure issues to the current title before commenting.
- Ignore pull requests when searching for matching fuzz-failure issues.
- Create a new issue only when no matching open issue exists.
- Removed the emoji from the scheduled fuzz-failure issue title.

Concerns:
- Complete the remaining required-context rename steps.
- Remove the old emoji-named contexts after ruleset migration.
- Replace the mirrors by renaming the real jobs in the final step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->