### PR TITLE
ci(workflows): drop emoji from job and workflow names

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -175,7 +175,7 @@ test('secret scanning gates full history and the tracked working tree', () => {
   const job = workflow.jobs?.secrets;
 
   expect(job).toMatchObject({
-    name: '🔑 Security: Secrets',
+    name: 'Security: Secrets',
     needs: ['security-actions'],
     'runs-on': 'ubuntu-24.04',
     'timeout-minutes': 10,
@@ -389,13 +389,13 @@ test('load-test workflow runs load profiles in parallel jobs', () => {
     "github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))";
 
   expect(workflow.jobs?.['load-test-ci']).toMatchObject({
-    name: '⚡ Load Test: CI',
+    name: 'Load Test: CI',
     if: releaseMatrixCondition,
     needs: ['build'],
     'timeout-minutes': expect.any(Number),
   });
   expect(workflow.jobs?.['load-test-behavior']).toMatchObject({
-    name: '⚡ Load Test: Behavior + Stress (Advisory)',
+    name: 'Load Test: Behavior + Stress (Advisory)',
     if: releaseMatrixCondition,
     needs: ['build'],
     'timeout-minutes': expect.any(Number),

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -1,11 +1,11 @@
-name: "🔬 CI Verify"
+name: "CI Verify"
 run-name: >-
   ${{
-    github.event_name == 'pull_request' && format('🔬 CI Verify — PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title) ||
-    github.event_name == 'push' && format('🔬 CI Verify — {0}', github.event.head_commit.message) ||
-    github.event_name == 'merge_group' && format('🔬 CI Verify — Merge Queue: {0}', github.ref_name) ||
-    github.event_name == 'workflow_call' && format('🔬 CI Verify — workflow_call ({0})', github.sha) ||
-    format('🔬 CI Verify — {0}', github.ref_name)
+    github.event_name == 'pull_request' && format('CI Verify — PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title) ||
+    github.event_name == 'push' && format('CI Verify — {0}', github.event.head_commit.message) ||
+    github.event_name == 'merge_group' && format('CI Verify — Merge Queue: {0}', github.ref_name) ||
+    github.event_name == 'workflow_call' && format('CI Verify — workflow_call ({0})', github.sha) ||
+    format('CI Verify — {0}', github.ref_name)
   }}
 
 on:
@@ -75,7 +75,7 @@ jobs:
       run-lint: false
 
   secrets:
-    name: "🔑 Security: Secrets"
+    name: "Security: Secrets"
     needs: [security-actions]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -138,7 +138,7 @@ jobs:
         run: scripts/scan-secrets.sh
 
   changes:
-    name: "🔎 Changes: Path Filter"
+    name: "Changes: Path Filter"
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -184,7 +184,7 @@ jobs:
           filters: .github/filters/runtime.yml
 
   codeql:
-    name: "🛡️ SAST: CodeQL"
+    name: "SAST: CodeQL"
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [security-actions]
     runs-on: ubuntu-24.04
@@ -224,7 +224,7 @@ jobs:
           category: /language:${{ matrix.language }}
 
   fuzz:
-    name: "🎯 Fuzz Testing"
+    name: "Fuzz Testing"
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [security-actions]
     runs-on: ubuntu-24.04
@@ -363,7 +363,7 @@ jobs:
         run: exit 1
 
   dependency-review:
-    name: "📦 Security: Dependency Review"
+    name: "Security: Dependency Review"
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -585,7 +585,7 @@ jobs:
           fail_ci_if_error: false
 
   web:
-    name: "🌐 Web: Site Build & Scripts Tests"
+    name: "Web: Site Build & Scripts Tests"
     # apps/web ships via Vercel (separate from the Docker image), and Vercel only
     # runs `next build` — never the node:test scripts suite. This job is that gate.
     # Path-filtered: skips (→ counts as pass) on changesets that don't touch the
@@ -743,7 +743,7 @@ jobs:
           retention-days: 1
 
   grype-image:
-    name: "🐳 Security: Grype Image"
+    name: "Security: Grype Image"
     # security-grype.yml's own grype-image job only runs on workflow_dispatch
     # and schedule, so the image every PR actually ships is never scanned
     # pre-merge. This job closes that gap by scanning the same QA image
@@ -827,7 +827,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   dast-zap-baseline:
-    name: "🕷️ DAST: ZAP + Nuclei"
+    name: "DAST: ZAP + Nuclei"
     runs-on: ubuntu-24.04
     timeout-minutes: 25  # Includes QA stack startup and scanner container runtime
     # Run on every merge to main (gates the next release-cut), on legacy
@@ -1364,7 +1364,7 @@ jobs:
   # still gate on it via release-cut.yml's second wait step.
 
   load-test-ci:
-    name: "⚡ Load Test: CI"
+    name: "Load Test: CI"
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))
@@ -1489,7 +1489,7 @@ jobs:
           retention-days: 30
 
   load-test-behavior:
-    name: "⚡ Load Test: Behavior + Stress (Advisory)"
+    name: "Load Test: Behavior + Stress (Advisory)"
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')))

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,10 +1,10 @@
-name: "🎭 E2E: Playwright"
+name: "E2E: Playwright"
 run-name: >-
   ${{
-    github.event_name == 'pull_request' && format('🎭 E2E: Playwright — PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title) ||
-    github.event_name == 'push' && format('🎭 E2E: Playwright — {0}', github.event.head_commit.message) ||
-    github.event_name == 'merge_group' && format('🎭 E2E: Playwright — Merge Queue: {0}', github.ref_name) ||
-    format('🎭 E2E: Playwright — {0}', github.ref_name)
+    github.event_name == 'pull_request' && format('E2E: Playwright — PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title) ||
+    github.event_name == 'push' && format('E2E: Playwright — {0}', github.event.head_commit.message) ||
+    github.event_name == 'merge_group' && format('E2E: Playwright — Merge Queue: {0}', github.ref_name) ||
+    format('E2E: Playwright — {0}', github.ref_name)
   }}
 
 # Playwright lives in its own workflow so a single failing UI assertion
@@ -49,7 +49,7 @@ env:
 
 jobs:
   changes:
-    name: "🔎 Changes: Path Filter"
+    name: "Changes: Path Filter"
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/i18n-crowdin.yml
+++ b/.github/workflows/i18n-crowdin.yml
@@ -1,4 +1,4 @@
-name: "🌐 i18n: Crowdin Sync"
+name: "i18n: Crowdin Sync"
 
 on:
   push:

--- a/.github/workflows/quality-mutation-monthly.yml
+++ b/.github/workflows/quality-mutation-monthly.yml
@@ -1,8 +1,8 @@
-name: "🧬 Quality: Mutation Testing"
+name: "Quality: Mutation Testing"
 run-name: >-
   ${{
-    github.event_name == 'schedule' && '🧬 Quality: Mutation Testing — Monthly schedule' ||
-    format('🧬 Quality: Mutation Testing — Manual by {0}', github.actor)
+    github.event_name == 'schedule' && 'Quality: Mutation Testing — Monthly schedule' ||
+    format('Quality: Mutation Testing — Manual by {0}', github.actor)
   }}
 
 # Keep mutation testing out of the push/PR fast path.
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   stryker:
-    name: "🧬 Quality: Stryker Advisory (${{ matrix.name }})"
+    name: "Quality: Stryker Advisory (${{ matrix.name }})"
     runs-on: ubuntu-latest
     environment: mutation
     timeout-minutes: 360  # GitHub Actions maximum; mutation testing is expensive and advisory-only
@@ -268,7 +268,7 @@ jobs:
           retention-days: 14
 
   aggregate:
-    name: "🧬 Quality: Aggregate Mutation Score"
+    name: "Quality: Aggregate Mutation Score"
     needs: stryker
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-portwing-fleet-soak.yml
+++ b/.github/workflows/quality-portwing-fleet-soak.yml
@@ -1,9 +1,9 @@
-name: "⏱️ Quality: Portwing Fleet Soak"
+name: "Quality: Portwing Fleet Soak"
 run-name: >-
   ${{
-    github.event_name == 'schedule' && '⏱️ Portwing Fleet Soak — Weekly' ||
-    github.event_name == 'pull_request' && format('⏱️ Portwing Fleet Soak — PR #{0}', github.event.pull_request.number) ||
-    format('⏱️ Portwing Fleet Soak — Manual by {0}', github.actor)
+    github.event_name == 'schedule' && 'Portwing Fleet Soak — Weekly' ||
+    github.event_name == 'pull_request' && format('Portwing Fleet Soak — PR #{0}', github.event.pull_request.number) ||
+    format('Portwing Fleet Soak — Manual by {0}', github.actor)
   }}
 
 on:
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   fleet-soak:
-    name: "⏱️ Cross-repo fleet, exec, reconnect, backpressure"
+    name: "Cross-repo fleet, exec, reconnect, backpressure"
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,5 +1,5 @@
-name: "🏷️ Release: Cut"
-run-name: "🏷️ Release: Cut — manual by ${{ github.actor }}"
+name: "Release: Cut"
+run-name: "Release: Cut — manual by ${{ github.actor }}"
 
 # Recoverable release pipeline. Build output is first published under
 # run-scoped staging tags, signed, attested, and attached to a draft release.
@@ -50,7 +50,7 @@ env:
 
 jobs:
   release:
-    name: "🚀 Release: Build, Publish, Tag"
+    name: "Release: Build, Publish, Tag"
     runs-on: ubuntu-latest
     timeout-minutes: 120  # Multi-arch build, signing, attestations, release upload, and CI-success polling budget
     environment: release-publish

--- a/.github/workflows/security-grype.yml
+++ b/.github/workflows/security-grype.yml
@@ -1,9 +1,9 @@
-name: "🛡️ Security: Grype"
+name: "Security: Grype"
 run-name: >-
   ${{
-    github.event_name == 'schedule' && '🛡️ Security: Grype — Weekly run' ||
-    github.event_name == 'pull_request' && format('🛡️ Security: Grype — PR #{0}', github.event.pull_request.number) ||
-    format('🛡️ Security: Grype — Manual by {0}', github.actor)
+    github.event_name == 'schedule' && 'Security: Grype — Weekly run' ||
+    github.event_name == 'pull_request' && format('Security: Grype — PR #{0}', github.event.pull_request.number) ||
+    format('Security: Grype — Manual by {0}', github.actor)
   }}
 
 on:
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   grype-deps:
-    name: "📦 Security: Grype Dependency Scan (npm lockfiles)"
+    name: "Security: Grype Dependency Scan (npm lockfiles)"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -81,7 +81,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   grype-image:
-    name: "🐳 Security: Grype Container Scan"
+    name: "Security: Grype Container Scan"
     # The image build is the heavy step; keep it on scheduled/manual runs.
     # PRs get fast, accurate dependency coverage from grype-deps without
     # paying for a Docker build on every push.

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -1,10 +1,10 @@
-name: "🛡️ Security: OpenSSF Scorecard"
+name: "Security: OpenSSF Scorecard"
 run-name: >-
   ${{
-    github.event_name == 'branch_protection_rule' && '🛡️ Security: OpenSSF Scorecard — Branch protection changed' ||
-    github.event_name == 'schedule' && '🛡️ Security: OpenSSF Scorecard — Weekly schedule' ||
-    github.event_name == 'workflow_dispatch' && format('🛡️ Security: OpenSSF Scorecard — Manual by {0}', github.actor) ||
-    format('🛡️ Security: OpenSSF Scorecard — {0}', github.ref_name)
+    github.event_name == 'branch_protection_rule' && 'Security: OpenSSF Scorecard — Branch protection changed' ||
+    github.event_name == 'schedule' && 'Security: OpenSSF Scorecard — Weekly schedule' ||
+    github.event_name == 'workflow_dispatch' && format('Security: OpenSSF Scorecard — Manual by {0}', github.actor) ||
+    format('Security: OpenSSF Scorecard — {0}', github.ref_name)
   }}
 
 on:
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   analysis:
-    name: "🛡️ Security: Scorecard Analysis"
+    name: "Security: Scorecard Analysis"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apk add --no-cache \
     curl \
     git=2.54.0-r0 \
     jq=1.8.1-r0 \
-    openssl=3.5.7-r0 \
+    openssl=3.5.8-r0 \
     su-exec=0.3-r0 \
     tini=0.19.0-r3 \
     tzdata=2026c-r0 \


### PR DESCRIPTION
Unblocks `dev/v1.6`. Ruleset 20957219 gates `refs/heads/dev/*`, not just `dev/v1.7`, so it covers this branch too. It was migrated onto the emoji-free required context names while only `dev/v1.7` had jobs publishing them, which left `dev/v1.6` requiring five contexts no job here produces. A required context that nothing produces leaves every PR pending forever.

Nothing is stuck: there are exactly two `dev/*` branches and nothing was open against this one. What it actually blocked was the v1.6.1 backport, which is why this goes first.

## The five that matter

Renamed to match the ruleset exactly:

| was | now |
|---|---|
| `🔑 Security: Secrets` | `Security: Secrets` |
| `🛡️ SAST: CodeQL` | `SAST: CodeQL` (context picks up ` (javascript-typescript)` from the matrix) |
| `📦 Security: Dependency Review` | `Security: Dependency Review` |
| `🌐 Web: Site Build & Scripts Tests` | `Web: Site Build & Scripts Tests` |
| `🐳 Security: Grype Image` | `Security: Grype Image` |

## Why there are no mirror jobs here

`dev/v1.7` needed a four-step additive rename because the rulesets still required the emoji names at the time. They do not any more. Publishing an emoji name now would be publishing something nothing requires, so the mirrors would be dead weight.

This PR passes on its own merits: a `pull_request` run uses the workflow file from the merge ref, so this branch's renamed jobs are what execute and report. That is step 4 without steps 1 through 3, and it is only safe in this direction, and only while nothing is open against the ref.

Both `ci-verify.yml` and `e2e-playwright.yml` trigger on `pull_request` into `dev/**` on this branch, so the required contexts all get produced here.

## Non-gated names taken in the same pass

`Changes: Path Filter`, `Fuzz Testing`, `DAST: ZAP + Nuclei`, and the two `Load Test:` jobs, plus workflow-level `name:`/`run-name:` values across ci-verify, e2e-playwright, i18n-crowdin, quality-mutation-monthly, release-cut, security-grype and security-scorecard. None are required contexts, so they rename freely, and doing them now avoids touching these files twice.

## What is deliberately left alone

`ISSUE_TITLE` keeps its emoji. The fuzz notifier matches open issues by that exact title before deciding whether to comment or file a new one, so renaming it without legacy-title handling orphans anything already filed and starts posting duplicates beside it. That handling exists on `dev/v1.7` and does not exist here.

Local: `npm run test:workflows` 15 files / 87 tests pass, `scripts/qlty-check-gate.sh all` exit 0 with only the pre-existing non-gating `ripgrep:NOTE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

🔧 Changed
- Removed emoji prefixes from GitHub Actions workflow, run, and job names.
- Renamed required job contexts to match ruleset `20957219`.
- Updated workflow tests for the new job names.
- Retained `ISSUE_TITLE` emoji matching.

🔒 Security
- Updated security job contexts: Secrets, CodeQL, Dependency Review, and Grype.

⚠️ Concerns
- Review the pre-existing non-gating `ripgrep:NOTE` warning if the quality gate must be warning-free.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->