### PR TITLE
test(scripts): opt fleet-soak agents into portwing's plaintext edge URL gate

### DIFF
--- a/scripts/portwing-fleet-soak.mjs
+++ b/scripts/portwing-fleet-soak.mjs
@@ -313,6 +313,9 @@ function spawnAgent(index) {
       DD_POLL_INTERVAL: '2',
       DOCKER_SOCKET: socketPath,
       DRYDOCK_URL: `http://127.0.0.1:${controllerAddress.port}`,
+      // portwing v0.9.9+ refuses plaintext controller URLs in edge mode unless
+      // this opt-in is set; the soak dials loopback over http by design.
+      ALLOW_INSECURE_EDGE_URL: 'true',
       LOG_LEVEL: 'warn',
       MAX_RECONNECT_DELAY: '2',
       NO_COLOR: '1',

--- a/scripts/portwing-fleet-soak.test.mjs
+++ b/scripts/portwing-fleet-soak.test.mjs
@@ -52,3 +52,19 @@ test('continues closing agents after one component cleanup fails', async () => {
   assert.deepEqual(removed, ['fleet-agent-0', 'fleet-agent-1']);
   assert.deepEqual(errors, ['fleet-agent-0:cleanup failed']);
 });
+
+test('spawned agents opt into the plaintext loopback controller URL', async () => {
+  // portwing v0.9.9 (PR CodesWhat/portwing#201) fails closed on http:// or
+  // ws:// controller URLs in edge mode unless ALLOW_INSECURE_EDGE_URL=true.
+  // The soak dials http://127.0.0.1 by design, so dropping this opt-in makes
+  // every spawned agent exit at config load and the soak time out at 0/8
+  // registered. Guard the env wiring at the source level.
+  const { readFile } = await import('node:fs/promises');
+  const source = await readFile(new URL('./portwing-fleet-soak.mjs', import.meta.url), 'utf8');
+  assert.match(source, /ALLOW_INSECURE_EDGE_URL: 'true'/);
+  const envBlock = source.slice(source.indexOf('DRYDOCK_URL:'));
+  assert.ok(
+    envBlock.indexOf("ALLOW_INSECURE_EDGE_URL: 'true'") > -1,
+    'ALLOW_INSECURE_EDGE_URL must be set alongside the plaintext DRYDOCK_URL',
+  );
+});


### PR DESCRIPTION
Backport of `dcd211a3` (#870) from `dev/v1.7`. Straight cherry-pick, 2 files, 19 insertions, no conflicts.

## What broke

portwing v0.9.9 (`CodesWhat/portwing#201`) added a fail-closed check: edge mode refuses to start when `DRYDOCK_URL` uses a plaintext `http://` or `ws://` scheme, unless `ALLOW_INSECURE_EDGE_URL=true` is also set.

`scripts/portwing-fleet-soak.mjs` spawns its agents against `http://127.0.0.1:<port>` by design. Since that release every agent process exits at config parse, before attempting a WebSocket handshake, and the run times out with `initialConnections: 0`.

## Why this is v1.6's problem independently of v1.7

The workflow checks out `CodesWhat/portwing` at `ref: main`, a floating ref, so the gate arrived on a branch nobody was changing. Two things pin the cause to portwing rather than to anything here:

- Dispatching the soak on unmodified `dev/v1.6` (run 33046671451, drydock `e8638817`) reproduces it byte-for-byte against portwing `edf7394e`.
- It stayed red on #895, where the only diff to that workflow was three display-name strings.

`dev/v1.7` took the opt-in on 2026-08-25 and has been green since. `dev/v1.6` never got it, so the soak has been deterministically red here since 2026-08-23.

## Not a user-facing break

portwing has always documented edge mode's controller trust as TLS-only, and the supported form is `DRYDOCK_URL=https://...`. Anyone running drydock behind TLS sees no change on either line. The soak's loopback dial is what trips the new gate, which makes this a harness fix, not a compatibility fix.

The 16 lines in `portwing-fleet-soak.test.mjs` are a source assertion so the opt-in can't be dropped silently later.

## Worth doing separately

`ref: main` on a cross-repo checkout means a green run only proves compatibility with whatever portwing was at that minute, and a red one can't distinguish "we broke it" from "they shipped". That cost a diagnosis here and, separately, one in sockguard from the same portwing change. Tracked for follow-up; out of scope for a backport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed `scripts/portwing-fleet-soak.mjs` to set `ALLOW_INSECURE_EDGE_URL: 'true'` for spawned agents.
- 🐛 Fixed soak-agent startup failures caused by plaintext loopback edge URLs being rejected by portwing v0.9.9+.
- ✨ Added a source-level test that verifies the opt-in remains paired with the loopback controller URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->