### PR TITLE
fix(v1.6): backport the three rc.3 fixes from dev/v1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `ws`/`wss` value in `X-Forwarded-Proto` no longer rejects the WebSocket upgrade.** Traefik forwards the upgrade's client-facing scheme as `wss` rather than `https` ([traefik/traefik#6388](https://github.com/traefik/traefik/issues/6388)), which the origin check treated as an unsupported protocol and hard-rejected — so a default Traefik setup still 403'd even with the trust-proxy fix in 1.6.1-rc.2. `ws` and `wss` now map to `http:`/`https:` for the Origin comparison; genuinely unknown protocols are still rejected. ([#867](https://github.com/CodesWhat/drydock/issues/867), [#887](https://github.com/CodesWhat/drydock/pull/887))
+- **Startup no longer crashes when the store volume forbids `chmod`.** The permission tightening added in 1.6.0 now warns and continues on `EPERM`/`EACCES`/`ENOTSUP` instead of throwing, so mounts that reject `chmod` (NFS/CIFS volumes, non-root containers, some volume drivers) no longer take the whole process down at startup. `EROFS` is deliberately excluded and stays fatal: it means the filesystem itself is read-only, so the store's autosave (temp file plus rename) would fail on every write after boot, and continuing would leave a container that looks healthy while silently persisting nothing. ([#874](https://github.com/CodesWhat/drydock/discussions/874), [#886](https://github.com/CodesWhat/drydock/pull/886), [#891](https://github.com/CodesWhat/drydock/pull/891))
+- **The debug dump redacted env var names instead of values.** Container env vars appear in the dump as `{ key, value }` pairs, and the generic redaction walker matched the pair's `key` property against the `key` sensitive-token rule, so a var like `HF_TOKEN` showed up as `"key": "[REDACTED]", "value": "xyz"` — the name was hidden and the actual secret was left in plain text. Pair objects are now handled explicitly: the name always stays visible, and the value is redacted only when the name itself matches the sensitive-key rules. ([#875](https://github.com/CodesWhat/drydock/issues/875), [#885](https://github.com/CodesWhat/drydock/pull/885))
+
 ## [1.6.1-rc.2] — 2026-08-25
 
 ### Fixed

--- a/app/api/ws-upgrade-utils.test.ts
+++ b/app/api/ws-upgrade-utils.test.ts
@@ -127,6 +127,58 @@ describe('ws-upgrade-utils', () => {
       expect(isOriginAllowed(request, { trustproxy: 1 })).toBe(false);
     });
 
+    test('accepts an http Origin when a trusted proxy forwards http', () => {
+      const request = {
+        headers: {
+          origin: 'http://drydock.example.com',
+          host: 'drydock.example.com',
+          'x-forwarded-proto': 'http',
+        },
+        socket: { encrypted: false },
+      } as any;
+
+      expect(isOriginAllowed(request, { trustproxy: 1 })).toBe(true);
+    });
+
+    test('accepts an https Origin when a trusted proxy forwards wss (Traefik)', () => {
+      const request = {
+        headers: {
+          origin: 'https://drydock.example.com',
+          host: 'drydock.example.com',
+          'x-forwarded-proto': 'wss',
+        },
+        socket: { encrypted: false },
+      } as any;
+
+      expect(isOriginAllowed(request, { trustproxy: 1 })).toBe(true);
+    });
+
+    test('accepts an http Origin when a trusted proxy forwards ws', () => {
+      const request = {
+        headers: {
+          origin: 'http://drydock.example.com',
+          host: 'drydock.example.com',
+          'x-forwarded-proto': 'ws',
+        },
+        socket: { encrypted: false },
+      } as any;
+
+      expect(isOriginAllowed(request, { trustproxy: 1 })).toBe(true);
+    });
+
+    test('rejects an http Origin when a trusted proxy forwards wss', () => {
+      const request = {
+        headers: {
+          origin: 'http://drydock.example.com',
+          host: 'drydock.example.com',
+          'x-forwarded-proto': 'wss',
+        },
+        socket: { encrypted: false },
+      } as any;
+
+      expect(isOriginAllowed(request, { trustproxy: 1 })).toBe(false);
+    });
+
     test('rejects non-HTTP URL schemes in Origin', () => {
       const request = {
         headers: { origin: 'wss://drydock.example.com', host: 'drydock.example.com' },

--- a/app/api/ws-upgrade-utils.ts
+++ b/app/api/ws-upgrade-utils.ts
@@ -55,6 +55,23 @@ function getFirstForwardedValue(value: unknown): string | undefined {
   return firstValue || undefined;
 }
 
+function normalizeForwardedProtocol(forwardedProtocol: string): 'http:' | 'https:' | undefined {
+  // Some proxies forward the WebSocket upgrade's client-facing scheme as
+  // ws/wss rather than http/https (Traefik does, see traefik/traefik#6388).
+  // Each pair carries the same security level, so map ws(s) to its HTTP
+  // equivalent before comparing against the browser's http(s) Origin (#867).
+  switch (forwardedProtocol.toLowerCase()) {
+    case 'http':
+    case 'ws':
+      return 'http:';
+    case 'https':
+    case 'wss':
+      return 'https:';
+    default:
+      return undefined;
+  }
+}
+
 function getSocketOriginProtocol(request: IncomingMessage): 'http:' | 'https:' | undefined {
   const socket = request.socket as (Socket & { encrypted?: boolean }) | undefined;
   if (!socket) {
@@ -97,8 +114,8 @@ export function isOriginAllowed(
   if (!effectiveHost) {
     allowed = false;
   } else if (forwardedProtocol !== undefined) {
-    const normalizedProtocol = `${forwardedProtocol.toLowerCase()}:`;
-    if (normalizedProtocol !== 'http:' && normalizedProtocol !== 'https:') {
+    const normalizedProtocol = normalizeForwardedProtocol(forwardedProtocol);
+    if (normalizedProtocol === undefined) {
       allowed = false;
     } else {
       effectiveProtocol = normalizedProtocol;

--- a/app/debug/redact.test.ts
+++ b/app/debug/redact.test.ts
@@ -319,6 +319,74 @@ describe('debug/redact', () => {
     });
   });
 
+  test('env var pair objects keep the name visible when the name is not sensitive', () => {
+    const source = { key: 'DEBIAN_FRONTEND', value: 'noninteractive' };
+
+    const redacted = redactDebugDump(source);
+
+    expect(redacted).toEqual({ key: 'DEBIAN_FRONTEND', value: 'noninteractive' });
+  });
+
+  test('env var pair objects redact the value (not the name) when the name is sensitive', () => {
+    const source = { key: 'HF_TOKEN', value: 'xyz' };
+
+    const redacted = redactDebugDump(source);
+
+    expect(redacted).toEqual({ key: 'HF_TOKEN', value: '[REDACTED]' });
+  });
+
+  test('env var pair objects preserve an empty sensitive value per redactMatchedValue contract', () => {
+    const source = { key: 'MY_PASSWORD', value: '' };
+
+    const redacted = redactDebugDump(source);
+
+    expect(redacted).toEqual({ key: 'MY_PASSWORD', value: '' });
+  });
+
+  test('env var pair objects nested inside an array are redacted by name, matching the real dump shape', () => {
+    const source = {
+      env: [
+        { key: 'DEBIAN_FRONTEND', value: 'noninteractive' },
+        { key: 'HF_TOKEN', value: 'xyz' },
+      ],
+    };
+
+    const redacted = redactDebugDump(source);
+
+    expect(redacted).toEqual({
+      env: [
+        { key: 'DEBIAN_FRONTEND', value: 'noninteractive' },
+        { key: 'HF_TOKEN', value: '[REDACTED]' },
+      ],
+    });
+  });
+
+  test('a non-pair object with a key property still redacts that property as before', () => {
+    const source = { key: 'some-api-key-value', other: 'kept' };
+
+    const redacted = redactDebugDump(source);
+
+    expect(redacted).toEqual({ key: '[REDACTED]', other: 'kept' });
+  });
+
+  test('pair objects with extra properties keep name/value pair handling and walk extras generically', () => {
+    const source = {
+      key: 'HF_TOKEN',
+      value: 'xyz',
+      extra: { token: 'nested-secret' },
+      note: 'kept',
+    };
+
+    const redacted = redactDebugDump(source);
+
+    expect(redacted).toEqual({
+      key: 'HF_TOKEN',
+      value: '[REDACTED]',
+      extra: { token: '[REDACTED]' },
+      note: 'kept',
+    });
+  });
+
   test('keeps empty and null sensitive values unchanged', () => {
     const source = {
       secret: '',

--- a/app/debug/redact.ts
+++ b/app/debug/redact.ts
@@ -58,6 +58,12 @@ function redactMatchedValue(value: unknown): unknown {
   return REDACTED_VALUE;
 }
 
+function isNameValuePair(
+  node: Record<string, unknown>,
+): node is Record<string, unknown> & { key: string } {
+  return typeof node.key === 'string' && 'value' in node;
+}
+
 function redactNode(node: unknown, nodeKey?: string): unknown {
   if (nodeKey && isSensitiveKey(nodeKey)) {
     return redactMatchedValue(node);
@@ -69,6 +75,22 @@ function redactNode(node: unknown, nodeKey?: string): unknown {
 
   if (!isPlainObject(node)) {
     return node;
+  }
+
+  if (isNameValuePair(node)) {
+    const redactedPair: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (key === 'key') {
+        redactedPair[key] = value;
+      } else if (key === 'value') {
+        redactedPair[key] = isSensitiveKey(node.key)
+          ? redactMatchedValue(value)
+          : redactNode(value);
+      } else {
+        redactedPair[key] = redactNode(value, key);
+      }
+    }
+    return redactedPair;
   }
 
   const redactedObject: Record<string, unknown> = {};

--- a/app/store/index.test.ts
+++ b/app/store/index.test.ts
@@ -453,14 +453,14 @@ describe('Store Module', () => {
     expect(chmodSync).toHaveBeenCalledWith('/test/store/test.json', 0o600);
   });
 
-  test('should rethrow non-ENOENT errors from store file permission enforcement', async () => {
+  test('should rethrow unexpected (non-recoverable) errors from store file permission enforcement', async () => {
     vi.resetModules();
-    const permissionError = Object.assign(new Error('operation not permitted'), {
-      code: 'EPERM',
+    const unexpectedError = Object.assign(new Error('bad file descriptor'), {
+      code: 'EBADF',
     });
     const chmodSync = vi.fn((target: string) => {
       if (target === '/test/store/test.json') {
-        throw permissionError;
+        throw unexpectedError;
       }
     });
     registerCommonMocks({
@@ -473,7 +473,113 @@ describe('Store Module', () => {
     });
 
     const storeWithBadFilePermissions = await import('./index.js');
-    await expect(storeWithBadFilePermissions.init()).rejects.toThrow('operation not permitted');
+    await expect(storeWithBadFilePermissions.init()).rejects.toThrow('bad file descriptor');
+  });
+
+  test('should rethrow unexpected (non-recoverable) errors from store directory permission enforcement', async () => {
+    vi.resetModules();
+    const unexpectedError = Object.assign(new Error('bad file descriptor'), {
+      code: 'EBADF',
+    });
+    const chmodSync = vi.fn((target: string) => {
+      if (target === '/test/store') {
+        throw unexpectedError;
+      }
+    });
+    registerCommonMocks({
+      fs: {
+        existsSync: vi.fn(() => true),
+        mkdirSync: vi.fn(),
+        renameSync: vi.fn(),
+        chmodSync,
+      },
+    });
+
+    const storeWithBadDirError = await import('./index.js');
+    await expect(storeWithBadDirError.init()).rejects.toThrow('bad file descriptor');
+  });
+
+  test.each(['EPERM', 'EACCES', 'ENOTSUP'])(
+    'should warn and continue when directory permission enforcement fails with %s',
+    async (code) => {
+      vi.resetModules();
+      const permissionError = Object.assign(new Error(`chmod failed: ${code}`), { code });
+      const chmodSync = vi.fn((target: string) => {
+        if (target === '/test/store') {
+          throw permissionError;
+        }
+      });
+      registerCommonMocks({
+        fs: {
+          existsSync: vi.fn(() => true),
+          mkdirSync: vi.fn(),
+          renameSync: vi.fn(),
+          chmodSync,
+        },
+      });
+
+      const storeWithBadDirPermissions = await import('./index.js');
+      await expect(storeWithBadDirPermissions.init()).resolves.toBeUndefined();
+
+      const logger = (await import('../log/index.js')).default;
+      const scopedLog = logger.child.mock.results[0].value;
+      expect(scopedLog.warn).toHaveBeenCalledOnce();
+      expect(scopedLog.warn).toHaveBeenCalledWith(expect.stringContaining(code));
+      expect(chmodSync).toHaveBeenCalledWith('/test/store/test.json', 0o600);
+    },
+  );
+
+  test.each(['EPERM', 'EACCES', 'ENOTSUP'])(
+    'should warn and continue when store file permission enforcement fails with %s',
+    async (code) => {
+      vi.resetModules();
+      const permissionError = Object.assign(new Error(`chmod failed: ${code}`), { code });
+      const chmodSync = vi.fn((target: string) => {
+        if (target === '/test/store/test.json') {
+          throw permissionError;
+        }
+      });
+      registerCommonMocks({
+        fs: {
+          existsSync: vi.fn(() => true),
+          mkdirSync: vi.fn(),
+          renameSync: vi.fn(),
+          chmodSync,
+        },
+      });
+
+      const storeWithBadFilePermissions = await import('./index.js');
+      await expect(storeWithBadFilePermissions.init()).resolves.toBeUndefined();
+
+      const logger = (await import('../log/index.js')).default;
+      const scopedLog = logger.child.mock.results[0].value;
+      expect(scopedLog.warn).toHaveBeenCalledOnce();
+      expect(scopedLog.warn).toHaveBeenCalledWith(expect.stringContaining(code));
+    },
+  );
+
+  test.each([
+    ['directory', '/test/store'],
+    ['store file', '/test/store/test.json'],
+  ])('should reject when %s permission enforcement fails with EROFS', async (_label, target) => {
+    vi.resetModules();
+    const readOnlyError = Object.assign(new Error('chmod failed: EROFS'), { code: 'EROFS' });
+    const chmodSync = vi.fn((chmodTarget: string) => {
+      if (chmodTarget === target) {
+        throw readOnlyError;
+      }
+    });
+    registerCommonMocks({
+      fs: {
+        existsSync: vi.fn(() => true),
+        mkdirSync: vi.fn(),
+        renameSync: vi.fn(),
+        chmodSync,
+      },
+    });
+
+    const storeOnReadOnlyVolume = await import('./index.js');
+    await expect(storeOnReadOnlyVolume.init()).rejects.toThrow('chmod failed: EROFS');
   });
 
   test('should throw when store configuration is invalid', async () => {

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -47,14 +47,45 @@ let storeDirectoryResolved: string | undefined;
 const STORE_DIRECTORY_MODE = 0o700;
 const STORE_FILE_MODE = 0o600;
 
+// Permission tightening is hardening, not a functional requirement: some
+// volume mounts (NFS/CIFS, non-root containers, certain volume drivers)
+// reject chmod outright. Failing to tighten permissions there must warn and
+// keep starting up, not crash — this is a regression from v1.6.0's
+// unconditional chmodSync on the store directory (#874).
+//
+// EROFS is deliberately NOT in this set. The codes below mean the metadata
+// operation was refused while writes to the volume can still succeed; EROFS
+// means the filesystem itself is read-only, so Loki's autosave (temp file
+// plus rename) fails on every subsequent write. Starting up there would
+// leave a process that looks healthy and silently persists nothing, so it
+// fails fast at boot with the real cause instead.
+const RECOVERABLE_CHMOD_ERROR_CODES = new Set(['EPERM', 'EACCES', 'ENOTSUP']);
+
 function enforceStorePermissions(storeDirectory: string, storePath: string): void {
-  fs.chmodSync(storeDirectory, STORE_DIRECTORY_MODE);
+  try {
+    fs.chmodSync(storeDirectory, STORE_DIRECTORY_MODE);
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (!code || !RECOVERABLE_CHMOD_ERROR_CODES.has(code)) {
+      throw error;
+    }
+    log.warn(
+      `Could not tighten permissions on store directory (${storeDirectory}): ${code}; continuing without enforced permissions`,
+    );
+  }
   try {
     fs.chmodSync(storePath, STORE_FILE_MODE);
   } catch (error: unknown) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return;
+    }
+    if (!code || !RECOVERABLE_CHMOD_ERROR_CODES.has(code)) {
       throw error;
     }
+    log.warn(
+      `Could not tighten permissions on store file (${storePath}): ${code}; continuing without enforced permissions`,
+    );
   }
 }
 


### PR DESCRIPTION
The three fixes that shipped in v1.7.0-rc.4 and apply to the 1.6 line, backported for 1.6.1-rc.3. Each is its own commit with its own tests; the fourth commit is the changelog.

| commit | fix | upstream |
|---|---|---|
| `8fd795ec` | map `ws`/`wss` forwarded protocols in the websocket origin check | #887 |
| `6259b322` | tolerate chmod failures on the store volume at startup | #886 + #891 |
| `93cf5216` | redact env pair values instead of names in the debug dump | #885 |

## The one that isn't a straight cherry-pick

`6259b322` is the **squashed-correct** version of the store fix, not #886 followed by #891. #886 shipped with `EROFS` in the recoverable set, and #891 corrected it to fatal. Backporting them separately would put a known bug on the 1.6 line and then take it off again, so the commit here excludes `EROFS` from the start and its message says why.

That distinction is load-bearing rather than cosmetic. `EROFS` means the filesystem itself is read-only, so the store's autosave (temp file plus rename) fails on every write after boot. Continuing past it produces a container that looks healthy and silently persists nothing, which is worse than the crash it replaces.

## Who is waiting on this

[#867](https://github.com/CodesWhat/drydock/issues/867)'s reporter is on 1.6.1-rc.2 with a Traefik middleware overriding `X-Forwarded-Proto` as a workaround. `8fd795ec` is what lets them drop it: Traefik forwards the upgrade's client-facing scheme as `wss` rather than `https` ([traefik/traefik#6388](https://github.com/traefik/traefik/issues/6388)), which the origin check was rejecting as an unsupported protocol even after the trust-proxy fix in rc.2.

## Rebase

Rebased from base `e8638817` onto `412f8f1c` with zero conflicts. No overlap was possible: this branch touches `CHANGELOG.md` plus `app/api/ws-upgrade-utils`, `app/debug/redact` and `app/store/index`, while everything `dev/v1.6` gained since that base is workflow files, the `Dockerfile`, and the two fleet-soak scripts.

## Checks

Full pre-push gate green: biome, qlty, qlty-smells, scripts-test, workflow-tests, typecheck-ui, web-scripts-test, coverage at 100%, build, zizmor.

The changelog entries land under `[Unreleased]`. Promoting that heading to `[1.6.1-rc.3]` and rolling the version fixtures is a separate identity PR, as usual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed WebSocket origin checks for forwarded `ws` and `wss` protocols.
- 🐛 Fixed store permission handling:
  - Continue after `EPERM`, `EACCES`, and `ENOTSUP`.
  - Continue to treat `EROFS` and other unexpected errors as fatal.
- 🔒 Fixed debug redaction to preserve environment variable names and redact sensitive values.
- ✨ Added tests for all three fixes.
- 🔧 Updated the `[Unreleased]` changelog.

## Concerns

- Confirm that warning logs clearly identify permission failures that allow startup or saves to continue.
- Confirm that environment-variable pair detection does not alter redaction for unrelated objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->