### PR TITLE
chore(release): roll v1.6 identity to 1.6.1-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1-rc.3] — 2026-08-27
+
 ### Fixed
 
 - **A `ws`/`wss` value in `X-Forwarded-Proto` no longer rejects the WebSocket upgrade.** Traefik forwards the upgrade's client-facing scheme as `wss` rather than `https` ([traefik/traefik#6388](https://github.com/traefik/traefik/issues/6388)), which the origin check treated as an unsupported protocol and hard-rejected — so a default Traefik setup still 403'd even with the trust-proxy fix in 1.6.1-rc.2. `ws` and `wss` now map to `http:`/`https:` for the Origin comparison; genuinely unknown protocols are still rejected. ([#867](https://github.com/CodesWhat/drydock/issues/867), [#887](https://github.com/CodesWhat/drydock/pull/887))
@@ -2417,7 +2419,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.2...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.3...HEAD
+[1.6.1-rc.3]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.2...v1.6.1-rc.3
 [1.6.1-rc.2]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.1...v1.6.1-rc.2
 [1.6.1-rc.1]: https://github.com/CodesWhat/drydock/compare/v1.6.0...v1.6.1-rc.1
 [1.6.0]: https://github.com/CodesWhat/drydock/compare/v1.6.0-rc.13...v1.6.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.2-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.3-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,6 +179,17 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.6.1-rc.3 highlights</strong></summary>
+
+- **A `ws`/`wss` value in `X-Forwarded-Proto` no longer rejects the WebSocket upgrade** — Traefik forwards the upgrade's client-facing scheme as `wss` rather than `https`, which the origin check hard-rejected as an unsupported protocol; `ws` and `wss` now map to `http:`/`https:` for the comparison. ([#867](https://github.com/CodesWhat/drydock/issues/867))
+- **Startup no longer crashes when the store volume forbids `chmod`** — the 1.6.0 permission tightening now warns and continues on `EPERM`/`EACCES`/`ENOTSUP`, so NFS/CIFS mounts and non-root containers start again. `EROFS` stays fatal on purpose: the store could never persist. ([#874](https://github.com/CodesWhat/drydock/discussions/874))
+- **The debug dump redacts env var values instead of their names** — a var like `HF_TOKEN` used to come out as `"key": "[REDACTED]", "value": "xyz"`, hiding the name and printing the secret. ([#875](https://github.com/CodesWhat/drydock/issues/875))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc3--2026-08-27).
+
+</details>
+
+<details>
 <summary><strong>v1.6.1-rc.2 highlights</strong></summary>
 
 - **WebSocket log streams behind a TLS-terminating proxy no longer 403** — with trust proxy enabled and `X-Forwarded-Proto` absent on the upgrade request, the origin check no longer falls back to the local socket's TLS state; the protocol is treated as unknown and host validation keeps working. ([#867](https://github.com/CodesWhat/drydock/issues/867))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1-rc.2',
+    version: '1.6.1-rc.3',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1-rc.2 started',
+    details: 'Drydock v1.6.1-rc.3 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.2',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.3',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1-rc.2',
+    tag: '1.6.1-rc.3',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1-rc.2',
+  version: '1.6.1-rc.3',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1-rc.2',
+      version: '1.6.1-rc.3',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1-rc.2', mode: 'demo' },
+        server: { version: '1.6.1-rc.3', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1-rc.2",
+  version: "1.6.1-rc.3",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1-rc.2",
+    version: "v1.6.1-rc.3",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1-rc.2",
+      "version": "1.6.1-rc.3",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1-rc.2",
+    "version": "1.6.1-rc.3",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1-rc.2"
+  "version":"1.6.1-rc.3"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1-rc.2",
+    "version": "1.6.1-rc.3",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1-rc.2",
+      "drydockVersion": "1.6.1-rc.3",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1-rc.2` | Immutable release candidate; best for reproducible testing |
+| `1.6.1-rc.3` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,16 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.6.1-rc.3 Highlights — August 27, 2026
+
+Three bug fixes: a `ws`/`wss` value in `X-Forwarded-Proto` no longer rejects the
+WebSocket upgrade, so a default Traefik setup stops 403'ing log streams; startup
+no longer crashes when the store volume forbids `chmod`, which unblocks NFS/CIFS
+mounts and non-root containers; and the debug dump now redacts env var values
+instead of their names, so a var like `HF_TOKEN` no longer prints its secret in
+plain text. See [CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc3--2026-08-27)
+for the full release notes.
+
 ## v1.6.1-rc.2 Highlights — August 25, 2026
 
 Two bug fixes: WebSocket log-stream connections behind a TLS-terminating proxy

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.2...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.3...HEAD`],
+    ['1.6.1-rc.3', `${repositoryUrl}/compare/v1.6.1-rc.2...v1.6.1-rc.3`],
     ['1.6.1-rc.2', `${repositoryUrl}/compare/v1.6.1-rc.1...v1.6.1-rc.2`],
     ['1.6.1-rc.1', `${repositoryUrl}/compare/v1.6.0...v1.6.1-rc.1`],
     ['1.6.0', `${repositoryUrl}/compare/v1.6.0-rc.13...v1.6.0`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1-rc.2';
-const PREV_RC_VERSION = '1.6.1-rc.1';
-const RC_DATE = '2026-08-25';
-const RC_DISPLAY_DATE = 'August 25, 2026';
+const RC_VERSION = '1.6.1-rc.3';
+const PREV_RC_VERSION = '1.6.1-rc.2';
+const RC_DATE = '2026-08-27';
+const RC_DISPLAY_DATE = 'August 27, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1-rc.2';
+const RC_VERSION = '1.6.1-rc.3';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Rolls the v1.6 candidate identity from `1.6.1-rc.2` to `1.6.1-rc.3` so the three backported fixes in #899 can be cut.

`[Unreleased]` becomes `## [1.6.1-rc.3] — 2026-08-27` with a fresh empty `[Unreleased]` above it, plus the two comparison links. Everything else here is a version fixture that `scripts/release-identity.test.mjs` and `scripts/release-docs-identity.test.mjs` assert:

- README version badge and a new highlights block, with rc.2's collapsed
- `apps/web/src/lib/site-config.ts` and the `status: "next"` entry in `site-content.ts`
- demo mocks: server, agents, containers, audit, and the app handler
- quickstart tag matrix, so the stale rc.2 candidate row doesn't linger
- `content/docs/current/api/{app,agent,portwing}.mdx` response samples
- the updates page, with rc.3 highlights

`BASE_VERSION` and every `package.json` stay at `1.6.1`. Only the candidate identity moves.

Three things I checked rather than assumed:

- `CHANGELOG.md` still mentions `1.6.1-rc.2` in two places on purpose: the prose in the ws/wss entry that refers back to the trust-proxy fix, and the historical rc.2 heading and link. Same for the existing rc.2 row in `changelog-links.test.mjs`.
- `node scripts/release-precut-check.mjs v1.6.1-rc.3` is clean.
- All 19 assertions across the two identity suites pass locally.

After this merges, the cut is `release-cut.yml --ref main -f release_tag=v1.6.1-rc.3 -f source_ref=dev/v1.6`, which needs `ci-verify.yml` and `e2e-playwright.yml` dispatched on the final `dev/v1.6` SHA first — neither runs on push to that branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

🔧 **Changed**
- Updated the release candidate identity from `1.6.1-rc.2` to `1.6.1-rc.3`.
- Updated changelog links, README, site content, quickstart tags, API examples, and demo mocks.
- Added release highlights for three backported fixes.
- Updated release identity tests for the new version and August 27, 2026 release date.
- Kept `BASE_VERSION` and `package.json` versions at `1.6.1`.

🐛 **Fixed**
- WebSocket proxy handling for `X-Forwarded-Proto` values `ws` and `wss`.
- Startup on store volumes that reject `chmod`.
- Debug dump redaction to hide environment variable values.

## Concerns

- Verify all release references use `1.6.1-rc.3`; no stale `1.6.1-rc.2` references should remain outside historical changelog data.
- Run both release identity test suites and the release precut check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->