### PR TITLE
chore(scripts): drop decorative emoji from CLI output

### DIFF
--- a/scripts/cleanup-test-containers.sh
+++ b/scripts/cleanup-test-containers.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-echo "🧹 Cleaning up test containers..."
+echo "Cleaning up test containers..."
 
 # Stop and remove test containers
 docker rm -f ecr_sub_sub_test ghcr_radarr gitlab_test hub_homeassistant_202161 hub_homeassistant_latest hub_nginx_120 hub_nginx_latest hub_traefik_245 lscr_radarr trueforge_radarr quay_prometheus drydock 2>/dev/null || true
 
-echo "✅ Test containers cleaned up"
+echo "Test containers cleaned up"

--- a/scripts/commit-message.mjs
+++ b/scripts/commit-message.mjs
@@ -92,7 +92,7 @@ export function formatValidationFailure(rawMessage, errors) {
   const formattedErrors = errors.map((error) => `  - ${error}`).join('\n');
 
   return [
-    '❌ Invalid commit message.',
+    'Invalid commit message.',
     '',
     `Current subject: ${subject || '<empty>'}`,
     '',

--- a/scripts/pre-commit-coverage.sh
+++ b/scripts/pre-commit-coverage.sh
@@ -26,11 +26,11 @@ if ! "${has_app}" && ! "${has_ui}"; then
 fi
 
 if "${has_app}"; then
-	echo "⏳ app: running tests on changed files..."
+	echo "app: running tests on changed files..."
 	(cd app && npx vitest run --changed HEAD --reporter=dot)
 fi
 
 if "${has_ui}"; then
-	echo "⏳ ui: running tests on changed files..."
+	echo "ui: running tests on changed files..."
 	(cd ui && npx vitest run --changed HEAD --reporter=dot)
 fi

--- a/scripts/pre-push-build.sh
+++ b/scripts/pre-push-build.sh
@@ -33,10 +33,10 @@ for i in "${!pids[@]}"; do
 	if ! wait "${pids[$i]}"; then
 		fail=1
 		failed_labels+=("${labels[$i]}")
-		echo "❌ ${labels[$i]}: build failed"
+		echo "${labels[$i]}: build failed"
 		echo "   full log: ${log_files[$i]}"
 	else
-		echo "✅ ${labels[$i]}: build succeeded"
+		echo "${labels[$i]}: build succeeded"
 	fi
 done
 

--- a/scripts/pre-push-coverage.sh
+++ b/scripts/pre-push-coverage.sh
@@ -66,11 +66,11 @@ run_coverage() {
 
 	if (cd "${workspace}" && npx vitest run --coverage --reporter=dot >"${log_file}" 2>&1); then
 		rm -f "${gap_file}"
-		echo "✅ ${workspace}: coverage met"
+		echo "${workspace}: coverage met"
 		return 0
 	fi
 
-	echo "❌ ${workspace}: coverage below threshold"
+	echo "${workspace}: coverage below threshold"
 	echo "   vitest log: ${log_file}"
 	node scripts/coverage-gaps.mjs --workspace "${workspace}" --write "${gap_file}" --print
 	fail=1
@@ -124,7 +124,7 @@ pids=()
 
 for workspace in "${requested_workspaces[@]}"; do
 	gap_files+=(".coverage-gaps.${workspace}.json")
-	echo "📊 ${workspace}: running coverage..."
+	echo "${workspace}: running coverage..."
 done
 
 if [ "${FAIL_FAST}" -eq 1 ] || [ ${#requested_workspaces[@]} -eq 1 ]; then
@@ -164,4 +164,4 @@ fi
 
 # Clean state — remove gap files when everything passes
 rm -f "${GAPS_FILE}" .coverage-gaps.app.json .coverage-gaps.ui.json
-echo "✅ Coverage thresholds met (100%)."
+echo "Coverage thresholds met (100%)."

--- a/scripts/release-precut-check.mjs
+++ b/scripts/release-precut-check.mjs
@@ -87,14 +87,14 @@ export function parsePendingReplies(markdown, tag) {
 
 export function formatReport(pending, tag) {
   if (pending.length === 0) {
-    return `✓ No pending discussion replies for ${tag}.`;
+    return `No pending discussion replies for ${tag}.`;
   }
 
   const noun = pending.length === 1 ? 'discussion' : 'discussions';
   const items = pending.map((p) => `   #${p.discussion} ${p.feature}`).join('\n');
 
   const verb = pending.length === 1 ? 'needs' : 'need';
-  return `⚠  ${pending.length} ${noun} still ${verb} a "shipped in ${tag}" reply:\n${items}\n\nPost replies + check the boxes in current-tracker.md,\nor re-run with --force to cut anyway.`;
+  return `${pending.length} ${noun} still ${verb} a "shipped in ${tag}" reply:\n${items}\n\nPost replies + check the boxes in current-tracker.md,\nor re-run with --force to cut anyway.`;
 }
 
 function parseArgs(argv) {
@@ -145,7 +145,7 @@ function main() {
     contents = readFileSync(trackerPath, 'utf8');
   } catch (err) {
     if (err.code === 'ENOENT') {
-      console.warn(`⚠  Tracker not found at ${trackerPath}; skipping discussion-reply check.`);
+      console.warn(`Tracker not found at ${trackerPath}; skipping discussion-reply check.`);
       return;
     }
     throw err;

--- a/scripts/release-precut-check.test.mjs
+++ b/scripts/release-precut-check.test.mjs
@@ -119,7 +119,7 @@ test('parsePendingReplies returns empty array when no pending replies match', ()
 
 test('formatReport returns the success line when pending is empty', () => {
   const report = formatReport([], 'v1.6.0');
-  assert.equal(report, '✓ No pending discussion replies for v1.6.0.');
+  assert.equal(report, 'No pending discussion replies for v1.6.0.');
 });
 
 test('formatReport uses singular "discussion" for a single item', () => {

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -23,7 +23,7 @@ restart_colima() {
 		return
 	fi
 
-	echo "🔄 Restarting Colima..."
+	echo "Restarting Colima..."
 	colima stop >/dev/null 2>&1 || true
 	colima start >/dev/null
 }
@@ -33,7 +33,7 @@ wait_for_docker_engine() {
 		return
 	fi
 
-	echo "⏳ Waiting for Docker engine..."
+	echo "Waiting for Docker engine..."
 	for _ in $(seq 1 60); do
 		if docker info >/dev/null 2>&1; then
 			return
@@ -41,7 +41,7 @@ wait_for_docker_engine() {
 		sleep 1
 	done
 
-	echo "❌ Docker engine did not become ready."
+	echo "Docker engine did not become ready."
 	exit 1
 }
 
@@ -61,16 +61,16 @@ acquire_lock() {
 
 		current_time=$(date +%s)
 		if [ $((current_time - started_at)) -ge "$LOCK_TIMEOUT_SECONDS" ]; then
-			echo "❌ Timed out waiting for e2e lock after ${LOCK_TIMEOUT_SECONDS}s"
+			echo "Timed out waiting for e2e lock after ${LOCK_TIMEOUT_SECONDS}s"
 			exit 1
 		fi
 
-		echo "⏳ Waiting for active e2e run to finish..."
+		echo "Waiting for active e2e run to finish..."
 		sleep 1
 	done
 
 	echo "$$" >"$LOCK_DIR/pid"
-	echo "🔒 Acquired e2e lock"
+	echo "Acquired e2e lock"
 }
 
 release_lock() {
@@ -79,12 +79,12 @@ release_lock() {
 
 # Always clean up on exit (success or failure)
 cleanup() {
-	echo "🧹 Cleaning up e2e environment..."
+	echo "Cleaning up e2e environment..."
 	"$SCRIPT_DIR/cleanup-test-containers.sh"
 }
 trap 'cleanup; release_lock' EXIT
 
-echo "🧪 Running complete e2e test suite..."
+echo "Running complete e2e test suite..."
 
 restart_colima
 wait_for_docker_engine
@@ -102,14 +102,14 @@ acquire_lock
 
 # Query the assigned port from the running container (works for IPv4 and IPv6 outputs)
 E2E_PORT=$(docker port drydock 3000/tcp | head -n1 | awk -F: '{print $NF}')
-echo "🔌 Drydock available on port $E2E_PORT"
+echo "Drydock available on port $E2E_PORT"
 
 # Run e2e tests with the dynamically assigned port
-echo "🏃 Running cucumber tests..."
+echo "Running cucumber tests..."
 CUCUMBER_ARGS=()
 if [ -z "${GITLAB_TOKEN:-}" ]; then
 	CUCUMBER_ARGS+=(--tags "not @requires_gitlab")
 fi
 (cd "$SCRIPT_DIR/../e2e" && DD_PORT="$E2E_PORT" npm run cucumber -- "${CUCUMBER_ARGS[@]}")
 
-echo "✅ E2E tests completed!"
+echo "E2E tests completed!"

--- a/scripts/run-playwright-qa.sh
+++ b/scripts/run-playwright-qa.sh
@@ -36,7 +36,7 @@ restart_colima() {
 		return
 	fi
 
-	echo "🔄 Restarting Colima..."
+	echo "Restarting Colima..."
 	colima stop >/dev/null 2>&1 || true
 	colima start >/dev/null
 }
@@ -49,7 +49,7 @@ wait_for_docker_engine() {
 		sleep 1
 	done
 
-	echo "❌ Docker engine did not become ready."
+	echo "Docker engine did not become ready."
 	exit 1
 }
 
@@ -65,7 +65,7 @@ remove_stale_playwright_containers() {
 		return
 	fi
 
-	echo "🧹 Removing stale Playwright containers..."
+	echo "Removing stale Playwright containers..."
 	while IFS= read -r name; do
 		[[ -z $name ]] && continue
 		docker rm -f "$name" >/dev/null 2>&1 || true
@@ -77,7 +77,7 @@ wait_for_docker_engine
 remove_stale_playwright_containers
 
 if ! is_port_available "$DD_PLAYWRIGHT_PORT"; then
-	echo "❌ DD_PLAYWRIGHT_PORT=$DD_PLAYWRIGHT_PORT is already in use."
+	echo "DD_PLAYWRIGHT_PORT=$DD_PLAYWRIGHT_PORT is already in use."
 	if command -v lsof >/dev/null 2>&1; then
 		echo "   Holders (lsof -nP -iTCP:${DD_PLAYWRIGHT_PORT}):"
 		lsof -nP -iTCP:"$DD_PLAYWRIGHT_PORT" 2>/dev/null | sed 's/^/     /' || true
@@ -125,72 +125,72 @@ PY
 
 should_build_qa_image() {
 	if ! docker image inspect "$QA_IMAGE" >/dev/null 2>&1; then
-		echo "ℹ️  QA image '$QA_IMAGE' not found; building..."
+		echo "QA image '$QA_IMAGE' not found; building..."
 		return 0
 	fi
 
 	local image_created
 	image_created=$(docker image inspect --format='{{.Created}}' "$QA_IMAGE" 2>/dev/null | head -n 1 || true)
 	if [[ -z $image_created ]]; then
-		echo "ℹ️  Unable to read '$QA_IMAGE' creation timestamp; building..."
+		echo "Unable to read '$QA_IMAGE' creation timestamp; building..."
 		return 0
 	fi
 
 	local last_commit_epoch
 	last_commit_epoch=$(git -C "$REPO_ROOT" log -1 --format=%ct 2>/dev/null || true)
 	if [[ ! $last_commit_epoch =~ ^[0-9]+$ ]]; then
-		echo "ℹ️  Unable to read latest git commit timestamp; building..."
+		echo "Unable to read latest git commit timestamp; building..."
 		return 0
 	fi
 
 	if ! command -v python3 >/dev/null 2>&1; then
-		echo "ℹ️  python3 is unavailable for timestamp parsing; building..."
+		echo "python3 is unavailable for timestamp parsing; building..."
 		return 0
 	fi
 
 	local image_created_epoch
 	if ! image_created_epoch=$(iso8601_to_epoch "$image_created"); then
-		echo "ℹ️  Unable to parse '$QA_IMAGE' creation timestamp; building..."
+		echo "Unable to parse '$QA_IMAGE' creation timestamp; building..."
 		return 0
 	fi
 
 	if ((image_created_epoch >= last_commit_epoch)); then
-		echo "♻️  Reusing '$QA_IMAGE' (newer than latest commit)."
+		echo "Reusing '$QA_IMAGE' (newer than latest commit)."
 		return 1
 	fi
 
-	echo "ℹ️  Latest commit is newer than '$QA_IMAGE'; rebuilding..."
+	echo "Latest commit is newer than '$QA_IMAGE'; rebuilding..."
 	return 0
 }
 
-echo "🧹 Ensuring no stale Playwright QA stack is running..."
+echo "Ensuring no stale Playwright QA stack is running..."
 docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" down -v --remove-orphans >/dev/null 2>&1 || true
 
 if should_build_qa_image; then
-	echo "🐳 Building drydock QA image ($QA_IMAGE)..."
+	echo "Building drydock QA image ($QA_IMAGE)..."
 	docker build --build-arg DD_VERSION=prepush --tag "$QA_IMAGE" "$REPO_ROOT"
 fi
 
-echo "🚀 Starting Playwright QA stack..."
+echo "Starting Playwright QA stack..."
 docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" up -d
 
-echo "⏳ Waiting for Playwright QA health: $HEALTH_URL"
+echo "Waiting for Playwright QA health: $HEALTH_URL"
 for _ in $(seq 1 60); do
 	if curl -sf "$HEALTH_URL" >/dev/null 2>&1; then
-		echo "✅ Playwright QA is healthy"
+		echo "Playwright QA is healthy"
 		break
 	fi
 	sleep 2
 done
 
 if ! curl -sf "$HEALTH_URL" >/dev/null 2>&1; then
-	echo "❌ Playwright QA failed to become healthy after 120 seconds."
+	echo "Playwright QA failed to become healthy after 120 seconds."
 	docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" ps || true
 	docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" logs --no-color --tail 80 || true
 	exit 1
 fi
 
-echo "🧪 Running Playwright E2E tests..."
+echo "Running Playwright E2E tests..."
 (cd "$REPO_ROOT/e2e" && DD_PLAYWRIGHT_BASE_URL="$PLAYWRIGHT_BASE_URL" npm run test:playwright)
 
-echo "✅ Playwright E2E tests completed"
+echo "Playwright E2E tests completed"

--- a/scripts/setup-test-containers.sh
+++ b/scripts/setup-test-containers.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "🐳 Setting up test containers for local e2e tests..."
+echo "Setting up test containers for local e2e tests..."
 
 # Login to private registries (if credentials available)
 if [ -n "${GITLAB_TOKEN:-}" ]; then
@@ -10,7 +10,7 @@ if [ -n "${GITLAB_TOKEN:-}" ]; then
 	if [ -n "$gitlab_username" ]; then
 		docker login registry.gitlab.com -u "$gitlab_username" -p "$GITLAB_TOKEN"
 	else
-		echo "⚠️  Skipping GitLab login (GITLAB_TOKEN set but GITLAB_USERNAME missing)"
+		echo "Skipping GitLab login (GITLAB_TOKEN set but GITLAB_USERNAME missing)"
 	fi
 fi
 
@@ -34,10 +34,10 @@ docker pull homeassistant/home-assistant:2021.6.1
 # Pull traefik
 docker pull traefik:2.4.5
 
-echo "✅ Docker images pulled and tagged"
+echo "Docker images pulled and tagged"
 
 # Run containers for tests
-echo "🚀 Starting test containers..."
+echo "Starting test containers..."
 
 readonly LABEL_WATCH='dd.watch=true'
 
@@ -55,14 +55,14 @@ run_test_container ecr_sub_sub_test --label "$LABEL_WATCH" 229211676173.dkr.ecr.
 if [ -n "${GITHUB_USERNAME:-}" ]; then
 	run_test_container ghcr_radarr --label "$LABEL_WATCH" --label 'dd.tag.include=^\d+\.\d+\.\d+\.\d+-ls\d+$' ghcr.io/linuxserver/radarr:5.14.0.9383-ls245
 else
-	echo "⚠️  Skipping ghcr_radarr (no GITHUB_USERNAME set)"
+	echo "Skipping ghcr_radarr (no GITHUB_USERNAME set)"
 fi
 
 # GITLAB — requires a token now that rejected credentials do not fall back to anonymous pulls
 if [ -n "${GITLAB_TOKEN:-}" ]; then
 	run_test_container gitlab_test --label "$LABEL_WATCH" --label 'dd.tag.include=^v16\.[01]\.0$' registry.gitlab.com/gitlab-org/gitlab-runner:v16.0.0
 else
-	echo "⚠️  Skipping gitlab_test (no GITLAB_TOKEN set)"
+	echo "Skipping gitlab_test (no GITLAB_TOKEN set)"
 fi
 
 # HUB
@@ -85,7 +85,7 @@ run_test_container hub_traefik_245 --label "$LABEL_WATCH" --label 'dd.tag.includ
 if [ -n "${GITHUB_USERNAME:-}" ]; then
 	run_test_container lscr_radarr --label "$LABEL_WATCH" --label 'dd.tag.include=^\d+\.\d+\.\d+\.\d+-ls\d+$' lscr.io/linuxserver/radarr:5.14.0.9383-ls245
 else
-	echo "⚠️  Skipping lscr_radarr (no GITHUB_USERNAME set)"
+	echo "Skipping lscr_radarr (no GITHUB_USERNAME set)"
 fi
 
 # TrueForge
@@ -96,5 +96,5 @@ run_test_container trueforge_radarr --label "$LABEL_WATCH" --label 'dd.tag.inclu
 # QUAY
 run_test_container quay_prometheus --label "$LABEL_WATCH" --label 'dd.tag.include=^v\d+\.\d+\.\d+$' --user root --tmpfs /prometheus:rw,mode=777 quay.io/prometheus/prometheus:v2.52.0
 
-echo "✅ Test containers started"
+echo "Test containers started"
 docker ps --format "table {{.Names}}\t{{.Image}}\t{{.Status}}" | grep -E "(ecr_|ghcr_|gitlab_|hub_|lscr_|quay_|trueforge_)"

--- a/scripts/start-drydock.sh
+++ b/scripts/start-drydock.sh
@@ -34,7 +34,7 @@ build_drydock_image() {
 		fi
 
 		if [ "$attempt" -lt "$max_attempts" ]; then
-			echo "⚠️ Docker build failed, pruning builder cache and retrying once..."
+			echo "Docker build failed, pruning builder cache and retrying once..."
 			docker builder prune -af >/dev/null 2>&1 || true
 			sleep 1
 		fi
@@ -47,7 +47,7 @@ build_drydock_image() {
 # convenient source-build default.
 if [ "${DD_E2E_SKIP_BUILD:-false}" = "true" ]; then
 	if ! docker image inspect "$DRYDOCK_IMAGE" >/dev/null 2>&1; then
-		echo "❌ prebuilt drydock image not found: $DRYDOCK_IMAGE"
+		echo "prebuilt drydock image not found: $DRYDOCK_IMAGE"
 		exit 1
 	fi
 else
@@ -138,11 +138,11 @@ echo "drydock started on http://localhost:${E2E_PORT}"
 echo "Waiting for drydock to be ready..."
 for i in $(seq 1 30); do
 	if curl --silent --show-error --fail --connect-timeout 2 "http://localhost:${E2E_PORT}/health" >/dev/null 2>&1; then
-		echo "✅ drydock is healthy"
+		echo "drydock is healthy"
 		break
 	fi
 	if [ "$i" -eq 30 ]; then
-		echo "❌ drydock failed to become healthy after 60s"
+		echo "drydock failed to become healthy after 60s"
 		docker logs drydock --tail 30
 		exit 1
 	fi
@@ -157,7 +157,7 @@ done
 AUTH_HEADER="Basic $(echo -n 'john:doe' | base64)"
 REQUIRED_FIXTURES_FILE=${DD_E2E_REQUIRED_FIXTURES_FILE:-"$SCRIPT_DIR/../e2e/config/cucumber-core-fixtures.txt"}
 if [ ! -s "$REQUIRED_FIXTURES_FILE" ]; then
-	echo "❌ required Cucumber fixture manifest is missing or empty: $REQUIRED_FIXTURES_FILE"
+	echo "required Cucumber fixture manifest is missing or empty: $REQUIRED_FIXTURES_FILE"
 	exit 1
 fi
 REQUIRED_FIXTURES=()
@@ -168,7 +168,7 @@ while IFS= read -r fixture || [ -n "$fixture" ]; do
 	REQUIRED_FIXTURES+=("$fixture")
 done <"$REQUIRED_FIXTURES_FILE"
 if [ "${#REQUIRED_FIXTURES[@]}" -eq 0 ]; then
-	echo "❌ required Cucumber fixture manifest contains no required fixtures: $REQUIRED_FIXTURES_FILE"
+	echo "required Cucumber fixture manifest contains no required fixtures: $REQUIRED_FIXTURES_FILE"
 	exit 1
 fi
 
@@ -225,19 +225,19 @@ for i in $(seq 1 75); do
 		done <<<"${READINESS}"
 	fi
 	if [ "$READY" -eq "$EXPECTED_CONTAINERS" ]; then
-		echo "✅ drydock resolved all ${READY} required fixtures"
+		echo "drydock resolved all ${READY} required fixtures"
 		break
 	fi
 	if [ "$i" -eq 75 ]; then
-		echo "❌ drydock only resolved ${READY}/${EXPECTED_CONTAINERS} required fixtures after 150s"
+		echo "drydock only resolved ${READY}/${EXPECTED_CONTAINERS} required fixtures after 150s"
 		if [ "${#MISSING_FIXTURES[@]}" -gt 0 ]; then
-			printf '❌ missing required fixtures: %s\n' "$(
+			printf 'missing required fixtures: %s\n' "$(
 				IFS=,
 				echo "${MISSING_FIXTURES[*]}"
 			)"
 		fi
 		if [ "${#UNRESOLVED_FIXTURES[@]}" -gt 0 ]; then
-			printf '❌ unresolved required fixtures: %s\n' "$(
+			printf 'unresolved required fixtures: %s\n' "$(
 				IFS=';'
 				echo "${UNRESOLVED_FIXTURES[*]}"
 			)"

--- a/scripts/validate-commit-msg.mjs
+++ b/scripts/validate-commit-msg.mjs
@@ -7,7 +7,7 @@ function main() {
   const commitMessageFile = process.argv[2];
 
   if (!commitMessageFile) {
-    console.error('❌ Missing commit message file argument.');
+    console.error('Missing commit message file argument.');
     console.error('This script must be executed by the git commit-msg hook.');
     return 1;
   }
@@ -16,7 +16,7 @@ function main() {
   try {
     commitMessage = readFileSync(commitMessageFile, 'utf8');
   } catch (error) {
-    console.error(`❌ Failed to read commit message file: ${commitMessageFile}`);
+    console.error(`Failed to read commit message file: ${commitMessageFile}`);
     console.error(error instanceof Error ? error.message : String(error));
     return 1;
   }

--- a/scripts/validate-commit-range.mjs
+++ b/scripts/validate-commit-range.mjs
@@ -125,7 +125,7 @@ export function main(
   try {
     ({ baseSha, headSha } = parseArgs(args));
   } catch (error) {
-    stderr('❌ Missing commit range arguments.');
+    stderr('Missing commit range arguments.');
     stderr(error instanceof Error ? error.message : String(error));
     stderr('Usage: node scripts/validate-commit-range.mjs --base <base-sha> --head <head-sha>');
     return 1;
@@ -139,7 +139,7 @@ export function main(
       commits = getCommits(baseSha, headSha);
     }
   } catch (error) {
-    stderr(`❌ Failed to read commits in range ${baseSha}..${headSha}`);
+    stderr(`Failed to read commits in range ${baseSha}..${headSha}`);
     stderr(error instanceof Error ? error.message : String(error));
     return 1;
   }
@@ -151,7 +151,7 @@ export function main(
 
   const failures = findInvalidCommitMessages(commits);
   if (failures.length === 0) {
-    stdout(`✅ Validated ${commits.length} commit message(s) in range ${baseSha}..${headSha}.`);
+    stdout(`Validated ${commits.length} commit message(s) in range ${baseSha}..${headSha}.`);
     return 0;
   }
 
@@ -159,7 +159,7 @@ export function main(
     printFailure(failure, stderr);
   }
 
-  stderr(`\n❌ ${failures.length} of ${commits.length} commit message(s) failed validation.`);
+  stderr(`\n${failures.length} of ${commits.length} commit message(s) failed validation.`);
   return 1;
 }
 


### PR DESCRIPTION
Backports #896's sweep to the v1.6 maintenance line, finishing what #895 started on the workflow and job names.

69 lines across 13 scripts lose an emoji prefix and the whitespace that separated it from the message. The diff is 69 insertions against 69 deletions, and every pair is identical once the glyph and whitespace are removed, so no wording, indentation, or control flow moved.

**Two sites keep their emoji, because there the character is data rather than decoration:**

- `release-precut-check.mjs:56` parses tracker markdown for a literal `☐`, and `release-precut-check.test.mjs` fixtures both box states across 8 lines
- `commit-message.test.mjs:66,141` feeds gitmoji in as the input under test

v1.6 has two keep-site categories where v1.7 had four, and I checked rather than carrying the number over: `release-docs-archive.test.mjs` doesn't exist on this line, and `portwing-transport-docs.test.mjs` exists but carries no docs-table glyph yet.

`release-precut-check.mjs`'s report strings lose their prefixes, so the one exact-match assertion on them (`release-precut-check.test.mjs:122`) moves with them. Every other assertion on a stripped line already used an unanchored substring regex.

**On detection:** by Unicode category rather than codepoint range, since the pictographic ranges are non-contiguous. Two characters a naive rule misses — U+FE0F VARIATION SELECTOR-16 is `Mn` and has to go with its base, and U+2139 INFORMATION SOURCE is `Ll`, so the `ℹ️` prefix only reads as an emoji through the selector that follows it. A checker that inspects one character at a time can't express that second clause and will report those lines as unchanged.

All 148 scripts tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🗑️ Removed decorative emoji prefixes and separating whitespace from 69 user-facing messages across 13 scripts.
- 🔧 Updated exact-match test expectations for the changed output.
- 🔒 Preserved emoji used as data in tracker checkboxes, test fixtures, and gitmoji inputs.
- 🔧 Preserved wording, indentation, control flow, and error handling.
- 🔧 Accounted for Unicode categories, variation selectors, and multi-character emoji sequences.
- 🔧 Confirmed that all 148 script tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->