### PR TITLE
fix(v1.6): backport the bare-integer tag ranking fix from dev/v1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tag suggestion no longer ranks a bare integer build-number tag above a real dotted version.** A bare integer tag (e.g. `168`) coerces via `semver.coerce()` into a fake `168.0.0`, which previously outranked a real release like `1.43.3` — for `linuxserver/plex`, this meant the suggested-tag badge and, with a permissive `dd.tag.include` filter, the actionable update candidate itself could point at a destructive downgrade. Bare integer tags are now only ever ranked among themselves (never against a real dotted version, and never at all when the population contains any other non-integer version signal, such as a prerelease-only or coercion-lossy tag), sorted numerically rather than lexically. The rule is shared between the suggested-tag badge (`tag/suggest.ts`) and the actionable non-semver/`includeTags` recovery path (`watchers/providers/docker/tag-candidates.ts`) via a new `tag/version-population.ts` module so the two paths can't drift apart again. ([#859](https://github.com/CodesWhat/drydock/issues/859))
+
 ## [1.6.1-rc.3] — 2026-08-27
 
 ### Fixed

--- a/app/tag/suggest.test.ts
+++ b/app/tag/suggest.test.ts
@@ -247,4 +247,146 @@ describe('tag/suggest', () => {
       parseSpy.mockRestore();
     }
   });
+
+  // #859: linuxserver/plex repro — a bare integer build-number tag ("168")
+  // coerces via semver.coerce() into a fake "168.0.0" that outranks a real
+  // dotted release ("1.43.3"). A bare integer must never be compared against
+  // a real version directly; see tag/version-population.ts.
+  describe('bare integer tags never outrank real dotted versions (#859)', () => {
+    test('picks the highest dotted version over a bare integer', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['latest', '168', '1.43.2', '1.43.3'])).toBe('1.43.3');
+    });
+
+    test('picks the highest dotted version over a bare integer regardless of input order', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['1.43.3', '1.43.2', '168', 'latest'])).toBe('1.43.3');
+    });
+
+    test('picks the highest v-prefixed dotted version over a v-prefixed bare integer', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['v168', 'v1.43.2', 'v1.43.3'])).toBe('v1.43.3');
+    });
+
+    test('the literal issue #859 repro: 168 vs 1.43.3', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['168', '1.43.3'])).toBe('1.43.3');
+    });
+
+    test('a two-part version beats a numerically larger bare integer', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['13.4', '168'])).toBe('13.4');
+    });
+
+    test('a two-part version beats multiple numerically larger bare integers', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['168', '169', '13.4'])).toBe('13.4');
+    });
+
+    test('in-tier magnitude comparison is untouched by this change', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['13.4', '13.4.2'])).toBe('13.4.2');
+    });
+
+    test('CalVer beats a numerically larger bare integer', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['latest', '9999', '2026.7.1', '2026.8.0'])).toBe(
+        '2026.8.0',
+      );
+    });
+
+    test('CalVer behavior is unaffected when no bare integer is present', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['2026.7.1', '2026.8.0'])).toBe('2026.8.0');
+    });
+
+    test('a genuinely integer-only pool still works, sorted numerically', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['latest', '166', '168', '167'])).toBe('168');
+    });
+
+    test('a genuinely integer-only pool sorts numerically, not lexically', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['latest', 'v9', 'v10'])).toBe('v10');
+    });
+
+    test('returns null for a mixed signal: prerelease-only real version + bare integer', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['168', '1.44.0-rc.1'])).toBeNull();
+    });
+
+    test('returns null when a coercion-lossy tag counts as a non-integer version signal', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['168', '3.11-bullseye'])).toBeNull();
+    });
+
+    test('preserves existing PEP 440 dev-nightly behavior alongside a bare integer', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['168', '2026.8.0.dev202607050315', '2026.7.1'])).toBe(
+        '2026.7.1',
+      );
+    });
+
+    test('an unadorned tag wins a tie against the same core with build metadata', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['1.43.3+build.5', '1.43.3'])).toBe('1.43.3');
+    });
+
+    test('an unadorned tag wins a tie against build metadata regardless of input order', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['1.43.3', '1.43.3+build.5'])).toBe('1.43.3');
+    });
+
+    test('excludeTags narrows the population before classification', () => {
+      const container = createContainer({
+        image: { tag: { value: 'latest' } },
+        excludeTags: '^168$',
+      });
+
+      expect(suggest(container as any, ['168', '1.43.3'])).toBe('1.43.3');
+    });
+
+    test('includeTags narrows the population to integers-only before classification, so the integer wins', () => {
+      const container = createContainer({
+        image: { tag: { value: 'latest' } },
+        includeTags: String.raw`^\d+$`,
+      });
+
+      expect(suggest(container as any, ['168', '1.43.3'])).toBe('168');
+    });
+
+    test('breaks a same-version, no-build-metadata tie deterministically by tag text', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['v1.2.3', '1.2.3'])).toBe('1.2.3');
+    });
+
+    test('breaks a same-version, no-build-metadata tie deterministically regardless of input order', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['1.2.3', 'v1.2.3'])).toBe('1.2.3');
+    });
+
+    test('breaks a same-version tie deterministically when both candidates share the exact tag text', () => {
+      const container = createContainer({ image: { tag: { value: 'latest' } } });
+
+      expect(suggest(container as any, ['1.2.3', '1.2.3'])).toBe('1.2.3');
+    });
+  });
 });

--- a/app/tag/suggest.ts
+++ b/app/tag/suggest.ts
@@ -1,7 +1,6 @@
 import { RE2JS } from 're2js';
-import semver from 'semver';
 import type { Container } from '../model/container.js';
-import { parse as parseSemver } from './index.js';
+import { pickPreferredVersionTag } from './version-population.js';
 
 interface SafeRegex {
   test(s: string): boolean;
@@ -9,13 +8,6 @@ interface SafeRegex {
 
 interface TagSuggestionLogger {
   warn?: (message: string) => void;
-}
-
-interface StableSemverCandidate {
-  tag: string;
-  major: number;
-  minor: number;
-  patch: number;
 }
 
 interface MessageLikeError {
@@ -94,78 +86,6 @@ function isLatestOrUntagged(tagValue: string | undefined): boolean {
   return normalizedTag === '' || normalizedTag === 'latest';
 }
 
-// semver.coerce() (parse()'s last-resort fallback in app/tag/index.ts) can
-// only emit a bare "major.minor.patch", silently discarding any suffix it
-// didn't understand — a PEP 440 dev/post release ("2026.8.0.dev202607050315",
-// "1.2.3.post1"), an OS-variant suffix ("3.11-bullseye"), or a CalVer date
-// ("2024-01-15"). When coercion was required, the only raw shapes that
-// provably lost nothing are an optional "v" plus 1-3 dot-separated numeric
-// groups; anything else must not be offered as a stable pin target. See #473.
-const BARE_NUMERIC_VERSION_PATTERN = /^v?\d+(?:\.\d+){0,2}$/i;
-
-// NOTE: parse() in app/tag/index.ts also has a normalizeNumericMultiSegmentTag
-// branch in its fallback chain, checked before the semver.clean/semver.parse
-// steps mirrored here. That branch only matches tags with 4+ dot-separated
-// numeric groups and always rewrites them to "major.minor.patch-<rest>", so
-// any tag that hits it always comes back with a non-empty prerelease array
-// and is already rejected by the prerelease check above before this guard
-// runs. If that branch's behavior changes upstream, re-verify this invariant
-// still holds.
-function requiredCoercionFallback(tag: string): boolean {
-  const cleaned = semver.clean(tag, { loose: true });
-  return semver.parse(cleaned ?? tag) === null;
-}
-
-function isBareNumericVersion(tag: string): boolean {
-  return BARE_NUMERIC_VERSION_PATTERN.test(tag.trim());
-}
-
-function isStableSemverCandidate(tag: string): StableSemverCandidate | null {
-  const parsed = parseSemver(tag);
-  if (!parsed) {
-    return null;
-  }
-
-  const prerelease = Array.isArray(parsed.prerelease) ? parsed.prerelease : [];
-  if (prerelease.length > 0) {
-    return null;
-  }
-
-  if (requiredCoercionFallback(tag) && !isBareNumericVersion(tag)) {
-    return null;
-  }
-
-  if (
-    !Number.isInteger(parsed.major) ||
-    !Number.isInteger(parsed.minor) ||
-    !Number.isInteger(parsed.patch)
-  ) {
-    return null;
-  }
-
-  return {
-    tag,
-    major: parsed.major,
-    minor: parsed.minor,
-    patch: parsed.patch,
-  };
-}
-
-function sortBySemverDescending(candidates: StableSemverCandidate[]): void {
-  candidates.sort((candidate1, candidate2) => {
-    if (candidate1.major !== candidate2.major) {
-      return candidate2.major - candidate1.major;
-    }
-    if (candidate1.minor !== candidate2.minor) {
-      return candidate2.minor - candidate1.minor;
-    }
-    if (candidate1.patch !== candidate2.patch) {
-      return candidate2.patch - candidate1.patch;
-    }
-    return 0;
-  });
-}
-
 export function suggest(
   container: Pick<Container, 'includeTags' | 'excludeTags' | 'image'>,
   tags: string[],
@@ -182,14 +102,8 @@ export function suggest(
     container.excludeTags,
     logger,
   );
-  const stableSemverCandidates = filteredTags
-    .map((tag) => isStableSemverCandidate(tag))
-    .filter((candidate): candidate is StableSemverCandidate => candidate !== null);
 
-  if (stableSemverCandidates.length === 0) {
-    return null;
-  }
-
-  sortBySemverDescending(stableSemverCandidates);
-  return stableSemverCandidates[0].tag;
+  // #859: never let a bare integer build-number tag ("168") outrank a real
+  // dotted release ("1.43.3") — see tag/version-population.ts.
+  return pickPreferredVersionTag(filteredTags);
 }

--- a/app/tag/version-population.ts
+++ b/app/tag/version-population.ts
@@ -1,0 +1,210 @@
+import semver from 'semver';
+import { parse as parseSemver } from './index.js';
+
+/**
+ * #859: a bare integer tag ("168") is exactly what semver.coerce() turns
+ * into "168.0.0" — a fake version whose inflated "major" can outrank a real
+ * dotted release ("1.43.3"). Anything matching this pattern (an optional "v"
+ * plus digits and nothing else) must never be compared against a real
+ * version directly; see selectVersionPopulation/pickPreferredVersionTag.
+ */
+const BARE_INTEGER_TAG_PATTERN = /^v?\d+$/i;
+
+// semver.coerce() (parse()'s last-resort fallback in app/tag/index.ts) can
+// only emit a bare "major.minor.patch", silently discarding any suffix it
+// didn't understand — a PEP 440 dev/post release ("2026.8.0.dev202607050315",
+// "1.2.3.post1"), an OS-variant suffix ("3.11-bullseye"), or a CalVer date
+// ("2024-01-15"). When coercion was required, the only raw shapes that
+// provably lost nothing are an optional "v" plus 1-3 dot-separated numeric
+// groups; anything else must not be offered as a stable pin target. See #473.
+const BARE_NUMERIC_VERSION_PATTERN = /^v?\d+(?:\.\d+){0,2}$/i;
+
+export interface VersionTagSource {
+  /** The tag value to return when this source wins (e.g. the raw registry tag). */
+  tag: string;
+  /** The value semver classification runs against (e.g. after dd.tag.transform). */
+  versionTag: string;
+}
+
+interface StableSemverCandidate {
+  tag: string;
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+// NOTE: parse() in app/tag/index.ts also has a normalizeNumericMultiSegmentTag
+// branch in its fallback chain, checked before the semver.clean/semver.parse
+// steps mirrored here. That branch only matches tags with 4+ dot-separated
+// numeric groups and always rewrites them to "major.minor.patch-<rest>", so
+// any tag that hits it always comes back with a non-empty prerelease array
+// and is already rejected by the prerelease check above before this guard
+// runs. If that branch's behavior changes upstream, re-verify this invariant
+// still holds.
+function requiredCoercionFallback(tag: string): boolean {
+  const cleaned = semver.clean(tag, { loose: true });
+  return semver.parse(cleaned ?? tag) === null;
+}
+
+function isBareNumericVersion(tag: string): boolean {
+  return BARE_NUMERIC_VERSION_PATTERN.test(tag.trim());
+}
+
+function isBareIntegerTag(tag: string): boolean {
+  return BARE_INTEGER_TAG_PATTERN.test(tag.trim());
+}
+
+/**
+ * A tag whose semver build-metadata suffix (e.g. "1.43.3+build.5") should
+ * lose a tie against the same core version without it. parse()'s own
+ * clean()+parse() path strips build metadata before it ever reaches the
+ * caller, so this checks the raw tag text rather than the parsed result.
+ */
+function hasBuildMetadataSuffix(tag: string): boolean {
+  return tag.includes('+');
+}
+
+/**
+ * True when `tag` parses as a stable (no prerelease), coercion-safe semver
+ * version. Bare integers and bare 1-3 part numeric versions ("168", "13.4")
+ * pass this; prerelease-only tags ("1.44.0-rc.1") and coercion-lossy tags
+ * ("3.11-bullseye") do not. Shared by tag/suggest.ts's suggested-tag badge.
+ */
+function isStableSemverCandidate(tag: string): StableSemverCandidate | null {
+  const parsed = parseSemver(tag);
+  if (!parsed) {
+    return null;
+  }
+
+  const prerelease = Array.isArray(parsed.prerelease) ? parsed.prerelease : [];
+  if (prerelease.length > 0) {
+    return null;
+  }
+
+  if (requiredCoercionFallback(tag) && !isBareNumericVersion(tag)) {
+    return null;
+  }
+
+  if (
+    !Number.isInteger(parsed.major) ||
+    !Number.isInteger(parsed.minor) ||
+    !Number.isInteger(parsed.patch)
+  ) {
+    return null;
+  }
+
+  return {
+    tag,
+    major: parsed.major,
+    minor: parsed.minor,
+    patch: parsed.patch,
+  };
+}
+
+/**
+ * #859: partition an already include/exclude-filtered tag population and
+ * decide which pool is safe to rank as "the version candidates" — never
+ * letting a bare integer build counter (e.g. "168") compete directly against
+ * a real dotted release (e.g. "1.43.3").
+ *
+ * `sources` pairs each candidate's classification value (`versionTag` — what
+ * `isEligible` and semver parsing run against, e.g. after dd.tag.transform)
+ * with the tag string to actually return (`tag`). For untransformed callers
+ * the two are identical. `isEligible` lets each call site keep its own
+ * eligibility rules (tag/suggest.ts's stable-only badge vs.
+ * tag-candidates.ts's more permissive "parses as semver at all", which
+ * tolerates prerelease tags) while sharing this same partition rule.
+ *
+ * Rule (caller must already have applied include/exclude filters):
+ *  1. Partition `isEligible` candidates into `preferred` (not a bare integer
+ *     tag) and `bareIntegers`.
+ *  2. If `preferred` is non-empty, the winning pool is `preferred` — bare
+ *     integers are discarded entirely, never compared against a real version.
+ *  3. Else, if the population contains ANY tag that parses as semver at all
+ *     and is not a bare integer — even one `isEligible` rejected, such as a
+ *     prerelease-only tag or a coercion-lossy tag — refuse to offer a
+ *     suggestion at all (empty pool). The repo clearly versions "for real",
+ *     so substituting a build counter is unsafe. This is deliberate and
+ *     conservative: it does not fall back to the integer.
+ *  4. Else (the population is genuinely integer-only; non-version aliases
+ *     like "latest"/"nightly" don't disqualify this case), the winning pool
+ *     is `bareIntegers`.
+ *
+ * Returns the winning pool's sources, in source order (unsorted) — callers
+ * apply their own ordering.
+ */
+export function selectVersionPopulation<T extends VersionTagSource>(
+  sources: T[],
+  isEligible: (source: T) => boolean,
+): T[] {
+  const eligible = sources.filter((source) => isEligible(source));
+
+  const preferred = eligible.filter((source) => !isBareIntegerTag(source.versionTag));
+  if (preferred.length > 0) {
+    return preferred;
+  }
+
+  const hasNonIntegerVersionSignal = sources.some(
+    (source) => parseSemver(source.versionTag) !== null && !isBareIntegerTag(source.versionTag),
+  );
+  if (hasNonIntegerVersionSignal) {
+    return [];
+  }
+
+  return eligible.filter((source) => isBareIntegerTag(source.versionTag));
+}
+
+interface SortablePoolEntry extends StableSemverCandidate {
+  hasBuildMetadata: boolean;
+}
+
+/**
+ * Sort by major/minor/patch descending. Ties prefer the tag without a
+ * semver build-metadata suffix (e.g. "1.43.3" over "1.43.3+build.5"),
+ * regardless of input order, then fall back to a stable lexical tie-break.
+ */
+function sortStablePoolDescending(entries: SortablePoolEntry[]): void {
+  entries.sort((a, b) => {
+    if (a.major !== b.major) return b.major - a.major;
+    if (a.minor !== b.minor) return b.minor - a.minor;
+    if (a.patch !== b.patch) return b.patch - a.patch;
+    if (a.hasBuildMetadata !== b.hasBuildMetadata) return a.hasBuildMetadata ? 1 : -1;
+    if (a.tag === b.tag) return 0;
+    return a.tag < b.tag ? -1 : 1;
+  });
+}
+
+interface StableCandidateSource extends VersionTagSource {
+  candidate: StableSemverCandidate | null;
+}
+
+/**
+ * #859: pick the single highest-ranked tag from an already include/exclude-
+ * filtered, untransformed tag list, using the stable-only eligibility rules
+ * (see isStableSemverCandidate) and never letting a bare integer tag outrank
+ * a real dotted version. Used by tag/suggest.ts's suggested-tag badge and the
+ * digest-comparison fallback in image-comparison.ts.
+ */
+export function pickPreferredVersionTag(tags: string[]): string | null {
+  const sources: StableCandidateSource[] = tags.map((tag) => ({
+    tag,
+    versionTag: tag,
+    candidate: isStableSemverCandidate(tag),
+  }));
+
+  const pool = selectVersionPopulation(sources, (source) => source.candidate !== null);
+
+  if (pool.length === 0) {
+    return null;
+  }
+
+  const candidates: SortablePoolEntry[] = pool.map((source) => ({
+    // selectVersionPopulation only keeps sources whose isEligible callback
+    // returned true above, i.e. sources with a non-null candidate.
+    ...(source.candidate as StableSemverCandidate),
+    hasBuildMetadata: hasBuildMetadataSuffix(source.tag),
+  }));
+
+  sortStablePoolDescending(candidates);
+  return candidates[0].tag;
+}

--- a/app/watchers/providers/docker/image-comparison.test.ts
+++ b/app/watchers/providers/docker/image-comparison.test.ts
@@ -1089,6 +1089,113 @@ describe('image-comparison', () => {
     expect(getImageManifestDigest).toHaveBeenCalled();
   });
 
+  // #859: linuxserver/plex repro — a bare integer build-number tag ("168")
+  // must never outrank a real dotted release ("1.43.3"), neither in the
+  // suggested-tag badge nor in the actionable tag advanced to result.tag.
+  test('watched latest tag suggests the dotted version over a bare integer and leaves the actionable tag untouched (#859)', async () => {
+    const actualSuggest =
+      await vi.importActual<typeof import('../../../tag/suggest.js')>('../../../tag/suggest.js');
+    mockSuggestTag.mockImplementation(actualSuggest.suggest);
+    const getImageManifestDigest = createManifestLookup();
+    mockGetState.mockReturnValue({
+      registry: {
+        hub: {
+          getTags: vi.fn().mockResolvedValue(['168', '1.43.3']),
+          getImageManifestDigest,
+          normalizeImage: identityNormalizeImage,
+        },
+      },
+    });
+    const log = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    const container = {
+      image: {
+        id: 'image-1',
+        registry: { name: 'hub' },
+        name: 'linuxserver/plex',
+        tag: { value: 'latest', semver: false },
+        digest: { watch: true, repo: 'sha256:local' },
+      },
+    };
+    const result = await findNewVersion(container as never, log);
+    expect(result.suggestedTag).toBe('1.43.3');
+    // No includeTags is set, so getTagCandidates never enters the recovery
+    // branch — the actionable tag stays put rather than forcing an update.
+    expect(result.tag).toBe('latest');
+  });
+
+  test('a permissive includeTags never lets the actionable tag advance to a bare integer over a real dotted version (#859)', async () => {
+    const actualSuggest =
+      await vi.importActual<typeof import('../../../tag/suggest.js')>('../../../tag/suggest.js');
+    mockSuggestTag.mockImplementation(actualSuggest.suggest);
+    const getImageManifestDigest = createManifestLookup();
+    mockGetState.mockReturnValue({
+      registry: {
+        hub: {
+          getTags: vi.fn().mockResolvedValue(['168', '1.43.3']),
+          getImageManifestDigest,
+          normalizeImage: identityNormalizeImage,
+        },
+      },
+    });
+    const log = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    const container = {
+      includeTags: String.raw`^\d+(\.\d+)*$`,
+      image: {
+        id: 'image-1',
+        registry: { name: 'hub' },
+        name: 'linuxserver/plex',
+        tag: { value: 'latest', semver: false },
+        digest: { watch: true, repo: 'sha256:local' },
+      },
+    };
+    const result = await findNewVersion(container as never, log);
+    expect(result.suggestedTag).toBe('1.43.3');
+    expect(result.tag).toBe('1.43.3');
+    expect(result.tag).not.toBe('168');
+  });
+
+  test('digest comparison never resolves a bare integer tag over a real dotted version (#859)', async () => {
+    const actualSuggest =
+      await vi.importActual<typeof import('../../../tag/suggest.js')>('../../../tag/suggest.js');
+    mockSuggestTag.mockImplementation(actualSuggest.suggest);
+    const getImageManifestDigest = createManifestLookup();
+    mockGetState.mockReturnValue({
+      registry: {
+        hub: {
+          getTags: vi.fn().mockResolvedValue(['168', '1.43.3']),
+          getImageManifestDigest,
+          normalizeImage: identityNormalizeImage,
+        },
+      },
+    });
+    const log = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+
+    await findNewVersion(createDigestOnlyContainer() as never, log);
+
+    expect(getImageManifestDigest.mock.calls[0][0].tag.value).toBe('1.43.3');
+  });
+
+  test('digest comparison sorts a genuinely integer-only tag pool numerically, not lexically (#859)', async () => {
+    const actualSuggest =
+      await vi.importActual<typeof import('../../../tag/suggest.js')>('../../../tag/suggest.js');
+    mockSuggestTag.mockImplementation(actualSuggest.suggest);
+    const getImageManifestDigest = createManifestLookup();
+    mockGetState.mockReturnValue({
+      registry: {
+        hub: {
+          getTags: vi.fn().mockResolvedValue(['9', '10']),
+          getImageManifestDigest,
+          normalizeImage: identityNormalizeImage,
+        },
+      },
+    });
+    const log = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+
+    await findNewVersion(createDigestOnlyContainer() as never, log);
+
+    expect(getImageManifestDigest.mock.calls[0][0].tag.value).toBe('10');
+  });
+
   test('publishedTag falls back to container.image.tag.value when result.tag is falsy', async () => {
     const getImagePublishedAt = vi.fn().mockResolvedValue('2026-04-01T00:00:00.000Z');
     mockGetState.mockReturnValue({

--- a/app/watchers/providers/docker/tag-candidates.test.ts
+++ b/app/watchers/providers/docker/tag-candidates.test.ts
@@ -996,6 +996,105 @@ describe('docker tag candidates module', () => {
     expect(result.tags).toEqual([]);
   });
 
+  // #859: linuxserver/plex repro at the actionable-candidate layer — a bare
+  // integer build-number tag ("168") must never outrank a real dotted
+  // release ("1.43.3") in this fallback recommendation either.
+  describe('non-semver current tag with includeTags never ranks a bare integer over a real dotted version (#859)', () => {
+    test('picks the real dotted version over a bare integer', () => {
+      const container = createContainer({
+        image: {
+          tag: {
+            value: 'latest',
+            semver: false,
+          },
+        },
+        includeTags: String.raw`^\d+(\.\d+)*$`,
+      });
+      const log = { warn: vi.fn(), debug: vi.fn() };
+
+      const result = getTagCandidates(container, ['168', '1.43.3'], log);
+
+      expect(result.tags[0]).toBe('1.43.3');
+      expect(result.tags).not.toContain('168');
+    });
+
+    test('picks a numerically higher bare integer when the population is genuinely integer-only', () => {
+      const container = createContainer({
+        image: {
+          tag: {
+            value: 'latest',
+            semver: false,
+          },
+        },
+        includeTags: String.raw`^\d+$`,
+      });
+      const log = { warn: vi.fn(), debug: vi.fn() };
+
+      const result = getTagCandidates(container, ['9', '10'], log);
+
+      expect(result.tags[0]).toBe('10');
+    });
+
+    // This branch's eligibility stays permissive (tolerates prerelease tags,
+    // unlike tag/suggest.ts's stable-only badge — see selectVersionPopulation
+    // in tag/version-population.ts), so a prerelease-only real version is
+    // itself an eligible, non-bare-integer "preferred" candidate here and
+    // wins outright rather than triggering the "no safe suggestion" rule.
+    test('a prerelease-only real version still outranks a bare integer', () => {
+      const container = createContainer({
+        image: {
+          tag: {
+            value: 'latest',
+            semver: false,
+          },
+        },
+        includeTags: String.raw`^(\d+|\d+\.\d+\.\d+-rc\.\d+)$`,
+      });
+      const log = { warn: vi.fn(), debug: vi.fn() };
+
+      const result = getTagCandidates(container, ['168', '1.44.0-rc.1'], log);
+
+      expect(result.tags[0]).toBe('1.44.0-rc.1');
+      expect(result.tags).not.toContain('168');
+    });
+
+    test('an includeTags filter that narrows the population to integers-only lets the integer win', () => {
+      const container = createContainer({
+        image: {
+          tag: {
+            value: 'latest',
+            semver: false,
+          },
+        },
+        includeTags: String.raw`^\d+$`,
+      });
+      const log = { warn: vi.fn(), debug: vi.fn() };
+
+      const result = getTagCandidates(container, ['168', '1.43.3'], log);
+
+      expect(result.tags[0]).toBe('168');
+    });
+
+    test('applies dd.tag.transform before classifying bare integers vs real versions', () => {
+      const container = createContainer({
+        image: {
+          tag: {
+            value: 'latest',
+            semver: false,
+          },
+        },
+        includeTags: '^build-',
+        transformTags: 'build-(.+) => $1',
+      });
+      const log = { warn: vi.fn(), debug: vi.fn() };
+
+      const result = getTagCandidates(container, ['build-168', 'build-1.43.3'], log);
+
+      expect(result.tags[0]).toBe('build-1.43.3');
+      expect(result.tags).not.toContain('build-168');
+    });
+  });
+
   // Coverage for pre-existing branch: warn when filteredTags is empty after include/exclude
   test('warns when all tags are filtered out before semver candidate pass', () => {
     const container = createContainer({

--- a/app/watchers/providers/docker/tag-candidates.ts
+++ b/app/watchers/providers/docker/tag-candidates.ts
@@ -13,6 +13,7 @@ import {
   getNumericTagShape as getSharedNumericTagShape,
   type NumericTagShape,
 } from '../../../tag/precision.js';
+import { selectVersionPopulation, type VersionTagSource } from '../../../tag/version-population.js';
 import { getErrorMessage } from '../../../util/error.js';
 
 interface SafeRegex {
@@ -535,13 +536,6 @@ function sortSemverDescending(
 }
 
 /**
- * Keep only tags that are valid semver.
- */
-function filterSemverOnly(tags: string[], transformTags: string | undefined): string[] {
-  return tags.filter((tag) => parseSemver(transformTag(transformTags, tag)) !== null);
-}
-
-/**
  * #498: classify a pin-gate insight's version bump as major/minor/patch.
  * diffSemver() treats a shared suffix as a semver prerelease field, so a
  * cross-major bump between two same-suffix tags reports as "premajor" (not
@@ -729,7 +723,21 @@ export function getTagCandidates(
     logContainer.warn(
       `Current tag "${container.image.tag.value}" is not semver but includeTags filter "${container.includeTags}" is set. Advising best semver tag from filtered candidates.`,
     );
-    const semverTags = filterSemverOnly(baseTags, container.transformTags);
+    const versionTagSources: VersionTagSource[] = baseTags.map((tag) => ({
+      tag,
+      versionTag: transformTag(container.transformTags, tag),
+    }));
+    // #859: never let a bare integer build-number tag ("168") outrank a real
+    // dotted release ("1.43.3") — shares its partition rule with
+    // tag/suggest.ts's suggested-tag badge (see selectVersionPopulation) so
+    // the two paths cannot drift. Eligibility here stays permissive (any tag
+    // that parses as semver, prereleases included) to preserve this
+    // fallback's existing best-effort behavior; only the bare-integer-vs-real
+    // partition is shared.
+    const semverTags = selectVersionPopulation(
+      versionTagSources,
+      (source) => parseSemver(source.versionTag) !== null,
+    ).map((source) => source.tag);
     sortSemverDescending(semverTags, container.transformTags, container.image.tag.value);
     return { tags: semverTags };
   }


### PR DESCRIPTION
Backports `ae77c069` (#871) from `dev/v1.7`, where it shipped in v1.7.0-rc.4.

## Why this one

A bare integer tag like `168` coerces through `semver.coerce()` into a fake `168.0.0`, which outranks a real dotted release like `1.43.3`. On `linuxserver/plex` that meant the suggested-tag badge, and with a permissive `dd.tag.include` filter the actionable update candidate itself, could point at a destructive downgrade.

That is a user-harming bug, and v1.6 is where users sit until v1.7.0 GA, which is not imminent. Leaving it in a maintenance line we are about to GA is the wrong trade.

## Why not #888 as well

`757bfe18` (#888, prune store records for containers that leave watch scope) is the other fix that landed on `dev/v1.7` after the backport branch was cut. It is deliberately not included: it is hygiene with no data loss and no wrong action taken, and it does not justify another RC on the v1.6.1 train. It ships in v1.7.0.

## Contents

Cherry-pick applied clean to all six code files. The only conflict was `CHANGELOG.md`, where the entry had landed inside the already-shipped `[1.6.1-rc.2]` section. Resolved by restoring rc.2 to its released content and placing the new entry under `[Unreleased]`, so no shipped section was rewritten.

Local: 303 tests pass across `app/tag/` and the two watcher suites. Full pre-push gate green in 275s, coverage included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added shared version-population utilities for safe stable-tag classification and selection.
- ✨ Added regression coverage for bare integer tags, dotted releases, prereleases, CalVer tags, filtering, transformations, and tie-breaking.
- 🔧 Changed tag suggestion and Docker candidate selection to use `pickPreferredVersionTag`.
- 🐛 Fixed bare integer tags such as `168` incorrectly outranking releases such as `1.43.3`.
- 🐛 Fixed actionable candidates and digest comparisons that could suggest destructive downgrades.
- 🗑️ Removed duplicated semver filtering and sorting logic.
- 🔧 Preserved released `1.6.1-rc.2` changelog content and added the backport entry under `[Unreleased]`.

## Concerns

- Confirm that all provider-specific tag-selection paths use the shared version-population utilities.
- Verify `pickPreferredVersionTag` behavior for integer-only, prerelease-only, and transformed tag populations.
- Confirm that the 303 targeted tests and full pre-push gate remain passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->