### PR TITLE
chore(release): roll v1.6 identity to 1.6.1-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1-rc.4] — 2026-08-27
+
 ### Fixed
 
 - **Tag suggestion no longer ranks a bare integer build-number tag above a real dotted version.** A bare integer tag (e.g. `168`) coerces via `semver.coerce()` into a fake `168.0.0`, which previously outranked a real release like `1.43.3` — for `linuxserver/plex`, this meant the suggested-tag badge and, with a permissive `dd.tag.include` filter, the actionable update candidate itself could point at a destructive downgrade. Bare integer tags are now only ever ranked among themselves (never against a real dotted version, and never at all when the population contains any other non-integer version signal, such as a prerelease-only or coercion-lossy tag), sorted numerically rather than lexically. The rule is shared between the suggested-tag badge (`tag/suggest.ts`) and the actionable non-semver/`includeTags` recovery path (`watchers/providers/docker/tag-candidates.ts`) via a new `tag/version-population.ts` module so the two paths can't drift apart again. ([#859](https://github.com/CodesWhat/drydock/issues/859))
@@ -2423,7 +2425,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.3...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.4...HEAD
+[1.6.1-rc.4]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.3...v1.6.1-rc.4
 [1.6.1-rc.3]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.2...v1.6.1-rc.3
 [1.6.1-rc.2]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.1...v1.6.1-rc.2
 [1.6.1-rc.1]: https://github.com/CodesWhat/drydock/compare/v1.6.0...v1.6.1-rc.1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.3-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.4-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,6 +179,15 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.6.1-rc.4 highlights</strong></summary>
+
+- **Tag suggestion no longer ranks a bare integer build-number tag above a real dotted version** — a tag like `168` coerced into a fake `168.0.0` and outranked a real release like `1.43.3`, so on `linuxserver/plex` the suggested-tag badge and, with a permissive `dd.tag.include` filter, the update candidate itself could point at a downgrade. ([#859](https://github.com/CodesWhat/drydock/issues/859))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc4--2026-08-27).
+
+</details>
+
+<details>
 <summary><strong>v1.6.1-rc.3 highlights</strong></summary>
 
 - **A `ws`/`wss` value in `X-Forwarded-Proto` no longer rejects the WebSocket upgrade** — Traefik forwards the upgrade's client-facing scheme as `wss` rather than `https`, which the origin check hard-rejected as an unsupported protocol; `ws` and `wss` now map to `http:`/`https:` for the comparison. ([#867](https://github.com/CodesWhat/drydock/issues/867))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1-rc.3',
+    version: '1.6.1-rc.4',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1-rc.3 started',
+    details: 'Drydock v1.6.1-rc.4 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.3',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.4',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1-rc.3',
+    tag: '1.6.1-rc.4',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1-rc.3',
+  version: '1.6.1-rc.4',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1-rc.3',
+      version: '1.6.1-rc.4',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1-rc.3', mode: 'demo' },
+        server: { version: '1.6.1-rc.4', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1-rc.3",
+  version: "1.6.1-rc.4",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1-rc.3",
+    version: "v1.6.1-rc.4",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1-rc.3",
+      "version": "1.6.1-rc.4",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1-rc.3",
+    "version": "1.6.1-rc.4",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1-rc.3"
+  "version":"1.6.1-rc.4"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1-rc.3",
+    "version": "1.6.1-rc.4",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1-rc.3",
+      "drydockVersion": "1.6.1-rc.4",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1-rc.3` | Immutable release candidate; best for reproducible testing |
+| `1.6.1-rc.4` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,16 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.6.1-rc.4 Highlights — August 27, 2026
+
+One bug fix: tag suggestion no longer ranks a bare integer build-number tag
+above a real dotted version. A tag like `168` coerced into a fake `168.0.0` and
+could outrank a real release like `1.43.3`, so on `linuxserver/plex` the
+suggested-tag badge and, with a permissive `dd.tag.include` filter, the update
+candidate itself could point at a downgrade. See
+[CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc4--2026-08-27)
+for the full release notes.
+
 ## v1.6.1-rc.3 Highlights — August 27, 2026
 
 Three bug fixes: a `ws`/`wss` value in `X-Forwarded-Proto` no longer rejects the

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.3...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.4...HEAD`],
+    ['1.6.1-rc.4', `${repositoryUrl}/compare/v1.6.1-rc.3...v1.6.1-rc.4`],
     ['1.6.1-rc.3', `${repositoryUrl}/compare/v1.6.1-rc.2...v1.6.1-rc.3`],
     ['1.6.1-rc.2', `${repositoryUrl}/compare/v1.6.1-rc.1...v1.6.1-rc.2`],
     ['1.6.1-rc.1', `${repositoryUrl}/compare/v1.6.0...v1.6.1-rc.1`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1-rc.3';
-const PREV_RC_VERSION = '1.6.1-rc.2';
+const RC_VERSION = '1.6.1-rc.4';
+const PREV_RC_VERSION = '1.6.1-rc.3';
 const RC_DATE = '2026-08-27';
 const RC_DISPLAY_DATE = 'August 27, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1-rc.3';
+const RC_VERSION = '1.6.1-rc.4';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Cut prep for v1.6.1-rc.4. rc.4 carries exactly one change: the bare-integer tag ranking backport from #902.

## What moved

- `CHANGELOG.md`: the Unreleased tag-ranking entry becomes a dated `[1.6.1-rc.4] — 2026-08-27` section, gains its compare link, and Unreleased now compares against rc.4.
- Candidate identity bumped rc.3 to rc.4 across the demo fixtures, website config, quickstart, and the three API docs.
- README gains an rc.4 highlights block; rc.3 demoted from `<details open>` to `<details>`. Same treatment on the docs updates page.
- `release-identity` RC_VERSION, `release-docs-identity` RC_VERSION and PREV_RC_VERSION, and the changelog compare-link expectations.

`RC_DATE` is unchanged on purpose: rc.3 and rc.4 both cut on 2026-08-27.

## Verification

19/19 identity tests pass (`release-identity`, `release-docs-identity`, `changelog-links`). Full pre-push gate green in 290s, coverage included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed tag ranking so bare integer build tags cannot outrank dotted versions and suggest downgrades.
- ✨ Added v1.6.1-rc.4 highlights to the README, updates, and changelog.
- 🔧 Updated release links, documentation, site configuration, demo fixtures, and release identity tests from rc.3 to rc.4.
- 🔧 Preserved `RC_DATE` because both candidates use `2026-08-27`.
- 🔧 Updated comparison links from rc.3 to rc.4.
- 🔧 All 19 release identity tests and the full pre-push gate pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->