### PR TITLE
fix(v1.6): backport the compose runtime-defaults refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Compose updates now pick up runtime defaults the new image ships.** A container recreated by the compose action was rebuilt from the stored config rather than re-reading the defaults baked into the pulled image, so anything the image sets for itself — `APP_VERSION`, `RELEASE_VERSION` and the like — carried over from the old container and made the UI keep reporting an update while the running image was already current. A manual `docker compose down && docker compose up -d` fixed it because compose rebuilds that config from the image every time. Backported from the v1.7 line, where the reporter's version could not reach it. ([#734](https://github.com/CodesWhat/drydock/issues/734), [#736](https://github.com/CodesWhat/drydock/pull/736))
+
 ## [1.6.1-rc.4] — 2026-08-27
 
 ### Fixed

--- a/app/triggers/providers/dockercompose/Dockercompose.compose-exec-and-hooks.test.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.compose-exec-and-hooks.test.ts
@@ -145,6 +145,65 @@ describe('Dockercompose Trigger', () => {
     expect(startContainerSpy).toHaveBeenCalledTimes(1);
   });
 
+  test('updateContainerWithCompose should remove stale image-inherited env defaults while preserving runtime env', async () => {
+    trigger.configuration.dryrun = false;
+    const currentContainer = makeDockerContainerHandle({
+      image: 'example/app:old',
+    });
+    currentContainer.inspect.mockResolvedValue({
+      Id: 'container-id',
+      Name: '/nginx',
+      Config: {
+        Image: 'example/app:old',
+        Env: ['APP_VERSION=old', 'RUNTIME_VALUE=keep'],
+        Labels: {},
+      },
+      HostConfig: {},
+      NetworkSettings: { Networks: {} },
+      State: { Running: true },
+    });
+    mockDockerApi.getContainer.mockReturnValue(currentContainer);
+    mockDockerApi.getImage.mockImplementation((imageRef) => ({
+      inspect: vi.fn().mockResolvedValue(
+        imageRef === 'example/app:old'
+          ? { Config: { Env: ['APP_VERSION=old'] } }
+          : {
+              Architecture: process.arch === 'x64' ? 'amd64' : process.arch,
+              Os: 'linux',
+              Config: { Env: ['APP_VERSION=new'] },
+            },
+      ),
+    }));
+    vi.spyOn(trigger, 'pullImage').mockResolvedValue();
+    vi.spyOn(trigger, 'stopContainer').mockResolvedValue();
+    vi.spyOn(trigger, 'removeContainer').mockResolvedValue();
+    const createContainerSpy = vi.spyOn(trigger, 'createContainer').mockResolvedValue({
+      start: vi.fn().mockResolvedValue(undefined),
+    } as any);
+
+    await trigger.updateContainerWithCompose(
+      '/opt/drydock/test/stack.yml',
+      'nginx',
+      makeContainer(),
+      {
+        skipPull: true,
+        runtimeContext: {
+          dockerApi: mockDockerApi,
+          newImage: 'example/app:new',
+        },
+      },
+    );
+
+    expect(createContainerSpy).toHaveBeenCalledWith(
+      mockDockerApi,
+      expect.objectContaining({
+        Env: ['RUNTIME_VALUE=keep'],
+      }),
+      'nginx',
+      expect.anything(),
+    );
+  });
+
   test('updateContainerWithCompose should preserve stopped runtime state', async () => {
     trigger.configuration.dryrun = false;
     const pullImageSpy = vi.spyOn(trigger, 'pullImage').mockResolvedValue();

--- a/app/triggers/providers/dockercompose/Dockercompose.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.ts
@@ -2346,11 +2346,12 @@ class Dockercompose extends Docker<DockercomposeTriggerConfiguration> {
     newImage,
     container,
     logContainer: { info: (msg: string) => void; warn: (msg: string) => void },
+    cloneRuntimeConfigOptions,
   ): Promise<void> {
     const containerToCreateInspect = this.cloneContainer(
       currentContainerSpec,
       newImage,
-      logContainer,
+      cloneRuntimeConfigOptions,
     );
     let newContainer: unknown;
 
@@ -2446,6 +2447,12 @@ class Dockercompose extends Docker<DockercomposeTriggerConfiguration> {
     // before performing any destructive step. On arch mismatch the old
     // container is left running and we throw without touching it.
     await this.verifyPulledImageCompatibility(dockerApi as DockerApiLike, newImage, logContainer);
+    const cloneRuntimeConfigOptions = await this.runtimeConfigManager.getCloneRuntimeConfigOptions(
+      dockerApi,
+      currentContainerSpec,
+      newImage,
+      logContainer,
+    );
 
     // Capture the original container spec for rollback before we do anything
     // destructive. The Config.Image field holds the old image reference.
@@ -2484,6 +2491,7 @@ class Dockercompose extends Docker<DockercomposeTriggerConfiguration> {
         newImage,
         container,
         logContainer,
+        cloneRuntimeConfigOptions,
       );
     } catch (recreateError: unknown) {
       const rollbackOutcome = await this.attemptRollbackRestoreOldContainer(


### PR DESCRIPTION
Cherry-pick of `154c4e0b` (#736) onto the 1.6 line.

#734 reported that `APP_VERSION` and `RELEASE_VERSION` stop matching the running image after a compose update, so the UI keeps showing an update against an image that is already current. A manual `docker compose down && docker compose up -d` clears it, because compose rebuilds the container config from the image every time and drydock was rebuilding it from the stored config instead.

That fix landed on `dev/v1.7` only. The reporter runs 1.6.0, so it was unreachable on the line they are actually on, and v1.6.1 has not shipped yet. Backporting it here rather than making them wait for a major.

Cherry-picked clean, no conflicts, no adaptation. 2 files, +68/-1, all of it the original change plus its regression.

Verified on this branch: `Dockercompose.compose-exec-and-hooks.test.ts` 68 tests passing, and the full pre-push gate green including coverage at 100%.

Fixes: #734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- 🐛 Fixed Compose container recreation to refresh image-provided runtime defaults, including `APP_VERSION` and `RELEASE_VERSION`.
- 🔧 Changed `refreshComposeServiceWithDockerApi` to pass clone runtime configuration options to `cloneContainer`.
- ✨ Added regression coverage for removing stale image defaults while preserving runtime-defined variables.

## Concerns

- Verify the clone runtime configuration path matches conventions used by other providers.
- Confirm the 68 Compose tests and full pre-push gate pass on `v1.6`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->