### PR TITLE
chore(release): roll v1.6 identity to 1.6.1-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1-rc.5] — 2026-08-27
+
 ### Fixed
 
 - **Compose updates now pick up runtime defaults the new image ships.** A container recreated by the compose action was rebuilt from the stored config rather than re-reading the defaults baked into the pulled image, so anything the image sets for itself — `APP_VERSION`, `RELEASE_VERSION` and the like — carried over from the old container and made the UI keep reporting an update while the running image was already current. A manual `docker compose down && docker compose up -d` fixed it because compose rebuilds that config from the image every time. Backported from the v1.7 line, where the reporter's version could not reach it. ([#734](https://github.com/CodesWhat/drydock/issues/734), [#736](https://github.com/CodesWhat/drydock/pull/736))
-- **The Crowdin translation-sync workflow failed on every push to `dev/v1.6`** while a newer `dev/v1.7` branch also existed on origin, dying with `Your local changes to the following files would be overwritten by checkout`. The base-branch resolver always targeted the highest `dev/vX.Y` branch on origin regardless of which branch triggered the run, but the crowdin action had already downloaded translations into the working tree by the time that step ran, so checking out a *different* branch over those changes failed. A push straight to a `dev/vX.Y` branch now targets that branch directly as the base instead of going through the highest-wins lookup; scheduled and `workflow_dispatch` runs are unaffected and keep using it. (PR_LINK_PLACEHOLDER)
+- **The Crowdin translation-sync workflow failed on every push to `dev/v1.6`** while a newer `dev/v1.7` branch also existed on origin, dying with `Your local changes to the following files would be overwritten by checkout`. The base-branch resolver always targeted the highest `dev/vX.Y` branch on origin regardless of which branch triggered the run, but the crowdin action had already downloaded translations into the working tree by the time that step ran, so checking out a *different* branch over those changes failed. A push straight to a `dev/vX.Y` branch now targets that branch directly as the base instead of going through the highest-wins lookup; scheduled and `workflow_dispatch` runs are unaffected and keep using it. ([#906](https://github.com/CodesWhat/drydock/pull/906))
 
 ## [1.6.1-rc.4] — 2026-08-27
 
@@ -2430,7 +2432,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.4...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.5...HEAD
+[1.6.1-rc.5]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.4...v1.6.1-rc.5
 [1.6.1-rc.4]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.3...v1.6.1-rc.4
 [1.6.1-rc.3]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.2...v1.6.1-rc.3
 [1.6.1-rc.2]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.1...v1.6.1-rc.2

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.4-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.5-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,6 +179,16 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.6.1-rc.5 highlights</strong></summary>
+
+- **Compose updates now pick up the runtime defaults the new image ships** — a container recreated by the compose action was rebuilt from the stored config instead of re-reading the pulled image, so values like `APP_VERSION` carried over from the old container and the UI kept reporting an update that was already applied. Backported from the v1.7 line. ([#734](https://github.com/CodesWhat/drydock/issues/734))
+- **The Crowdin translation-sync workflow no longer fails on pushes to `dev/v1.6`** — it always resolved its base branch as the highest `dev/vX.Y` on origin, so a push to `dev/v1.6` while a newer `dev/v1.7` branch also existed tried to check out that branch over files it had already downloaded and failed. A push to a `dev/vX.Y` branch now targets that branch directly. ([#906](https://github.com/CodesWhat/drydock/pull/906))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc5--2026-08-27).
+
+</details>
+
+<details>
 <summary><strong>v1.6.1-rc.4 highlights</strong></summary>
 
 - **Tag suggestion no longer ranks a bare integer build-number tag above a real dotted version** — a tag like `168` coerced into a fake `168.0.0` and outranked a real release like `1.43.3`, so on `linuxserver/plex` the suggested-tag badge and, with a permissive `dd.tag.include` filter, the update candidate itself could point at a downgrade. ([#859](https://github.com/CodesWhat/drydock/issues/859))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1-rc.4',
+    version: '1.6.1-rc.5',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1-rc.4 started',
+    details: 'Drydock v1.6.1-rc.5 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.4',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.5',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1-rc.4',
+    tag: '1.6.1-rc.5',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1-rc.4',
+  version: '1.6.1-rc.5',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1-rc.4',
+      version: '1.6.1-rc.5',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1-rc.4', mode: 'demo' },
+        server: { version: '1.6.1-rc.5', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1-rc.4",
+  version: "1.6.1-rc.5",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1-rc.4",
+    version: "v1.6.1-rc.5",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1-rc.4",
+      "version": "1.6.1-rc.5",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1-rc.4",
+    "version": "1.6.1-rc.5",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1-rc.4"
+  "version":"1.6.1-rc.5"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1-rc.4",
+    "version": "1.6.1-rc.5",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1-rc.4",
+      "drydockVersion": "1.6.1-rc.5",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1-rc.4` | Immutable release candidate; best for reproducible testing |
+| `1.6.1-rc.5` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,16 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.6.1-rc.5 Highlights — August 27, 2026
+
+Two fixes: compose updates now pick up the runtime defaults the new image
+ships, instead of carrying over values like `APP_VERSION` from the old
+container and reporting an update that's already applied; and the Crowdin
+translation-sync workflow no longer fails on pushes to `dev/v1.6` when a newer
+`dev/v1.7` branch also exists on origin. See
+[CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc5--2026-08-27)
+for the full release notes.
+
 ## v1.6.1-rc.4 Highlights — August 27, 2026
 
 One bug fix: tag suggestion no longer ranks a bare integer build-number tag

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.4...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.5...HEAD`],
+    ['1.6.1-rc.5', `${repositoryUrl}/compare/v1.6.1-rc.4...v1.6.1-rc.5`],
     ['1.6.1-rc.4', `${repositoryUrl}/compare/v1.6.1-rc.3...v1.6.1-rc.4`],
     ['1.6.1-rc.3', `${repositoryUrl}/compare/v1.6.1-rc.2...v1.6.1-rc.3`],
     ['1.6.1-rc.2', `${repositoryUrl}/compare/v1.6.1-rc.1...v1.6.1-rc.2`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1-rc.4';
-const PREV_RC_VERSION = '1.6.1-rc.3';
+const RC_VERSION = '1.6.1-rc.5';
+const PREV_RC_VERSION = '1.6.1-rc.4';
 const RC_DATE = '2026-08-27';
 const RC_DISPLAY_DATE = 'August 27, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1-rc.4';
+const RC_VERSION = '1.6.1-rc.5';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Rolls the v1.6 line to `1.6.1-rc.5` so the RC can be cut, and repairs a placeholder that shouldn't have shipped.

## The placeholder

`#906` merged with the literal string `(PR_LINK_PLACEHOLDER)` in its CHANGELOG bullet, where `([#906](...))` belonged. I wrote it meaning to fill the number in once the PR existed, and didn't. It's now the real citation.

Worth saying plainly: it survived the full pre-push gate, CI, CodeRabbit, and two approvals, because nothing anywhere looks for it. That's the same shape as the diff3 markers that shipped in v1.7.0-rc.4, which is to say text that is obviously wrong to a person and invisible to every automated check, and permanent once it reaches a published tag and the generated docs changelog.

Conflict markers got a guard after they shipped (`scripts/conflict-markers.test.mjs`, plus a grep in `release-cut.yml`). Placeholders have none. A guard for that class is queued separately rather than bolted onto a release commit.

Related: `scripts/conflict-markers.test.mjs` doesn't exist on this branch at all. It's v1.7-only and unmerged, so the v1.6 line has no local conflict-marker guard either. Backporting it is also queued separately. This branch's CHANGELOG is verified clean by hand.

## The roll

Promotes `## [Unreleased]` to `## [1.6.1-rc.5] — 2026-08-27` carrying its two entries (the compose runtime-defaults backport and the Crowdin fix), leaves a fresh empty `Unreleased`, and adds the compare link reference.

Identity rolled across the sites the previous roll (#903, `487db3af`) established: README badge and highlights, `content/docs/current/updates/index.mdx`, the API and quickstart pages, the demo mocks, the web site config, and the three identity test scripts.

`package.json` is untouched on all four workspaces. The base version has no prerelease component, so it stays `1.6.1` across every RC, and `release-cut.yml` asserts exactly that.

## Checks

`changelog-links` 4/4, `release-identity` 4/4, `release-docs-identity` 11/11, `release:precheck` clean, and no `PLACEHOLDER` string survives anywhere in the CHANGELOG.
