### PR TITLE
fix(store): persist updatePolicyRetentionCache across process restart on v1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Maturity-policy overrides no longer get wiped by drydock's own self-update.** `updatePolicyRetentionCache` — the stash that lets a recreated container inherit its predecessor's maturity mode, min-age, skip list, and snooze — lived only in a bare in-memory Map, so the SIGTERM-driven restart that is drydock's own self-update (recreate action, SIGTERM, new process) wiped the stash before the replacement container could consume it, silently dropping controller-set update policy. The cache now writes through to a durable LokiJS-backed store and rehydrates from it at startup before the first container is inserted, the same treatment the sibling lifecycle cache already had. Backported from the v1.7 line, where the reporter's version could not reach it. ([#565](https://github.com/CodesWhat/drydock/issues/565))
+
 ## [1.6.1-rc.5] — 2026-08-27
 
 ### Fixed

--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -5847,6 +5847,68 @@ describe('updatePolicyRetentionCache carry-forward (#496)', () => {
     expect(persistedKeys).toEqual(['::local::live-app-2']);
   });
 
+  test('rehydrateUpdatePolicyRetentionCacheFromStore re-applies the size cap, dropping the oldest records from the Map and the durable store', () => {
+    // Lowering DD_UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES between processes leaves the
+    // store holding more rows than the new limit allows. The stash path only trims after
+    // it has already restored them, so rehydration has to enforce the cap itself.
+    const nowMs = Date.now();
+    const maxEntries = container.UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES;
+    const overCap = [];
+    for (let i = 0; i <= maxEntries; i++) {
+      overCap.push({
+        cacheKey: `::local::overcap-app-${i}`,
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 60_000 + i,
+      });
+    }
+    mountPolicyRetentionStore(overCap);
+
+    container.rehydrateUpdatePolicyRetentionCacheFromStore();
+
+    const cache = container._getUpdatePolicyRetentionCacheForTests();
+    expect(cache.size).toBe(maxEntries);
+    expect(cache.has('::local::overcap-app-0')).toBe(false);
+    expect(cache.has(`::local::overcap-app-${maxEntries}`)).toBe(true);
+
+    const persistedKeys = updatePolicyRetentionCacheStore
+      .listRecords()
+      .map((record) => record.cacheKey);
+    expect(persistedKeys).toHaveLength(maxEntries);
+    expect(persistedKeys).not.toContain('::local::overcap-app-0');
+  });
+
+  test('rehydrateUpdatePolicyRetentionCacheFromStore restores oldest-first so the stash path still evicts the oldest', () => {
+    // listRecords() returns LokiJS document order. Inserting straight from it would leave
+    // the Map's insertion order unrelated to stash age, and the stash path's eviction
+    // reads that order as its LRU.
+    const nowMs = Date.now();
+    mountPolicyRetentionStore([
+      {
+        cacheKey: '::local::order-newest',
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 90_000,
+      },
+      {
+        cacheKey: '::local::order-oldest',
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 30_000,
+      },
+      {
+        cacheKey: '::local::order-middle',
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 60_000,
+      },
+    ]);
+
+    container.rehydrateUpdatePolicyRetentionCacheFromStore();
+
+    expect([...container._getUpdatePolicyRetentionCacheForTests().keys()]).toEqual([
+      '::local::order-oldest',
+      '::local::order-middle',
+      '::local::order-newest',
+    ]);
+  });
+
   // #565: unlike the lifecycle/clock cache, updatePolicyRetentionCache never got a durable
   // write-through store, so a self-update (recreate -> SIGTERM -> new process) lost the
   // stashed maturity policy even though the clock survived it. This pins the fix.

--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -5,6 +5,7 @@ import { createContainerFixture } from '../test/helpers.js';
 import { updateContainerFromInspect } from '../watchers/providers/docker/container-event-update.js';
 import { pruneOldContainers } from '../watchers/providers/docker/container-init.js';
 import * as container from './container.js';
+import * as updatePolicyRetentionCacheStore from './update-policy-retention-cache.js';
 
 vi.mock('./migrate');
 vi.mock('../event');
@@ -5318,6 +5319,59 @@ describe('updatePolicyRetentionCache carry-forward (#496)', () => {
     return collection;
   }
 
+  function createPolicyRetentionStoreCollection(
+    initialDocs: updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord[] = [],
+  ) {
+    const docs = [...initialDocs];
+    return {
+      findOne: vi.fn(
+        (
+          query: Record<string, unknown>,
+        ): updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord | null =>
+          docs.find((doc) =>
+            Object.entries(query).every(([k, v]) => (doc as Record<string, unknown>)[k] === v),
+          ) ?? null,
+      ),
+      find: vi.fn(
+        (
+          query?: Record<string, unknown>,
+        ): updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord[] => {
+          if (!query || Object.keys(query).length === 0) {
+            return [...docs];
+          }
+          return docs.filter((doc) =>
+            Object.entries(query).every(([k, v]) => (doc as Record<string, unknown>)[k] === v),
+          );
+        },
+      ),
+      insert: vi.fn((doc: updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord) => {
+        docs.push(doc);
+      }),
+      update: vi.fn(),
+      remove: vi.fn((doc: updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord) => {
+        const index = docs.indexOf(doc);
+        if (index !== -1) {
+          docs.splice(index, 1);
+        }
+      }),
+    };
+  }
+
+  function mountPolicyRetentionStore(
+    initialDocs: updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord[] = [],
+  ) {
+    const collection = createPolicyRetentionStoreCollection(initialDocs);
+    updatePolicyRetentionCacheStore.createCollections({
+      getCollection: () => collection,
+      addCollection: () => collection,
+    });
+    return collection;
+  }
+
+  beforeEach(() => {
+    updatePolicyRetentionCacheStore.clearCollectionForTesting();
+  });
+
   test('carries updatePolicy forward across a container recreate (new id, same watcher+name)', () => {
     const oldFixture = makePolicyFixture({
       id: 'policy-old-1',
@@ -5711,6 +5765,121 @@ describe('updatePolicyRetentionCache carry-forward (#496)', () => {
     // preceding replacement-delete must not inherit anything
     const later = container.insertContainer(makePolicyFixture({ id: 'policy-once-later' }));
     expect(later.updatePolicy).toBeUndefined();
+  });
+
+  test('deleteContainer write-throughs the stash to the durable store', () => {
+    mountPolicyRetentionStore();
+    const oldFixture = makePolicyFixture({
+      id: 'policy-durable-old-1',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    container.deleteContainer('policy-durable-old-1', { replacementExpected: true });
+
+    const [record] = updatePolicyRetentionCacheStore.listRecords();
+    expect(record).toMatchObject({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: MATURITY_POLICY,
+    });
+  });
+
+  test('insertContainer deletes the persisted record on a consumed cache hit', () => {
+    mountPolicyRetentionStore();
+    const oldFixture = makePolicyFixture({
+      id: 'policy-durable-old-2',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+    container.deleteContainer('policy-durable-old-2', { replacementExpected: true });
+    expect(updatePolicyRetentionCacheStore.listRecords()).toHaveLength(1);
+
+    container.insertContainer(makePolicyFixture({ id: 'policy-durable-new-2' }));
+
+    expect(updatePolicyRetentionCacheStore.listRecords()).toEqual([]);
+  });
+
+  test('rehydrateUpdatePolicyRetentionCacheFromStore repopulates the in-memory Map from non-expired persisted records only', () => {
+    const nowMs = Date.now();
+    mountPolicyRetentionStore([
+      {
+        cacheKey: '::local::live-app',
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 60_000,
+      },
+      {
+        cacheKey: '::local::expired-app',
+        updatePolicyOverrides: { maturityMode: 'all' },
+        expiresAt: nowMs - 1,
+      },
+    ]);
+
+    container.rehydrateUpdatePolicyRetentionCacheFromStore();
+
+    const policyRetentionCache = container._getUpdatePolicyRetentionCacheForTests();
+    expect(policyRetentionCache.has('::local::live-app')).toBe(true);
+    expect(policyRetentionCache.get('::local::live-app')?.updatePolicyOverrides).toEqual(
+      MATURITY_POLICY,
+    );
+    expect(policyRetentionCache.has('::local::expired-app')).toBe(false);
+  });
+
+  test('rehydrateUpdatePolicyRetentionCacheFromStore prunes expired records from the durable store, not just the in-memory Map', () => {
+    const nowMs = Date.now();
+    mountPolicyRetentionStore([
+      {
+        cacheKey: '::local::live-app-2',
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 60_000,
+      },
+      {
+        cacheKey: '::local::expired-app-2',
+        updatePolicyOverrides: { maturityMode: 'all' },
+        expiresAt: nowMs - 1,
+      },
+    ]);
+
+    container.rehydrateUpdatePolicyRetentionCacheFromStore();
+
+    const persistedKeys = updatePolicyRetentionCacheStore
+      .listRecords()
+      .map((record) => record.cacheKey);
+    expect(persistedKeys).toEqual(['::local::live-app-2']);
+  });
+
+  // #565: unlike the lifecycle/clock cache, updatePolicyRetentionCache never got a durable
+  // write-through store, so a self-update (recreate -> SIGTERM -> new process) lost the
+  // stashed maturity policy even though the clock survived it. This pins the fix.
+  test('end-to-end: a simulated process restart still carries updatePolicy forward', () => {
+    mountPolicyRetentionStore();
+    const oldFixture = makePolicyFixture({
+      id: 'policy-persist-restart-old',
+      updatePolicy: MATURITY_POLICY,
+    });
+    mountWith([{ data: oldFixture }]);
+
+    // 1. Self-update fires: the old container is torn down and its policy overrides are
+    //    stashed into both the in-memory Map and (write-through) the durable store.
+    container.deleteContainer('policy-persist-restart-old', { replacementExpected: true });
+    expect(updatePolicyRetentionCacheStore.listRecords()).toHaveLength(1);
+
+    // 2. SIGTERM: simulate the old process exiting — the in-memory Map is gone, but the
+    //    durable store (our stand-in for the persisted dd.json) survives untouched.
+    container._resetContainerStoreStateForTests();
+    expect(container._getUpdatePolicyRetentionCacheForTests().size).toBe(0);
+
+    // 3. New process boots: store/index.ts's createCollections() would call
+    //    rehydrateUpdatePolicyRetentionCacheFromStore() right after re-creating the
+    //    collections.
+    container.rehydrateUpdatePolicyRetentionCacheFromStore();
+    expect(container._getUpdatePolicyRetentionCacheForTests().has('::local::myapp')).toBe(true);
+
+    // 4. The watcher discovers the replacement container under the same watcher+name —
+    //    insertContainer's Map lookup now hits even though it's a brand-new process.
+    const inserted = container.insertContainer(
+      makePolicyFixture({ id: 'policy-persist-restart-new' }),
+    );
+    expect(inserted.updatePolicy).toEqual(MATURITY_POLICY);
   });
 });
 

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -31,6 +31,7 @@ import {
   getUpdatePolicyOverrides,
 } from '../model/update-policy.js';
 import { resolveTriggerLabelValuesPure } from '../watchers/providers/docker/trigger-label-resolution.js';
+import * as updatePolicyRetentionCacheStore from './update-policy-retention-cache.js';
 import { initCollection } from './util.js';
 
 let containers: ReturnType<typeof initCollection> | undefined;
@@ -999,15 +1000,22 @@ function stashUpdatePolicyForReplacement(containerRaw) {
     return;
   }
   updatePolicyRetentionCache.delete(cacheKey);
-  updatePolicyRetentionCache.set(cacheKey, {
+  const entry: UpdatePolicyRetentionCacheEntry = {
     updatePolicyOverrides,
     expiresAt: Date.now() + UPDATE_POLICY_RETENTION_CACHE_TTL_MS,
-  });
+  };
+  updatePolicyRetentionCache.set(cacheKey, entry);
+  // #565: write-through to the durable store so this stash survives the
+  // cross-process recreation that IS drydock's own self-update (recreate
+  // action -> SIGTERM -> shutdown()'s store.save() -> new process ->
+  // rehydrateUpdatePolicyRetentionCacheFromStore()).
+  updatePolicyRetentionCacheStore.upsertRecord({ cacheKey, ...entry });
   if (updatePolicyRetentionCache.size > UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES) {
     const nowMs = Date.now();
     for (const [expiredKey, expiredEntry] of updatePolicyRetentionCache.entries()) {
       if (expiredEntry.expiresAt <= nowMs) {
         updatePolicyRetentionCache.delete(expiredKey);
+        updatePolicyRetentionCacheStore.deleteRecord(expiredKey);
       }
     }
   }
@@ -1018,6 +1026,7 @@ function stashUpdatePolicyForReplacement(containerRaw) {
       break;
     }
     updatePolicyRetentionCache.delete(oldestKey);
+    updatePolicyRetentionCacheStore.deleteRecord(oldestKey);
   }
 }
 
@@ -1045,6 +1054,7 @@ function restoreRetainedUpdatePolicy(container) {
     return;
   }
   updatePolicyRetentionCache.delete(cacheKey);
+  updatePolicyRetentionCacheStore.deleteRecord(cacheKey);
   if (entry.expiresAt <= Date.now()) {
     return;
   }
@@ -1560,6 +1570,30 @@ export function deleteContainer(id, options: DeleteContainerOptions = {}) {
         replacementExpected: options.replacementExpected,
       });
     }
+  }
+}
+
+/**
+ * Repopulate the in-memory updatePolicyRetentionCache Map from its durable store
+ * counterpart. Called once at startup (see store/index.ts's createCollections())
+ * after both the containers collection and the update-policy-retention-cache
+ * collection have been created. Drops any record whose TTL already lapsed while
+ * the process was down rather than resurrecting a stale stash (#565).
+ */
+export function rehydrateUpdatePolicyRetentionCacheFromStore(): void {
+  const nowMs = Date.now();
+  for (const record of updatePolicyRetentionCacheStore.listRecords()) {
+    if (record.expiresAt <= nowMs) {
+      // Prune expired records from the durable store too, not just skip them —
+      // otherwise a long-stopped process leaves dead rows in the collection
+      // forever (it only ever grows via the write-through path elsewhere).
+      updatePolicyRetentionCacheStore.deleteRecord(record.cacheKey);
+      continue;
+    }
+    updatePolicyRetentionCache.set(record.cacheKey, {
+      updatePolicyOverrides: record.updatePolicyOverrides as container.ContainerUpdatePolicy,
+      expiresAt: record.expiresAt,
+    });
   }
 }
 

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -1582,6 +1582,7 @@ export function deleteContainer(id, options: DeleteContainerOptions = {}) {
  */
 export function rehydrateUpdatePolicyRetentionCacheFromStore(): void {
   const nowMs = Date.now();
+  const surviving: updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord[] = [];
   for (const record of updatePolicyRetentionCacheStore.listRecords()) {
     if (record.expiresAt <= nowMs) {
       // Prune expired records from the durable store too, not just skip them —
@@ -1590,6 +1591,23 @@ export function rehydrateUpdatePolicyRetentionCacheFromStore(): void {
       updatePolicyRetentionCacheStore.deleteRecord(record.cacheKey);
       continue;
     }
+    surviving.push(record);
+  }
+  // Oldest first. Every stash uses the same TTL, so ascending expiresAt is
+  // ascending stash time, which is the order the stash path's Map-insertion-order
+  // eviction assumes. listRecords() returns LokiJS document order, so inserting
+  // straight from it would leave the next eviction dropping an arbitrary entry
+  // instead of the oldest one.
+  surviving.sort((a, b) => a.expiresAt - b.expiresAt);
+  // Re-apply the cap here rather than leaving it to the next stash: lowering
+  // DD_UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES between processes leaves the
+  // store holding more rows than the new limit allows, and the stash path only
+  // trims after it has already restored them.
+  const overflow = Math.max(surviving.length - UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES, 0);
+  for (const record of surviving.slice(0, overflow)) {
+    updatePolicyRetentionCacheStore.deleteRecord(record.cacheKey);
+  }
+  for (const record of surviving.slice(overflow)) {
     updatePolicyRetentionCache.set(record.cacheKey, {
       updatePolicyOverrides: record.updatePolicyOverrides as container.ContainerUpdatePolicy,
       expiresAt: record.expiresAt,

--- a/app/store/index.test.ts
+++ b/app/store/index.test.ts
@@ -55,6 +55,7 @@ const {
       ...createCollectionsMock(),
       getContainersRaw: vi.fn(() => []),
       updateContainer: vi.fn(),
+      rehydrateUpdatePolicyRetentionCacheFromStore: vi.fn(),
       ...overrides,
     };
   }
@@ -113,6 +114,7 @@ const {
     vi.doMock('./settings', createCollectionsMock);
     vi.doMock('./ui-preferences', createCollectionsMock);
     vi.doMock('./update-operation', createCollectionsMock);
+    vi.doMock('./update-policy-retention-cache', createCollectionsMock);
     vi.doMock('../log', createLogMock);
   }
 
@@ -150,6 +152,7 @@ vi.mock('./secrets', createCollectionsMock);
 vi.mock('./settings', createCollectionsMock);
 vi.mock('./ui-preferences', createCollectionsMock);
 vi.mock('./update-operation', createCollectionsMock);
+vi.mock('./update-policy-retention-cache', createCollectionsMock);
 vi.mock('../log', createLogMock);
 
 describe('Store Module', () => {
@@ -183,6 +186,7 @@ describe('Store Module', () => {
     const settings = await import('./settings.js');
     const uiPreferences = await import('./ui-preferences.js');
     const updateOperation = await import('./update-operation.js');
+    const updatePolicyRetentionCache = await import('./update-policy-retention-cache.js');
 
     expect(app.createCollections).toHaveBeenCalled();
     expect(container.createCollections).toHaveBeenCalled();
@@ -194,6 +198,19 @@ describe('Store Module', () => {
     expect(container.createCollections.mock.invocationCallOrder[0]).toBeLessThan(
       app.completeStartupInitialization.mock.invocationCallOrder[0],
     );
+
+    // #565: the update-policy-retention-cache collection must exist, and container's
+    // in-memory Map must be rehydrated from it, before startup is considered complete.
+    expect(updatePolicyRetentionCache.createCollections).toHaveBeenCalled();
+    expect(container.createCollections.mock.invocationCallOrder[0]).toBeLessThan(
+      updatePolicyRetentionCache.createCollections.mock.invocationCallOrder[0],
+    );
+    expect(updatePolicyRetentionCache.createCollections.mock.invocationCallOrder[0]).toBeLessThan(
+      container.rehydrateUpdatePolicyRetentionCacheFromStore.mock.invocationCallOrder[0],
+    );
+    expect(
+      container.rehydrateUpdatePolicyRetentionCacheFromStore.mock.invocationCallOrder[0],
+    ).toBeLessThan(app.completeStartupInitialization.mock.invocationCallOrder[0]);
   });
 
   test('should create directory if it does not exist', async () => {

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -24,6 +24,7 @@ import * as secrets from './secrets.js';
 import * as settings from './settings.js';
 import * as uiPreferences from './ui-preferences.js';
 import * as updateOperation from './update-operation.js';
+import * as updatePolicyRetentionCacheStore from './update-policy-retention-cache.js';
 
 // Store Configuration Schema
 const configurationSchema = joi.object().keys({
@@ -95,6 +96,10 @@ function createCollections() {
   audit.createCollections(db);
   backup.createCollections(db);
   container.createCollections(db);
+  // #565: the update-policy-retention-cache collection must exist before
+  // rehydration repopulates container.ts's in-memory Map from it.
+  updatePolicyRetentionCacheStore.createCollections(db);
+  container.rehydrateUpdatePolicyRetentionCacheFromStore();
   nameBindings.createCollections(db);
   notification.createCollections(db);
   notificationHistory.createCollections(db);

--- a/app/store/update-policy-retention-cache.test.ts
+++ b/app/store/update-policy-retention-cache.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the update-policy-retention-cache store — the durable backing for
+ * container.ts's in-memory updatePolicyRetentionCache Map (#565).
+ */
+import * as updatePolicyRetentionCache from './update-policy-retention-cache.js';
+
+function createMockCollection(
+  initialDocs: updatePolicyRetentionCache.UpdatePolicyRetentionCacheRecord[] = [],
+) {
+  const docs = [...initialDocs];
+  return {
+    docs,
+    findOne: vi.fn(
+      (
+        query: Record<string, unknown>,
+      ): updatePolicyRetentionCache.UpdatePolicyRetentionCacheRecord | null => {
+        const match = docs.find((doc) => {
+          return Object.entries(query).every(([k, v]) => (doc as Record<string, unknown>)[k] === v);
+        });
+        return match ?? null;
+      },
+    ),
+    find: vi.fn(
+      (
+        query?: Record<string, unknown>,
+      ): updatePolicyRetentionCache.UpdatePolicyRetentionCacheRecord[] => {
+        if (!query || Object.keys(query).length === 0) {
+          return [...docs];
+        }
+        return docs.filter((doc) =>
+          Object.entries(query).every(([k, v]) => (doc as Record<string, unknown>)[k] === v),
+        );
+      },
+    ),
+    insert: vi.fn((doc: updatePolicyRetentionCache.UpdatePolicyRetentionCacheRecord) => {
+      docs.push(doc);
+    }),
+    update: vi.fn(),
+    remove: vi.fn((doc: updatePolicyRetentionCache.UpdatePolicyRetentionCacheRecord) => {
+      const index = docs.indexOf(doc);
+      if (index !== -1) {
+        docs.splice(index, 1);
+      }
+    }),
+  };
+}
+
+function createMockDb(collection = createMockCollection()) {
+  return {
+    getCollection: vi.fn(() => collection),
+    addCollection: vi.fn(() => collection),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updatePolicyRetentionCache.clearCollectionForTesting();
+});
+
+describe('createCollections', () => {
+  test('uses existing collection when present', () => {
+    const collection = createMockCollection();
+    const db = createMockDb(collection);
+    updatePolicyRetentionCache.createCollections(db);
+    expect(db.addCollection).not.toHaveBeenCalled();
+  });
+
+  test('creates collection when not present', () => {
+    const collection = createMockCollection();
+    const db = {
+      getCollection: vi.fn(() => null),
+      addCollection: vi.fn(() => collection),
+    };
+    updatePolicyRetentionCache.createCollections(db);
+    expect(db.addCollection).toHaveBeenCalled();
+  });
+});
+
+describe('upsertRecord', () => {
+  test('inserts a new record when none exists for the cacheKey', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'mature', maturityMinAgeDays: 5 },
+      expiresAt: 1_000,
+    });
+
+    expect(collection.insert).toHaveBeenCalledWith({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'mature', maturityMinAgeDays: 5 },
+      expiresAt: 1_000,
+    });
+    expect(updatePolicyRetentionCache.listRecords()).toHaveLength(1);
+  });
+
+  test('updates fields in place on a second call for the same cacheKey', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'mature' },
+      expiresAt: 1_000,
+    });
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'all' },
+      expiresAt: 2_000,
+    });
+
+    expect(collection.insert).toHaveBeenCalledTimes(1);
+    expect(collection.update).toHaveBeenCalledTimes(1);
+    const [record] = updatePolicyRetentionCache.listRecords();
+    expect(record.updatePolicyOverrides).toEqual({ maturityMode: 'all' });
+    expect(record.expiresAt).toBe(2_000);
+  });
+
+  test('is a no-op when the collection has not been initialized', () => {
+    expect(() =>
+      updatePolicyRetentionCache.upsertRecord({
+        cacheKey: '::local::myapp',
+        updatePolicyOverrides: {},
+        expiresAt: 1_000,
+      }),
+    ).not.toThrow();
+    expect(updatePolicyRetentionCache.listRecords()).toEqual([]);
+  });
+});
+
+describe('deleteRecord', () => {
+  test('removes the record for the given cacheKey', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'mature' },
+      expiresAt: 1_000,
+    });
+
+    updatePolicyRetentionCache.deleteRecord('::local::myapp');
+
+    expect(collection.remove).toHaveBeenCalledTimes(1);
+    expect(updatePolicyRetentionCache.listRecords()).toEqual([]);
+  });
+
+  test('is a no-op when no record exists for the cacheKey', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+
+    expect(() => updatePolicyRetentionCache.deleteRecord('never-stashed')).not.toThrow();
+    expect(collection.remove).not.toHaveBeenCalled();
+  });
+
+  test('is a no-op when the collection has not been initialized', () => {
+    expect(() => updatePolicyRetentionCache.deleteRecord('::local::myapp')).not.toThrow();
+  });
+});
+
+describe('listRecords', () => {
+  test('returns an empty array when the collection has not been initialized', () => {
+    expect(updatePolicyRetentionCache.listRecords()).toEqual([]);
+  });
+
+  test('returns every persisted record', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::app-1',
+      updatePolicyOverrides: { maturityMode: 'mature' },
+      expiresAt: 1_000,
+    });
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::app-2',
+      updatePolicyOverrides: { maturityMode: 'all' },
+      expiresAt: 2_000,
+    });
+
+    expect(updatePolicyRetentionCache.listRecords()).toHaveLength(2);
+  });
+});
+
+describe('clearCollectionForTesting', () => {
+  test('resets the module back to the uninitialized state', () => {
+    const collection = createMockCollection();
+    updatePolicyRetentionCache.createCollections(createMockDb(collection));
+    updatePolicyRetentionCache.upsertRecord({
+      cacheKey: '::local::myapp',
+      updatePolicyOverrides: { maturityMode: 'mature' },
+      expiresAt: 1_000,
+    });
+    expect(updatePolicyRetentionCache.listRecords()).toHaveLength(1);
+
+    updatePolicyRetentionCache.clearCollectionForTesting();
+
+    expect(updatePolicyRetentionCache.listRecords()).toEqual([]);
+    expect(() =>
+      updatePolicyRetentionCache.upsertRecord({
+        cacheKey: '::local::myapp',
+        updatePolicyOverrides: { maturityMode: 'mature' },
+        expiresAt: 1_000,
+      }),
+    ).not.toThrow();
+    expect(updatePolicyRetentionCache.listRecords()).toEqual([]); // still a no-op post-clear
+  });
+});

--- a/app/store/update-policy-retention-cache.ts
+++ b/app/store/update-policy-retention-cache.ts
@@ -1,0 +1,103 @@
+/**
+ * Persisted update-policy retention cache: survives drydock's own container recreation.
+ *
+ * Backs the in-memory `updatePolicyRetentionCache` Map in app/store/container.ts — the
+ * cache that lets a recreated container inherit its predecessor's updatePolicyOverrides
+ * (maturity mode, min-days, skip list, snooze) instead of losing them. Mirrors
+ * update-lifecycle-cache.ts: one LokiJS collection, loaded/autosaved by the shared
+ * store, one document per cache entry.
+ *
+ * Without this, the cache lived only in a bare process-memory Map — wiped on every
+ * restart, including the SIGTERM-driven restart that IS drydock's own self-update
+ * (recreate action -> SIGTERM -> shutdown() -> store.save() -> process.exit ->
+ * new process). Every self-update therefore lost the stash before the replacement
+ * container could consume it, silently dropping controller-set update policy (#565).
+ * Persisting the cache means a restarted process still has the stash before the
+ * replacement container is discovered.
+ */
+import { initCollection } from './util.js';
+
+export interface UpdatePolicyRetentionCacheRecord {
+  cacheKey: string; // deriveContainerIdentityKey() — same key the in-memory Map uses
+  updatePolicyOverrides: unknown;
+  expiresAt: number; // epoch ms — same TTL semantics as the in-memory Map
+}
+
+interface UpdatePolicyRetentionCacheCollection {
+  findOne(query: Record<string, unknown>): UpdatePolicyRetentionCacheRecord | null;
+  find(query?: Record<string, unknown>): UpdatePolicyRetentionCacheRecord[];
+  insert(document: UpdatePolicyRetentionCacheRecord): void;
+  update(document: UpdatePolicyRetentionCacheRecord): void;
+  remove(document: UpdatePolicyRetentionCacheRecord): void;
+}
+
+interface UpdatePolicyRetentionCacheStoreDb {
+  getCollection(name: string): UpdatePolicyRetentionCacheCollection | null;
+  addCollection(
+    name: string,
+    options?: Record<string, unknown>,
+  ): UpdatePolicyRetentionCacheCollection;
+}
+
+let updatePolicyRetentionCacheCollection: UpdatePolicyRetentionCacheCollection | undefined;
+
+/**
+ * Create the update-policy-retention-cache collection.
+ * @param db
+ */
+export function createCollections(db: UpdatePolicyRetentionCacheStoreDb): void {
+  updatePolicyRetentionCacheCollection = initCollection(db, 'update-policy-retention-cache', {
+    indices: ['cacheKey'],
+  }) as UpdatePolicyRetentionCacheCollection;
+}
+
+/**
+ * Insert or update the persisted record for record.cacheKey.
+ * A no-op (rather than a throw) when the collection has not been initialized
+ * yet — callers (container.ts) run this on every replacement-expected
+ * deleteContainer and must not fail the stash just because the durable store
+ * isn't wired up (e.g. in unit tests that only exercise the in-memory cache).
+ */
+export function upsertRecord(record: UpdatePolicyRetentionCacheRecord): void {
+  if (!updatePolicyRetentionCacheCollection) {
+    return;
+  }
+  const existing = updatePolicyRetentionCacheCollection.findOne({ cacheKey: record.cacheKey });
+  if (existing) {
+    existing.updatePolicyOverrides = record.updatePolicyOverrides;
+    existing.expiresAt = record.expiresAt;
+    updatePolicyRetentionCacheCollection.update(existing);
+    return;
+  }
+  updatePolicyRetentionCacheCollection.insert(record);
+}
+
+/**
+ * Delete the persisted record for cacheKey, if any.
+ */
+export function deleteRecord(cacheKey: string): void {
+  if (!updatePolicyRetentionCacheCollection) {
+    return;
+  }
+  const existing = updatePolicyRetentionCacheCollection.findOne({ cacheKey });
+  if (existing) {
+    updatePolicyRetentionCacheCollection.remove(existing);
+  }
+}
+
+/**
+ * List every persisted record. Used once at startup to rehydrate the in-memory
+ * updatePolicyRetentionCache Map — see
+ * rehydrateUpdatePolicyRetentionCacheFromStore() in container.ts.
+ */
+export function listRecords(): UpdatePolicyRetentionCacheRecord[] {
+  if (!updatePolicyRetentionCacheCollection) {
+    return [];
+  }
+  return updatePolicyRetentionCacheCollection.find();
+}
+
+/** Exposed for tests to reset module state between cases. */
+export function clearCollectionForTesting(): void {
+  updatePolicyRetentionCacheCollection = undefined;
+}


### PR DESCRIPTION
Backports `e37e742b` from the v1.7 line. Fixes #565 on the maintenance line, where the reporter's version actually is.

## The bug

`updatePolicyRetentionCache` is the stash that lets a recreated container inherit its predecessor's maturity mode, min-age, skip list and snooze. It lived only in a bare in-memory `Map`.

Drydock updating itself is a recreate action followed by SIGTERM and a new process. That restart wiped the stash before the replacement container could read it, so a controller-set update policy was silently dropped on exactly the operation most likely to trigger it.

## The fix

A durable LokiJS-backed collection mirroring what `update-lifecycle-cache` already does: write through on stash, delete on consume, and rehydrate at startup in `store/index.ts` before the first `insertContainer` runs. Ordering matters there, so the rehydration is wired ahead of it rather than alongside.

## Why it isn't a straight cherry-pick

v1.6 doesn't have the durable-store scaffolding from #556 that the v1.7 fix reuses, so the new module and its startup wiring are self-contained here. The in-memory `Map` and the stash/restore logic the fix hangs off are otherwise identical between the two lines, so the behavior being restored is the same.

## Changelog placement

The bullet goes under `## [Unreleased]`, not into `## [1.6.1-rc.5]`. That section is already cut and published, so editing it would put the repo's changelog out of step with the release notes GitHub is serving.

Worth noting the rebase surfaced a `PR_LINK_PLACEHOLDER` on this branch's side of the CHANGELOG conflict, the exact string the new guard on the v1.7 line catches. The resolved version carries the real #906 link that `dev/v1.6` already had.

## Verification

Full pre-push gate green from an installed worktree: biome, qlty, qlty-smells, scripts tests, workflow tests, ui typecheck, web scripts tests, coverage at the 100% thresholds (228s), build, and zizmor with no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added LokiJS-backed `update-policy-retention-cache` storage.
- ✨ Added startup rehydration for retained update-policy overrides.
- 🔧 Synchronized durable and in-memory caches during stash, restore, expiry, and eviction.
- 🔧 Enforced the cache size limit during startup rehydration.
- 🐛 Fixed maturity settings reset after Drydock self-update restarts.
- 🔧 Added tests for persistence, rehydration, expiry pruning, size limits, LRU ordering, and initialization order.
- ✨ Added the fix to `## [Unreleased]`.

## Concerns

- Verify `updatePolicyOverrides: unknown` matches the shared update-policy type.
- Add or confirm a typecheck declaration test for `update-policy-retention-cache.createCollections`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->