### PR TITLE
fix(store): enforce the retention-cache size cap and restore order at rehydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Restoring the maturity-policy stash at startup no longer ignores the size cap, or evicts the wrong entry afterwards.** The durable `updatePolicyRetentionCache` added in 1.7.0-rc.2 restored every non-expired persisted record straight into memory without checking `DD_UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES`, so lowering that limit between restarts came back over it and the extra entries stayed live until the next stash trimmed them. Restoring also used the store's document order, which has nothing to do with stash age, and the eviction that runs when the cap is hit reads that order as its LRU, so the first eviction after any restart could drop the newest entry and keep the oldest. Startup now restores oldest first and enforces the cap against both the in-memory cache and the persisted records. ([#565](https://github.com/CodesWhat/drydock/issues/565))
+
 ## [1.7.0-rc.5] — 2026-08-27
 
 ### Security

--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -6155,6 +6155,68 @@ describe('updatePolicyRetentionCache carry-forward (#496)', () => {
     expect(persistedKeys).toEqual(['::local::live-app-2']);
   });
 
+  test('rehydrateUpdatePolicyRetentionCacheFromStore re-applies the size cap, dropping the oldest records from the Map and the durable store', () => {
+    // Lowering DD_UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES between processes leaves the
+    // store holding more rows than the new limit allows. The stash path only trims after
+    // it has already restored them, so rehydration has to enforce the cap itself.
+    const nowMs = Date.now();
+    const maxEntries = container.UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES;
+    const overCap = [];
+    for (let i = 0; i <= maxEntries; i++) {
+      overCap.push({
+        cacheKey: `::local::overcap-app-${i}`,
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 60_000 + i,
+      });
+    }
+    mountPolicyRetentionStore(overCap);
+
+    container.rehydrateUpdatePolicyRetentionCacheFromStore();
+
+    const cache = container._getUpdatePolicyRetentionCacheForTests();
+    expect(cache.size).toBe(maxEntries);
+    expect(cache.has('::local::overcap-app-0')).toBe(false);
+    expect(cache.has(`::local::overcap-app-${maxEntries}`)).toBe(true);
+
+    const persistedKeys = updatePolicyRetentionCacheStore
+      .listRecords()
+      .map((record) => record.cacheKey);
+    expect(persistedKeys).toHaveLength(maxEntries);
+    expect(persistedKeys).not.toContain('::local::overcap-app-0');
+  });
+
+  test('rehydrateUpdatePolicyRetentionCacheFromStore restores oldest-first so the stash path still evicts the oldest', () => {
+    // listRecords() returns LokiJS document order. Inserting straight from it would leave
+    // the Map's insertion order unrelated to stash age, and the stash path's eviction
+    // reads that order as its LRU.
+    const nowMs = Date.now();
+    mountPolicyRetentionStore([
+      {
+        cacheKey: '::local::order-newest',
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 90_000,
+      },
+      {
+        cacheKey: '::local::order-oldest',
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 30_000,
+      },
+      {
+        cacheKey: '::local::order-middle',
+        updatePolicyOverrides: MATURITY_POLICY,
+        expiresAt: nowMs + 60_000,
+      },
+    ]);
+
+    container.rehydrateUpdatePolicyRetentionCacheFromStore();
+
+    expect([...container._getUpdatePolicyRetentionCacheForTests().keys()]).toEqual([
+      '::local::order-oldest',
+      '::local::order-middle',
+      '::local::order-newest',
+    ]);
+  });
+
   // #565: unlike the lifecycle/clock cache (#556), updatePolicyRetentionCache never got a
   // durable write-through store, so a self-update (recreate -> SIGTERM -> new process) lost
   // the stashed maturity policy even though the clock survived it. This pins the fix.

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -1632,6 +1632,7 @@ export function rehydrateUpdateLifecycleCacheFromStore(): void {
  */
 export function rehydrateUpdatePolicyRetentionCacheFromStore(): void {
   const nowMs = Date.now();
+  const surviving: updatePolicyRetentionCacheStore.UpdatePolicyRetentionCacheRecord[] = [];
   for (const record of updatePolicyRetentionCacheStore.listRecords()) {
     if (record.expiresAt <= nowMs) {
       // Prune expired records from the durable store too, not just skip them —
@@ -1640,6 +1641,23 @@ export function rehydrateUpdatePolicyRetentionCacheFromStore(): void {
       updatePolicyRetentionCacheStore.deleteRecord(record.cacheKey);
       continue;
     }
+    surviving.push(record);
+  }
+  // Oldest first. Every stash uses the same TTL, so ascending expiresAt is
+  // ascending stash time, which is the order the stash path's Map-insertion-order
+  // eviction assumes. listRecords() returns LokiJS document order, so inserting
+  // straight from it would leave the next eviction dropping an arbitrary entry
+  // instead of the oldest one.
+  surviving.sort((a, b) => a.expiresAt - b.expiresAt);
+  // Re-apply the cap here rather than leaving it to the next stash: lowering
+  // DD_UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES between processes leaves the
+  // store holding more rows than the new limit allows, and the stash path only
+  // trims after it has already restored them.
+  const overflow = Math.max(surviving.length - UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES, 0);
+  for (const record of surviving.slice(0, overflow)) {
+    updatePolicyRetentionCacheStore.deleteRecord(record.cacheKey);
+  }
+  for (const record of surviving.slice(overflow)) {
     updatePolicyRetentionCache.set(record.cacheKey, {
       updatePolicyOverrides: record.updatePolicyOverrides as container.ContainerUpdatePolicy,
       expiresAt: record.expiresAt,


### PR DESCRIPTION
Ports `a7172d2c` from the v1.6 line. Same two defects, byte-identical function.

CodeRabbit flagged the cap half of this on #914. It was right, and fixing it exposed a second problem it didn't name.

## The cap

`rehydrateUpdatePolicyRetentionCacheFromStore()` restored every non-expired persisted record straight into the Map with no `UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES` check. The stash path does enforce it, but only *after* it has already restored, so lowering `DD_UPDATE_POLICY_RETENTION_CACHE_MAX_ENTRIES` between processes came back over the new limit and the extra entries stayed live until the next stash trimmed them.

## The ordering

This one needs no env change at all. `listRecords()` returns LokiJS document order, which has nothing to do with stash age. So a trim loop popping from the front of the Map would drop whatever LokiJS happened to return first, not the oldest entry. Worse, the stash path's existing eviction reads that same Map insertion order as its LRU, so the first cap-triggered eviction after any restart could already drop the newest entry and keep the oldest.

Rehydration now collects the survivors, sorts them ascending by `expiresAt`, drops the overflow from both the Map and the durable store, then inserts the rest in that order. Every stash uses the same constant TTL, so ascending `expiresAt` is ascending stash time, which is the order the stash path assumes.

## Why it needs its own changelog entry

Unlike v1.6, where #565's fix is still unreleased and this is a correction to a bullet that hasn't shipped, #565 shipped on this line in `1.7.0-rc.2`. So this is a new fix against released behavior and gets its own `[Unreleased]` bullet rather than an amendment.

## Verification

Full pre-push gate green from an installed worktree: biome, knip, qlty, qlty-smells, scripts tests, workflow tests, ui typecheck, coverage at the 100% thresholds (248s), and build.

Two tests, same as the v1.6 side: one persisting `MAX_ENTRIES + 1` records and asserting the oldest is gone from both the Map and the store while the newest survives, and one asserting the restored key order is oldest-first from a store deliberately out of order.
