### PR TITLE
chore(release): roll v1.6 identity to 1.6.1-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1-rc.6] — 2026-08-28
+
 ### Fixed
 
 - **Maturity-policy overrides no longer get wiped by drydock's own self-update.** `updatePolicyRetentionCache` — the stash that lets a recreated container inherit its predecessor's maturity mode, min-age, skip list, and snooze — lived only in a bare in-memory Map, so the SIGTERM-driven restart that is drydock's own self-update (recreate action, SIGTERM, new process) wiped the stash before the replacement container could consume it, silently dropping controller-set update policy. The cache now writes through to a durable LokiJS-backed store and rehydrates from it at startup before the first container is inserted, the same treatment the sibling lifecycle cache already had. Backported from the v1.7 line, where the reporter's version could not reach it. ([#565](https://github.com/CodesWhat/drydock/issues/565))
@@ -2438,7 +2440,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.5...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.6...HEAD
+[1.6.1-rc.6]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.5...v1.6.1-rc.6
 [1.6.1-rc.5]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.4...v1.6.1-rc.5
 [1.6.1-rc.4]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.3...v1.6.1-rc.4
 [1.6.1-rc.3]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.2...v1.6.1-rc.3

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.5-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.6-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,6 +179,15 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.6.1-rc.6 highlights</strong></summary>
+
+- **Maturity-policy overrides survive drydock updating itself** — the stash that lets a recreated container inherit its predecessor's maturity mode, min-age, skip list and snooze lived only in process memory, so the restart that is drydock's own self-update wiped it before the replacement container could read it and the controller-set policy was silently dropped. It now persists across the restart. Backported from the v1.7 line. ([#565](https://github.com/CodesWhat/drydock/issues/565))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc6--2026-08-28).
+
+</details>
+
+<details>
 <summary><strong>v1.6.1-rc.5 highlights</strong></summary>
 
 - **Compose updates now pick up the runtime defaults the new image ships** — a container recreated by the compose action was rebuilt from the stored config instead of re-reading the pulled image, so values like `APP_VERSION` carried over from the old container and the UI kept reporting an update that was already applied. Backported from the v1.7 line. ([#734](https://github.com/CodesWhat/drydock/issues/734))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1-rc.5',
+    version: '1.6.1-rc.6',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1-rc.5 started',
+    details: 'Drydock v1.6.1-rc.6 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.5',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.6',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1-rc.5',
+    tag: '1.6.1-rc.6',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1-rc.5',
+  version: '1.6.1-rc.6',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1-rc.5',
+      version: '1.6.1-rc.6',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1-rc.5', mode: 'demo' },
+        server: { version: '1.6.1-rc.6', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1-rc.5",
+  version: "1.6.1-rc.6",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1-rc.5",
+    version: "v1.6.1-rc.6",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1-rc.5",
+      "version": "1.6.1-rc.6",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1-rc.5",
+    "version": "1.6.1-rc.6",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1-rc.5"
+  "version":"1.6.1-rc.6"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1-rc.5",
+    "version": "1.6.1-rc.6",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1-rc.5",
+      "drydockVersion": "1.6.1-rc.6",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1-rc.5` | Immutable release candidate; best for reproducible testing |
+| `1.6.1-rc.6` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,16 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.6.1-rc.6 Highlights — August 28, 2026
+
+One bug fix: maturity-policy overrides now survive drydock updating itself. The
+stash that lets a recreated container inherit its predecessor's maturity mode,
+min-age, skip list and snooze lived only in process memory, so the restart that
+is drydock's own self-update wiped it before the replacement container could
+read it. It now persists across the restart. See
+[CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc6--2026-08-28)
+for the full release notes.
+
 ## v1.6.1-rc.5 Highlights — August 27, 2026
 
 Two fixes: compose updates now pick up the runtime defaults the new image

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.5...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.6...HEAD`],
+    ['1.6.1-rc.6', `${repositoryUrl}/compare/v1.6.1-rc.5...v1.6.1-rc.6`],
     ['1.6.1-rc.5', `${repositoryUrl}/compare/v1.6.1-rc.4...v1.6.1-rc.5`],
     ['1.6.1-rc.4', `${repositoryUrl}/compare/v1.6.1-rc.3...v1.6.1-rc.4`],
     ['1.6.1-rc.3', `${repositoryUrl}/compare/v1.6.1-rc.2...v1.6.1-rc.3`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1-rc.5';
-const PREV_RC_VERSION = '1.6.1-rc.4';
-const RC_DATE = '2026-08-27';
-const RC_DISPLAY_DATE = 'August 27, 2026';
+const RC_VERSION = '1.6.1-rc.6';
+const PREV_RC_VERSION = '1.6.1-rc.5';
+const RC_DATE = '2026-08-28';
+const RC_DISPLAY_DATE = 'August 28, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1-rc.5';
+const RC_VERSION = '1.6.1-rc.6';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Rolls the v1.6 release identity from `1.6.1-rc.5` to `1.6.1-rc.6` so the maturity-policy persistence backport (#914, fixes #565) has a candidate to ship in.

Same shape as `e6d8f29c`, the rc.4 to rc.5 roll:

- Promotes the `Unreleased` #565 bullet into a dated `## [1.6.1-rc.6] — 2026-08-28` section, adds its compare link, and retargets `Unreleased` against rc.6.
- Bumps the candidate identity across the demo fixtures, the website config, the quickstart tag table, and the three API docs.
- Adds the rc.6 highlights block to the README and the docs updates page, collapsing rc.5 into a closed `<details>`.
- Rolls `RC_VERSION` in `release-identity.test.mjs`, `RC_VERSION`/`PREV_RC_VERSION`/`RC_DATE`/`RC_DISPLAY_DATE` in `release-docs-identity.test.mjs`, and the changelog compare-link expectations in `changelog-links.test.mjs`.

The roll ran as a script with a per-site expected-occurrence assertion rather than a blind find-and-replace, so a moved or renamed string fails loudly instead of silently not rolling. The README and updates-page edits are structural (new section above, previous one demoted), not substitutions.

## Verification

Full pre-push gate green from an installed worktree, including the three release guard tests that exist to catch exactly this class of half-finished roll.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed maturity-policy overrides persisting across self-update restarts. This preserves maturity mode, minimum age, skip list, and snooze settings for `#565`.
- ✨ Added `1.6.1-rc.6` release highlights to the README and updates documentation.
- 🔧 Updated release identity references from `1.6.1-rc.5` to `1.6.1-rc.6` across fixtures, site configuration, quickstart documentation, API examples, and release tests.
- 🔧 Promoted the changelog `Unreleased` entry to the dated `1.6.1-rc.6` section and updated comparison links.
- 🔧 Updated release guard test expectations and per-site occurrence assertions.

## Concerns

- Verify that all release references use `1.6.1-rc.6`.
- Verify the three release guard tests before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->