### PR TITLE
fix(updates): preserve healthy self-update after cleanup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The self-update helper could destroy a health-verified replacement when removing the old controller failed.** The main Docker update path already treated old-container cleanup as best effort after its health gate, but the helper still sent a 409, timeout, or other removal failure into rollback. That rollback force-removed the healthy replacement first and could then fail to restore an old container that Docker had already reaped. The helper now treats a missing old container as already cleaned up and records every other cleanup failure on the successful operation without rolling back the replacement.
+
 ## [1.7.0-rc.7] — 2026-08-29
 
 ### Security

--- a/app/triggers/providers/docker/self-update-controller.test.ts
+++ b/app/triggers/providers/docker/self-update-controller.test.ts
@@ -199,6 +199,121 @@ describe('self-update-controller orchestration', () => {
     );
   });
 
+  test('treats old container removal 404 as already removed and completes successfully', async () => {
+    const oldContainer = createOldContainer({
+      remove: vi
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error('No such container: old-container-id'), { statusCode: 404 }),
+        ),
+    });
+    const newContainer = createNewContainer();
+    mockDocker(oldContainer, newContainer);
+
+    await expect(runSelfUpdateController()).resolves.toBeUndefined();
+
+    expect(oldContainer.remove).toHaveBeenCalledWith({ force: true });
+    expect(newContainer.remove).not.toHaveBeenCalled();
+    expect(oldContainer.start).not.toHaveBeenCalled();
+    expect(oldContainer.rename).not.toHaveBeenCalled();
+    expect(newContainer.exec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Env: expect.not.arrayContaining([expect.stringMatching(/^DD_SELF_UPDATE_LAST_ERROR=/)]),
+      }),
+    );
+  });
+
+  test.each([
+    ['message-only', { message: 'No such container: old-container-id' }],
+    ['reason-only', { reason: 'No such container: old-container-id' }],
+    ['json.message', { json: { message: 'No such container: old-container-id' } }],
+  ])(
+    'treats old container removal with %s not-found details as already removed',
+    async (_, error) => {
+      const oldContainer = createOldContainer({
+        remove: vi.fn().mockRejectedValue(error),
+      });
+      const newContainer = createNewContainer();
+      mockDocker(oldContainer, newContainer);
+
+      await expect(runSelfUpdateController()).resolves.toBeUndefined();
+
+      expect(newContainer.remove).not.toHaveBeenCalled();
+      expect(newContainer.exec).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Env: expect.not.arrayContaining([expect.stringMatching(/^DD_SELF_UPDATE_LAST_ERROR=/)]),
+        }),
+      );
+    },
+  );
+
+  test('does not classify a primitive no-such-container rejection as already removed', async () => {
+    const oldContainer = createOldContainer({
+      remove: vi.fn().mockRejectedValue('No such container: old-container-id'),
+    });
+    const newContainer = createNewContainer();
+    mockDocker(oldContainer, newContainer);
+
+    await expect(runSelfUpdateController()).resolves.toBeUndefined();
+
+    expect(newContainer.remove).not.toHaveBeenCalled();
+    expect(newContainer.exec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Env: expect.arrayContaining([
+          'DD_SELF_UPDATE_LAST_ERROR=cleanup_old_failed: No such container: old-container-id',
+        ]),
+      }),
+    );
+  });
+
+  test('keeps the verified new container when old container removal conflicts', async () => {
+    const oldContainer = createOldContainer({
+      remove: vi.fn().mockRejectedValue(
+        Object.assign(new Error('removal of container old-container-id is already in progress'), {
+          statusCode: 409,
+        }),
+      ),
+    });
+    const newContainer = createNewContainer();
+    mockDocker(oldContainer, newContainer);
+
+    await expect(runSelfUpdateController()).resolves.toBeUndefined();
+
+    expect(newContainer.remove).not.toHaveBeenCalled();
+    expect(oldContainer.start).not.toHaveBeenCalled();
+    expect(oldContainer.rename).not.toHaveBeenCalled();
+    expect(newContainer.exec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Env: expect.arrayContaining([
+          'DD_SELF_UPDATE_LAST_ERROR=cleanup_old_failed: removal of container old-container-id is already in progress',
+        ]),
+      }),
+    );
+  });
+
+  test('keeps the verified new container when old container removal times out', async () => {
+    const timeoutError = new Error('The operation was aborted due to timeout');
+    timeoutError.name = 'TimeoutError';
+    const oldContainer = createOldContainer({
+      remove: vi.fn().mockRejectedValue(timeoutError),
+    });
+    const newContainer = createNewContainer();
+    mockDocker(oldContainer, newContainer);
+
+    await expect(runSelfUpdateController()).resolves.toBeUndefined();
+
+    expect(newContainer.remove).not.toHaveBeenCalled();
+    expect(oldContainer.start).not.toHaveBeenCalled();
+    expect(oldContainer.rename).not.toHaveBeenCalled();
+    expect(newContainer.exec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Env: expect.arrayContaining([
+          'DD_SELF_UPDATE_LAST_ERROR=cleanup_old_failed: The operation was aborted due to timeout',
+        ]),
+      }),
+    );
+  });
+
   test('uses default op id and old container name when optional env vars are unset', async () => {
     setControllerEnv({
       DD_SELF_UPDATE_OP_ID: undefined,

--- a/app/triggers/providers/docker/self-update-controller.ts
+++ b/app/triggers/providers/docker/self-update-controller.ts
@@ -27,6 +27,10 @@ type SelfUpdateControllerConfig = {
 type ErrorWithStatusCode = {
   statusCode?: number;
   status?: number;
+  reason?: string;
+  json?: {
+    message?: unknown;
+  };
 };
 
 type ContainerInspectState = {
@@ -115,6 +119,26 @@ function isContainerAlreadyStartedError(error: unknown): boolean {
   }
   const message = getErrorMessage(error, '').toLowerCase();
   return message.includes('already started');
+}
+
+function isContainerNotFoundError(error: unknown): boolean {
+  const statusCode = getErrorStatusCode(error);
+  if (statusCode === 404) {
+    return true;
+  }
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const errorWithStatusCode = error as ErrorWithStatusCode;
+  const message = [
+    getErrorMessage(error, ''),
+    errorWithStatusCode.reason,
+    errorWithStatusCode.json?.message,
+  ]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ')
+    .toLowerCase();
+  return message.includes('no such container');
 }
 
 function hasHealthcheck(containerInspect: ContainerInspectState): boolean {
@@ -246,10 +270,23 @@ class SelfUpdateController {
     );
   }
 
-  async commitUpdate(): Promise<void> {
+  async commitUpdate(): Promise<string | undefined> {
     this.logState('COMMIT');
     const oldContainer = this.docker.getContainer(this.config.oldContainerId);
-    await oldContainer.remove({ force: true });
+    try {
+      await oldContainer.remove({ force: true });
+      return undefined;
+    } catch (error: unknown) {
+      const errorMessage = getErrorMessage(error, String(error));
+      if (isContainerNotFoundError(error)) {
+        this.logState('COMMIT_OLD_ALREADY_REMOVED', errorMessage);
+        return undefined;
+      }
+
+      const cleanupError = `cleanup_old_failed: ${errorMessage}`;
+      this.logState('COMMIT_OLD_REMOVE_FAILED', cleanupError);
+      return cleanupError;
+    }
   }
 
   async waitForExecStream(execStream: ContainerExecStream): Promise<void> {
@@ -369,19 +406,21 @@ class SelfUpdateController {
       'PREPARE',
       `old=${this.config.oldContainerName}(${this.config.oldContainerId}), new=${this.config.newContainerId}`,
     );
+    let commitLastError: string | undefined;
     try {
       await this.stopOldContainer();
       await this.waitOldContainerStopped();
       await this.startNewContainer();
       await this.waitNewContainerRunning();
       await this.waitNewContainerHealthy();
-      await this.commitUpdate();
+      commitLastError = await this.commitUpdate();
     } catch (error: unknown) {
       await this.rollback(error);
     }
     await this.maybeFinalizeCallbackInContainer(this.config.newContainerId, {
       status: 'succeeded',
       phase: 'succeeded',
+      ...(commitLastError ? { lastError: commitLastError } : {}),
     });
     this.logState('SUCCEEDED');
   }


### PR DESCRIPTION
Fixes DR-20 so an old-container removal failure after health verification cannot roll back the healthy replacement. A missing old container is treated as already removed; other cleanup failures are recorded on the succeeded operation. Validation: 40 focused tests plus the full protected pre-push gate with qlty/OSV, 100% app and UI coverage, and both builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🐛 Fixed self-update rollback after verified replacement health.
- 🔧 Treats missing old containers as already removed.
- 🔧 Records other cleanup failures as `cleanup_old_failed: ...` in `lastError`.
- 🔧 Supports Docker not-found errors from status, message, reason, and `json.message`.
- ✨ Added focused tests for not-found, conflict, timeout, and primitive rejection cases.
- 🔒 Validation passed with 40 focused tests, protected pre-push checks, qlty/OSV checks, full application and UI coverage, and both builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->