### PR TITLE
chore(release): roll v1.6 identity to 1.6.1-rc.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1-rc.7] — 2026-09-03
+
 ### Fixed
 
 - **`DD_AGENT_ALLOW_INSECURE_SECRET` was parsed as an agent named `allow`.** `getAgentConfigurations()` handed the whole `ddEnvVars` map to the generic `dd.agent` prefix parser, and that documented flat flag matches the prefix as `DD_AGENT_ALLOW_INSECURE_SECRET`, producing an `{insecure: {secret: 'true'}}` agent literally named `allow`. Registration then rejected it every boot with `Agent allow failed to register ("host" is required)`, on every install that set the flag regardless of whether any real agents were configured. The flag is now excluded before the map is parsed. Reported by [@depuits](https://github.com/depuits) in [#945](https://github.com/CodesWhat/drydock/issues/945).
@@ -2450,7 +2452,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.6...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.7...HEAD
+[1.6.1-rc.7]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.6...v1.6.1-rc.7
 [1.6.1-rc.6]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.5...v1.6.1-rc.6
 [1.6.1-rc.5]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.4...v1.6.1-rc.5
 [1.6.1-rc.4]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.3...v1.6.1-rc.4

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.6-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.7-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,6 +179,20 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.6.1-rc.7 highlights</strong></summary>
+
+- **`DD_AGENT_ALLOW_INSECURE_SECRET` no longer registers a phantom agent named `allow`** — the flag matched the generic `dd.agent` prefix parser and produced an `{insecure: {secret: 'true'}}` agent that failed to register on every install setting the flag, whether or not any real agents were configured. Reported by [@depuits](https://github.com/depuits). ([#945](https://github.com/CodesWhat/drydock/issues/945))
+- **A container seen before its registry was configured no longer stays stamped `unknown` forever** — the repair path only re-derived a stored image reference when the tag itself looked unknown or digest-shaped, so a container whose registry name was `unknown` but tag was normal never got picked up until it was recreated. It now re-resolves on the next refresh cycle. ([#945](https://github.com/CodesWhat/drydock/issues/945))
+- **The self-update helper no longer destroys a health-verified replacement when removing the old controller fails** — a 409, timeout, or other removal failure used to trigger a rollback that force-removed the healthy replacement first, and could then fail to restore an old container Docker had already reaped. A missing old container is now treated as already cleaned up.
+- **A reconnecting agent reporting zero containers no longer wipes every maturity-policy override it holds** — three of the four container-list ingestion paths already skipped pruning on an empty list, but the `dd:watcher-snapshot` handler didn't, so an agent restart's legitimately-empty first snapshot looked like a mass removal and deleted policy overrides with nothing left to restore them from. ([#565](https://github.com/CodesWhat/drydock/issues/565))
+- **Debug dumps no longer expose Apprise service URLs, Rocket.Chat user IDs, or Telegram chat IDs** — these provider-specific credential fields are now redacted without hiding ordinary `parse.urls` configuration flags.
+- **Compose and ordinary Docker updates now scan and deploy the exact image that was pulled, not whatever a mutable tag points at next** — both paths used to gate signature verification, vulnerability scanning and SBOM generation against a mutable `repo:tag` reference and only then create the replacement container, so a registry retag landing in that window meant one image was gated and a different one deployed. Both now pin the pulled image's digest before running the gate. ([#952](https://github.com/CodesWhat/drydock/pull/952))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc7--2026-09-03).
+
+</details>
+
+<details>
 <summary><strong>v1.6.1-rc.6 highlights</strong></summary>
 
 - **Maturity-policy overrides survive drydock updating itself** — the stash that lets a recreated container inherit its predecessor's maturity mode, min-age, skip list and snooze lived only in process memory, so the restart that is drydock's own self-update wiped it before the replacement container could read it and the controller-set policy was silently dropped. It now persists across the restart. Backported from the v1.7 line. ([#565](https://github.com/CodesWhat/drydock/issues/565))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1-rc.6',
+    version: '1.6.1-rc.7',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1-rc.6 started',
+    details: 'Drydock v1.6.1-rc.7 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.6',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.7',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1-rc.6',
+    tag: '1.6.1-rc.7',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1-rc.6',
+  version: '1.6.1-rc.7',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1-rc.6',
+      version: '1.6.1-rc.7',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1-rc.6', mode: 'demo' },
+        server: { version: '1.6.1-rc.7', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1-rc.6",
+  version: "1.6.1-rc.7",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1-rc.6",
+    version: "v1.6.1-rc.7",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1-rc.6",
+      "version": "1.6.1-rc.7",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1-rc.6",
+    "version": "1.6.1-rc.7",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1-rc.6"
+  "version":"1.6.1-rc.7"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1-rc.6",
+    "version": "1.6.1-rc.7",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1-rc.6",
+      "drydockVersion": "1.6.1-rc.7",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1-rc.6` | Immutable release candidate; best for reproducible testing |
+| `1.6.1-rc.7` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,20 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.6.1-rc.7 Highlights — September 3, 2026
+
+Six fixes: `DD_AGENT_ALLOW_INSECURE_SECRET` no longer registers a phantom
+agent named `allow`; a container seen before its registry was configured no
+longer stays stamped `unknown` forever; the self-update helper no longer
+destroys a health-verified replacement when removing the old controller
+fails; a reconnecting agent reporting zero containers no longer wipes every
+maturity-policy override it holds; debug dumps no longer expose Apprise
+service URLs, Rocket.Chat user IDs, or Telegram chat IDs; and Compose and
+ordinary Docker updates now scan and deploy the exact image that was pulled
+instead of whatever a mutable tag points at next. See
+[CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc7--2026-09-03)
+for the full release notes.
+
 ## v1.6.1-rc.6 Highlights — August 28, 2026
 
 One bug fix: maturity-policy overrides now survive drydock updating itself. The

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.6...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.7...HEAD`],
+    ['1.6.1-rc.7', `${repositoryUrl}/compare/v1.6.1-rc.6...v1.6.1-rc.7`],
     ['1.6.1-rc.6', `${repositoryUrl}/compare/v1.6.1-rc.5...v1.6.1-rc.6`],
     ['1.6.1-rc.5', `${repositoryUrl}/compare/v1.6.1-rc.4...v1.6.1-rc.5`],
     ['1.6.1-rc.4', `${repositoryUrl}/compare/v1.6.1-rc.3...v1.6.1-rc.4`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1-rc.6';
-const PREV_RC_VERSION = '1.6.1-rc.5';
-const RC_DATE = '2026-08-28';
-const RC_DISPLAY_DATE = 'August 28, 2026';
+const RC_VERSION = '1.6.1-rc.7';
+const PREV_RC_VERSION = '1.6.1-rc.6';
+const RC_DATE = '2026-09-03';
+const RC_DISPLAY_DATE = 'September 3, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1-rc.6';
+const RC_VERSION = '1.6.1-rc.7';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Rolls the v1.6 identity to 1.6.1-rc.7, mirroring #916 file for file.

The six Fixed bullets under Unreleased move into a `## [1.6.1-rc.7] — 2026-09-03` section (Unreleased is now empty), the compare links follow, and the README, updates page, demo mocks, site config, API docs and quickstart pick up the new identity. The three identity tests are updated to pin it. package.json stays at 1.6.1, as it did for every previous RC.

Verification: scripts tests 149 pass, `npm run release:precheck v1.6.1-rc.7` exits 0, and the full pre-push gate passed. Once merged, this is the tree for the v1.6.1-rc.7 maintenance cut with `source_ref=dev/v1.6`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changelog

🔧 **Changed**
- Rolled release identity from `1.6.1-rc.6` to `1.6.1-rc.7`.
- Added dated `1.6.1-rc.7` release notes with six fixes.
- Updated README, website content, demo fixtures, API docs, quickstart, and comparison links.
- Kept `package.json` at base version `1.6.1`.
- Updated release identity tests and release date assertions.

✅ **Verification**
- 149 script tests passed.
- `npm run release:precheck v1.6.1-rc.7` passed.
- Full pre-push gate passed.

### Concerns

- Confirm the release date `September 3, 2026` is correct before merging.
- Confirm all runtime fixtures use `1.6.1-rc.7` while workspace manifests remain at `1.6.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->