### PR TITLE
docs(deprecations): align the 1.6 deprecation entries with the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Deprecation docs realigned with the shipped code.** `DEPRECATIONS.md` and the generated deprecations page now double the `$` in the curl-healthcheck compose migration snippet so it actually expands inside the container instead of the host, name `PUT /api/v1/settings` instead of the tombstoned unversioned path, note that the `GET /api/auth/methods` `Sunset` header's 2027-07-01 date is a conservative earliest instant rather than the real removal (the v1.7.0 release), add the previously undocumented `WUD_AGENT_SECRET`/`WUD_AGENT_SECRET_FILE` fallback removal, add the WebSocket origin-check, anonymous-auth grandfather, and session cookie rename entries that were missing from the generated page, and use `**Removal**` instead of `**Removed in**` for still-pending removals so the table doesn't assert a version has already shipped.
+
 ## [1.6.1-rc.7] — 2026-09-03
 
 ### Fixed

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -76,7 +76,7 @@ In v1.7.0 these reasons become **hard** blockers: the Update button is locked wh
 
 The official Docker image keeps `curl` available in v1.5.x and v1.6.x for backward compatibility with custom healthcheck overrides. The default built-in `HEALTHCHECK` uses the lightweight static binary (`/bin/healthcheck`) instead.
 
-**Migration:** Custom `curl`-based healthcheck overrides remain supported in v1.5.x. v1.6.0 is the final warning release. Removal is scheduled for v1.7.0. Prefer the built-in image healthcheck, or switch custom intervals to `test: /bin/healthcheck $${DD_SERVER_PORT:-3000}` (the doubled `$` is compose escaping, so the variable is expanded inside the container instead of from the host environment before the container starts). See [Monitoring](https://getdrydock.com/docs/monitoring).
+**Migration:** Custom `curl`-based healthcheck overrides remain supported through v1.6.x, and v1.6.0 is the final warning release. Removal is scheduled for v1.7.0. Prefer the built-in image healthcheck, or switch custom intervals to `test: /bin/healthcheck $${DD_SERVER_PORT:-3000}` (the doubled `$` is compose escaping, so the variable is expanded inside the container instead of from the host environment before the container starts). See [Monitoring](https://getdrydock.com/docs/monitoring).
 
 ---
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -30,7 +30,7 @@ The unversioned `/api/settings` path is not a working alias for this endpoint. L
 | **Removal** | v1.7.0 |
 | **Affects** | API consumers using `GET /api/auth/methods` |
 
-`GET /api/auth/methods` is a legacy, unversioned auth-discovery alias kept unauthenticated so the login screen can render before a session exists. It logs a deprecation warning on each request, returns RFC 9745 `Deprecation` and RFC 8594 `Sunset` response headers, and points callers directly to `GET /api/v1/auth/status`. It is registered directly on the app, so it survives the general unversioned `/api/*` removal on its own v1.7.0 timeline. `GET /api/auth/status` is a standing compatibility alias for `GET /api/v1/auth/status` with no removal scheduled. The `Sunset` header advertises 2027-07-01 as a conservative earliest retirement instant; the actual removal ships with the v1.7.0 release.
+`GET /api/auth/methods` is a legacy, unversioned auth-discovery alias kept unauthenticated so the login screen can render before a session exists. It logs a deprecation warning on each request, returns RFC 9745 `Deprecation` and RFC 8594 `Sunset` response headers, and points callers directly to `GET /api/v1/auth/status`. It is registered directly on the app, so it survives the general unversioned `/api/*` removal on its own v1.7.0 timeline. `GET /api/auth/status` is a standing compatibility alias for `GET /api/v1/auth/status` with no removal scheduled. The `Sunset` header carries 2027-07-01 only because the header needs a date; that date is not a floor on the removal, which ships in v1.7.0, whose release candidates already return 410.
 
 **Migration:** Replace `GET /api/auth/methods` with `GET /api/v1/auth/status`.
 
@@ -41,7 +41,7 @@ The unversioned `/api/settings` path is not a working alias for this endpoint. L
 | | |
 | --- | --- |
 | **Deprecated in** | v1.6.0 |
-| **Removed in** | v1.8.0 |
+| **Removal** | v1.8.0 |
 | **Affects** | Clients reading `{ strategies, warnings }` from `GET /auth/strategies` |
 
 `GET /auth/strategies` returns the older `{ strategies, warnings }` response shape. The canonical replacement, `GET /api/v1/auth/status` (also available at `/api/auth/status` and `/auth/status`), returns `{ providers, errors }`. Each request now logs a deprecation warning and returns RFC 9745 `Deprecation` and RFC 8594 `Sunset` headers for its v1.8.0 removal.
@@ -152,11 +152,11 @@ The migration CLI intentionally retains knowledge of the removed WUD names so it
 
 | | |
 | --- | --- |
-| **Deprecated in** | Never, removed directly with no deprecation period |
+| **Deprecated in** | v1.4.0 (via the general `WUD_*` warning; this specific fallback's removal was never separately announced) |
 | **Removed in** | v1.6.0-rc.1 |
 | **Affects** | Agent-mode deployments (`app/agent/api/index.ts`) configured with only `WUD_AGENT_SECRET` / `WUD_AGENT_SECRET_FILE`, no `DD_AGENT_SECRET` / `DD_AGENT_SECRET_FILE` |
 
-This is a separate, undocumented removal from the general `WUD_*` table above. Unlike the general configuration loader, which never read `WUD_*` variables at all, agent mode's secret lookup carried its own explicit fallback through v1.5.2: `process.env.DD_AGENT_SECRET ?? process.env.WUD_AGENT_SECRET` (and the equivalent for `_FILE`). v1.6.0-rc.1 dropped both fallbacks with no warning release first. An agent that had only `WUD_AGENT_SECRET` set went straight from authenticating successfully to `init()` throwing `Agent mode requires DD_AGENT_SECRET or DD_AGENT_SECRET_FILE` at startup, an error message that never mentions the `WUD_` variable the operator actually configured. This entry was never recorded at the time of the v1.6.0 release; it is added here retroactively.
+This is a separate, undocumented removal from the general `WUD_*` table above. Agent mode's secret lookup carried its own explicit fallback through v1.5.2, on top of the general configuration loader: `process.env.DD_AGENT_SECRET ?? process.env.WUD_AGENT_SECRET` (and the equivalent for `_FILE`). The general loader did read `WUD_AGENT_SECRET` / `WUD_AGENT_SECRET_FILE` like every other `WUD_*` variable: it remapped them to `DD_AGENT_SECRET` / `DD_AGENT_SECRET_FILE` and logged the same "deprecated and scheduled for removal in v1.6.0" warning as the rest of the `WUD_*` surface, starting in v1.4.0. So operators relying on the `WUD_` name did get a warning release through that generic mechanism, even though this specific code-level fallback's removal at v1.6.0-rc.1 was never separately announced. An agent that had only `WUD_AGENT_SECRET` set went straight from authenticating successfully to `init()` throwing `Agent mode requires DD_AGENT_SECRET or DD_AGENT_SECRET_FILE` at startup, an error message that never mentions the `WUD_` variable the operator actually configured. This entry was never recorded at the time of the v1.6.0 release; it is added here retroactively.
 
 **Migration:** Rename `WUD_AGENT_SECRET` to `DD_AGENT_SECRET` and `WUD_AGENT_SECRET_FILE` to `DD_AGENT_SECRET_FILE`.
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -6,17 +6,19 @@ Active deprecations and their removal timeline. Each entry includes the version 
 
 ## Active
 
-### PUT /api/settings
+### PUT /api/v1/settings
 
 | | |
 | --- | --- |
 | **Deprecated in** | v1.4.0 |
 | **Removal** | Deferred to API v2 — `/api/v1` is frozen, so the method cannot be dropped from it; the `Sunset` header advertises 2027-01-01 as the earliest retirement instant |
-| **Affects** | API consumers using `PUT /api/settings` |
+| **Affects** | API consumers using `PUT /api/v1/settings` |
 
-`PUT /api/settings` is a compatibility alias for `PATCH /api/settings`. Use `PATCH` for partial settings updates. An earlier revision of this entry scheduled the removal for v1.6.0; that predated the API versioning policy freezing `/api/v1`, under which removing a method from the versioned surface is a breaking change reserved for `/api/v2`.
+`PUT /api/v1/settings` is a compatibility alias for `PATCH /api/v1/settings`. Use `PATCH` for partial settings updates. An earlier revision of this entry scheduled the removal for v1.6.0; that predated the API versioning policy freezing `/api/v1`, under which removing a method from the versioned surface is a breaking change reserved for `/api/v2`.
 
-**Migration:** Replace `PUT /api/settings` calls with `PATCH /api/settings`.
+The unversioned `/api/settings` path is not a working alias for this endpoint. Like the rest of the unversioned surface it returns `410 Gone` (see the Unversioned `/api/*` path entry below); settings is not one of the four wud-card compatibility endpoints exempted from that tombstone.
+
+**Migration:** Replace `PUT /api/v1/settings` calls with `PATCH /api/v1/settings`.
 
 ---
 
@@ -25,10 +27,10 @@ Active deprecations and their removal timeline. Each entry includes the version 
 | | |
 | --- | --- |
 | **Deprecated in** | v1.6.0 |
-| **Removed in** | v1.7.0 |
+| **Removal** | v1.7.0 |
 | **Affects** | API consumers using `GET /api/auth/methods` |
 
-`GET /api/auth/methods` is a legacy, unversioned auth-discovery alias kept unauthenticated so the login screen can render before a session exists. It logs a deprecation warning on each request, returns RFC 9745 `Deprecation` and RFC 8594 `Sunset` response headers, and points callers directly to `GET /api/v1/auth/status`. It is registered directly on the app, so it survives the general unversioned `/api/*` removal on its own v1.7.0 timeline. `GET /api/auth/status` is a standing compatibility alias for `GET /api/v1/auth/status` with no removal scheduled.
+`GET /api/auth/methods` is a legacy, unversioned auth-discovery alias kept unauthenticated so the login screen can render before a session exists. It logs a deprecation warning on each request, returns RFC 9745 `Deprecation` and RFC 8594 `Sunset` response headers, and points callers directly to `GET /api/v1/auth/status`. It is registered directly on the app, so it survives the general unversioned `/api/*` removal on its own v1.7.0 timeline. `GET /api/auth/status` is a standing compatibility alias for `GET /api/v1/auth/status` with no removal scheduled. The `Sunset` header advertises 2027-07-01 as a conservative earliest retirement instant; the actual removal ships with the v1.7.0 release.
 
 **Migration:** Replace `GET /api/auth/methods` with `GET /api/v1/auth/status`.
 
@@ -53,7 +55,7 @@ Active deprecations and their removal timeline. Each entry includes the version 
 | | |
 | --- | --- |
 | **Deprecated in** | v1.5.0 |
-| **Removed in** | v1.7.0 |
+| **Removal** | v1.7.0 |
 | **Affects** | Containers labeled with `dd.action.include` / `dd.action.exclude` (or the legacy `dd.trigger.include` / `dd.trigger.exclude`) where the labels filter out the matching docker / dockercompose action trigger |
 
 In v1.5.x the eligibility model classifies `trigger-not-included` and `trigger-excluded` as **soft** blockers: the row pill says *Trigger filtered* / *Trigger excluded*, but clicking the per-row Update button still queues the update (the confirm modal lists the soft blocker and switches the accept label to *Update anyway*). This preserves the pre-v1.5 behavior where include/exclude was an *auto-trigger* filter only — manual click bypassed it.
@@ -69,12 +71,12 @@ In v1.7.0 these reasons become **hard** blockers: the Update button is locked wh
 | | |
 | --- | --- |
 | **Deprecated in** | v1.5.0 |
-| **Removed in** | v1.7.0 |
+| **Removal** | v1.7.0 |
 | **Affects** | Custom `healthcheck:` overrides in compose files that use `curl` |
 
 The official Docker image keeps `curl` available in v1.5.x and v1.6.x for backward compatibility with custom healthcheck overrides. The default built-in `HEALTHCHECK` uses the lightweight static binary (`/bin/healthcheck`) instead.
 
-**Migration:** Custom `curl`-based healthcheck overrides remain supported in v1.5.x. v1.6.0 is the final warning release. Removal is scheduled for v1.7.0. Prefer the built-in image healthcheck, or switch custom intervals to `test: /bin/healthcheck ${DD_SERVER_PORT:-3000}`. See [Monitoring](https://getdrydock.com/docs/monitoring).
+**Migration:** Custom `curl`-based healthcheck overrides remain supported in v1.5.x. v1.6.0 is the final warning release. Removal is scheduled for v1.7.0. Prefer the built-in image healthcheck, or switch custom intervals to `test: /bin/healthcheck $${DD_SERVER_PORT:-3000}` (the doubled `$` is compose escaping, so the variable is expanded inside the container instead of from the host environment before the container starts). See [Monitoring](https://getdrydock.com/docs/monitoring).
 
 ---
 
@@ -83,7 +85,7 @@ The official Docker image keeps `curl` available in v1.5.x and v1.6.x for backwa
 | | |
 | --- | --- |
 | **Deprecated in** | v1.5.0 |
-| **Removed in** | v1.7.0 |
+| **Removal** | v1.7.0 |
 | **Affects** | Trigger configs using `DD_TRIGGER_*` env vars and container labels `dd.trigger.include` / `dd.trigger.exclude` |
 
 Legacy trigger prefixes are accepted as compatibility aliases while the trigger taxonomy moves to action/notification prefixes.
@@ -143,6 +145,20 @@ The following v1.4-era compatibility inputs are no longer executed in v1.6.0:
 | Token-only Hub/DHI public instance configuration (for example `DD_REGISTRY_HUB_PUBLIC_TOKEN` without `..._PUBLIC_LOGIN`) | Registry validation fails closed instead of silently switching to anonymous access. The `TOKEN` key itself remains valid when paired with `LOGIN`. | Configure the named instance with `LOGIN`+`PASSWORD`, `LOGIN`+`TOKEN`, or `AUTH`; remove credentials entirely for intentional anonymous access. |
 
 The migration CLI intentionally retains knowledge of the removed WUD names so it can rewrite old configuration files; this is migration support, not runtime compatibility.
+
+---
+
+### Agent-mode `WUD_AGENT_SECRET` / `WUD_AGENT_SECRET_FILE` fallback
+
+| | |
+| --- | --- |
+| **Deprecated in** | Never, removed directly with no deprecation period |
+| **Removed in** | v1.6.0-rc.1 |
+| **Affects** | Agent-mode deployments (`app/agent/api/index.ts`) configured with only `WUD_AGENT_SECRET` / `WUD_AGENT_SECRET_FILE`, no `DD_AGENT_SECRET` / `DD_AGENT_SECRET_FILE` |
+
+This is a separate, undocumented removal from the general `WUD_*` table above. Unlike the general configuration loader, which never read `WUD_*` variables at all, agent mode's secret lookup carried its own explicit fallback through v1.5.2: `process.env.DD_AGENT_SECRET ?? process.env.WUD_AGENT_SECRET` (and the equivalent for `_FILE`). v1.6.0-rc.1 dropped both fallbacks with no warning release first. An agent that had only `WUD_AGENT_SECRET` set went straight from authenticating successfully to `init()` throwing `Agent mode requires DD_AGENT_SECRET or DD_AGENT_SECRET_FILE` at startup, an error message that never mentions the `WUD_` variable the operator actually configured. This entry was never recorded at the time of the v1.6.0 release; it is added here retroactively.
+
+**Migration:** Rename `WUD_AGENT_SECRET` to `DD_AGENT_SECRET` and `WUD_AGENT_SECRET_FILE` to `DD_AGENT_SECRET_FILE`.
 
 ---
 

--- a/app/api/settings.test.ts
+++ b/app/api/settings.test.ts
@@ -190,7 +190,7 @@ describe('Settings Router', () => {
     expect(res.setHeader).toHaveBeenCalledWith('Deprecation', deprecatedPutDeprecation);
     expect(res.setHeader).toHaveBeenCalledWith('Sunset', deprecatedPutSunset);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      'PUT /api/settings is deprecated and will be removed in API v2. Use PATCH /api/settings instead.',
+      'PUT /api/v1/settings is deprecated and will be removed in API v2. Use PATCH /api/v1/settings instead.',
     );
 
     // RFC 9745: Deprecation is the instant the resource BECAME deprecated

--- a/app/api/settings.ts
+++ b/app/api/settings.ts
@@ -8,10 +8,14 @@ import { sanitizeApiError } from './helpers.js';
 
 const router = express.Router();
 const log = logger.child({ component: 'settings' });
+// Versioned paths on purpose. The unversioned `/api` alias was removed in
+// v1.6.0 and settings is not one of the four wud-card compat endpoints that
+// survived it, so `/api/settings` now returns 410. Pointing a consumer at it
+// would send them somewhere that no longer answers.
 const deprecatedPutWarning =
-  'PUT /api/settings is deprecated and will be removed in API v2. Use PATCH /api/settings instead.';
+  'PUT /api/v1/settings is deprecated and will be removed in API v2. Use PATCH /api/v1/settings instead.';
 // '@1772236800' = 2026-02-28T00:00:00Z, the v1.4.0 GA date (see CHANGELOG.md
-// and the "PUT /api/settings" entry in DEPRECATIONS.md) — the date this
+// and the "PUT /api/v1/settings" entry in DEPRECATIONS.md), the date this
 // route actually became deprecated. Per RFC 9745 the Deprecation value must
 // be the instant the resource became deprecated, a past/current date, never
 // the same instant as the future Sunset removal date below.

--- a/content/docs/current/configuration/index.mdx
+++ b/content/docs/current/configuration/index.mdx
@@ -98,7 +98,7 @@ services:
     # The image includes a built-in HEALTHCHECK — no override needed.
     # If you need custom intervals, use the built-in binary:
     healthcheck:
-      test: /bin/healthcheck ${DD_SERVER_PORT:-3000}
+      test: /bin/healthcheck $${DD_SERVER_PORT:-3000}
       interval: 10s
       timeout: 10s
       retries: 3

--- a/content/docs/current/configuration/server/index.mdx
+++ b/content/docs/current/configuration/server/index.mdx
@@ -68,7 +68,7 @@ If Home Assistant runs on a different origin than drydock, pair `DD_COMPAT_WUDCA
 
 The official Docker image includes a built-in `HEALTHCHECK` that polls the `/health` endpoint using a lightweight static binary. When `DD_SERVER_TLS_ENABLED=true`, the healthcheck automatically switches to HTTPS (with `--insecure` semantics for self-signed certificates). No additional configuration is needed — remove any custom `healthcheck:` blocks from your compose file.
 
-<Callout type="warn">**Deprecated:** Custom `curl`-based healthcheck overrides (e.g. `test: curl --fail http://localhost:3000/health`) remain supported for backward compatibility in v1.5.x. When Drydock can inspect its own container through the local Docker socket, the UI shows a deprecation banner if it detects a curl-based override. v1.6.0 is the final warning release, and `curl` will be removed from the image in v1.7.0. Use the built-in probe or switch to `/bin/healthcheck ${DD_SERVER_PORT:-3000}` for custom intervals.</Callout>
+<Callout type="warn">**Deprecated:** Custom `curl`-based healthcheck overrides (e.g. `test: curl --fail http://localhost:3000/health`) remain supported for backward compatibility in v1.5.x. When Drydock can inspect its own container through the local Docker socket, the UI shows a deprecation banner if it detects a curl-based override. v1.6.0 is the final warning release, and `curl` will be removed from the image in v1.7.0. Use the built-in probe or switch to `/bin/healthcheck $${DD_SERVER_PORT:-3000}` (the doubled `$` is compose escaping, so the variable is expanded inside the container instead of from the host environment before the container starts) for custom intervals.</Callout>
 
 ## Plain HTTP Deployments
 

--- a/content/docs/current/deprecations/index.mdx
+++ b/content/docs/current/deprecations/index.mdx
@@ -175,7 +175,7 @@ The official Docker image keeps `curl` available in v1.5.x and v1.6.x for backwa
 | --- | --- |
 | **Deprecated since** | v1.5.0 |
 | **Detection** | UI deprecation banner when Drydock can inspect its own container via the local Docker socket; otherwise manual config review |
-| **Migration** | Custom `curl`-based healthcheck overrides remain supported in v1.5.x. v1.6.0 is the final warning release. Removal is scheduled for v1.7.0. Prefer the built-in image healthcheck, or switch custom intervals to `test: /bin/healthcheck $${DD_SERVER_PORT:-3000}` (the doubled `$` is compose escaping, so the variable is expanded inside the container instead of from the host environment before the container starts). See [Monitoring](/docs/monitoring) |
+| **Migration** | Custom `curl`-based healthcheck overrides remain supported through v1.6.x, and v1.6.0 is the final warning release. Removal is scheduled for v1.7.0. Prefer the built-in image healthcheck, or switch custom intervals to `test: /bin/healthcheck $${DD_SERVER_PORT:-3000}` (the doubled `$` is compose escaping, so the variable is expanded inside the container instead of from the host environment before the container starts). See [Monitoring](/docs/monitoring) |
 
 ### `DD_TRIGGER_*` environment variable prefix {#legacy-trigger-prefix}
 

--- a/content/docs/current/deprecations/index.mdx
+++ b/content/docs/current/deprecations/index.mdx
@@ -157,11 +157,11 @@ Hub/DHI public instances that provide `PUBLIC_TOKEN` without the matching `PUBLI
 
 ### Agent-mode `WUD_AGENT_SECRET` / `WUD_AGENT_SECRET_FILE` fallback {#agent-secret-fallback}
 
-Agent mode's secret lookup carried its own explicit fallback through v1.5.2, separate from the general `WUD_*` removal above: `DD_AGENT_SECRET` falling back to `WUD_AGENT_SECRET` (and the equivalent for `_FILE`). v1.6.0-rc.1 dropped both fallbacks with no warning release first. An agent configured with only `WUD_AGENT_SECRET` now fails startup with an error that never mentions the `WUD_` variable actually configured.
+Agent mode's secret lookup carried its own explicit fallback through v1.5.2, on top of the general `WUD_*` removal above: `DD_AGENT_SECRET` falling back to `WUD_AGENT_SECRET` (and the equivalent for `_FILE`). The general configuration loader also read `WUD_AGENT_SECRET`/`WUD_AGENT_SECRET_FILE` like every other `WUD_*` variable, remapping them to `DD_*` and logging the same removal warning since v1.4.0, so operators did get a warning release through that generic mechanism, even though this specific fallback's removal at v1.6.0-rc.1 was never separately announced. An agent configured with only `WUD_AGENT_SECRET` now fails startup with an error that never mentions the `WUD_` variable actually configured.
 
 | | |
 | --- | --- |
-| **Deprecated since** | Never, removed directly with no deprecation period |
+| **Deprecated since** | v1.4.0 (via the general `WUD_*` warning; this specific fallback's removal was never separately announced) |
 | **Removed since** | v1.6.0-rc.1 |
 | **Migration** | Rename `WUD_AGENT_SECRET` to `DD_AGENT_SECRET` and `WUD_AGENT_SECRET_FILE` to `DD_AGENT_SECRET_FILE` |
 
@@ -211,7 +211,7 @@ In v1.5.x, the `trigger-not-included` and `trigger-excluded` eligibility reasons
 
 ### Unversioned `GET /api/auth/methods` alias {#api-auth-methods}
 
-`GET /api/auth/methods` is a legacy, unversioned auth-discovery alias kept unauthenticated so the login screen can render before a session exists. It's registered directly on the app, ahead of the `/api` mounts, so it survived the [`/api/*` path removal](#unversioned-api-paths) in v1.6.0 and keeps working on its own separate v1.7.0 timeline. The `Sunset` header advertises 2027-07-01 as a conservative earliest retirement instant; the actual removal ships with the v1.7.0 release.
+`GET /api/auth/methods` is a legacy, unversioned auth-discovery alias kept unauthenticated so the login screen can render before a session exists. It's registered directly on the app, ahead of the `/api` mounts, so it survived the [`/api/*` path removal](#unversioned-api-paths) in v1.6.0 and keeps working on its own separate v1.7.0 timeline. The `Sunset` header carries 2027-07-01 only because the header needs a date; that date is not a floor on the removal, which ships in v1.7.0, whose release candidates already return 410.
 
 | | |
 | --- | --- |

--- a/content/docs/current/deprecations/index.mdx
+++ b/content/docs/current/deprecations/index.mdx
@@ -84,16 +84,16 @@ Simple template aliases (`id`, `name`, `watcher`, `kind`, `semver`, `local`, `re
 | **Removed since** | v1.6.0 |
 | **Migration** | Replace with `container.*` equivalents: `id` &rarr; `container.id`, `name` &rarr; `container.name`, `count` &rarr; `containers.length`, etc. See [Trigger templates](/docs/configuration/triggers#template-variable-reference) |
 
-### `PUT /api/settings` {#put-api-settings}
+### `PUT /api/v1/settings` {#put-api-settings}
 
-The `PUT` method on `/api/settings` is a compatibility alias for `PATCH`. Responses include `Deprecation` and `Sunset` HTTP headers.
+The `PUT` method on `/api/v1/settings` is a compatibility alias for `PATCH`. Responses include `Deprecation` and `Sunset` HTTP headers. The unversioned `/api/settings` path is not a working alias for this endpoint; like the rest of the unversioned surface it returns `410 Gone`, since settings is not one of the four wud-card compatibility endpoints exempted from that tombstone.
 
 | | |
 | --- | --- |
 | **Deprecated since** | v1.4.0 |
 | **Removal** | Deferred to API v2 — `/api/v1` is frozen, so the method cannot be dropped from the versioned surface; the `Sunset` header advertises the earliest retirement instant |
 | **Detection** | Log warning on each `PUT` request; `Deprecation` and `Sunset` response headers |
-| **Migration** | Change `PUT /api/settings` to `PATCH /api/settings` |
+| **Migration** | Change `PUT /api/v1/settings` to `PATCH /api/v1/settings` |
 
 ### HTTP OIDC discovery URLs {#oidc-http-discovery}
 
@@ -155,6 +155,16 @@ Hub/DHI public instances that provide `PUBLIC_TOKEN` without the matching `PUBLI
 | **Removed since** | v1.6.0 |
 | **Migration** | Add the matching login and use `LOGIN`+`TOKEN`, use `LOGIN`+`PASSWORD`, use `AUTH`, or remove credentials for intentional anonymous access |
 
+### Agent-mode `WUD_AGENT_SECRET` / `WUD_AGENT_SECRET_FILE` fallback {#agent-secret-fallback}
+
+Agent mode's secret lookup carried its own explicit fallback through v1.5.2, separate from the general `WUD_*` removal above: `DD_AGENT_SECRET` falling back to `WUD_AGENT_SECRET` (and the equivalent for `_FILE`). v1.6.0-rc.1 dropped both fallbacks with no warning release first. An agent configured with only `WUD_AGENT_SECRET` now fails startup with an error that never mentions the `WUD_` variable actually configured.
+
+| | |
+| --- | --- |
+| **Deprecated since** | Never, removed directly with no deprecation period |
+| **Removed since** | v1.6.0-rc.1 |
+| **Migration** | Rename `WUD_AGENT_SECRET` to `DD_AGENT_SECRET` and `WUD_AGENT_SECRET_FILE` to `DD_AGENT_SECRET_FILE` |
+
 ## Removal in v1.7.0
 
 ### `curl` in Docker image {#curl-healthcheck-override}
@@ -165,7 +175,7 @@ The official Docker image keeps `curl` available in v1.5.x and v1.6.x for backwa
 | --- | --- |
 | **Deprecated since** | v1.5.0 |
 | **Detection** | UI deprecation banner when Drydock can inspect its own container via the local Docker socket; otherwise manual config review |
-| **Migration** | Custom `curl`-based healthcheck overrides remain supported in v1.5.x. v1.6.0 is the final warning release. Removal is scheduled for v1.7.0. Prefer the built-in image healthcheck, or switch custom intervals to `test: /bin/healthcheck ${DD_SERVER_PORT:-3000}`. See [Monitoring](/docs/monitoring) |
+| **Migration** | Custom `curl`-based healthcheck overrides remain supported in v1.5.x. v1.6.0 is the final warning release. Removal is scheduled for v1.7.0. Prefer the built-in image healthcheck, or switch custom intervals to `test: /bin/healthcheck $${DD_SERVER_PORT:-3000}` (the doubled `$` is compose escaping, so the variable is expanded inside the container instead of from the host environment before the container starts). See [Monitoring](/docs/monitoring) |
 
 ### `DD_TRIGGER_*` environment variable prefix {#legacy-trigger-prefix}
 
@@ -201,7 +211,7 @@ In v1.5.x, the `trigger-not-included` and `trigger-excluded` eligibility reasons
 
 ### Unversioned `GET /api/auth/methods` alias {#api-auth-methods}
 
-`GET /api/auth/methods` is a legacy, unversioned auth-discovery alias kept unauthenticated so the login screen can render before a session exists. It's registered directly on the app, ahead of the `/api` mounts, so it survived the [`/api/*` path removal](#unversioned-api-paths) in v1.6.0 and keeps working on its own separate v1.7.0 timeline.
+`GET /api/auth/methods` is a legacy, unversioned auth-discovery alias kept unauthenticated so the login screen can render before a session exists. It's registered directly on the app, ahead of the `/api` mounts, so it survived the [`/api/*` path removal](#unversioned-api-paths) in v1.6.0 and keeps working on its own separate v1.7.0 timeline. The `Sunset` header advertises 2027-07-01 as a conservative earliest retirement instant; the actual removal ships with the v1.7.0 release.
 
 | | |
 | --- | --- |
@@ -243,6 +253,15 @@ These behaviors were removed immediately rather than going through a grace perio
 | **Removed since** | v1.5.0-rc.30 |
 | **Migration** | Set `DD_SERVER_TRUSTPROXY` to the number of proxy hops in front of Drydock (e.g. `1`) if you terminate TLS at a reverse proxy. See the [FAQ](/docs/faq#csrf-validation-failed-403-behind-a-reverse-proxy) |
 
+### Implicit reverse-proxy header trust for WebSocket origin checks {#ws-origin-proxy-trust}
+
+The log-stream (`/api/v1/log/stream`) and container log-stream (`/api/v1/containers/{id}/logs/stream`) WebSocket endpoints used to validate an upgrade's `Origin` header by comparing host only, the same gap the CSRF check above had. The check now also validates scheme, honoring `X-Forwarded-Proto` / `X-Forwarded-Host` only when Express `trust proxy` is enabled.
+
+| | |
+| --- | --- |
+| **Removed since** | v1.6.0-rc.3 |
+| **Migration** | Set `DD_SERVER_TRUSTPROXY` to the number of proxy hops in front of Drydock (e.g. `1`) if you terminate TLS at a reverse proxy. See the [FAQ](/docs/faq#csrf-validation-failed-403-behind-a-reverse-proxy) |
+
 ### Command trigger process-environment inheritance {#command-trigger-env-inheritance}
 
 | | |
@@ -257,6 +276,24 @@ These behaviors were removed immediately rather than going through a grace perio
 | **Removed since** | v1.5.0-rc.35 |
 | **Migration** | A deployment that genuinely needs a link-local target sets `DD_NOTIFICATION_HTTP_{name}_ALLOWMETADATA=true` on that trigger. See [HTTP trigger](/docs/configuration/triggers/http) |
 
+### Anonymous-auth grandfather path for upgrades {#anonymous-auth-grandfather}
+
+Upgrading instances (an existing `/store/dd.json`) with no authentication configured used to be let through with anonymous access and a startup warning, the same grandfather path drydock used before v1.4.0 enforced authentication on fresh installs. Unconfirmed anonymous registration is now rejected for upgrades exactly as it already was for fresh installs.
+
+| | |
+| --- | --- |
+| **Removed since** | v1.6.0-rc.3 |
+| **Migration** | Set `DD_AUTH_BASIC_<name>_USER`/`_HASH` (or configure OIDC) before upgrading, or set `DD_ANONYMOUS_AUTH_CONFIRM=true` to explicitly keep the instance anonymous. See [Authentication](/docs/configuration/authentications) |
+
+### Session cookie renamed `connect.sid` → `drydock.sid` {#session-cookie-rename}
+
+Drydock used to serve sessions under Express's default cookie name, `connect.sid`, the same name countless other Express apps use, making a drydock session fingerprintable and a potential collision risk with another Express app on the same host/path. Sessions are now served under `drydock.sid`.
+
+| | |
+| --- | --- |
+| **Removed since** | v1.6.0-rc.3 |
+| **Migration** | None required. Existing `connect.sid` cookies are simply no longer recognized, so every user is signed out once on upgrade and needs to log back in. No data is lost |
+
 ## Detection summary
 
 Drydock provides multiple channels for discovering deprecated feature usage:
@@ -266,5 +303,5 @@ Drydock provides multiple channels for discovering deprecated feature usage:
 | **Startup log warnings** | All runtime-detectable deprecations |
 | **UI deprecation banners** | Active v1.7 trigger-prefix inputs |
 | **Prometheus counters** | `dd_legacy_input_total{source,key}` for active trigger-prefix inputs, API tombstones, and historical observations |
-| **HTTP response headers** | `Deprecation` and `Sunset` on `PUT /api/settings`, `GET /api/auth/methods`, and `GET /auth/strategies` |
+| **HTTP response headers** | `Deprecation` and `Sunset` on `PUT /api/v1/settings`, `GET /api/auth/methods`, and `GET /auth/strategies` |
 | **Migration CLI** | `node dist/index.js config migrate --dry-run` previews all env var and label renames |

--- a/content/docs/current/monitoring/index.mdx
+++ b/content/docs/current/monitoring/index.mdx
@@ -43,7 +43,7 @@ services:
     image: codeswhat/drydock:latest
     ...
     healthcheck:
-      test: /bin/healthcheck ${DD_SERVER_PORT:-3000}
+      test: /bin/healthcheck $${DD_SERVER_PORT:-3000}
       interval: 10s
       timeout: 10s
       retries: 3

--- a/ui/src/layouts/AppLayout.vue
+++ b/ui/src/layouts/AppLayout.vue
@@ -1629,7 +1629,7 @@ onUnmounted(() => {
           @dismiss="curlHealthcheckDeprecationBanner.dismissForSession"
           @dismiss-permanent="curlHealthcheckDeprecationBanner.dismissPermanently">
           <i18n-t keypath="appShell.banners.curlHealthcheckBody" tag="span">
-            <template #bin><code class="px-1 py-0.5 dd-rounded-sm" :style="{ backgroundColor: 'var(--dd-bg)', color: 'var(--dd-warning)' }">/bin/healthcheck ${DD_SERVER_PORT:-3000}</code></template>
+            <template #bin><code class="px-1 py-0.5 dd-rounded-sm" :style="{ backgroundColor: 'var(--dd-bg)', color: 'var(--dd-warning)' }">/bin/healthcheck $${DD_SERVER_PORT:-3000}</code></template>
           </i18n-t>
           <span v-if="curlHealthcheckOverrideSummary?.commandPreview" class="block mt-1 truncate">
             {{ t('appShell.banners.healthcheckCommandLabel', { command: curlHealthcheckOverrideSummary.commandPreview }) }}

--- a/ui/tests/layouts/AppLayout.spec.ts
+++ b/ui/tests/layouts/AppLayout.spec.ts
@@ -586,7 +586,7 @@ describe('AppLayout', () => {
     expect(banner.exists()).toBe(true);
     expect(banner.text()).toContain('custom curl-based healthcheck override');
     expect(banner.text()).toContain('v1.7.0');
-    expect(banner.text()).toContain('/bin/healthcheck');
+    expect(banner.text()).toContain('/bin/healthcheck $${DD_SERVER_PORT:-3000}');
     expect(banner.text()).toContain('View migration guide');
 
     const link = wrapper.find('[data-testid="curl-healthcheck-deprecation-banner-link"]');


### PR DESCRIPTION
## Why

The deprecation entries on the 1.6 line had drifted from what the code does. Found by the deprecation alignment pass across all three lines (DR-62).

## What

- The curl healthcheck migration snippet used a single `$` in three places (DEPRECATIONS.md, the deprecations page, the server page). Compose expands that from the host before the container starts, so the port default never reached the container. Now `$$` with the same note main carries.
- The `PUT /api/settings` entries named the unversioned path, which returns 410. They now name `PUT /api/v1/settings`, and the settings deprecation message and comments in `app/api/settings.ts` say the same route (backport of main's wording).
- The `GET /api/auth/methods` entry says the Sunset header's 2027-07-01 date is a conservative floor and the removal ships with v1.7.0.
- Backported the `WUD_AGENT_SECRET` / `WUD_AGENT_SECRET_FILE` removal entry, which 1.6.0 dropped without documenting.
- The deprecations page gained the three enforced security entries that DEPRECATIONS.md already had (WebSocket origin header trust, anonymous-auth grandfather path, session cookie rename).
- Active entries say `Removal` instead of `Removed in` for removals that have not shipped.
- The curl healthcheck banner in the UI rendered `${DD_SERVER_PORT:-3000}` with a single `$`, which breaks the same way when pasted into compose. Now `$$`.

## Verification

- `node --test scripts/*.test.mjs`: 149 pass
- `ui`: AppLayout spec 29 passed; `app/api/settings.test.ts` 9 passed, `settings.ts` 100% lines, branches, functions, statements
- Full pre-push gate green on 726d0837f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added deprecation entries for agent-secret fallback, WebSocket origin checks, anonymous-auth upgrades, and session cookie renaming.
- 🔧 Changed documentation and comments to use `PUT /api/v1/settings`.
- 🔧 Escaped Compose healthcheck variables with `$$`.
- 🔧 Clarified `GET /api/auth/methods` removal timing and Sunset date.
- 🔧 Changed pending-removal labels from `Removed in` to `Removal`.
- 🗑️ Documented removal of `WUD_AGENT_SECRET` and `WUD_AGENT_SECRET_FILE`.
- ⚠️ Documented removal of the unversioned `/api/settings` alias and related migration behavior.
- 🔒 Documented WebSocket origin-check and authentication deprecations.
- 🐛 Added regression coverage for the UI healthcheck banner.
- ✅ Node, UI, API, coverage, and pre-push checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->