### PR TITLE
build(deps): override fflate to 0.8.3 for CVE-2026-45820

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`fflate` override added in `e2e/` for CVE-2026-45820.** `@smithy/middleware-compression` pins `fflate` at 0.8.1 exactly, so the fix had to come through an npm override; `fflate` now resolves to 0.8.3 in `e2e/package-lock.json`, which is the only workspace that carried the vulnerable range. Lockfile-only change, no runtime code touched.
+
 ## [1.7.0-rc.8] — 2026-09-03
 
 ### Fixed

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -4372,9 +4372,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
-      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
     },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -38,6 +38,7 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
+    "fflate": "0.8.3",
     "js-yaml": "3.15.1",
     "fast-xml-parser": "5.10.1",
     "joi": "18.2.3",


### PR DESCRIPTION
## Why

`fflate` 0.8.1 is pinned exactly by `@smithy/middleware-compression` in `e2e/`, and CVE-2026-45820 (GHSA-px8p-9vwx-vf98) makes osv-scanner in the qlty pre-push gate fail every push on this line. Same override #982 carries on dev/v1.8; dev/v1.6 already resolves 0.8.3.

## What

- `e2e/package.json` overrides `fflate` to 0.8.3; `e2e/package-lock.json` regenerated with `npm install --package-lock-only --ignore-scripts`.
- CHANGELOG `### Security` bullet under Unreleased.

## Verification

- Full pre-push gate green on 3335d37b2 (qlty osv-scanner clean)
- Grype lockfile scan and dependency review run on the PR
