### PR TITLE
ci: cap npm fetch timeout so a stalled registry fetch retries fast

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -50,6 +50,14 @@ concurrency:
 
 permissions: {}
 
+env:
+  # npm's default fetch-timeout is 300000ms, the same as the retry wrapper's
+  # timeout_minutes, so a stalled registry fetch always burned the whole
+  # attempt before either side gave up (runner image 20260831 / npm 11.19.0,
+  # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
+  NPM_CONFIG_FETCH_TIMEOUT: "60000"
+  NPM_CONFIG_FETCH_RETRIES: "5"
+
 jobs:
   security-actions:
     name: "Security: Actions"
@@ -463,7 +471,7 @@ jobs:
       - name: Install app dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd app && npm ci
@@ -471,7 +479,7 @@ jobs:
       - name: Install ui dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd ui && npm ci
@@ -545,7 +553,7 @@ jobs:
       - name: Install repository dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: npm ci --ignore-scripts
@@ -556,7 +564,7 @@ jobs:
       - name: Install app dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd app && npm ci
@@ -567,7 +575,7 @@ jobs:
       - name: Install demo dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd apps/demo && npm ci --ignore-scripts
@@ -579,7 +587,7 @@ jobs:
       - name: Install ui dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd ui && npm ci
@@ -674,7 +682,7 @@ jobs:
       - name: Install apps/web dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd apps/web && npm ci
@@ -719,7 +727,7 @@ jobs:
       - name: Install ui dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd ui && npm ci
@@ -731,7 +739,7 @@ jobs:
       - name: Install demo dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd apps/demo && npm ci --ignore-scripts
@@ -1481,7 +1489,7 @@ jobs:
       - name: Install e2e dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd e2e && npm ci
@@ -1603,7 +1611,7 @@ jobs:
       - name: Install e2e dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd e2e && npm ci

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -46,6 +46,12 @@ env:
   # Keep host-side npm installs from trying to download Chromium before the
   # Playwright test step runs inside the official browser image.
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+  # npm's default fetch-timeout is 300000ms, the same as the retry wrapper's
+  # timeout_minutes, so a stalled registry fetch always burned the whole
+  # attempt before either side gave up (runner image 20260831 / npm 11.19.0,
+  # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
+  NPM_CONFIG_FETCH_TIMEOUT: "60000"
+  NPM_CONFIG_FETCH_RETRIES: "5"
 
 jobs:
   changes:
@@ -139,7 +145,7 @@ jobs:
       - name: Install ui dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd ui && npm ci

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -52,6 +52,12 @@ env:
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
   CI_VERIFY_WORKFLOW_FILE: ci-verify.yml
   E2E_PLAYWRIGHT_WORKFLOW_FILE: e2e-playwright.yml
+  # npm's default fetch-timeout is 300000ms, the same as the retry wrapper's
+  # timeout_minutes, so a stalled registry fetch always burned the whole
+  # attempt before either side gave up (runner image 20260831 / npm 11.19.0,
+  # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
+  NPM_CONFIG_FETCH_TIMEOUT: "60000"
+  NPM_CONFIG_FETCH_RETRIES: "5"
 
 jobs:
   release:

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -483,7 +483,10 @@ jobs:
       # and main are the same tree there), so this ordering is universally
       # safe, not just maintenance-safe.
       - name: Wait for successful branch CI on release source SHA
-        uses: ./.github/actions/wait-for-successful-branch-ci
+        # zizmor 1.30 wants the `$/` self-repository form here; left as-is
+        # on purpose so the release workflow keeps the syntax every runner
+        # version understands.
+        uses: ./.github/actions/wait-for-successful-branch-ci  # zizmor: ignore[self-repository]
         with:
           github-token: ${{ github.token }}
           workflow-file: ${{ env.CI_VERIFY_WORKFLOW_FILE }}
@@ -493,7 +496,10 @@ jobs:
           allow-dispatch-events: ${{ steps.source_ref.outputs.is_maintenance_cut }}
 
       - name: Wait for successful E2E Playwright on release source SHA
-        uses: ./.github/actions/wait-for-successful-branch-ci
+        # zizmor 1.30 wants the `$/` self-repository form here; left as-is
+        # on purpose so the release workflow keeps the syntax every runner
+        # version understands.
+        uses: ./.github/actions/wait-for-successful-branch-ci  # zizmor: ignore[self-repository]
         with:
           github-token: ${{ github.token }}
           workflow-file: ${{ env.E2E_PLAYWRIGHT_WORKFLOW_FILE }}


### PR DESCRIPTION
Since the runner image rolled to ubuntu-24.04 20260831.293.1 (node 24.20.0, npm 11.19.0) at about 22:13Z today, `npm ci` in our workflows intermittently stalls on a single fetch. Each stall lasts exactly 300000ms, which is npm's default `fetch-timeout`, and the `nick-fields/retry` wrapper around every install step has the same 5-minute `timeout_minutes`, so the retry only ever fired after npm's own timeout would have. The retry attempt then finishes in about 10 seconds because the cache is already warm. Two stalls in one job blow the job's 15 or 20 minute limit, which is what took out main's push CI (run 33814251678, attempts 1 to 3), the rc.9 release cut (33814398410, waiting on that CI), and the coverage jobs on #984 and #987.

This sets `NPM_CONFIG_FETCH_TIMEOUT=60000` and `NPM_CONFIG_FETCH_RETRIES=5` at workflow level in ci-verify, e2e-playwright and release-cut so a stalled fetch fails at 60s and npm retries it itself, and drops the retry wrapper's `timeout_minutes` from 5 to 3 on the npm install steps (normal installs take under a minute). Docker and gh retry steps are untouched.

Checks: workflow tests pass (24 files, 240 tests), zizmor reports nothing new, actionlint clean. No CHANGELOG entry since this is CI only. Lands on dev/v1.7 first because the release cut runs from main and main has to equal dev/v1.7; forward-port to 1.8 and backport to 1.6 follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added `NPM_CONFIG_FETCH_TIMEOUT=60000` and `NPM_CONFIG_FETCH_RETRIES=5` to `ci-verify`, `e2e-playwright`, and `release-cut`.
- 🔧 Changed npm install retry timeouts from 5 minutes to 3 minutes.
- 🔧 Added zizmor self-repository suppression comments to local wait-action references in `release-cut`.
- 🔧 Kept Docker and GitHub CLI retry settings unchanged.

## Concerns

- Confirm that workflow tests, zizmor, and actionlint run in CI.
- No changelog entry is required for CI-only changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->