### PR TITLE
ci: cap npm fetch timeout so a stalled registry fetch retries fast (1.6 backport)

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -50,6 +50,14 @@ concurrency:
 
 permissions: {}
 
+env:
+  # npm's default fetch-timeout is 300000ms, the same as the retry wrapper's
+  # timeout_minutes, so a stalled registry fetch always burned the whole
+  # attempt before either side gave up (runner image 20260831 / npm 11.19.0,
+  # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
+  NPM_CONFIG_FETCH_TIMEOUT: "60000"
+  NPM_CONFIG_FETCH_RETRIES: "5"
+
 jobs:
   security-actions:
     name: "Security: Actions"
@@ -500,7 +508,7 @@ jobs:
       - name: Install repository dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: npm ci --ignore-scripts
@@ -511,7 +519,7 @@ jobs:
       - name: Install app dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd app && npm ci
@@ -522,7 +530,7 @@ jobs:
       - name: Install demo dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd apps/demo && npm ci --ignore-scripts
@@ -534,7 +542,7 @@ jobs:
       - name: Install ui dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd ui && npm ci
@@ -629,7 +637,7 @@ jobs:
       - name: Install apps/web dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd apps/web && npm ci
@@ -674,7 +682,7 @@ jobs:
       - name: Install ui dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd ui && npm ci
@@ -686,7 +694,7 @@ jobs:
       - name: Install demo dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd apps/demo && npm ci --ignore-scripts
@@ -1400,7 +1408,7 @@ jobs:
       - name: Install e2e dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd e2e && npm ci
@@ -1522,7 +1530,7 @@ jobs:
       - name: Install e2e dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd e2e && npm ci

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -46,6 +46,12 @@ env:
   # Keep host-side npm installs from trying to download Chromium before the
   # Playwright test step runs inside the official browser image.
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+  # npm's default fetch-timeout is 300000ms, the same as the retry wrapper's
+  # timeout_minutes, so a stalled registry fetch always burned the whole
+  # attempt before either side gave up (runner image 20260831 / npm 11.19.0,
+  # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
+  NPM_CONFIG_FETCH_TIMEOUT: "60000"
+  NPM_CONFIG_FETCH_RETRIES: "5"
 
 jobs:
   changes:
@@ -139,7 +145,7 @@ jobs:
       - name: Install ui dependencies
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
-          timeout_minutes: 5
+          timeout_minutes: 3
           max_attempts: 3
           retry_wait_seconds: 30
           command: cd ui && npm ci

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -47,6 +47,12 @@ env:
   DOCKER_PLATFORMS: linux/amd64,linux/arm64
   CI_VERIFY_WORKFLOW_FILE: ci-verify.yml
   E2E_PLAYWRIGHT_WORKFLOW_FILE: e2e-playwright.yml
+  # npm's default fetch-timeout is 300000ms, the same as the retry wrapper's
+  # timeout_minutes, so a stalled registry fetch always burned the whole
+  # attempt before either side gave up (runner image 20260831 / npm 11.19.0,
+  # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
+  NPM_CONFIG_FETCH_TIMEOUT: "60000"
+  NPM_CONFIG_FETCH_RETRIES: "5"
 
 jobs:
   release:


### PR DESCRIPTION
Backport of #992 to the 1.6 line. Same change: npm's default fetch-timeout (300000ms) equals the nick-fields/retry wrapper's 5 minute timeout, so when a registry fetch stalls on the 20260831 runner image (npm 11.19.0) the whole attempt burns before either side gives up. Set `NPM_CONFIG_FETCH_TIMEOUT=60000` and `NPM_CONFIG_FETCH_RETRIES=5` at workflow level in ci-verify, e2e-playwright and release-cut, and drop the npm install retry steps from 5 to 3 minutes.

The only conflict was the Knip block in ci-verify, which 1.6 doesn't carry; resolved by keeping the 1.6 side. release-cut already had the zizmor `self-repository` ignores on this branch.

On 1.7 every install now runs in about 61s instead of 5 minutes per stalled attempt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

### ✨ Added
- Set `NPM_CONFIG_FETCH_TIMEOUT=60000` and `NPM_CONFIG_FETCH_RETRIES=5` at workflow level in `ci-verify`, `e2e-playwright`, and `release-cut`.

### 🔧 Changed
- Reduced npm install retry step timeouts from 5 to 3 minutes.
- Retained the 1.6 branch version during `ci-verify` conflict resolution.
- Retained existing `zizmor self-repository` ignores in `release-cut`.

## Concerns

- Verify that all npm install retry steps requiring the new timeout are covered.
- Confirm that the workflow-level npm environment variables apply to every intended npm invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->