### PR TITLE
chore(release): prepare v1.6.1-rc.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1-rc.8] — 2026-09-04
+
 ### Fixed
 
 - **`watchFromCron()` had no re-entrancy guard, so overlapping scans on a large fleet fired the same trigger multiple times for one update.** A full scan can take minutes, and the cron schedule, the docker-events debounce, and the startup timer could all start one while the previous scan was still running. Each overlapping call ran its own `watch()`, and a tag first seen mid-burst passed the `once=true` history check in every one of them before any of them recorded it, so a trigger like Telegram fired once per overlapping scan for the same update. `watchFromCron()` is now single-flight: a request while a scan is running does not start a second one, it records that a rescan was requested, and exactly one follow-up scan runs once the current scan finishes, so a docker event that arrives mid-scan is not lost. A scan that never settles cannot wedge later ticks either: the in-flight scan is raced against a deadline, and when it fires every caller waiting on that scan, the one that started it and any that coalesced into it, resolves to an empty result and the next tick starts a fresh scan. The "Cron started" log line now also names what triggered the scan (schedule, docker-event, startup, or maintenance-window). Reported by [@tarzan77cz](https://github.com/tarzan77cz) in [#972](https://github.com/CodesWhat/drydock/issues/972).
@@ -2464,7 +2466,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.7...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.8...HEAD
+[1.6.1-rc.8]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.7...v1.6.1-rc.8
 [1.6.1-rc.7]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.6...v1.6.1-rc.7
 [1.6.1-rc.6]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.5...v1.6.1-rc.6
 [1.6.1-rc.5]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.4...v1.6.1-rc.5

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.7-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.8-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,6 +179,18 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.6.1-rc.8 highlights</strong></summary>
+
+- **Overlapping scans no longer fire the same trigger repeatedly for one update** — a full scan can take minutes, and the cron schedule, the docker-events debounce and the startup timer could each start one while the previous was still running, so a tag first seen mid-burst passed the `once=true` history check in every overlapping scan before any of them recorded it. `watchFromCron()` is now single-flight: a request arriving during a scan records that a rescan is wanted, and exactly one follow-up runs once the current scan finishes. Reported by [@tarzan77cz](https://github.com/tarzan77cz). ([#972](https://github.com/CodesWhat/drydock/issues/972))
+- **A `once=true` trigger no longer re-fires hours later for an update it already announced** — the notification-history hash for a tag update included the digest and fell back to the image's `created` timestamp when the digest was missing, so a rate-limited digest lookup swapped `created` into the hash for one scan and back out on the next, and the history stopped matching. A tag update on a container with digest watching configured is now keyed on the tag alone. Reported by [@tarzan77cz](https://github.com/tarzan77cz). ([#972](https://github.com/CodesWhat/drydock/issues/972))
+- **Batch and digest updates can no longer be sent twice by an overlapping manual scan** — the `once=true` reservation covered the simple notification path only, so batch and digest eligibility still did a plain read of a history that is written after the send resolves. Both now take the same synchronous reservation. The cron scan's deadline timer also moved onto the watcher state, so deregistering a watcher clears it instead of leaving it to warn about a scan nothing owns, and a scan requested after teardown is refused outright. ([#999](https://github.com/CodesWhat/drydock/pull/999))
+- **Deprecation docs match the shipped code again** — the compose curl-healthcheck snippet doubles its `$` so it expands inside the container instead of the host, the settings entry names `PUT /api/v1/settings` rather than the tombstoned unversioned path, and the WebSocket origin-check, anonymous-auth grandfather and session cookie rename entries that were missing from the generated page are back. ([#985](https://github.com/CodesWhat/drydock/pull/985))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc8--2026-09-04).
+
+</details>
+
+<details>
 <summary><strong>v1.6.1-rc.7 highlights</strong></summary>
 
 - **`DD_AGENT_ALLOW_INSECURE_SECRET` no longer registers a phantom agent named `allow`** — the flag matched the generic `dd.agent` prefix parser and produced an `{insecure: {secret: 'true'}}` agent that failed to register on every install setting the flag, whether or not any real agents were configured. Reported by [@depuits](https://github.com/depuits). ([#945](https://github.com/CodesWhat/drydock/issues/945))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1-rc.7',
+    version: '1.6.1-rc.8',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1-rc.7 started',
+    details: 'Drydock v1.6.1-rc.8 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.7',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.8',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1-rc.7',
+    tag: '1.6.1-rc.8',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1-rc.7',
+  version: '1.6.1-rc.8',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1-rc.7',
+      version: '1.6.1-rc.8',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1-rc.7', mode: 'demo' },
+        server: { version: '1.6.1-rc.8', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1-rc.7",
+  version: "1.6.1-rc.8",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1-rc.7",
+    version: "v1.6.1-rc.8",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1-rc.7",
+      "version": "1.6.1-rc.8",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1-rc.7",
+    "version": "1.6.1-rc.8",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1-rc.7"
+  "version":"1.6.1-rc.8"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1-rc.7",
+    "version": "1.6.1-rc.8",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1-rc.7",
+      "drydockVersion": "1.6.1-rc.8",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1-rc.7` | Immutable release candidate; best for reproducible testing |
+| `1.6.1-rc.8` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,20 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.6.1-rc.8 Highlights — September 4, 2026
+
+Three fixes and a docs pass: overlapping scans no longer fire the same
+trigger repeatedly for one update, because `watchFromCron()` is now
+single-flight; a `once=true` trigger no longer re-fires hours later for an
+update it already announced when a rate-limited digest lookup shifts the
+notification-history hash; batch and digest updates now take the same
+notification reservation the simple path does, so an overlapping manual scan
+cannot double-send, and a deregistered watcher no longer warns about a scan
+deadline it no longer owns; and `DEPRECATIONS.md` and the generated
+deprecations page are realigned with the shipped code. See
+[CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc8--2026-09-04)
+for the full release notes.
+
 ## v1.6.1-rc.7 Highlights — September 3, 2026
 
 Six fixes: `DD_AGENT_ALLOW_INSECURE_SECRET` no longer registers a phantom

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -7,7 +7,7 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## v1.6.1-rc.8 Highlights — September 4, 2026
 
-Three fixes and a docs pass: overlapping scans no longer fire the same
+Four fixes and a docs pass: overlapping scans no longer fire the same
 trigger repeatedly for one update, because `watchFromCron()` is now
 single-flight; a `once=true` trigger no longer re-fires hours later for an
 update it already announced when a rate-limited digest lookup shifts the

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.7...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.8...HEAD`],
+    ['1.6.1-rc.8', `${repositoryUrl}/compare/v1.6.1-rc.7...v1.6.1-rc.8`],
     ['1.6.1-rc.7', `${repositoryUrl}/compare/v1.6.1-rc.6...v1.6.1-rc.7`],
     ['1.6.1-rc.6', `${repositoryUrl}/compare/v1.6.1-rc.5...v1.6.1-rc.6`],
     ['1.6.1-rc.5', `${repositoryUrl}/compare/v1.6.1-rc.4...v1.6.1-rc.5`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1-rc.7';
-const PREV_RC_VERSION = '1.6.1-rc.6';
-const RC_DATE = '2026-09-03';
-const RC_DISPLAY_DATE = 'September 3, 2026';
+const RC_VERSION = '1.6.1-rc.8';
+const PREV_RC_VERSION = '1.6.1-rc.7';
+const RC_DATE = '2026-09-04';
+const RC_DISPLAY_DATE = 'September 4, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1-rc.7';
+const RC_VERSION = '1.6.1-rc.8';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Release identity for v1.6.1-rc.8: CHANGELOG heading and compare links, README badge and highlights block, demo mock versions, site config, api and quickstart docs, updates page, and the tests that pin the current rc. Same file set as the rc.7 prepare. Needed before the cut: release-cut validates the CHANGELOG heading and failed on run 33843880950 without it.

Since rc.7 the line carries #985, #991, #995 and #999.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

🔧 **Changed**
- Updated release identity from `1.6.1-rc.7` to `1.6.1-rc.8` across the README, demo mocks, site configuration, documentation, and tests.
- Updated CHANGELOG comparison links and release documentation references.
- Added README and updates-page highlights for the release fixes.
- Updated API examples and quickstart image tags.

🐛 **Fixed**
- Documented single-flight `watchFromCron()` behavior for overlapping scans.
- Documented stable notification-history hashing for `once=true` triggers.
- Documented synchronous notification reservation for batch and digest updates.
- Documented watcher deregistration deadline handling.
- Documented deprecation-page alignment with shipped code.

- Run release identity and changelog link tests.
- Verify all `1.6.1-rc.7` references that require migration are updated.
- Verify the CHANGELOG heading and compare links match the release-cut validation format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->