### PR TITLE
ci: skip npm audit and fund lookups in workflow installs

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -57,6 +57,12 @@ env:
   # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
   NPM_CONFIG_FETCH_TIMEOUT: "60000"
   NPM_CONFIG_FETCH_RETRIES: "5"
+  # Every host-side npm ci on that image still stalled exactly once per install
+  # (61s flat with the timeout above) while the Dockerfile's
+  # `npm ci --no-audit --no-fund` never did. Skip the audit and fund lookups
+  # here too; they add nothing in CI.
+  NPM_CONFIG_AUDIT: "false"
+  NPM_CONFIG_FUND: "false"
 
 jobs:
   security-actions:

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -52,6 +52,12 @@ env:
   # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
   NPM_CONFIG_FETCH_TIMEOUT: "60000"
   NPM_CONFIG_FETCH_RETRIES: "5"
+  # Every host-side npm ci on that image still stalled exactly once per install
+  # (61s flat with the timeout above) while the Dockerfile's
+  # `npm ci --no-audit --no-fund` never did. Skip the audit and fund lookups
+  # here too; they add nothing in CI.
+  NPM_CONFIG_AUDIT: "false"
+  NPM_CONFIG_FUND: "false"
 
 jobs:
   changes:

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -58,6 +58,12 @@ env:
   # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
   NPM_CONFIG_FETCH_TIMEOUT: "60000"
   NPM_CONFIG_FETCH_RETRIES: "5"
+  # Every host-side npm ci on that image still stalled exactly once per install
+  # (61s flat with the timeout above) while the Dockerfile's
+  # `npm ci --no-audit --no-fund` never did. Skip the audit and fund lookups
+  # here too; they add nothing in CI.
+  NPM_CONFIG_AUDIT: "false"
+  NPM_CONFIG_FUND: "false"
 
 jobs:
   release:


### PR DESCRIPTION
Experiment for the per-install stall left after #992 (DR-71 on the roadmap). Since the 20260831 runner image, every host-side `npm ci` stalls exactly once and completes at 61s flat with the fetch timeout, while the Dockerfile's `npm ci --no-audit --no-fund` on the same runs never stalled. This sets `NPM_CONFIG_AUDIT=false` and `NPM_CONFIG_FUND=false` at workflow level in ci-verify, e2e-playwright and release-cut.

If the install steps on this PR's run drop from 61s to single-digit seconds, the audit or fund lookup is the stalled request and this is the fix. If they stay at 61s, the stall is a tarball fetch and this PR becomes a small cleanup only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added:
- Set `NPM_CONFIG_AUDIT=false` and `NPM_CONFIG_FUND=false` at workflow scope in `ci-verify`, `e2e-playwright`, and `release-cut`.
- Disable npm audit and fund lookups for host-side `npm ci`.
- Match Dockerfile install behavior: `npm ci --no-audit --no-fund`.

⚠️ Concerns:
- Compare install durations with and without these variables to identify whether the 61-second stall is caused by audit/fund lookups or tarball fetches.
- Confirm that the workflow-level environment also applies to every intended containerized install.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->