### PR TITLE
ci: skip npm audit and fund lookups in workflow installs

### DIFF
--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -57,6 +57,12 @@ env:
   # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
   NPM_CONFIG_FETCH_TIMEOUT: "60000"
   NPM_CONFIG_FETCH_RETRIES: "5"
+  # Every host-side npm ci on that image still stalled exactly once per install
+  # (61s flat with the timeout above) while the Dockerfile's
+  # `npm ci --no-audit --no-fund` never did. Skip the audit and fund lookups
+  # here too; they add nothing in CI.
+  NPM_CONFIG_AUDIT: "false"
+  NPM_CONFIG_FUND: "false"
 
 jobs:
   security-actions:

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -52,6 +52,12 @@ env:
   # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
   NPM_CONFIG_FETCH_TIMEOUT: "60000"
   NPM_CONFIG_FETCH_RETRIES: "5"
+  # Every host-side npm ci on that image still stalled exactly once per install
+  # (61s flat with the timeout above) while the Dockerfile's
+  # `npm ci --no-audit --no-fund` never did. Skip the audit and fund lookups
+  # here too; they add nothing in CI.
+  NPM_CONFIG_AUDIT: "false"
+  NPM_CONFIG_FUND: "false"
 
 jobs:
   changes:

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -53,6 +53,12 @@ env:
   # 2026-09-03). Fail the fetch at 60s and let npm retry it itself.
   NPM_CONFIG_FETCH_TIMEOUT: "60000"
   NPM_CONFIG_FETCH_RETRIES: "5"
+  # Every host-side npm ci on that image still stalled exactly once per install
+  # (61s flat with the timeout above) while the Dockerfile's
+  # `npm ci --no-audit --no-fund` never did. Skip the audit and fund lookups
+  # here too; they add nothing in CI.
+  NPM_CONFIG_AUDIT: "false"
+  NPM_CONFIG_FUND: "false"
 
 jobs:
   release:


### PR DESCRIPTION
Backport of #1005 (DR-71). Every host-side `npm ci` on the 20260831 runner image stalled once per install and completed at 61s flat with the fetch timeout from #992. Setting `NPM_CONFIG_AUDIT=false` and `NPM_CONFIG_FUND=false` in the workflow env blocks took the install steps on the dev/v1.8 run from 61s to 2 to 24s, so the audit/fund lookup was the stalled request. Same change, cherry-picked.
