### PR TITLE
docs: cover registries on agents and what the maintenance window gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **The agents page didn't say registries have to be configured on every agent, not just the controller.** A traditional agent runs its own watcher and does its own registry matching and update checks, so `DD_REGISTRY_*` configured only on the controller left every agent-reported container from that registry stamped `unknown`, credentials are never pushed from controller to agent. The controller needs the same registry configured too, or the container's registry link in the UI resolves to a registry the controller was never told about. A new "Registries on agents" section spells this out with a worked Gitea example on both sides. Reported in [#945](https://github.com/CodesWhat/drydock/issues/945).
+- **The watchers page said manual updates bypass the maintenance window but didn't say the window gates the entire scheduled scan, not just installing an update.** A closed window means new containers stay invisible in the UI until the next window opens, container state shown in the UI goes stale (a container stopped during the last window still shows as stopped, and a start action on it fails because Docker refuses to start a container that's already running), and update notifications are deferred right along with the update itself. A manual scan (`POST /api/v1/containers/watch`, or the UI) bypasses the window the same way a manual update does, because it calls the watcher's `watch()` directly rather than the cron path that checks it. Discussed in [#946](https://github.com/CodesWhat/drydock/discussions/946).
+
 ## [1.7.0-rc.10] — 2026-09-04
 
 ### Fixed

--- a/content/docs/current/configuration/agents/index.mdx
+++ b/content/docs/current/configuration/agents/index.mdx
@@ -432,7 +432,7 @@ services:
     environment:
       - DD_AGENT_REMOTE1_HOST=192.168.1.50
       - DD_AGENT_REMOTE1_SECRET=pick-a-long-random-string   # must match the agent's DD_AGENT_SECRET
-      - DD_AGENT_ALLOW_INSECURE_SECRET=true                 # plain-HTTP LAN only; see note above
+      - DD_AGENT_REMOTE1_CAFILE=/certs/agent-ca.pem          # TLS to the agent, as in the setup example above
       - DD_REGISTRY_GITEA_PRIVATE_URL=https://git.example.com
       - DD_REGISTRY_GITEA_PRIVATE_LOGIN=john
       - DD_REGISTRY_GITEA_PRIVATE_PASSWORD=doe

--- a/content/docs/current/configuration/agents/index.mdx
+++ b/content/docs/current/configuration/agents/index.mdx
@@ -392,6 +392,54 @@ services:
 
 <Callout type="info">**You do not need to define `DD_ACTION_DOCKER_*` on the controller for each agent.** During the handshake, the controller automatically discovers the agent's triggers and creates internal proxies. The controller only needs its own `DD_ACTION_DOCKER_*` for updating containers on its local host.</Callout>
 
+## Registries on agents
+
+A traditional agent runs its own Docker watcher and does its own registry matching and update checks, it does not inherit the controller's registry configuration. Whatever registries the agent's containers are pulled from, that agent needs the matching `DD_REGISTRY_*` variables configured on itself, with the same values you'd use on a standalone instance.
+
+<Callout type="warn">**Credentials are not pushed from the controller to agents.** If you configure `DD_REGISTRY_GITEA_PRIVATE_*` only on the controller, every agent-reported container that comes from that registry shows up as registry `unknown`, the agent never learned about it.</Callout>
+
+The controller needs the same registry configured too, even though it isn't doing the matching for that agent's containers. The controller's UI links a container to its registry page, but that page is served from the controller's own registry configuration, if the controller was never given `DD_REGISTRY_GITEA_PRIVATE_*`, the link resolves to a registry the controller doesn't know about.
+
+In short: for a registry used by an agent's containers, configure the same `DD_REGISTRY_{provider}_{name}_*` variables on **both** that agent and the controller.
+
+**Agent**: needs the registry to do the matching and update check:
+
+```yaml
+services:
+  drydock-agent:
+    image: codeswhat/drydock
+    command: --agent
+    ports:
+      - "3000:3000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - DD_AGENT_SECRET=pick-a-long-random-string
+      - DD_WATCHER_LOCAL_SOCKET=/var/run/docker.sock
+      - DD_REGISTRY_GITEA_PRIVATE_URL=https://git.example.com
+      - DD_REGISTRY_GITEA_PRIVATE_LOGIN=john
+      - DD_REGISTRY_GITEA_PRIVATE_PASSWORD=doe
+```
+
+**Controller**: needs the same registry so the container's registry link resolves:
+
+```yaml
+services:
+  drydock:
+    image: codeswhat/drydock
+    ports:
+      - "3000:3000"
+    environment:
+      - DD_AGENT_REMOTE1_HOST=192.168.1.50
+      - DD_AGENT_REMOTE1_SECRET=pick-a-long-random-string   # must match the agent's DD_AGENT_SECRET
+      - DD_AGENT_ALLOW_INSECURE_SECRET=true                 # plain-HTTP LAN only; see note above
+      - DD_REGISTRY_GITEA_PRIVATE_URL=https://git.example.com
+      - DD_REGISTRY_GITEA_PRIVATE_LOGIN=john
+      - DD_REGISTRY_GITEA_PRIVATE_PASSWORD=doe
+```
+
+See the [Gitea registry](/docs/configuration/registries/gitea) page for the full variable list, including `AUTH`, `CAFILE`, `INSECURE`, and mTLS options.
+
 ## Reliability notes
 
 ### Transient enumeration failures

--- a/content/docs/current/configuration/watchers/index.mdx
+++ b/content/docs/current/configuration/watchers/index.mdx
@@ -687,7 +687,19 @@ docker run \
 
 A maintenance window restricts **when drydock is allowed to act on its own**. Outside the window, scheduled checks are skipped and automatic updates are deferred until the window next opens. Detection is not lost: drydock queues one pending check and runs it as soon as the window opens.
 
+<Callout type="warn" title="The window gates the whole scheduled scan, not just installing an update">
+Today, `MAINTENANCE_WINDOW` gates the entire scheduled watcher cycle, container discovery and registry checks, not only the step that installs an update. A closed window means the watcher does not run at all on its schedule, with consequences beyond deferred updates:
+
+- **New containers don't show up.** A container created outside the window is invisible in the UI and API until the next window opens and the queued check runs.
+- **Container state goes stale.** The UI shows whatever the last scan saw. If a container was stopped during the last window and you stop or start it again outside the window, drydock's records don't reflect the change until the next scan, a container drydock still thinks is stopped, but that's actually running, will fail a **Start** action because Docker refuses to start a container that's already running.
+- **Update notifications are deferred too**, along with the update itself, since they fire from the same scan.
+
+Separating detection from the installation step, so discovery and registry checks keep running on schedule and only the actual install waits for the window, is planned but not shipped.
+</Callout>
+
 The window never applies to you. **Manual updates from the UI or API are not gated by it** — the container's Update action stays available at any hour. When you use it outside the window, the confirm dialog notes that the update is currently policy-blocked with _"Outside maintenance window — auto update deferred until the window opens"_ and the button reads **Update anyway**. That is a heads-up, not a refusal. See [Update Eligibility & Blockers](/docs/configuration/actions/update-eligibility#maintenance-window-closed-in-the-update-dialog).
+
+A manual scan is not gated. Triggering a scan from the UI, or calling `POST /api/v1/containers/watch` (all watchers) or `POST /api/v1/containers/{id}/watch` (a single container) directly, runs immediately regardless of the window, those calls go straight to the watcher's `watch()` method, which the maintenance-window check never sits in front of. Only the scheduled cron tick (and the queued catch-up it leaves behind) is gated.
 
 Only allow automatic updates between 2 AM and 4 AM in Europe/Berlin:
 

--- a/content/docs/current/configuration/watchers/index.mdx
+++ b/content/docs/current/configuration/watchers/index.mdx
@@ -699,7 +699,7 @@ Separating detection from the installation step, so discovery and registry check
 
 The window never applies to you. **Manual updates from the UI or API are not gated by it** — the container's Update action stays available at any hour. When you use it outside the window, the confirm dialog notes that the update is currently policy-blocked with _"Outside maintenance window — auto update deferred until the window opens"_ and the button reads **Update anyway**. That is a heads-up, not a refusal. See [Update Eligibility & Blockers](/docs/configuration/actions/update-eligibility#maintenance-window-closed-in-the-update-dialog).
 
-A manual scan is not gated. Triggering a scan from the UI, or calling `POST /api/v1/containers/watch` (all watchers) or `POST /api/v1/containers/{id}/watch` (a single container) directly, runs immediately regardless of the window, those calls go straight to the watcher's `watch()` method, which the maintenance-window check never sits in front of. Only the scheduled cron tick (and the queued catch-up it leaves behind) is gated.
+A manual recheck is not gated. The recheck-all action on the containers view, or calling `POST /api/v1/containers/watch` (all watchers) or `POST /api/v1/containers/{id}/watch` (a single container) directly, runs immediately regardless of the window. Those calls go straight to the watcher's `watch()` method, which the maintenance-window check never sits in front of. This is the watcher recheck, not the security **Scan now** action, which calls `/scan` and is unrelated to the window. Only the scheduled cron tick (and the queued catch-up it leaves behind) is gated.
 
 Only allow automatic updates between 2 AM and 4 AM in Europe/Berlin:
 


### PR DESCRIPTION
Two docs gaps from this week's reports, both on the current line.

#945: the agents page never said that a traditional agent does its own registry matching, so every `DD_REGISTRY_*` has to be configured on each agent, and that the controller still needs the same registry for the container's registry link to resolve. New "Registries on agents" section with a complete controller plus agent compose example using a Gitea registry.

Discussion #946: the watchers page said manual updates bypass the maintenance window but not that the window gates the entire scheduled scan. New callout spelling out the consequences (new containers invisible until the next window, stale container state and the failed start that follows from it, deferred notifications), that a manual scan from the UI or `POST /api/v1/containers/watch` is not gated (those go straight to `watch()`, which has no window check), and that splitting detection from installation is planned, not shipped. The split itself is being built on dev/v1.8.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

✨ Added:
- Documented registry configuration for traditional agents and the controller.
- Added a Gitea registry Docker Compose example.
- Documented that registry credentials are not sent from the controller to agents.
- Documented maintenance-window behavior for scheduled and manual watcher scans.
- Documented the planned separation of detection and installation for v1.8.

🔧 Changed:
- Clarified that maintenance windows gate detection, state updates, registry checks, and notifications.

- Confirm whether the documented v1.8 behavior matches the current roadmap.
- Verify that all `DD_REGISTRY_{provider}_{name}_*` variables in the Compose examples match the Gitea registry documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->