### PR TITLE
ci(release): verify base image indexes and platform binaries at the cut (1.6)

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -518,5 +518,7 @@ test('build job checks base image pins before building, for the platforms it smo
   // digest resolves the same for every --platform, so the arm64 stage builds
   // green on an amd64 rootfs (#1021). Both must cover the same platforms.
   expect(smokePlatforms).toBe('linux/amd64,linux/arm64');
-  expect(guard?.run).toBe(`scripts/check-dockerfile-base-indexes.sh Dockerfile ${smokePlatforms}`);
+  expect(guard?.with?.command).toBe(
+    `scripts/check-dockerfile-base-indexes.sh Dockerfile ${smokePlatforms}`,
+  );
 });

--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -496,3 +496,27 @@ test('load-test processor only exports Artillery hooks used by scenarios', () =>
 
   expect(processorSource).not.toContain('ensureContainerId');
 });
+
+test('build job checks base image pins before building, for the platforms it smoke-builds', () => {
+  const workflow = loadWorkflow();
+  const steps = workflow.jobs?.build?.steps ?? [];
+  const guardIndex = steps.findIndex(
+    (step) => step.name === 'Verify base image pins are multi-arch indexes',
+  );
+  const guard = steps[guardIndex];
+  const smokeBuild = getWorkflowStep('build', 'Docker build (multi-arch smoke)');
+  const smokePlatforms = /--platform ([^\s\\]+)/u.exec(String(smokeBuild?.with?.command))?.[1];
+
+  expect(guardIndex).toBeGreaterThan(-1);
+  expect(guardIndex).toBeLessThan(
+    steps.findIndex((step) => step.name === 'Docker build (QA image + smoke test)'),
+  );
+  expect(guardIndex).toBeLessThan(
+    steps.findIndex((step) => step.name === 'Docker build (multi-arch smoke)'),
+  );
+  // The smoke build cannot catch a per-platform manifest pin on its own: a
+  // digest resolves the same for every --platform, so the arm64 stage builds
+  // green on an amd64 rootfs (#1021). Both must cover the same platforms.
+  expect(smokePlatforms).toBe('linux/amd64,linux/arm64');
+  expect(guard?.run).toBe(`scripts/check-dockerfile-base-indexes.sh Dockerfile ${smokePlatforms}`);
+});

--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -505,7 +505,7 @@ test('build job checks base image pins before building, for the platforms it smo
   );
   const guard = steps[guardIndex];
   const smokeBuild = getWorkflowStep('build', 'Docker build (multi-arch smoke)');
-  const smokePlatforms = /--platform ([^\s\\]+)/u.exec(String(smokeBuild?.with?.command))?.[1];
+  const smokePlatforms = smokeBuild?.with?.platforms as string | undefined;
 
   expect(guardIndex).toBeGreaterThan(-1);
   expect(guardIndex).toBeLessThan(

--- a/.github/tests/release-cut-platform-guards.test.ts
+++ b/.github/tests/release-cut-platform-guards.test.ts
@@ -1,0 +1,81 @@
+import { statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { loadWorkflow, type WorkflowStep } from './workflow-test-utils';
+
+const workflowPath = fileURLToPath(new URL('../workflows/release-cut.yml', import.meta.url));
+const baseIndexScriptPath = fileURLToPath(
+  new URL('../../scripts/check-dockerfile-base-indexes.sh', import.meta.url),
+);
+const imageArchScriptPath = fileURLToPath(
+  new URL('../../scripts/check-image-arch.sh', import.meta.url),
+);
+
+function loadReleaseSteps(): WorkflowStep[] {
+  return loadWorkflow(workflowPath).jobs?.release?.steps ?? [];
+}
+
+function getStep(name: string): WorkflowStep | undefined {
+  return loadReleaseSteps().find((step) => step.name === name);
+}
+
+function indexOf(name: string): number {
+  return loadReleaseSteps().findIndex((step) => step.name === name);
+}
+
+test('release-cut checks base image pins against the platforms it builds for', () => {
+  const step = getStep('Verify base image pins are multi-arch indexes');
+
+  expect(loadWorkflow(workflowPath).env?.DOCKER_PLATFORMS).toBe('linux/amd64,linux/arm64');
+  // GA promotes an existing digest instead of building, so the Dockerfile it
+  // would check is not the one the promoted image came from.
+  expect(step?.if).toContain("steps.tag.outputs.is_prerelease == 'true'");
+  expect(step?.run).toContain('scripts/check-dockerfile-base-indexes.sh Dockerfile');
+  expect(step?.run).toContain('"${DOCKER_PLATFORMS}"');
+});
+
+test('release-cut checks base image pins before it builds anything', () => {
+  const guardIndex = indexOf('Verify base image pins are multi-arch indexes');
+
+  expect(guardIndex).toBeGreaterThan(-1);
+  expect(guardIndex).toBeLessThan(indexOf('Build and push staging image'));
+  expect(guardIndex).toBeLessThan(indexOf('Retry full build on total build failure'));
+});
+
+test('release-cut reads the shipped binaries of every platform it publishes', () => {
+  const step = getStep('Verify image binaries match their platform');
+
+  expect(step?.env).toMatchObject({
+    DIGEST: '${{ steps.digest.outputs.value }}',
+    TAGS: '${{ steps.image_refs.outputs.tags }}',
+  });
+  expect(step?.run).toContain('scripts/check-image-arch.sh "${image_ref}" "${platform}"');
+  expect(step?.run).toContain("${DOCKER_PLATFORMS//,/$'\\n'}");
+  expect(step?.run).toContain('"${tag}@${DIGEST}"');
+  // #1021 shipped x86-64 arm64 images for seven release candidates. A GA
+  // promotes an RC digest without rebuilding, so this guard has to run on the
+  // promotion path too or the broken digest walks straight through.
+  expect(step?.if).toBeUndefined();
+});
+
+test('release-cut verifies platform binaries after the build and before it publishes anything', () => {
+  const guardIndex = indexOf('Verify image binaries match their platform');
+
+  expect(guardIndex).toBeGreaterThan(indexOf('Build and push staging image'));
+  expect(guardIndex).toBeGreaterThan(indexOf('Retry full build on total build failure'));
+  expect(guardIndex).toBeGreaterThan(
+    indexOf('Retry manifest publish on transient registry failure'),
+  );
+  expect(guardIndex).toBeGreaterThan(indexOf('Resolve image digest'));
+  expect(guardIndex).toBeGreaterThan(indexOf('Resolve image source references'));
+  expect(guardIndex).toBeLessThan(indexOf('Sign container images'));
+  expect(guardIndex).toBeLessThan(indexOf('Publish release image tags'));
+  expect(guardIndex).toBeLessThan(indexOf('Push release tag'));
+  expect(guardIndex).toBeLessThan(indexOf('Publish GitHub Release'));
+});
+
+test('both platform guards are committed executable', () => {
+  for (const scriptPath of [baseIndexScriptPath, imageArchScriptPath]) {
+    expect(statSync(scriptPath).mode & 0o111).toBeGreaterThan(0);
+  }
+});

--- a/.github/tests/release-cut-platform-guards.test.ts
+++ b/.github/tests/release-cut-platform-guards.test.ts
@@ -39,7 +39,6 @@ test('release-cut checks base image pins before it builds anything', () => {
 
   expect(guardIndex).toBeGreaterThan(-1);
   expect(guardIndex).toBeLessThan(indexOf('Build and push staging image'));
-  expect(guardIndex).toBeLessThan(indexOf('Retry full build on total build failure'));
 });
 
 test('release-cut reads the shipped binaries of every platform it publishes', () => {

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -712,6 +712,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
 
+      # The multi-arch smoke build below cannot catch a base image pinned to a
+      # per-platform manifest digest: buildx resolves a digest identically for
+      # every --platform, so the arm64 stage builds green on an amd64 rootfs and
+      # the resulting image is x86-64 under an arm64 label (#1021). Check the
+      # pins on the PR that changes them.
+      - name: Verify base image pins are multi-arch indexes
+        run: scripts/check-dockerfile-base-indexes.sh Dockerfile linux/amd64,linux/arm64
+
       - name: Docker build (QA image + smoke test)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -718,7 +718,11 @@ jobs:
       # the resulting image is x86-64 under an arm64 label (#1021). Check the
       # pins on the PR that changes them.
       - name: Verify base image pins are multi-arch indexes
-        run: scripts/check-dockerfile-base-indexes.sh Dockerfile linux/amd64,linux/arm64
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          command: scripts/check-dockerfile-base-indexes.sh Dockerfile linux/amd64,linux/arm64
 
       - name: Docker build (QA image + smoke test)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -520,6 +520,16 @@ jobs:
             set -euo pipefail
             echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin
 
+      # A digest pin resolves to the same manifest for every --platform, so
+      # pinning a per-platform manifest instead of an image index builds the
+      # arm64 stage on an amd64 rootfs and nothing in the build, the manifest
+      # list, or the scans notices. That shipped x86-64 binaries under an arm64
+      # label in v1.7.0-rc.4 through rc.10 (#1021). Only prereleases build; GA
+      # promotes an already-verified RC digest.
+      - name: Verify base image pins are multi-arch indexes
+        if: steps.tag.outputs.is_prerelease == 'true'
+        run: scripts/check-dockerfile-base-indexes.sh Dockerfile "${DOCKER_PLATFORMS}"
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
@@ -675,6 +685,34 @@ jobs:
             fi
             echo 'DRYDOCK_IMAGE_REFS'
           } >> "$GITHUB_OUTPUT"
+
+      # The manifest list is not evidence: #1021's broken images listed both
+      # platforms and every digest in them was real. Read the ELF e_machine of
+      # the binaries that actually ship, per platform, before anything is
+      # signed, tagged, or promoted to a public tag.
+      - name: Verify image binaries match their platform
+        env:
+          DIGEST: ${{ steps.digest.outputs.value }}
+          TAGS: ${{ steps.image_refs.outputs.tags }}
+        run: |
+          set -euo pipefail
+          image_ref=""
+          while IFS= read -r tag; do
+            if [ -n "${tag}" ]; then
+              image_ref="${tag}@${DIGEST}"
+              break
+            fi
+          done <<< "${TAGS}"
+
+          if [ -z "${image_ref}" ]; then
+            echo "::error::No image reference available to verify platform binaries."
+            exit 1
+          fi
+
+          while IFS= read -r platform; do
+            [ -n "${platform}" ] || continue
+            scripts/check-image-arch.sh "${image_ref}" "${platform}"
+          done <<< "${DOCKER_PLATFORMS//,/$'\n'}"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The release cut now verifies a base image pin is a multi-platform index before building, and checks the published arm64 and amd64 images' own binaries before signing and tagging them.** The v1.7 line shipped an arm64 image that was actually amd64 wearing an arm64 label, because a base image digest pin named a single-platform manifest instead of the multi-arch index, and buildx resolved that digest the same way for every `--platform` ([#1021](https://github.com/CodesWhat/drydock/issues/1021)). The 1.6 line was never affected — its `node:24-alpine` and `alpine:3.24` pins were never rolled to the bad digests — but the release cut now runs `check-dockerfile-base-indexes.sh` against the Dockerfile's `FROM` pins and `check-image-arch.sh` against each published platform's `/sbin/tini`, `/usr/local/bin/node` and `/bin/healthcheck` before promoting, so the same class of bug can't ship silently again.
+
 ### Fixed
 
 - **`watch()` still pruned on an empty container list, the same gap the rc.7 fix closed for `handleWatcherSnapshotEvent()` but never actually closed here.** The rc.7 CHANGELOG entry claimed `watch()` was already among the guarded entry points; it wasn't. It ran `processAuthoritativeContainers()` first and then `pruneOldContainers()` unconditionally, so a manual recheck of a watcher that came back with zero containers — the same ambiguous-empty-list case as the other three entry points — pruned every container that watcher owns, deleting them without `replacementExpected` and losing whatever update policy override they had with nothing left to restore it from. `watch()` now builds the container list first, prunes it before ingest (so a same-identity replacement's stashed update policy exists for `insertContainer()` to restore), and skips the prune entirely on an empty list, warning instead once the agent has connected before. Ported from the v1.7 line ([#922](https://github.com/CodesWhat/drydock/pull/922)). ([#565](https://github.com/CodesWhat/drydock/issues/565))

--- a/scripts/check-dockerfile-base-indexes.sh
+++ b/scripts/check-dockerfile-base-indexes.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Fail unless every digest-pinned FROM in a Dockerfile resolves to a
+# multi-platform image index covering every platform we ship.
+#
+# Why this exists: buildx resolves a digest pin identically for every
+# --platform value, because the digest already names one manifest. Pin a
+# per-platform manifest (application/vnd.oci.image.manifest.v1+json) and the
+# arm64 stage builds on an amd64 rootfs with no error anywhere, producing an
+# x86-64 image under an arm64 label. That is drydock#1021: v1.7.0-rc.4 through
+# rc.10 shipped x86-64 /sbin/tini, node and healthcheck binaries on arm64.
+#
+# Usage: scripts/check-dockerfile-base-indexes.sh <Dockerfile> <platforms-csv>
+#   scripts/check-dockerfile-base-indexes.sh Dockerfile linux/amd64,linux/arm64
+set -euo pipefail
+
+dockerfile="${1:-}"
+platforms_csv="${2:-}"
+
+if [ -z "${dockerfile}" ] || [ -z "${platforms_csv}" ]; then
+	echo "Usage: $0 <Dockerfile> <platforms-csv>" >&2
+	exit 2
+fi
+
+if [ ! -f "${dockerfile}" ]; then
+	echo "::error::Dockerfile not found: ${dockerfile}" >&2
+	exit 2
+fi
+
+# linux/arm64/v8 and linux/arm64 are the same platform for this check: the
+# variant only ever narrows an architecture, so comparing os/arch is what
+# decides whether a stage can build natively.
+normalize_platform() {
+	local value="$1"
+	local os="${value%%/*}"
+	local rest="${value#*/}"
+	local arch="${rest%%/*}"
+	printf '%s/%s\n' "${os}" "${arch}"
+}
+
+required_platforms=()
+while IFS= read -r platform; do
+	if [ -n "${platform}" ]; then
+		required_platforms+=("$(normalize_platform "${platform}")")
+	fi
+done <<<"${platforms_csv//,/$'\n'}"
+
+if [ "${#required_platforms[@]}" -eq 0 ]; then
+	echo "::error::No platforms given; expected a csv such as linux/amd64,linux/arm64" >&2
+	exit 2
+fi
+
+# FROM [--flag=value ...] <ref>@sha256:<64 hex> [AS <stage>]
+from_pattern='^[[:space:]]*[Ff][Rr][Oo][Mm][[:space:]]+(--[^[:space:]]+[[:space:]]+)*([^[:space:]]+@sha256:[0-9a-f]{64})([[:space:]]|$)'
+
+pinned_refs=()
+while IFS= read -r line || [ -n "${line}" ]; do
+	if [[ ${line} =~ ${from_pattern} ]]; then
+		ref="${BASH_REMATCH[2]}"
+		already_seen=false
+		for seen in ${pinned_refs[@]+"${pinned_refs[@]}"}; do
+			if [ "${seen}" = "${ref}" ]; then
+				already_seen=true
+				break
+			fi
+		done
+		if [ "${already_seen}" = false ]; then
+			pinned_refs+=("${ref}")
+		fi
+	fi
+done <"${dockerfile}"
+
+if [ "${#pinned_refs[@]}" -eq 0 ]; then
+	echo "::error::${dockerfile} has no digest-pinned FROM instructions; base images must be pinned to an image index digest."
+	exit 1
+fi
+
+echo "Checking ${#pinned_refs[@]} digest-pinned base image(s) in ${dockerfile} for ${required_platforms[*]}"
+
+failures=0
+
+for ref in "${pinned_refs[@]}"; do
+	# inspect legitimately fails on a deleted digest or a registry outage, so
+	# capture it rather than letting set -e abort with no explanation.
+	raw=""
+	if ! raw="$(docker buildx imagetools inspect --raw "${ref}" 2>&1)"; then
+		echo "::error::${ref}: could not inspect the manifest: ${raw}"
+		failures=$((failures + 1))
+		continue
+	fi
+
+	media_type=""
+	if ! media_type="$(printf '%s' "${raw}" | jq -r '.mediaType // ""')"; then
+		echo "::error::${ref}: manifest is not valid JSON."
+		failures=$((failures + 1))
+		continue
+	fi
+
+	# mediaType is optional in the OCI image spec, so the presence of a
+	# manifests array is the structural test and mediaType is the declared one.
+	is_index="$(printf '%s' "${raw}" | jq -r 'if (.manifests | type) == "array" then "true" else "false" end')"
+
+	case "${media_type}" in
+	application/vnd.oci.image.index.v1+json | application/vnd.docker.distribution.manifest.list.v2+json) ;;
+	"") ;;
+	*)
+		echo "::error::${ref}: pinned to a single-platform manifest (mediaType ${media_type}). Pin the image index digest instead. See drydock#1021."
+		failures=$((failures + 1))
+		continue
+		;;
+	esac
+
+	if [ "${is_index}" != "true" ]; then
+		echo "::error::${ref}: manifest carries no platform list, so it is a single-platform image. Pin the image index digest instead. See drydock#1021."
+		failures=$((failures + 1))
+		continue
+	fi
+
+	# unknown/unknown entries are attestation manifests, not platforms.
+	available="$(printf '%s' "${raw}" | jq -r '
+        [ .manifests[]?
+          | select(.platform != null)
+          | "\(.platform.os)/\(.platform.architecture)"
+          | select(. != "unknown/unknown")
+        ] | unique | .[]
+    ')"
+
+	missing=()
+	for platform in "${required_platforms[@]}"; do
+		found=false
+		while IFS= read -r candidate; do
+			if [ "${candidate}" = "${platform}" ]; then
+				found=true
+				break
+			fi
+		done <<<"${available}"
+		if [ "${found}" = false ]; then
+			missing+=("${platform}")
+		fi
+	done
+
+	if [ "${#missing[@]}" -gt 0 ]; then
+		echo "::error::${ref}: image index is missing ${missing[*]} (has: $(echo "${available}" | tr '\n' ' '))."
+		failures=$((failures + 1))
+		continue
+	fi
+
+	echo "ok: ${ref} is an image index covering ${required_platforms[*]}"
+done
+
+if [ "${failures}" -gt 0 ]; then
+	echo "::error::${failures} base image pin(s) in ${dockerfile} are not multi-platform image indexes."
+	exit 1
+fi
+
+echo "All base image pins in ${dockerfile} are image indexes covering ${required_platforms[*]}."

--- a/scripts/check-dockerfile-base-indexes.sh
+++ b/scripts/check-dockerfile-base-indexes.sh
@@ -52,8 +52,50 @@ fi
 # FROM [--flag=value ...] <ref>@sha256:<64 hex> [AS <stage>]
 from_pattern='^[[:space:]]*[Ff][Rr][Oo][Mm][[:space:]]+(--[^[:space:]]+[[:space:]]+)*([^[:space:]]+@sha256:[0-9a-f]{64})([[:space:]]|$)'
 
-pinned_refs=()
+# A Dockerfile instruction can span physical lines: a line ending in the
+# escape character continues on the next one, and comment lines inside the
+# continuation are dropped. Matching physical lines would let a pin written as
+# `FROM --platform=... \` + `<ref>` slip past the guard, so fold each logical
+# instruction first. The escape character defaults to backslash and can be
+# changed by a `# escape=` parser directive, which is only honoured before the
+# first instruction, comment or blank line.
+escape_char=$'\\'
+directive_pattern='^#[[:space:]]*[Ee][Ss][Cc][Aa][Pp][Ee][[:space:]]*=[[:space:]]*(.)[[:space:]]*$'
+logical_lines=()
+current=""
+directives_allowed=true
 while IFS= read -r line || [ -n "${line}" ]; do
+	line="${line%$'\r'}"
+	if [ "${directives_allowed}" = true ]; then
+		if [[ ${line} =~ ${directive_pattern} ]]; then
+			escape_char="${BASH_REMATCH[1]}"
+			continue
+		fi
+		directives_allowed=false
+	fi
+	if [[ ${line} =~ ^[[:space:]]*# ]]; then
+		continue
+	fi
+	# BuildKit warns on an empty continuation line and keeps folding, so a
+	# blank line never terminates an instruction here either.
+	if [[ ${line} =~ ^[[:space:]]*$ ]]; then
+		continue
+	fi
+	stripped="${line%"${line##*[![:space:]]}"}"
+	if [ "${stripped: -1}" = "${escape_char}" ]; then
+		current+="${stripped:0:${#stripped}-1} "
+		continue
+	fi
+	current+="${line}"
+	logical_lines+=("${current}")
+	current=""
+done <"${dockerfile}"
+if [ -n "${current}" ]; then
+	logical_lines+=("${current}")
+fi
+
+pinned_refs=()
+for line in ${logical_lines[@]+"${logical_lines[@]}"}; do
 	if [[ ${line} =~ ${from_pattern} ]]; then
 		ref="${BASH_REMATCH[2]}"
 		already_seen=false
@@ -67,7 +109,7 @@ while IFS= read -r line || [ -n "${line}" ]; do
 			pinned_refs+=("${ref}")
 		fi
 	fi
-done <"${dockerfile}"
+done
 
 if [ "${#pinned_refs[@]}" -eq 0 ]; then
 	echo "::error::${dockerfile} has no digest-pinned FROM instructions; base images must be pinned to an image index digest."

--- a/scripts/check-dockerfile-base-indexes.test.mjs
+++ b/scripts/check-dockerfile-base-indexes.test.mjs
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const scriptPath = fileURLToPath(new URL('check-dockerfile-base-indexes.sh', import.meta.url));
+
+const OCI_INDEX = 'application/vnd.oci.image.index.v1+json';
+const DOCKER_LIST = 'application/vnd.docker.distribution.manifest.list.v2+json';
+const OCI_MANIFEST = 'application/vnd.oci.image.manifest.v1+json';
+
+const NODE_REF =
+  'node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf';
+const ALPINE_REF =
+  'alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b';
+
+function fixtureKey(ref) {
+  return ref.replaceAll(/[^A-Za-z0-9]/gu, '_');
+}
+
+function index(platforms, mediaType = OCI_INDEX) {
+  const manifests = platforms.map((platform) => {
+    const [os, architecture, variant] = platform.split('/');
+    return {
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      digest: `sha256:${'0'.repeat(64)}`,
+      platform: variant ? { os, architecture, variant } : { os, architecture },
+    };
+  });
+  return mediaType === null ? { manifests } : { mediaType, manifests };
+}
+
+function singlePlatformManifest() {
+  return {
+    mediaType: OCI_MANIFEST,
+    config: { mediaType: 'application/vnd.oci.image.config.v1+json' },
+    layers: [],
+  };
+}
+
+/**
+ * Runs the guard against a throwaway Dockerfile with a fake `docker` first on
+ * PATH, so the parsing and platform-matching logic is exercised with no network.
+ */
+async function runGuard({
+  dockerfile,
+  manifests = {},
+  platforms = 'linux/amd64,linux/arm64',
+  args,
+} = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'drydock-base-index-'));
+  const fixtureDir = join(dir, 'fixtures');
+  const dockerfilePath = join(dir, 'Dockerfile');
+
+  await writeFile(dockerfilePath, dockerfile ?? '');
+  await mkdir(fixtureDir, { recursive: true });
+  for (const [ref, manifest] of Object.entries(manifests)) {
+    await writeFile(join(fixtureDir, fixtureKey(ref)), JSON.stringify(manifest));
+  }
+
+  const fakeDocker = join(dir, 'docker');
+  await writeFile(
+    fakeDocker,
+    `#!/bin/sh
+# docker buildx imagetools inspect --raw <ref>
+ref="$5"
+key="$(printf '%s' "$ref" | tr -c 'A-Za-z0-9' '_')"
+if [ -f "$DOCKER_FIXTURE_DIR/$key" ]; then
+  cat "$DOCKER_FIXTURE_DIR/$key"
+  exit 0
+fi
+echo "ERROR: manifest unknown: $ref" >&2
+exit 1
+`,
+  );
+  await chmod(fakeDocker, 0o755);
+
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      'bash',
+      [scriptPath, ...(args ?? [dockerfilePath, platforms])],
+      {
+        env: {
+          ...process.env,
+          DOCKER_FIXTURE_DIR: fixtureDir,
+          PATH: `${dir}:${process.env.PATH}`,
+        },
+      },
+    );
+    return { code: 0, output: `${stdout}${stderr}` };
+  } catch (error) {
+    return { code: error.code, output: `${error.stdout ?? ''}${error.stderr ?? ''}` };
+  }
+}
+
+test('passes when every pinned base image is an index covering both platforms', async () => {
+  const result = await runGuard({
+    dockerfile: `FROM ${NODE_REF} AS base\nFROM base AS app-build\nFROM ${ALPINE_REF} AS healthcheck-build\n`,
+    manifests: {
+      [NODE_REF]: index(['linux/amd64', 'linux/arm64']),
+      [ALPINE_REF]: index(['linux/amd64', 'linux/arm64']),
+    },
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /ok: node:24-alpine@sha256:e67514e5/u);
+  assert.match(result.output, /All base image pins/u);
+});
+
+test('rejects a per-platform manifest pin, the drydock#1021 shape', async () => {
+  const result = await runGuard({
+    dockerfile: `FROM ${NODE_REF} AS base\n`,
+    manifests: { [NODE_REF]: singlePlatformManifest() },
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /pinned to a single-platform manifest/u);
+  assert.match(result.output, /drydock#1021/u);
+});
+
+test('rejects an index that is missing a required platform', async () => {
+  const result = await runGuard({
+    dockerfile: `FROM ${NODE_REF} AS base\n`,
+    manifests: { [NODE_REF]: index(['linux/amd64', 'linux/s390x']) },
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /missing linux\/arm64/u);
+  assert.match(result.output, /has: linux\/amd64 linux\/s390x/u);
+});
+
+test('ignores unknown/unknown attestation entries and arch variants', async () => {
+  const result = await runGuard({
+    dockerfile: `FROM ${NODE_REF} AS base\n`,
+    manifests: {
+      [NODE_REF]: index(['linux/amd64', 'unknown/unknown', 'linux/arm64/v8', 'unknown/unknown']),
+    },
+  });
+
+  assert.equal(result.code, 0);
+});
+
+test('normalizes variants in the requested platform list too', async () => {
+  const result = await runGuard({
+    dockerfile: `FROM ${NODE_REF} AS base\n`,
+    manifests: { [NODE_REF]: index(['linux/amd64', 'linux/arm64']) },
+    platforms: 'linux/amd64,linux/arm64/v8',
+  });
+
+  assert.equal(result.code, 0);
+});
+
+test('accepts a docker manifest list and an index with no declared mediaType', async () => {
+  const listResult = await runGuard({
+    dockerfile: `FROM ${NODE_REF} AS base\n`,
+    manifests: { [NODE_REF]: index(['linux/amd64', 'linux/arm64'], DOCKER_LIST) },
+  });
+  const untypedResult = await runGuard({
+    dockerfile: `FROM ${NODE_REF} AS base\n`,
+    manifests: { [NODE_REF]: index(['linux/amd64', 'linux/arm64'], null) },
+  });
+
+  assert.equal(listResult.code, 0);
+  assert.equal(untypedResult.code, 0);
+});
+
+test('reads through FROM flags and skips stage-name FROM lines', async () => {
+  const result = await runGuard({
+    dockerfile: [
+      '# comment',
+      `FROM --platform=$BUILDPLATFORM ${NODE_REF} AS base`,
+      'FROM base AS app-build',
+      'FROM scratch',
+      '',
+    ].join('\n'),
+    manifests: { [NODE_REF]: index(['linux/amd64', 'linux/arm64']) },
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /Checking 1 digest-pinned base image/u);
+});
+
+test('inspects each distinct ref once', async () => {
+  const result = await runGuard({
+    dockerfile: `FROM ${NODE_REF} AS base\nFROM ${NODE_REF} AS second\n`,
+    manifests: { [NODE_REF]: index(['linux/amd64', 'linux/arm64']) },
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /Checking 1 digest-pinned base image/u);
+});
+
+test('fails when the Dockerfile pins nothing by digest', async () => {
+  const result = await runGuard({ dockerfile: 'FROM node:24-alpine AS base\n' });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /no digest-pinned FROM instructions/u);
+});
+
+test('fails loudly when the manifest cannot be inspected', async () => {
+  const result = await runGuard({ dockerfile: `FROM ${NODE_REF} AS base\n` });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /could not inspect the manifest/u);
+});
+
+test('exits 2 on a usage error', async () => {
+  const missingArgs = await runGuard({ dockerfile: 'FROM scratch\n', args: [] });
+  const missingFile = await runGuard({
+    dockerfile: 'FROM scratch\n',
+    args: ['/nonexistent/Dockerfile', 'linux/amd64'],
+  });
+
+  assert.equal(missingArgs.code, 2);
+  assert.match(missingArgs.output, /Usage:/u);
+  assert.equal(missingFile.code, 2);
+  assert.match(missingFile.output, /Dockerfile not found/u);
+});

--- a/scripts/check-dockerfile-base-indexes.test.mjs
+++ b/scripts/check-dockerfile-base-indexes.test.mjs
@@ -185,6 +185,83 @@ test('reads through FROM flags and skips stage-name FROM lines', async () => {
   assert.match(result.output, /Checking 1 digest-pinned base image/u);
 });
 
+test('folds a backslash-continued FROM before matching', async () => {
+  // A pin written as `FROM --platform=... \` + `<ref>` is one logical
+  // instruction. Matching physical lines skipped it, so a single-platform pin
+  // on the continued line passed as long as some other FROM was an index.
+  const result = await runGuard({
+    dockerfile: [
+      'FROM --platform=$TARGETPLATFORM \\',
+      `  ${NODE_REF} AS base`,
+      'FROM --platform=$TARGETPLATFORM \\',
+      '  # a comment inside the continuation is dropped, not a terminator',
+      '',
+      `  ${ALPINE_REF} AS healthcheck-build`,
+      'FROM base AS app-build',
+      '',
+    ].join('\n'),
+    manifests: {
+      [NODE_REF]: index(['linux/amd64', 'linux/arm64']),
+      [ALPINE_REF]: singlePlatformManifest(),
+    },
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /Checking 2 digest-pinned base image/u);
+  assert.match(
+    result.output,
+    /alpine:3\.24@sha256:[0-9a-f]+: pinned to a single-platform manifest/u,
+  );
+});
+
+test('honours the escape parser directive and CRLF line endings', async () => {
+  const result = await runGuard({
+    dockerfile: [
+      '# escape=`',
+      'FROM --platform=$TARGETPLATFORM `',
+      `  ${NODE_REF} AS base`,
+      'FROM --platform=$TARGETPLATFORM \\',
+      `  ${ALPINE_REF} AS healthcheck-build`,
+      '',
+    ].join('\r\n'),
+    manifests: { [NODE_REF]: index(['linux/amd64', 'linux/arm64']) },
+  });
+
+  // With backtick as the escape, the backslash line is a complete instruction
+  // whose ref is `\`, so only the folded node pin is checked.
+  assert.equal(result.code, 0);
+  assert.match(result.output, /Checking 1 digest-pinned base image/u);
+});
+
+test('ignores an escape directive that comes after the first instruction', async () => {
+  const result = await runGuard({
+    dockerfile: [
+      `FROM ${NODE_REF} AS base`,
+      '# escape=`',
+      'FROM --platform=$TARGETPLATFORM \\',
+      `  ${ALPINE_REF} AS healthcheck-build`,
+      '',
+    ].join('\n'),
+    manifests: {
+      [NODE_REF]: index(['linux/amd64', 'linux/arm64']),
+      [ALPINE_REF]: index(['linux/amd64', 'linux/arm64']),
+    },
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /Checking 2 digest-pinned base image/u);
+});
+
+test('keeps a continuation that ends the file', async () => {
+  const result = await runGuard({
+    dockerfile: `FROM --platform=$TARGETPLATFORM \\\n  ${NODE_REF}`,
+    manifests: { [NODE_REF]: index(['linux/amd64', 'linux/arm64']) },
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /Checking 1 digest-pinned base image/u);
+});
+
 test('inspects each distinct ref once', async () => {
   const result = await runGuard({
     dockerfile: `FROM ${NODE_REF} AS base\nFROM ${NODE_REF} AS second\n`,

--- a/scripts/check-image-arch.sh
+++ b/scripts/check-image-arch.sh
@@ -74,7 +74,7 @@ trap 'rm -f "${docker_stderr}"' EXIT
 # A pull failure or a missing emulator is a legitimate non-zero here, so keep
 # the output instead of letting set -e abort with nothing to read.
 output=""
-if ! output="$(docker run --rm --platform "${platform}" --entrypoint sh "${image_ref}" -c "${probe}" 2>"${docker_stderr}")"; then
+if ! output="$(docker run --rm --pull always --platform "${platform}" --entrypoint sh "${image_ref}" -c "${probe}" 2>"${docker_stderr}")"; then
 	echo "::error::Could not read ${image_ref} as ${platform}: $(cat "${docker_stderr}")"
 	exit 1
 fi

--- a/scripts/check-image-arch.sh
+++ b/scripts/check-image-arch.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Fail unless the binaries inside a built image are actually compiled for the
+# platform the image claims. Reads the ELF e_machine field (2 bytes at offset
+# 18, little-endian) straight out of the shipped binaries.
+#
+# Why this exists: a mislabelled base image pin produces an image whose index
+# entry says linux/arm64 while every binary in it is x86-64, and nothing in a
+# build, scan, or manifest check notices. Users find out with
+# "exec /sbin/tini: exec format error" on first start. That is drydock#1021.
+#
+# Usage: scripts/check-image-arch.sh <image-ref> <platform>
+#   scripts/check-image-arch.sh drydock:dev linux/arm64
+set -euo pipefail
+
+image_ref="${1:-}"
+platform="${2:-}"
+
+if [ -z "${image_ref}" ] || [ -z "${platform}" ]; then
+	echo "Usage: $0 <image-ref> <platform>" >&2
+	exit 2
+fi
+
+# Only the platforms drydock publishes. Anything else needs its own e_machine
+# value (and, for s390x or ppc64, the opposite byte order), so guess nothing.
+case "${platform}" in
+linux/amd64 | linux/amd64/*)
+	expected="3e 00"
+	expected_arch="x86-64"
+	;;
+linux/arm64 | linux/arm64/*)
+	expected="b7 00"
+	expected_arch="aarch64"
+	;;
+*)
+	echo "::error::Unsupported platform ${platform}. Add its ELF e_machine bytes to $0 before building for it."
+	exit 2
+	;;
+esac
+
+binaries=(/sbin/tini /usr/local/bin/node /bin/healthcheck)
+
+# busybox od is present in every alpine-based stage; -j18 -N2 -tx1 prints the
+# two e_machine bytes and nothing else. Only the paths interpolate here: the
+# rest of the probe must reach the container's sh unexpanded.
+# shellcheck disable=SC2016
+probe="set -- ${binaries[*]}"'
+for f in "$@"; do
+  if [ -r "$f" ]; then
+    printf "%s%s\n" "$f" "$(od -An -tx1 -j18 -N2 "$f")"
+  else
+    printf "%s MISSING MISSING\n" "$f"
+  fi
+done'
+
+is_expected_binary() {
+	local candidate="$1"
+	local known
+	for known in "${binaries[@]}"; do
+		if [ "${known}" = "${candidate}" ]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+echo "Checking ${image_ref} (${platform}) for ${expected_arch} binaries, e_machine ${expected}"
+
+# stderr has to stay out of the parsed output: docker writes pull progress
+# there, and on a runner that has never seen the image that is 30 lines of
+# "Pulling fs layer" ahead of the probe's three.
+docker_stderr="$(mktemp)"
+trap 'rm -f "${docker_stderr}"' EXIT
+
+# A pull failure or a missing emulator is a legitimate non-zero here, so keep
+# the output instead of letting set -e abort with nothing to read.
+output=""
+if ! output="$(docker run --rm --platform "${platform}" --entrypoint sh "${image_ref}" -c "${probe}" 2>"${docker_stderr}")"; then
+	echo "::error::Could not read ${image_ref} as ${platform}: $(cat "${docker_stderr}")"
+	exit 1
+fi
+
+failures=0
+checked=0
+
+while IFS= read -r line; do
+	[ -n "${line}" ] || continue
+	path=""
+	byte_low=""
+	byte_high=""
+	read -r path byte_low byte_high <<<"${line}"
+	# Anything the image writes to stdout that is not one of the probed paths
+	# is not evidence either way, so it cannot be allowed to move the count.
+	if ! is_expected_binary "${path}"; then
+		continue
+	fi
+	if [ -z "${byte_low}" ] || [ -z "${byte_high}" ]; then
+		echo "::error::Unreadable probe output for ${image_ref} (${platform}): ${line}"
+		failures=$((failures + 1))
+		continue
+	fi
+	checked=$((checked + 1))
+	actual="${byte_low} ${byte_high}"
+	if [ "${actual}" = "MISSING MISSING" ]; then
+		echo "::error::${platform} ${image_ref}: ${path} is missing from the image."
+		failures=$((failures + 1))
+		continue
+	fi
+	if [ "${actual}" = "${expected}" ]; then
+		echo "ok: ${platform} ${path} e_machine=${actual} (${expected_arch})"
+	else
+		echo "::error::${platform} ${image_ref}: ${path} has e_machine=${actual}, expected ${expected} (${expected_arch}). The image is labelled ${platform} but was built from another architecture. See drydock#1021."
+		failures=$((failures + 1))
+	fi
+done <<<"${output}"
+
+if [ "${checked}" -ne "${#binaries[@]}" ]; then
+	echo "::error::Expected ${#binaries[@]} binaries in ${image_ref} (${platform}), read ${checked}. Probe output: ${output}"
+	exit 1
+fi
+
+if [ "${failures}" -gt 0 ]; then
+	echo "::error::${image_ref} is not a ${platform} image: ${failures} of ${#binaries[@]} binaries have the wrong architecture."
+	exit 1
+fi
+
+echo "All ${#binaries[@]} binaries in ${image_ref} are ${expected_arch} (${platform})."

--- a/scripts/check-image-arch.test.mjs
+++ b/scripts/check-image-arch.test.mjs
@@ -170,7 +170,7 @@ test('probes the image with the platform, an sh entrypoint, and od at offset 18'
   assert.equal(result.code, 0);
   assert.match(
     result.dockerArgs,
-    /^run --rm --platform linux\/arm64 --entrypoint sh drydock:test -c/u,
+    /^run --rm --pull always --platform linux\/arm64 --entrypoint sh drydock:test -c/u,
   );
   assert.match(result.dockerArgs, /od -An -tx1 -j18 -N2/u);
   for (const path of BINARIES) {

--- a/scripts/check-image-arch.test.mjs
+++ b/scripts/check-image-arch.test.mjs
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { chmod, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const scriptPath = fileURLToPath(new URL('check-image-arch.sh', import.meta.url));
+
+const ARM64 = 'b7 00';
+const AMD64 = '3e 00';
+const BINARIES = ['/sbin/tini', '/usr/local/bin/node', '/bin/healthcheck'];
+
+function probeLines(bytesByBinary) {
+  // busybox `od -An` prefixes its output with a space, so the real probe emits
+  // "<path> <b0> <b1>" with runs of whitespace the caller has to collapse.
+  return BINARIES.map((path) => `${path}  ${bytesByBinary[path]}`).join('\n');
+}
+
+function allBinaries(bytes) {
+  return probeLines(Object.fromEntries(BINARIES.map((path) => [path, bytes])));
+}
+
+/**
+ * Runs the guard with a fake `docker` first on PATH that replays canned probe
+ * output, so the ELF byte comparison is exercised without building an image.
+ */
+async function runGuard({
+  probeOutput = allBinaries(ARM64),
+  dockerExit = 0,
+  dockerStderr = '',
+  args = ['drydock:test', 'linux/arm64'],
+} = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'drydock-image-arch-'));
+  const probeFile = join(dir, 'probe-output');
+  const argsLog = join(dir, 'docker-args.log');
+  await writeFile(probeFile, probeOutput === '' ? '' : `${probeOutput}\n`);
+
+  const fakeDocker = join(dir, 'docker');
+  await writeFile(
+    fakeDocker,
+    `#!/bin/sh
+printf '%s\\n' "$*" > "$DOCKER_ARGS_LOG"
+if [ -n "$DOCKER_STDERR" ]; then
+  printf '%s\\n' "$DOCKER_STDERR" >&2
+fi
+if [ "$DOCKER_EXIT" != "0" ]; then
+  exit "$DOCKER_EXIT"
+fi
+cat "$PROBE_OUTPUT_FILE"
+`,
+  );
+  await chmod(fakeDocker, 0o755);
+
+  const env = {
+    ...process.env,
+    DOCKER_ARGS_LOG: argsLog,
+    DOCKER_EXIT: String(dockerExit),
+    DOCKER_STDERR: dockerStderr,
+    PROBE_OUTPUT_FILE: probeFile,
+    PATH: `${dir}:${process.env.PATH}`,
+  };
+
+  const readArgs = async () => {
+    try {
+      return await readFile(argsLog, 'utf8');
+    } catch {
+      return '';
+    }
+  };
+
+  try {
+    const { stdout, stderr } = await execFileAsync('bash', [scriptPath, ...args], { env });
+    return { code: 0, output: `${stdout}${stderr}`, dockerArgs: await readArgs() };
+  } catch (error) {
+    return {
+      code: error.code,
+      output: `${error.stdout ?? ''}${error.stderr ?? ''}`,
+      dockerArgs: await readArgs(),
+    };
+  }
+}
+
+test('passes when every binary is aarch64 on linux/arm64', async () => {
+  const result = await runGuard();
+
+  assert.equal(result.code, 0);
+  for (const path of BINARIES) {
+    assert.match(result.output, new RegExp(`ok: linux/arm64 ${path} e_machine=b7 00`, 'u'));
+  }
+  assert.match(result.output, /All 3 binaries/u);
+});
+
+test('passes when every binary is x86-64 on linux/amd64', async () => {
+  const result = await runGuard({
+    probeOutput: allBinaries(AMD64),
+    args: ['drydock:test', 'linux/amd64'],
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /All 3 binaries in drydock:test are x86-64/u);
+});
+
+test('fails when an arm64-labelled image holds x86-64 binaries, the drydock#1021 shape', async () => {
+  const result = await runGuard({ probeOutput: allBinaries(AMD64) });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /\/sbin\/tini has e_machine=3e 00, expected b7 00/u);
+  assert.match(result.output, /3 of 3 binaries have the wrong architecture/u);
+  assert.match(result.output, /drydock#1021/u);
+});
+
+test('fails when a single binary is the wrong architecture', async () => {
+  const result = await runGuard({
+    probeOutput: probeLines({
+      '/sbin/tini': ARM64,
+      '/usr/local/bin/node': AMD64,
+      '/bin/healthcheck': ARM64,
+    }),
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /1 of 3 binaries have the wrong architecture/u);
+});
+
+test('fails when a checked binary is absent from the image', async () => {
+  const result = await runGuard({
+    probeOutput: probeLines({
+      '/sbin/tini': ARM64,
+      '/usr/local/bin/node': ARM64,
+      '/bin/healthcheck': 'MISSING MISSING',
+    }),
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /\/bin\/healthcheck is missing from the image/u);
+});
+
+test('fails when the probe returns fewer binaries than expected', async () => {
+  const result = await runGuard({ probeOutput: `/sbin/tini  ${ARM64}` });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /Expected 3 binaries in drydock:test \(linux\/arm64\), read 1/u);
+});
+
+test('fails when the probe returns nothing at all', async () => {
+  const result = await runGuard({ probeOutput: '' });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /read 0/u);
+});
+
+test('surfaces the docker error when the image cannot be run for the platform', async () => {
+  const result = await runGuard({
+    dockerExit: 125,
+    dockerStderr: 'no matching manifest for linux/arm64',
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /Could not read drydock:test as linux\/arm64/u);
+  assert.match(result.output, /no matching manifest for linux\/arm64/u);
+});
+
+test('probes the image with the platform, an sh entrypoint, and od at offset 18', async () => {
+  const result = await runGuard();
+
+  assert.equal(result.code, 0);
+  assert.match(
+    result.dockerArgs,
+    /^run --rm --platform linux\/arm64 --entrypoint sh drydock:test -c/u,
+  );
+  assert.match(result.dockerArgs, /od -An -tx1 -j18 -N2/u);
+  for (const path of BINARIES) {
+    assert.ok(result.dockerArgs.includes(path));
+  }
+});
+
+test('accepts an explicit platform variant', async () => {
+  const result = await runGuard({ args: ['drydock:test', 'linux/arm64/v8'] });
+
+  assert.equal(result.code, 0);
+});
+
+test('refuses a platform whose e_machine value it does not know', async () => {
+  const result = await runGuard({ args: ['drydock:test', 'linux/s390x'] });
+
+  assert.equal(result.code, 2);
+  assert.match(result.output, /Unsupported platform linux\/s390x/u);
+});
+
+test('exits 2 on a usage error', async () => {
+  const result = await runGuard({ args: ['drydock:test'] });
+
+  assert.equal(result.code, 2);
+  assert.match(result.output, /Usage:/u);
+});
+
+test('ignores the pull progress docker writes to stderr', async () => {
+  // docker run reports "Pulling fs layer" and friends on stderr, and a release
+  // runner has never seen the image, so that is around 30 lines ahead of the
+  // probe's three. Folding stderr into the parsed output made every fresh
+  // runner report a bogus count.
+  const result = await runGuard({
+    dockerStderr: [
+      "Unable to find image 'drydock:test' locally",
+      'docker.io/codeswhat/drydock@sha256:abc: Pulling from codeswhat/drydock',
+      '7187e76a6f79: Pulling fs layer',
+      '17aac500c743: Pull complete',
+      'Status: Downloaded newer image for drydock:test',
+    ].join('\n'),
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /All 3 binaries/u);
+});
+
+test('ignores stdout lines that are not one of the probed binaries', async () => {
+  const result = await runGuard({
+    probeOutput: `WARNING: something noisy\n${allBinaries(ARM64)}\n/usr/bin/env  b7 00`,
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.output, /All 3 binaries/u);
+});
+
+test('reports a probe line that carries no e_machine bytes', async () => {
+  const result = await runGuard({
+    probeOutput: `/sbin/tini\n/usr/local/bin/node  ${ARM64}\n/bin/healthcheck  ${ARM64}`,
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /Unreadable probe output/u);
+});


### PR DESCRIPTION
Script-only backport of the DR-111 release guards from #1024 (dev/v1.7). release-cut.yml checks out `source_ref` for a maintenance cut and calls `scripts/check-dockerfile-base-indexes.sh` and `scripts/check-image-arch.sh` from that tree, so dev/v1.6 needs the scripts before its next cut or the cut fails on a missing file.

No Dockerfile change: 1.6's `node:24-alpine` and `alpine:3.24` pins are already image indexes (verified against the registry by the guard itself), and the arm64 bug in drydock#1021 never shipped on this line. The two ported workflow tests were adapted to 1.6's workflow shape (plain `docker/build-push-action`, no retry-wrapped buildx step) in a separate commit so the three cherry-picks stay identical to their 1.7 source.

Verified: guard passes on the 1.6 Dockerfile, 179 script tests, 97 workflow tests, biome and qlty clean.
