### PR TITLE
chore(release): prepare v1.6.1-rc.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1-rc.9] — 2026-09-05
+
 ### Changed
 
 - **The release cut now verifies a base image pin is a multi-platform index before building, and checks the published arm64 and amd64 images' own binaries before signing and tagging them.** The v1.7 line shipped an arm64 image that was actually amd64 wearing an arm64 label, because a base image digest pin named a single-platform manifest instead of the multi-arch index, and buildx resolved that digest the same way for every `--platform` ([#1021](https://github.com/CodesWhat/drydock/issues/1021)). The 1.6 line was never affected — its `node:24-alpine` and `alpine:3.24` pins were never rolled to the bad digests — but the release cut now runs `check-dockerfile-base-indexes.sh` against the Dockerfile's `FROM` pins and `check-image-arch.sh` against each published platform's `/sbin/tini`, `/usr/local/bin/node` and `/bin/healthcheck` before promoting, so the same class of bug can't ship silently again.
@@ -2485,7 +2487,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.8...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.9...HEAD
+[1.6.1-rc.9]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.8...v1.6.1-rc.9
 [1.6.1-rc.8]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.7...v1.6.1-rc.8
 [1.6.1-rc.7]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.6...v1.6.1-rc.7
 [1.6.1-rc.6]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.5...v1.6.1-rc.6

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.8-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.9-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,6 +179,20 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.6.1-rc.9 highlights</strong></summary>
+
+- **The release cut now catches an arm64 image that is actually amd64 wearing an arm64 label before it ships** — a base image digest pin naming a single-platform manifest instead of a multi-arch index let buildx resolve the same digest for every `--platform`, which is how that shipped on the v1.7 line ([#1021](https://github.com/CodesWhat/drydock/issues/1021)); the 1.6 line was never affected, but the release cut now checks the Dockerfile's base image pins and each published platform's own binaries before promoting. ([#1032](https://github.com/CodesWhat/drydock/pull/1032))
+- **A manual recheck of a watcher that came back with zero containers no longer wipes out every container it owns** — `watch()` pruned unconditionally before this fix, deleting containers without staging a replacement and losing whatever update policy override they had. It now prunes before ingest and skips the prune entirely on an empty list. ([#1015](https://github.com/CodesWhat/drydock/pull/1015))
+- **A recreated agent-owned container no longer loses its update policy on reconnect** — the handshake, watcher-snapshot and edge container-sync paths had the same insert-before-prune ordering `watch()` was fixed for above, so a snooze, a maturity mode or skipped tags silently reverted to the declarative default the moment the container's next report arrived. All three now prune first. ([#1036](https://github.com/CodesWhat/drydock/pull/1036))
+- **A connected agent can no longer take over or delete a container id owned by another agent or the controller's own watcher** — bulk and incremental container ingestion had no ownership check at all. The gate is keyed on the container ids the controller's own watchers have actually enumerated, not on watcher name, since the controller's default watcher and an agent's watcher are both routinely named `local` while watching different hosts. ([#1019](https://github.com/CodesWhat/drydock/pull/1019))
+- **A rollback of a compose-managed container no longer redeploys the update it was undoing** — the compose recreate wrote the backup image into the compose file but handed the runtime refresh no image at all, so the refresh re-derived one from the container's own update candidate and ran it. An automatic rollback after a failed healthcheck also never pulled the backup image it was rolling back to, and could leave the failing update running when that image was no longer on the host; both are fixed. ([#1027](https://github.com/CodesWhat/drydock/pull/1027))
+- **A container that moved to an agent no longer stays stranded, or loses its update policy, when the controller's local watcher is off or a watcher fails to register** — `DD_LOCAL_WATCHER=false` used to leave the controller's stale record in place forever, and the same startup prune now carries a snooze, maturity mode, or skipped tags across to the agent's copy instead of clearing them. A second watcher registering fine no longer causes a broken sibling watcher's records to be pruned as though it had been renamed away. ([#1036](https://github.com/CodesWhat/drydock/pull/1036))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc9--2026-09-05).
+
+</details>
+
+<details>
 <summary><strong>v1.6.1-rc.8 highlights</strong></summary>
 
 - **Overlapping scans no longer fire the same trigger repeatedly for one update** — a full scan can take minutes, and the cron schedule, the docker-events debounce and the startup timer could each start one while the previous was still running, so a tag first seen mid-burst passed the `once=true` history check in every overlapping scan before any of them recorded it. `watchFromCron()` is now single-flight: a request arriving during a scan records that a rescan is wanted, and exactly one follow-up runs once the current scan finishes. Reported by [@tarzan77cz](https://github.com/tarzan77cz). ([#972](https://github.com/CodesWhat/drydock/issues/972))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1-rc.8',
+    version: '1.6.1-rc.9',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1-rc.8 started',
+    details: 'Drydock v1.6.1-rc.9 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.8',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.9',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1-rc.8',
+    tag: '1.6.1-rc.9',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1-rc.8',
+  version: '1.6.1-rc.9',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1-rc.8',
+      version: '1.6.1-rc.9',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1-rc.8', mode: 'demo' },
+        server: { version: '1.6.1-rc.9', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1-rc.8",
+  version: "1.6.1-rc.9",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1-rc.8",
+    version: "v1.6.1-rc.9",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1-rc.8",
+      "version": "1.6.1-rc.9",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1-rc.8",
+    "version": "1.6.1-rc.9",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1-rc.8"
+  "version":"1.6.1-rc.9"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1-rc.8",
+    "version": "1.6.1-rc.9",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1-rc.8",
+      "drydockVersion": "1.6.1-rc.9",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1-rc.8` | Immutable release candidate; best for reproducible testing |
+| `1.6.1-rc.9` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,28 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.6.1-rc.9 Highlights — September 5, 2026
+
+Six fixes: the release cut now catches an arm64 image that is actually amd64
+wearing an arm64 label before it ships, checking the Dockerfile's base image
+pins and each published platform's own binaries before promoting; a manual
+recheck of a watcher that came back with zero containers no longer wipes out
+every container it owns, and the same insert-before-prune ordering is fixed
+on the handshake, watcher-snapshot and edge container-sync paths so a
+recreated agent-owned container no longer loses its update policy on
+reconnect; a connected agent can no longer take over or delete a container id
+owned by another agent or the controller's own watcher, with the ownership
+gate keyed on the container ids the controller's own watchers have actually
+enumerated rather than on watcher name; a rollback of a compose-managed
+container no longer redeploys the update it was undoing, and an automatic
+rollback after a failed healthcheck now pulls the backup image it is rolling
+back to instead of leaving the failing update running; and a container that
+moved to an agent no longer stays stranded, or loses its update policy, when
+the controller's local watcher is off or a sibling watcher fails to
+register. See
+[CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc9--2026-09-05)
+for the full release notes.
+
 ## v1.6.1-rc.8 Highlights — September 4, 2026
 
 Four fixes and a docs pass: overlapping scans no longer fire the same

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.8...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.9...HEAD`],
+    ['1.6.1-rc.9', `${repositoryUrl}/compare/v1.6.1-rc.8...v1.6.1-rc.9`],
     ['1.6.1-rc.8', `${repositoryUrl}/compare/v1.6.1-rc.7...v1.6.1-rc.8`],
     ['1.6.1-rc.7', `${repositoryUrl}/compare/v1.6.1-rc.6...v1.6.1-rc.7`],
     ['1.6.1-rc.6', `${repositoryUrl}/compare/v1.6.1-rc.5...v1.6.1-rc.6`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1-rc.8';
-const PREV_RC_VERSION = '1.6.1-rc.7';
-const RC_DATE = '2026-09-04';
-const RC_DISPLAY_DATE = 'September 4, 2026';
+const RC_VERSION = '1.6.1-rc.9';
+const PREV_RC_VERSION = '1.6.1-rc.8';
+const RC_DATE = '2026-09-05';
+const RC_DISPLAY_DATE = 'September 5, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1-rc.8';
+const RC_VERSION = '1.6.1-rc.9';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Release prepare commit for v1.6.1-rc.9 on the 1.6 maintenance line, same shape as the rc.8 one (#1002): CHANGELOG heading and compare links, README highlights block, docs updates page, demo mock and docs version strings, release identity test fixtures. Highlights cover #1015, #1019, #1027, #1032 and #1036.
