### PR TITLE
docs(agents): serve TLS on the agent in the paired registry example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **The agents page's paired Gitea registry example had the controller talking HTTPS to an agent serving plain HTTP.** The controller block set `DD_AGENT_REMOTE1_CAFILE=/certs/agent-ca.pem`, but the agent block above it had no `DD_SERVER_TLS_*` variables or certificate mounts, so the example copied as written could never connect. The agent block now mounts `agent.pem`/`agent-key.pem` and sets `DD_SERVER_TLS_ENABLED`, `DD_SERVER_TLS_CERT`, and `DD_SERVER_TLS_KEY`, with a comment noting the certificate must be signed by the `agent-ca.pem` the controller mounts and be valid for the host the controller dials.
+
 ## [1.7.0-rc.11] — 2026-09-05
 
 ### Fixed

--- a/content/docs/current/configuration/agents/index.mdx
+++ b/content/docs/current/configuration/agents/index.mdx
@@ -415,9 +415,15 @@ services:
       - "3000:3000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      # Must be signed by the agent-ca.pem the controller mounts below, and valid for 192.168.1.50 (the host the controller dials)
+      - ./certs/agent.pem:/certs/agent.pem:ro
+      - ./certs/agent-key.pem:/certs/agent-key.pem:ro
     environment:
       - DD_AGENT_SECRET=pick-a-long-random-string
       - DD_WATCHER_LOCAL_SOCKET=/var/run/docker.sock
+      - DD_SERVER_TLS_ENABLED=true
+      - DD_SERVER_TLS_CERT=/certs/agent.pem
+      - DD_SERVER_TLS_KEY=/certs/agent-key.pem
       - DD_REGISTRY_GITEA_PRIVATE_URL=https://git.example.com
       - DD_REGISTRY_GITEA_PRIVATE_LOGIN=john
       - DD_REGISTRY_GITEA_PRIVATE_PASSWORD=doe


### PR DESCRIPTION
DR-116, docs only. The paired Gitea registry example on the agents page had the controller dialing the agent over HTTPS (`DD_AGENT_REMOTE1_CAFILE`) while the agent block served plain HTTP, so copied as-is it could not connect. The agent block now mounts a certificate and key and sets `DD_SERVER_TLS_ENABLED`, `DD_SERVER_TLS_CERT` and `DD_SERVER_TLS_KEY`, with a note that the certificate must be signed by the CA the controller mounts and be valid for the host it dials. Raised by CodeRabbit on #1041. Forward-port to 1.8 follows; 1.6 does not have the section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added TLS certificate and key mounts to the agent registry example.
- 🔧 Changed the example to set `DD_SERVER_TLS_ENABLED`, `DD_SERVER_TLS_CERT`, and `DD_SERVER_TLS_KEY`.
- 🐛 Fixed the controller-agent protocol mismatch by aligning the agent with the controller's HTTPS configuration.
- 🔒 Documented that the agent certificate must be CA-signed and valid for the target host.

## Concerns

- Ensure the example certificate matches the host used by the controller.
- Ensure the mounted CA signs the agent certificate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->