### PR TITLE
chore(security): allow the shifted webhook doc curl examples ahead of #1038

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -340,6 +340,10 @@ content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:115
 content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:122
 content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:129
 content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:46
+content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:117
+content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:124
+content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:131
+content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:48
 content/docs/v1.3/api/registry.mdx:generic-api-key:36
 content/docs/v1.3/api/registry.mdx:generic-api-key:56
 content/docs/v1.3/configuration/authentications/oidc/index.mdx:private-key:39


### PR DESCRIPTION
Additive only. #1038 adds two lines to content/docs/current/configuration/webhooks/index.mdx above the curl examples, which moves the four path-only curl-auth-header fingerprints from 46/115/122/129 to 48/117/124/131. The Secrets job checks out .gitleaksignore from the base branch, so a branch-side edit can't fix its own scan: the new line numbers have to be on dev/v1.8 first. This adds them next to the existing entries; the old ones stay until #1038 lands.
