### PR TITLE
fix(release): probe each platform by its own manifest digest in the image arch check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The arm64 pass of the image arch check failed on every multi-platform cut with `docker: cannot overwrite digest sha256:<index>`.** `scripts/check-image-arch.sh` ran once per platform against the same index-digest reference (`ghcr.io/codeswhat/drydock:release-staging-N@sha256:<index>`), and docker's classic image store cannot hold two platform variants under one digest, so the amd64 pass succeeded and the arm64 pass that followed it always failed. This killed the v1.6.1-rc.9 cut. The script now resolves each platform's own manifest digest out of the index via `docker buildx imagetools inspect --raw` and jq before it runs docker, skipping attestation entries, and falls back to running the reference unchanged when it isn't an index at all.
+
 ### Documentation
 
 - **The agents page's paired Gitea registry example had the controller talking HTTPS to an agent serving plain HTTP.** The controller block set `DD_AGENT_REMOTE1_CAFILE=/certs/agent-ca.pem`, but the agent block above it had no `DD_SERVER_TLS_*` variables or certificate mounts, so the example copied as written could never connect. The agent block now mounts `agent.pem`/`agent-key.pem` and sets `DD_SERVER_TLS_ENABLED`, `DD_SERVER_TLS_CERT`, and `DD_SERVER_TLS_KEY`, with a comment noting the certificate must be signed by the `agent-ca.pem` the controller mounts and be valid for the host the controller dials.

--- a/scripts/check-image-arch.sh
+++ b/scripts/check-image-arch.sh
@@ -65,6 +65,78 @@ is_expected_binary() {
 
 echo "Checking ${image_ref} (${platform}) for ${expected_arch} binaries, e_machine ${expected}"
 
+# The release workflow hands us the same *index* digest for every platform
+# ("...@sha256:<index>"), and running docker against that one reference twice
+# fails the second time: docker's classic image store cannot hold two
+# platform variants under one digest, and aborts with "cannot overwrite
+# digest sha256:<index>". Resolve the platform's own manifest digest first so
+# each docker run pulls a distinct reference. A reference that is not an
+# index at all (no digest, or already a single-platform manifest) has
+# nothing to resolve, so it runs unchanged.
+repository="${image_ref%@*}"
+last_segment="${repository##*/}"
+if [[ ${last_segment} == *:* ]]; then
+	repository="${repository%:*}"
+fi
+
+raw_manifest=""
+if ! raw_manifest="$(docker buildx imagetools inspect --raw "${image_ref}" 2>&1)"; then
+	echo "::error::Could not inspect ${image_ref}: ${raw_manifest}"
+	exit 1
+fi
+
+is_index="$(printf '%s' "${raw_manifest}" | jq -r 'if (.manifests | type) == "array" then "true" else "false" end')"
+
+run_ref="${image_ref}"
+if [ "${is_index}" = "true" ]; then
+	requested_os="${platform%%/*}"
+	requested_rest="${platform#*/}"
+	requested_arch="${requested_rest%%/*}"
+	requested_variant=""
+	if [[ ${requested_rest} == */* ]]; then
+		requested_variant="${requested_rest#*/}"
+	fi
+
+	# unknown/unknown platforms and vnd.docker.reference.type annotations mark
+	# attestation manifests, not platform images; exclude them explicitly
+	# rather than trust that they never collide with a real request.
+	matches="$(printf '%s' "${raw_manifest}" | jq -r --arg os "${requested_os}" --arg arch "${requested_arch}" --arg variant "${requested_variant}" '
+        [ .manifests[]?
+          | select(.platform != null)
+          | select(.platform.os != "unknown")
+          | select((.annotations["vnd.docker.reference.type"] // "") == "")
+          | select(.platform.os == $os and .platform.architecture == $arch)
+          | select($variant == "" or .platform.variant == $variant)
+          | .digest
+        ] | .[]
+    ')"
+
+	manifest_digests=()
+	while IFS= read -r digest; do
+		[ -n "${digest}" ] && manifest_digests+=("${digest}")
+	done <<<"${matches}"
+
+	if [ "${#manifest_digests[@]}" -eq 0 ]; then
+		available="$(printf '%s' "${raw_manifest}" | jq -r '
+            [ .manifests[]?
+              | select(.platform != null)
+              | select(.platform.os != "unknown")
+              | select((.annotations["vnd.docker.reference.type"] // "") == "")
+              | "\(.platform.os)/\(.platform.architecture)\(if .platform.variant then "/" + .platform.variant else "" end)"
+            ] | unique | .[]
+        ')"
+		echo "::error::${image_ref} has no manifest for ${platform}. Index contains: $(echo "${available}" | tr '\n' ' ')"
+		exit 1
+	fi
+
+	if [ "${#manifest_digests[@]}" -gt 1 ]; then
+		echo "::error::${image_ref} has ${#manifest_digests[@]} manifests matching ${platform}, expected exactly one: ${manifest_digests[*]}"
+		exit 1
+	fi
+
+	run_ref="${repository}@${manifest_digests[0]}"
+fi
+
 # stderr has to stay out of the parsed output: docker writes pull progress
 # there, and on a runner that has never seen the image that is 30 lines of
 # "Pulling fs layer" ahead of the probe's three.
@@ -74,8 +146,8 @@ trap 'rm -f "${docker_stderr}"' EXIT
 # A pull failure or a missing emulator is a legitimate non-zero here, so keep
 # the output instead of letting set -e abort with nothing to read.
 output=""
-if ! output="$(docker run --rm --pull always --platform "${platform}" --entrypoint sh "${image_ref}" -c "${probe}" 2>"${docker_stderr}")"; then
-	echo "::error::Could not read ${image_ref} as ${platform}: $(cat "${docker_stderr}")"
+if ! output="$(docker run --rm --pull always --platform "${platform}" --entrypoint sh "${run_ref}" -c "${probe}" 2>"${docker_stderr}")"; then
+	echo "::error::Could not read ${run_ref} as ${platform}: $(cat "${docker_stderr}")"
 	exit 1
 fi
 

--- a/scripts/check-image-arch.test.mjs
+++ b/scripts/check-image-arch.test.mjs
@@ -24,25 +24,86 @@ function allBinaries(bytes) {
   return probeLines(Object.fromEntries(BINARIES.map((path) => [path, bytes])));
 }
 
+const AMD64_DIGEST = 'sha256:1111111111111111111111111111111111111111111111111111111111aaaa';
+const ARM64_DIGEST = 'sha256:2222222222222222222222222222222222222222222222222222222222bbbb';
+const ATTESTATION_DIGEST = 'sha256:3333333333333333333333333333333333333333333333333333333333cccc';
+
+// A raw `docker buildx imagetools inspect --raw` document for a two-platform
+// index, plus an attestation entry (os "unknown" with a
+// vnd.docker.reference.type annotation) that must never be mistaken for a
+// requested platform's manifest.
+function twoPlatformIndex({ includeAmd64 = true, includeArm64 = true } = {}) {
+  const manifests = [];
+  if (includeAmd64) {
+    manifests.push({
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      digest: AMD64_DIGEST,
+      size: 1234,
+      platform: { architecture: 'amd64', os: 'linux' },
+    });
+  }
+  if (includeArm64) {
+    manifests.push({
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      digest: ARM64_DIGEST,
+      size: 1234,
+      platform: { architecture: 'arm64', os: 'linux' },
+    });
+  }
+  manifests.push({
+    mediaType: 'application/vnd.oci.image.manifest.v1+json',
+    digest: ATTESTATION_DIGEST,
+    size: 567,
+    platform: { architecture: 'unknown', os: 'unknown' },
+    annotations: {
+      'vnd.docker.reference.type': 'attestation-manifest',
+      'vnd.docker.reference.digest': AMD64_DIGEST,
+    },
+  });
+  return JSON.stringify({
+    schemaVersion: 2,
+    mediaType: 'application/vnd.oci.image.index.v1+json',
+    manifests,
+  });
+}
+
+// A single-platform manifest: no `manifests` array, so the script's is-index
+// check is false and it has to run the reference unchanged.
+const SINGLE_PLATFORM_MANIFEST = JSON.stringify({
+  schemaVersion: 2,
+  mediaType: 'application/vnd.oci.image.manifest.v1+json',
+  config: { mediaType: 'application/vnd.oci.image.config.v1+json', digest: AMD64_DIGEST },
+  layers: [],
+});
+
 /**
  * Runs the guard with a fake `docker` first on PATH that replays canned probe
  * output, so the ELF byte comparison is exercised without building an image.
+ * `buildx imagetools inspect --raw` is answered separately from `docker run`
+ * so the two calls the script now makes don't collide.
  */
 async function runGuard({
   probeOutput = allBinaries(ARM64),
   dockerExit = 0,
   dockerStderr = '',
+  rawManifest = SINGLE_PLATFORM_MANIFEST,
   args = ['drydock:test', 'linux/arm64'],
 } = {}) {
   const dir = await mkdtemp(join(tmpdir(), 'drydock-image-arch-'));
   const probeFile = join(dir, 'probe-output');
+  const manifestFile = join(dir, 'raw-manifest');
   const argsLog = join(dir, 'docker-args.log');
   await writeFile(probeFile, probeOutput === '' ? '' : `${probeOutput}\n`);
+  await writeFile(manifestFile, rawManifest);
 
   const fakeDocker = join(dir, 'docker');
   await writeFile(
     fakeDocker,
     `#!/bin/sh
+if [ "$1" = "buildx" ] && [ "$2" = "imagetools" ] && [ "$3" = "inspect" ]; then
+  cat "$RAW_MANIFEST_FILE"
+  exit 0
+fi
 printf '%s\\n' "$*" > "$DOCKER_ARGS_LOG"
 if [ -n "$DOCKER_STDERR" ]; then
   printf '%s\\n' "$DOCKER_STDERR" >&2
@@ -61,6 +122,7 @@ cat "$PROBE_OUTPUT_FILE"
     DOCKER_EXIT: String(dockerExit),
     DOCKER_STDERR: dockerStderr,
     PROBE_OUTPUT_FILE: probeFile,
+    RAW_MANIFEST_FILE: manifestFile,
     PATH: `${dir}:${process.env.PATH}`,
   };
 
@@ -233,4 +295,83 @@ test('reports a probe line that carries no e_machine bytes', async () => {
 
   assert.equal(result.code, 1);
   assert.match(result.output, /Unreadable probe output/u);
+});
+
+test('resolves the linux/amd64 manifest digest from an index and runs that, not the index digest', async () => {
+  const result = await runGuard({
+    args: ['ghcr.io/codeswhat/drydock:release-staging-1@sha256:indexdigest0000', 'linux/amd64'],
+    probeOutput: allBinaries(AMD64),
+    rawManifest: twoPlatformIndex(),
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.dockerArgs, new RegExp(`ghcr.io/codeswhat/drydock@${AMD64_DIGEST}`, 'u'));
+  assert.ok(!result.dockerArgs.includes('sha256:indexdigest0000'));
+});
+
+test('resolves the linux/arm64 manifest digest from the same index', async () => {
+  const result = await runGuard({
+    args: ['ghcr.io/codeswhat/drydock:release-staging-1@sha256:indexdigest0000', 'linux/arm64'],
+    probeOutput: allBinaries(ARM64),
+    rawManifest: twoPlatformIndex(),
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.dockerArgs, new RegExp(`ghcr.io/codeswhat/drydock@${ARM64_DIGEST}`, 'u'));
+  assert.ok(!result.dockerArgs.includes('sha256:indexdigest0000'));
+});
+
+test('fails before any docker run when a platform is missing from the index', async () => {
+  const result = await runGuard({
+    args: ['ghcr.io/codeswhat/drydock:release-staging-1@sha256:indexdigest0000', 'linux/arm64'],
+    rawManifest: twoPlatformIndex({ includeArm64: false }),
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /has no manifest for linux\/arm64/u);
+  assert.match(result.output, /linux\/amd64/u);
+  assert.equal(result.dockerArgs, '');
+});
+
+test('fails when an index carries more than one manifest for the requested platform', async () => {
+  const duplicateIndex = JSON.stringify({
+    schemaVersion: 2,
+    mediaType: 'application/vnd.oci.image.index.v1+json',
+    manifests: [
+      {
+        mediaType: 'application/vnd.oci.image.manifest.v1+json',
+        digest: AMD64_DIGEST,
+        size: 1234,
+        platform: { architecture: 'amd64', os: 'linux' },
+      },
+      {
+        mediaType: 'application/vnd.oci.image.manifest.v1+json',
+        digest: ARM64_DIGEST,
+        size: 1234,
+        platform: { architecture: 'amd64', os: 'linux' },
+      },
+    ],
+  });
+  const result = await runGuard({
+    args: ['ghcr.io/codeswhat/drydock:release-staging-1@sha256:indexdigest0000', 'linux/amd64'],
+    rawManifest: duplicateIndex,
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /2 manifests matching linux\/amd64/u);
+  assert.equal(result.dockerArgs, '');
+});
+
+test('runs a non-index reference unchanged', async () => {
+  const result = await runGuard({
+    args: ['ghcr.io/codeswhat/drydock:release-staging-1@sha256:indexdigest0000', 'linux/amd64'],
+    probeOutput: allBinaries(AMD64),
+    rawManifest: SINGLE_PLATFORM_MANIFEST,
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(
+    result.dockerArgs,
+    /ghcr\.io\/codeswhat\/drydock:release-staging-1@sha256:indexdigest0000/u,
+  );
 });


### PR DESCRIPTION
DR-118. The arch probe added in #1024 runs `docker run --platform <p> <repo>@<index digest>` once per platform. The classic image store keeps one variant per digest, so after the amd64 pass the arm64 pass dies with `docker: cannot overwrite digest`. That sank the v1.6.1-rc.9 cut (run 33945788381) after amd64 passed and would sink the rc.11 cut the same way; PR CI never saw it because the smoke build is single-arch.

The script now resolves the platform's own manifest digest from `docker buildx imagetools inspect --raw` (skipping attestation entries, erroring on zero or several matches) and runs that. A non-index reference runs unchanged. Fake-docker tests cover both platforms, the missing-platform error, the duplicate-match error and the single-manifest path. Ports to 1.8 and 1.6 follow; 1.6 gets re-cut after its port.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added platform digest resolution with `docker buildx imagetools inspect --raw`.
- 🔧 Changed index references to run with the matching `repository@digest`.
- 🔧 Skipped attestation manifests during platform matching.
- 🐛 Fixed handling for missing or duplicate platform manifests.
- 🔧 Preserved existing behavior for single-manifest references.
- ✨ Added fake-Docker tests for platform matches, attestations, errors, and single manifests.
- 🔧 Ported the change to the 1.8 and 1.6 branches.

## Concerns

- Verify that all supported environments provide `docker buildx imagetools`.
- Verify that backported branches preserve identical digest-selection and attestation-filtering behavior.
- Ensure tests assert the exact digest passed to `docker run`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->