### PR TITLE
chore(security): ignore the shifted webhook curl examples for the 1.7 port batch

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -341,6 +341,10 @@ content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:115
 content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:122
 content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:129
 content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:46
+content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:48
+content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:117
+content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:124
+content/docs/current/configuration/webhooks/index.mdx:curl-auth-header:131
 content/docs/v1.3/api/registry.mdx:generic-api-key:36
 content/docs/v1.3/api/registry.mdx:generic-api-key:56
 content/docs/v1.3/configuration/authentications/oidc/index.mdx:private-key:39


### PR DESCRIPTION
Additive gitleaks ignore entries so #1050 can pass the Secrets job, which scans the tracked tree under the base branch's ignore file. Same shape as #1043 on dev/v1.8. Lines 48/117/124/131 of the webhooks docs page are the existing curl examples moved down by the DR-60 docs edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

🔒 Security
- Added four `.gitleaksignore` entries for shifted `curl-auth-header` findings in the webhooks documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->