### PR TITLE
fix(v1.6): assert the OIDC success user and send Cross-Origin-Opener-Policy on the demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The demo site did not send `Cross-Origin-Opener-Policy`, so the weekly DAST scan failed on ZAP rule 90004 every run.** `apps/demo/vercel.json` now sends `same-origin`.
 - **The arm64 pass of the image arch check failed on every multi-platform cut with `docker: cannot overwrite digest sha256:<index>`.** `scripts/check-image-arch.sh` ran once per platform against the same index-digest reference (`ghcr.io/codeswhat/drydock:release-staging-N@sha256:<index>`), and docker's classic image store cannot hold two platform variants under one digest, so the amd64 pass succeeded and the arm64 pass that followed it always failed. This killed the v1.6.1-rc.9 cut. The script now resolves each platform's own manifest digest out of the index via `docker buildx imagetools inspect --raw` and jq before it runs docker, skipping attestation entries, and falls back to running the reference unchanged when it isn't an index at all.
 
 ## [1.6.1-rc.9] — 2026-09-05

--- a/app/authentications/providers/oidc/OidcStrategy.test.ts
+++ b/app/authentications/providers/oidc/OidcStrategy.test.ts
@@ -28,8 +28,9 @@ afterEach(() => {
 });
 
 test('authenticate should return user from session if so', async () => {
-  oidcStrategy.authenticate({ isAuthenticated: () => true });
-  expect(oidcStrategy.success).toHaveBeenCalled();
+  const user = { username: 'alice' };
+  oidcStrategy.authenticate({ isAuthenticated: () => true, user });
+  expect(oidcStrategy.success).toHaveBeenCalledWith(user);
 });
 
 test('authenticate should debug and fail when no authorization header is provided', async () => {

--- a/apps/demo/vercel.json
+++ b/apps/demo/vercel.json
@@ -11,7 +11,8 @@
         {
           "key": "Content-Security-Policy",
           "value": "frame-ancestors 'self' https://getdrydock.com https://*.vercel.app"
-        }
+        },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" }
       ]
     }
   ]


### PR DESCRIPTION
1.6 mirror of the rc.12 port batch, the parts that apply to this line.

- DR-30 (cherry-pick of 11128a0c3): the OIDC session tests assert which user reaches `success()`, so a stubbed callback or a hardcoded user fails.
- CI-11 (cherry-pick of ac51c8c53): the demo site sends `Cross-Origin-Opener-Policy: same-origin`. This line never received #878's other headers, so only COOP is added; the CHANGELOG bullet says so.

DR-105 was already on this line byte-identical. DR-118 landed in #1047. DR-121 (session store file) follows once #1055 settles on 1.8.

App 401 files / 12871 tests, 100% coverage.
