### PR TITLE
chore(release): prepare v1.6.1-rc.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1-rc.10] — 2026-09-06
+
 ### Fixed
 
 - **The demo site did not send `Cross-Origin-Opener-Policy`, so the weekly DAST scan failed on ZAP rule 90004 every run.** `apps/demo/vercel.json` now sends `same-origin`.
@@ -2493,7 +2495,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.9...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.10...HEAD
+[1.6.1-rc.10]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.9...v1.6.1-rc.10
 [1.6.1-rc.9]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.8...v1.6.1-rc.9
 [1.6.1-rc.8]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.7...v1.6.1-rc.8
 [1.6.1-rc.7]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.6...v1.6.1-rc.7

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.9-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.10-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,6 +179,17 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.6.1-rc.10 highlights</strong></summary>
+
+- **The demo site no longer fails the weekly DAST scan on ZAP rule 90004** — it never sent `Cross-Origin-Opener-Policy`, and `apps/demo/vercel.json` now sends `same-origin`.
+- **The arm64 pass of the image arch check no longer fails every multi-platform cut** — it ran against the same index-digest reference as the amd64 pass, and docker's classic image store cannot hold two platform variants under one digest, so the arm64 pass that followed always failed and killed the v1.6.1-rc.9 cut. `check-image-arch.sh` now resolves each platform's own manifest digest out of the index before running docker.
+- **DR-121: containers, settings, and audit rows written after startup no longer vanish, and a restart no longer logs everyone out** — the session store and the main store both wrote the same `/store/dd.json`, so whichever autosave ran last erased the other's data. The session store now writes to its own sibling file, `dd-sessions.json` by default, and the main store drops a stale `Sessions` collection left behind in `dd.json` by an older build instead of re-saving it.
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#161-rc10--2026-09-06).
+
+</details>
+
+<details>
 <summary><strong>v1.6.1-rc.9 highlights</strong></summary>
 
 - **The release cut now catches an arm64 image that is actually amd64 wearing an arm64 label before it ships** — a base image digest pin naming a single-platform manifest instead of a multi-arch index let buildx resolve the same digest for every `--platform`, which is how that shipped on the v1.7 line ([#1021](https://github.com/CodesWhat/drydock/issues/1021)); the 1.6 line was never affected, but the release cut now checks the Dockerfile's base image pins and each published platform's own binaries before promoting. ([#1032](https://github.com/CodesWhat/drydock/pull/1032))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1-rc.9',
+    version: '1.6.1-rc.10',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1-rc.9 started',
+    details: 'Drydock v1.6.1-rc.10 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.9',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.10',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1-rc.9',
+    tag: '1.6.1-rc.10',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1-rc.9',
+  version: '1.6.1-rc.10',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1-rc.9',
+      version: '1.6.1-rc.10',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1-rc.9', mode: 'demo' },
+        server: { version: '1.6.1-rc.10', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1-rc.9",
+  version: "1.6.1-rc.10",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1-rc.9",
+    version: "v1.6.1-rc.10",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1-rc.9",
+      "version": "1.6.1-rc.10",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1-rc.9",
+    "version": "1.6.1-rc.10",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1-rc.9"
+  "version":"1.6.1-rc.10"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1-rc.9",
+    "version": "1.6.1-rc.10",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1-rc.9",
+      "drydockVersion": "1.6.1-rc.10",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1-rc.9` | Immutable release candidate; best for reproducible testing |
+| `1.6.1-rc.10` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,20 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.6.1-rc.10 Highlights — September 6, 2026
+
+Three fixes: the demo site no longer fails the weekly DAST scan on ZAP rule
+90004, since it never sent `Cross-Origin-Opener-Policy` and now does; the
+arm64 pass of the image arch check no longer fails every multi-platform cut,
+since `check-image-arch.sh` now resolves each platform's own manifest digest
+out of the index before running docker instead of reusing the same
+index-digest reference for both platforms; and DR-121, where the session
+store and the main store both wrote the same `/store/dd.json` so whichever
+autosave ran last erased the other's data, is fixed by giving the session
+store its own sibling file. See
+[CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc10--2026-09-06)
+for the full release notes.
+
 ## v1.6.1-rc.9 Highlights — September 5, 2026
 
 Six fixes: the release cut now catches an arm64 image that is actually amd64

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.9...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.10...HEAD`],
+    ['1.6.1-rc.10', `${repositoryUrl}/compare/v1.6.1-rc.9...v1.6.1-rc.10`],
     ['1.6.1-rc.9', `${repositoryUrl}/compare/v1.6.1-rc.8...v1.6.1-rc.9`],
     ['1.6.1-rc.8', `${repositoryUrl}/compare/v1.6.1-rc.7...v1.6.1-rc.8`],
     ['1.6.1-rc.7', `${repositoryUrl}/compare/v1.6.1-rc.6...v1.6.1-rc.7`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1-rc.9';
-const PREV_RC_VERSION = '1.6.1-rc.8';
-const RC_DATE = '2026-09-05';
-const RC_DISPLAY_DATE = 'September 5, 2026';
+const RC_VERSION = '1.6.1-rc.10';
+const PREV_RC_VERSION = '1.6.1-rc.9';
+const RC_DATE = '2026-09-06';
+const RC_DISPLAY_DATE = 'September 6, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1-rc.9';
+const RC_VERSION = '1.6.1-rc.10';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',


### PR DESCRIPTION
Release-prepare commit for v1.6.1-rc.10, same 17-file shape as the rc.9 one (#1039).

Moves the three Unreleased bullets (demo COOP header, arm64 arch-check digest overwrite, DR-121 session store file) under `## [1.6.1-rc.10] — 2026-09-06`, adds the README and docs highlight blocks, and bumps the version string in the demo mocks, site config, API docs and release tests.
