### PR TITLE
chore(release): prepare v1.7.0-rc.12

### DIFF
--- a/.github/tests/readme-translations.test.ts
+++ b/.github/tests/readme-translations.test.ts
@@ -66,114 +66,123 @@ const localizedSurfaceFragments: Record<
     featureTableHeader: '| | Funktion | Beschreibung |',
     builtWithHeading: '<h2 align="center" id="built-with">Gebaut mit</h2>',
     communityQaHeading: '### Community-QA',
-    releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.11</strong></summary>',
+    releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.12</strong></summary>',
   },
   'README.es.md': {
     featureTableHeader: '| | Característica | Descripción |',
     builtWithHeading: '<h2 align="center" id="built-with">Construido con</h2>',
     communityQaHeading: '### Control de calidad de la comunidad',
-    releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.11</strong></summary>',
+    releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.12</strong></summary>',
   },
   'README.fr.md': {
     featureTableHeader: '| | Fonctionnalité | Descriptif |',
     builtWithHeading: '<h2 align="center" id="built-with">Construit avec</h2>',
     communityQaHeading: '### Contrôle qualité de la communauté',
-    releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.11</strong></summary>',
+    releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.12</strong></summary>',
   },
   'README.pl.md': {
     featureTableHeader: '| | Funkcja | Opis |',
     builtWithHeading: '<h2 align="center" id="built-with">Zbudowany z</h2>',
     communityQaHeading: '### Kontrola jakości społeczności',
     releaseHeading:
-      '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.11</strong></summary>',
+      '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.12</strong></summary>',
   },
   'README.pt-BR.md': {
     featureTableHeader: '| | Recurso | Descrição |',
     builtWithHeading: '<h2 align="center" id="built-with">Construído com</h2>',
     communityQaHeading: '### Controle de qualidade da comunidade',
-    releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.11</strong></summary>',
+    releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.12</strong></summary>',
   },
   'README.zh-CN.md': {
     featureTableHeader: '| |特色|描述 |',
     builtWithHeading: '<h2 align="center" id="built-with">技术栈</h2>',
     communityQaHeading: '### 社区质量检查',
-    releaseHeading: '<summary><strong>v1.7.0-rc.11 亮点</strong></summary>',
+    releaseHeading: '<summary><strong>v1.7.0-rc.12 亮点</strong></summary>',
   },
 };
 
 const localizedReleaseFragments: Record<
   string,
   {
-    oidcBounce: string;
-    routeScope: string;
-    composeRollback: string;
-    armImage: string;
-    indexDigest: string;
-    agentRegistryDocs: string;
+    coopHeader: string;
+    embedderHeader: string;
+    archDigestProbe: string;
+    sessionStoreSplit: string;
+    sessionsCollectionMention: string;
+    agentsTlsMismatch: string;
   }
 > = {
   'README.de.md': {
-    oidcBounce:
-      '**OIDC-Login springt nach der Weiterleitung durch den Identity Provider nicht mehr zur Login-Seite zurück.**',
-    routeScope: 'überspringt jetzt jede serverseitige Route',
-    composeRollback:
-      '**Ein Rollback eines Compose-verwalteten Containers stellt nicht mehr das Update wieder her, das es eigentlich rückgängig machen sollte.**',
-    armImage: '**Das veröffentlichte arm64-Image ist wieder ein echtes arm64-Image**',
-    indexDigest: 'Multi-Arch-Image-Index-Digests',
-    agentRegistryDocs:
-      '**Die Agents-Seite sagt jetzt, dass Registries auf jedem Agent konfiguriert werden müssen, nicht nur auf dem Controller**',
+    coopHeader:
+      '**Die Demo-Site sendete kein `Cross-Origin-Opener-Policy`, sodass der wöchentliche DAST-Scan bei jeder Ausführung an ZAP-Regel 90004 scheiterte.**',
+    embedderHeader: 'bereits vorhandenen `Cross-Origin-Embedder-Policy`-Header',
+    archDigestProbe:
+      '**Der arm64-Durchlauf der Image-Arch-Prüfung im Release schlug bei jedem Multi-Plattform-Cut mit `docker: cannot overwrite digest` fehl.**',
+    sessionStoreSplit:
+      '**DR-121: Der Session-Store und der Haupt-Store schrieben dieselbe `/store/dd.json`, und wer zuletzt speicherte, löschte die Daten des anderen.**',
+    sessionsCollectionMention: 'verwirft eine veraltete `Sessions`-Collection',
+    agentsTlsMismatch:
+      '**Das gepaarte Gitea-Registry-Beispiel der Agents-Seite ließ den Controller HTTPS mit einem Agent sprechen, der nur HTTP anbot.**',
   },
   'README.es.md': {
-    oidcBounce:
-      '**El inicio de sesión OIDC ya no vuelve a la página de login después de la redirección del proveedor de identidad.**',
-    routeScope: 'omite cada ruta propiedad del servidor',
-    composeRollback:
-      '**Una reversión de un contenedor gestionado por Compose ya no vuelve a desplegar la actualización que se suponía debía deshacer.**',
-    armImage: '**La imagen arm64 publicada vuelve a ser una imagen arm64 real**',
-    indexDigest: 'digests del índice de imagen multiarquitectura',
-    agentRegistryDocs:
-      '**La página de agentes ahora dice que los registries deben configurarse en cada agente, no solo en el controlador**',
+    coopHeader:
+      '**El sitio de demostración no enviaba `Cross-Origin-Opener-Policy`, por lo que el escaneo DAST semanal fallaba en la regla 90004 de ZAP en cada ejecución.**',
+    embedderHeader: 'cabecera `Cross-Origin-Embedder-Policy` ya existente',
+    archDigestProbe:
+      '**El paso arm64 de la comprobación de arquitectura de imagen del release fallaba en cada corte multiplataforma con `docker: cannot overwrite digest`.**',
+    sessionStoreSplit:
+      '**DR-121: el almacén de sesiones y el almacén principal escribían el mismo `/store/dd.json`, y el que guardaba último borraba los datos del otro.**',
+    sessionsCollectionMention: 'descarta una colección `Sessions` obsoleta',
+    agentsTlsMismatch:
+      '**El ejemplo emparejado de registry de Gitea de la página de agentes hacía que el controlador hablara HTTPS con un agente que servía HTTP simple.**',
   },
   'README.fr.md': {
-    oidcBounce:
-      "**La connexion OIDC ne revient plus à la page de connexion après la redirection du fournisseur d'identité.**",
-    routeScope: 'ignore désormais chaque route appartenant au serveur',
-    composeRollback:
-      "**Une restauration d'un conteneur géré par Compose ne redéploie plus la mise à jour qu'elle était censée annuler.**",
-    armImage: "**L'image arm64 publiée est de nouveau une véritable image arm64**",
-    indexDigest: "digests d'index d'image multi-architecture",
-    agentRegistryDocs:
-      '**La page des agents indique désormais que les registres doivent être configurés sur chaque agent, pas seulement sur le contrôleur**',
+    coopHeader:
+      "**Le site de démonstration n'envoyait pas `Cross-Origin-Opener-Policy`, si bien que le scan DAST hebdomadaire échouait sur la règle ZAP 90004 à chaque exécution.**",
+    embedderHeader: "l'en-tête `Cross-Origin-Embedder-Policy` déjà présent",
+    archDigestProbe:
+      "**Le passage arm64 du contrôle d'architecture d'image du release échouait à chaque coupe multiplateforme avec `docker: cannot overwrite digest`.**",
+    sessionStoreSplit:
+      "**DR-121 : le magasin de sessions et le magasin principal écrivaient dans le même `/store/dd.json`, et celui qui enregistrait en dernier effaçait les données de l'autre.**",
+    sessionsCollectionMention: 'abandonne une collection `Sessions` obsolète',
+    agentsTlsMismatch:
+      "**L'exemple apparié de registre Gitea de la page des agents faisait parler HTTPS au contrôleur avec un agent servant du HTTP simple.**",
   },
   'README.pl.md': {
-    oidcBounce:
-      '**Logowanie OIDC nie wraca już do strony logowania po przekierowaniu przez dostawcę tożsamości.**',
-    routeScope: 'pomija każdą trasę należącą do serwera',
-    composeRollback:
-      '**Wycofanie kontenera zarządzanego przez Compose nie wdraża już ponownie aktualizacji, którą miało cofnąć.**',
-    armImage: '**Publikowany obraz arm64 jest znowu prawdziwym obrazem arm64**',
-    indexDigest: 'digesty indeksu obrazu wieloarchitekturowego',
-    agentRegistryDocs:
-      '**Strona agentów mówi teraz, że registry trzeba skonfigurować na każdym agencie, nie tylko na kontrolerze**',
+    coopHeader:
+      '**Strona demo nie wysyłała `Cross-Origin-Opener-Policy`, przez co cotygodniowy skan DAST za każdym razem zawodził na regule ZAP 90004.**',
+    embedderHeader: 'istniejącego już nagłówka `Cross-Origin-Embedder-Policy`',
+    archDigestProbe:
+      '**Przebieg arm64 kontroli architektury obrazu wydania kończył się niepowodzeniem przy każdym wieloplatformowym cięciu z `docker: cannot overwrite digest`.**',
+    sessionStoreSplit:
+      '**DR-121: magazyn sesji i magazyn główny zapisywały ten sam plik `/store/dd.json`, a ten, który zapisał jako ostatni, kasował dane drugiego.**',
+    sessionsCollectionMention: 'odrzuca przestarzałą kolekcję `Sessions`',
+    agentsTlsMismatch:
+      '**Sparowany przykład rejestru Gitea na stronie agentów sprawiał, że kontroler mówił po HTTPS do agenta obsługującego zwykłe HTTP.**',
   },
   'README.pt-BR.md': {
-    oidcBounce:
-      '**O login OIDC não volta mais para a página de login depois do redirecionamento do provedor de identidade.**',
-    routeScope: 'ignora toda rota pertencente ao servidor',
-    composeRollback:
-      '**Um rollback de um contêiner gerenciado pelo Compose não reimplanta mais a atualização que deveria desfazer.**',
-    armImage: '**A imagem arm64 publicada volta a ser uma imagem arm64 de verdade**',
-    indexDigest: 'digests do índice de imagem multiarquitetura',
-    agentRegistryDocs:
-      '**A página de agentes agora diz que os registries precisam ser configurados em cada agente, não só no controlador**',
+    coopHeader:
+      '**O site de demonstração não enviava `Cross-Origin-Opener-Policy`, então a varredura DAST semanal falhava na regra 90004 do ZAP em toda execução.**',
+    embedderHeader: 'cabeçalho `Cross-Origin-Embedder-Policy` já existente',
+    archDigestProbe:
+      '**A etapa arm64 da verificação de arquitetura de imagem do release falhava em todo corte multiplataforma com `docker: cannot overwrite digest`.**',
+    sessionStoreSplit:
+      '**DR-121: o armazenamento de sessões e o armazenamento principal escreviam no mesmo `/store/dd.json`, e quem salvasse por último apagava os dados do outro.**',
+    sessionsCollectionMention: 'descarta uma coleção `Sessions` obsoleta',
+    agentsTlsMismatch:
+      '**O exemplo pareado de registry do Gitea na página de agentes fazia o controlador falar HTTPS com um agente servindo HTTP simples.**',
   },
   'README.zh-CN.md': {
-    oidcBounce: '**OIDC 登录在身份提供方重定向后不会再跳回登录页面。**',
-    routeScope: '跳过每个服务器专属路由',
-    composeRollback: '**对 Compose 管理容器的回滚不会再重新部署它本应撤销的更新。**',
-    armImage: '**发布的 arm64 镜像重新变回真正的 arm64 镜像**',
-    indexDigest: '多架构镜像索引摘要',
-    agentRegistryDocs: '**代理页面现在说明每个代理都要配置 registry，而不只是控制器**',
+    coopHeader:
+      '**演示站点此前没有发送 `Cross-Origin-Opener-Policy`，导致每周的 DAST 扫描每次都在 ZAP 规则 90004 上失败。**',
+    embedderHeader: '已有的 `Cross-Origin-Embedder-Policy` 头',
+    archDigestProbe:
+      '**发布流程中镜像架构检查的 arm64 环节在每次多平台构建中都会因 `docker: cannot overwrite digest` 而失败。**',
+    sessionStoreSplit:
+      '**DR-121：会话存储和主存储此前写入同一个 `/store/dd.json`，谁最后保存就会抹掉另一方的数据。**',
+    sessionsCollectionMention: '丢弃旧版本遗留下来的过期 `Sessions` 集合',
+    agentsTlsMismatch:
+      '**代理页面配对的 Gitea registry 示例让控制器以 HTTPS 与只提供纯 HTTP 的代理通信。**',
   },
 };
 
@@ -233,6 +242,7 @@ const requiredFragments = [
   './CHANGELOG.md#170-rc9--2026-09-03',
   './CHANGELOG.md#170-rc10--2026-09-04',
   './CHANGELOG.md#170-rc11--2026-09-05',
+  './CHANGELOG.md#170-rc12--2026-09-06',
   'Portwing 0.9.0+',
   'Standard HTTP',
   '`DD_EXPERIMENTAL_PORTWING=false`',
@@ -287,26 +297,25 @@ describe.each(translatedReadmes)('%s', (readme) => {
     const release = localizedReleaseFragments[readme];
     const releaseBlock = getReleaseBlock(content, surface.releaseHeading);
     const releaseBullets = [
-      release.oidcBounce,
-      release.composeRollback,
-      release.armImage,
-      release.agentRegistryDocs,
+      release.coopHeader,
+      release.archDigestProbe,
+      release.sessionStoreSplit,
+      release.agentsTlsMismatch,
     ].map((fragment) => getBullet(releaseBlock, fragment));
     const getUrls = (bullet: string | undefined) =>
       [...(bullet ?? '').matchAll(/https?:\/\/[^)<>"\s]+/g)].map(([url]) => url);
 
     expect(releaseBullets.every(Boolean)).toBe(true);
-    expect(releaseBullets[0]).toContain(release.routeScope);
-    expect(releaseBullets[2]).toContain(release.indexDigest);
+    expect(releaseBullets[0]).toContain(release.embedderHeader);
+    expect(releaseBullets[2]).toContain(release.sessionsCollectionMention);
     expect(releaseBullets.flatMap(getUrls).sort()).toEqual([
-      'https://github.com/CodesWhat/drydock/pull/1010',
-      'https://github.com/CodesWhat/drydock/pull/1016',
-      'https://github.com/CodesWhat/drydock/pull/1023',
-      'https://github.com/CodesWhat/drydock/pull/1024',
-      'https://github.com/CodesWhat/drydock/pull/1029',
+      'https://github.com/CodesWhat/drydock/pull/1042',
+      'https://github.com/CodesWhat/drydock/pull/1046',
+      'https://github.com/CodesWhat/drydock/pull/1050',
+      'https://github.com/CodesWhat/drydock/pull/1063',
     ]);
     expect(getUrls(releaseBullets[0]).sort()).toEqual([
-      'https://github.com/CodesWhat/drydock/pull/1016',
+      'https://github.com/CodesWhat/drydock/pull/1050',
     ]);
   });
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0-rc.12] — 2026-09-06
+
 ### Fixed
 
 - **The demo site did not send `Cross-Origin-Opener-Policy`, so the weekly DAST scan failed on ZAP rule 90004 every run.** `apps/demo/vercel.json` now sends `same-origin` next to the existing `Cross-Origin-Embedder-Policy` header.
@@ -2722,7 +2724,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.11...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.12...HEAD
+[1.7.0-rc.12]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.11...v1.7.0-rc.12
 [1.7.0-rc.11]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.10...v1.7.0-rc.11
 [1.7.0-rc.10]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.9...v1.7.0-rc.10
 [1.7.0-rc.9]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.8...v1.7.0-rc.9

--- a/README.de.md
+++ b/README.de.md
@@ -219,6 +219,21 @@ Weitere Informationen zu Docker Compose, Socket-Sicherheit, Reverse-Proxy und al
 <h2 align="center" id="recent-updates">Aktuelle Updates</h2>
 
 <details open>
+<summary><strong>Highlights von v1.7.0-rc.12</strong></summary>
+
+- **Die Demo-Site sendete kein `Cross-Origin-Opener-Policy`, sodass der wöchentliche DAST-Scan bei jeder Ausführung an ZAP-Regel 90004 scheiterte.** `apps/demo/vercel.json` sendet jetzt `same-origin` neben dem bereits vorhandenen `Cross-Origin-Embedder-Policy`-Header. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Der arm64-Durchlauf der Image-Arch-Prüfung im Release schlug bei jedem Multi-Plattform-Cut mit `docker: cannot overwrite digest` fehl.** `scripts/check-image-arch.sh` löst jetzt für jede Plattform den eigenen Manifest-Digest aus dem Multi-Arch-Index auf, bevor es ihn prüft, statt dieselbe Index-Digest-Referenz wiederzuverwenden, unter der Dockers klassischer Image-Speicher keine zwei Plattformvarianten halten kann. ([#1046](https://github.com/CodesWhat/drydock/pull/1046))
+- **Das Verschieben eines Containers zu einem anderen Agent oder das Entfernen eines Agents aus der Konfiguration setzt nicht mehr dessen Snooze, Reifemodus und übersprungene Tags zurück.** Die Bereinigung bei Agent-Entfernung und die eigene Bereinigung veralteter Container des Agents übergeben jetzt ebenfalls `identityChangeExpected: true` und legen die Update-Richtlinie des ausscheidenden Eintrags unter seiner Docker-ID ab, genau wie es die Startbereinigung bereits tat. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Ein manuelles „Jetzt prüfen“, das eintraf, während bereits ein Scan lief, konnte dieselbe Benachrichtigung zweimal auslösen.** Das Dashboard, die API, ein Webhook und der Controller beim Abfragen eines Agents laufen jetzt alle über dieselbe Single-Flight-Scan-Orchestrierung wie der Cron-Zeitplan, sodass ein überlappender Aufruf in den einen Folgelauf des laufenden Scans eingereiht wird (`result.coalesced` im JSON-Body, ein `X-Drydock-Watch-Coalesced`-Header am Agent-Endpunkt), statt einen eigenen unabhängigen Scan zu starten. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Eine `once=true`-Reservierung, deren Trigger nie antwortete, hielt ihren Dedup-Schlüssel für die gesamte Prozesslaufzeit.** Ein Handler, der sein 30-Sekunden-Zeitlimit überschritt, behielt seine Reservierung über den Scan hinaus, der sie angelegt hatte, und überging so stillschweigend jeden späteren Versand für dieses Ergebnis; jede Reservierung läuft jetzt über einen eigenen Timer ab und protokolliert eine Warnung mit dem Namen des Schlüssels, falls sie niemand vorher freigegeben hat. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **DR-121: Der Session-Store und der Haupt-Store schrieben dieselbe `/store/dd.json`, und wer zuletzt speicherte, löschte die Daten des anderen.** Der Session-Store schreibt jetzt in eine eigene Sibling-Datei, standardmäßig `dd-sessions.json`, und der Haupt-Store verwirft eine veraltete `Sessions`-Collection, die ein älterer Build hinterlassen hat, statt sie weiter mit zu speichern. ([#1063](https://github.com/CodesWhat/drydock/pull/1063))
+- **Das gepaarte Gitea-Registry-Beispiel der Agents-Seite ließ den Controller HTTPS mit einem Agent sprechen, der nur HTTP anbot.** Der Agent-Block mountet jetzt sein eigenes Zertifikat und setzt `DD_SERVER_TLS_ENABLED`, sodass das Beispiel wie geschrieben eine Verbindung aufbaut. ([#1042](https://github.com/CodesWhat/drydock/pull/1042))
+
+Vollständige Release-Notes in [CHANGELOG.md](./CHANGELOG.md#170-rc12--2026-09-06).
+
+</details>
+
+<details open>
 <summary><strong>Highlights von v1.7.0-rc.11</strong></summary>
 
 - **OIDC-Login springt nach der Weiterleitung durch den Identity Provider nicht mehr zur Login-Seite zurück.** Der Navigations-Fallback des Service Workers beantwortete bisher jede Dokument-Navigation außer `/api/` aus der zwischengespeicherten App-Shell, sodass der OIDC-Callback nie bei Express für den Code-Austausch ankam; er überspringt jetzt jede serverseitige Route (`/api`, `/auth/`, `/health`, `/metrics`). ([#1016](https://github.com/CodesWhat/drydock/pull/1016))

--- a/README.es.md
+++ b/README.es.md
@@ -219,6 +219,21 @@ Consulte la [guía de inicio rápido](https://getdrydock.com/docs/quickstart) pa
 <h2 align="center" id="recent-updates">Actualizaciones recientes</h2>
 
 <details open>
+<summary><strong>Aspectos destacados de v1.7.0-rc.12</strong></summary>
+
+- **El sitio de demostración no enviaba `Cross-Origin-Opener-Policy`, por lo que el escaneo DAST semanal fallaba en la regla 90004 de ZAP en cada ejecución.** `apps/demo/vercel.json` ahora envía `same-origin` junto a la cabecera `Cross-Origin-Embedder-Policy` ya existente. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **El paso arm64 de la comprobación de arquitectura de imagen del release fallaba en cada corte multiplataforma con `docker: cannot overwrite digest`.** `scripts/check-image-arch.sh` ahora resuelve el digest de manifiesto propio de cada plataforma a partir del índice multiarquitectura antes de comprobarlo, en lugar de reutilizar la misma referencia de digest de índice bajo la que el almacén de imágenes clásico de docker no puede mantener dos variantes de plataforma. ([#1046](https://github.com/CodesWhat/drydock/pull/1046))
+- **Mover un contenedor a otro agente, o eliminar un agente de la configuración, ya no restablece su snooze, modo de madurez y etiquetas omitidas.** La poda al eliminar un agente y la propia poda de contenedores obsoletos del agente ahora también pasan `identityChangeExpected: true` y guardan la política de actualización del registro saliente bajo su id de Docker, tal como ya hacía la poda de inicio. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Un "comprobar ahora" manual que llegaba mientras ya se ejecutaba un escaneo podía disparar la misma notificación dos veces.** El panel, la API, un webhook y el controlador al consultar a un agente ahora pasan todos por la misma orquestación de escaneo single-flight que usa la programación cron, de modo que una llamada superpuesta se pliega en el único seguimiento del escaneo en curso (`result.coalesced` en el cuerpo JSON, una cabecera `X-Drydock-Watch-Coalesced` en el endpoint del agente) en lugar de iniciar un escaneo independiente propio. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Una reserva `once=true` cuyo disparador nunca respondió mantenía su clave de deduplicación durante toda la vida del proceso.** Un manejador que superaba su límite de 30 segundos conservaba su reserva más allá del escaneo que la había tomado, omitiendo silenciosamente cada envío posterior para ese resultado; cada reserva ahora expira con su propio temporizador y registra una advertencia con el nombre de la clave si nadie la liberó antes. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **DR-121: el almacén de sesiones y el almacén principal escribían el mismo `/store/dd.json`, y el que guardaba último borraba los datos del otro.** El almacén de sesiones ahora escribe en su propio archivo hermano, `dd-sessions.json` por defecto, y el almacén principal descarta una colección `Sessions` obsoleta dejada por una versión anterior en lugar de seguir guardándola. ([#1063](https://github.com/CodesWhat/drydock/pull/1063))
+- **El ejemplo emparejado de registry de Gitea de la página de agentes hacía que el controlador hablara HTTPS con un agente que servía HTTP simple.** El bloque del agente ahora monta su propio certificado y establece `DD_SERVER_TLS_ENABLED`, de modo que el ejemplo conecta tal como está escrito. ([#1042](https://github.com/CodesWhat/drydock/pull/1042))
+
+Notas completas de la versión en [CHANGELOG.md](./CHANGELOG.md#170-rc12--2026-09-06).
+
+</details>
+
+<details open>
 <summary><strong>Aspectos destacados de v1.7.0-rc.11</strong></summary>
 
 - **El inicio de sesión OIDC ya no vuelve a la página de login después de la redirección del proveedor de identidad.** El fallback de navegación del service worker respondía antes cada navegación de documento desde la app shell en caché, excepto `/api/`, de modo que el callback de OIDC nunca llegaba a Express para el intercambio de código; ahora omite cada ruta propiedad del servidor (`/api`, `/auth/`, `/health`, `/metrics`). ([#1016](https://github.com/CodesWhat/drydock/pull/1016))

--- a/README.fr.md
+++ b/README.fr.md
@@ -219,6 +219,21 @@ Consultez le [Guide de démarrage rapide](https://getdrydock.com/docs/quickstart
 <h2 align="center" id="recent-updates">Mises à jour récentes</h2>
 
 <details open>
+<summary><strong>Points forts de la v1.7.0-rc.12</strong></summary>
+
+- **Le site de démonstration n'envoyait pas `Cross-Origin-Opener-Policy`, si bien que le scan DAST hebdomadaire échouait sur la règle ZAP 90004 à chaque exécution.** `apps/demo/vercel.json` envoie désormais `same-origin` à côté de l'en-tête `Cross-Origin-Embedder-Policy` déjà présent. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Le passage arm64 du contrôle d'architecture d'image du release échouait à chaque coupe multiplateforme avec `docker: cannot overwrite digest`.** `scripts/check-image-arch.sh` résout désormais le digest de manifeste propre à chaque plateforme à partir de l'index multi-architecture avant de le sonder, au lieu de réutiliser la même référence de digest d'index sous laquelle le magasin d'images classique de docker ne peut pas conserver deux variantes de plateforme. ([#1046](https://github.com/CodesWhat/drydock/pull/1046))
+- **Déplacer un conteneur vers un autre agent, ou retirer un agent de la configuration, ne réinitialise plus son snooze, son mode de maturité et ses tags ignorés.** L'élagage au retrait d'un agent et l'élagage propre à l'agent des conteneurs obsolètes transmettent désormais eux aussi `identityChangeExpected: true` et rangent la politique de mise à jour de l'enregistrement sortant sous son id Docker, comme le fait déjà l'élagage au démarrage. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Un « vérifier maintenant » manuel arrivant pendant qu'un scan était déjà en cours pouvait déclencher deux fois la même notification.** Le tableau de bord, l'API, un webhook et le contrôleur interrogeant un agent passent désormais tous par la même orchestration de scan single-flight que celle utilisée par la planification cron, si bien qu'un appel qui chevauche est replié dans l'unique suivi du scan en cours (`result.coalesced` dans le corps JSON, un en-tête `X-Drydock-Watch-Coalesced` sur le point de terminaison de l'agent) au lieu de démarrer un scan indépendant. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Une réservation `once=true` dont le déclencheur n'a jamais répondu conservait sa clé de déduplication pendant toute la durée de vie du processus.** Un gestionnaire qui dépassait son délai de 30 secondes conservait sa réservation au-delà du scan qui l'avait prise, ignorant silencieusement chaque envoi ultérieur pour ce résultat ; chaque réservation expire désormais via son propre minuteur et journalise un avertissement nommant la clé si personne ne l'a libérée avant. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **DR-121 : le magasin de sessions et le magasin principal écrivaient dans le même `/store/dd.json`, et celui qui enregistrait en dernier effaçait les données de l'autre.** Le magasin de sessions écrit désormais dans son propre fichier jumeau, `dd-sessions.json` par défaut, et le magasin principal abandonne une collection `Sessions` obsolète laissée par une ancienne version au lieu de continuer à l'enregistrer. ([#1063](https://github.com/CodesWhat/drydock/pull/1063))
+- **L'exemple apparié de registre Gitea de la page des agents faisait parler HTTPS au contrôleur avec un agent servant du HTTP simple.** Le bloc de l'agent monte désormais son propre certificat et définit `DD_SERVER_TLS_ENABLED`, si bien que l'exemple se connecte tel qu'écrit. ([#1042](https://github.com/CodesWhat/drydock/pull/1042))
+
+Notes complètes dans [CHANGELOG.md](./CHANGELOG.md#170-rc12--2026-09-06).
+
+</details>
+
+<details open>
 <summary><strong>Points forts de la v1.7.0-rc.11</strong></summary>
 
 - **La connexion OIDC ne revient plus à la page de connexion après la redirection du fournisseur d'identité.** Le repli de navigation du service worker répondait auparavant à chaque navigation de document depuis l'app shell en cache, sauf `/api/`, si bien que le callback OIDC n'atteignait jamais Express pour l'échange de code ; il ignore désormais chaque route appartenant au serveur (`/api`, `/auth/`, `/health`, `/metrics`). ([#1016](https://github.com/CodesWhat/drydock/pull/1016))

--- a/README.md
+++ b/README.md
@@ -222,6 +222,21 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.7.0-rc.12 highlights</strong></summary>
+
+- **The demo site was missing `Cross-Origin-Opener-Policy`, so the weekly DAST scan failed on ZAP rule 90004 every run.** `apps/demo/vercel.json` now sends `same-origin` next to the existing `Cross-Origin-Embedder-Policy` header. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **The arm64 pass of the release image-arch check failed on every multi-platform cut with `docker: cannot overwrite digest`.** `scripts/check-image-arch.sh` now resolves each platform's own manifest digest out of the multi-arch index before probing it, instead of reusing the single index-digest reference docker's classic image store can't hold two platform variants under. ([#1046](https://github.com/CodesWhat/drydock/pull/1046))
+- **Moving a container to another agent, or removing an agent from config, no longer resets its snooze, maturity mode, and skipped tags.** The agent-removal prune and the agent's own stale-container prune now pass `identityChangeExpected: true` and stash the departing record's update policy under its Docker id, the same way the startup prune already did. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **A manual "check now" landing while a scan was already running could fire the same notification twice.** The dashboard, the API, a webhook, and the controller polling an agent all route through the same single-flight scan orchestration the cron schedule uses, so an overlapping call is folded into the running scan's one follow-up (`result.coalesced` in the JSON body, an `X-Drydock-Watch-Coalesced` header on the agent endpoint) instead of starting an independent scan of its own. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **A `once=true` notification whose trigger never replied held its dedup key for the process lifetime.** A handler that outlived its 30-second timeout kept its reservation past the scan that took it, silently skipping every later send for that result; each reservation now expires on its own timer and logs a warning naming the key if nothing released it first. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **DR-121: the session store and the main store wrote the same `/store/dd.json`, and whichever saved last erased the other's data.** The session store now writes to its own sibling file, `dd-sessions.json` by default, and the main store drops a stale `Sessions` collection left behind by an older build instead of continuing to resave it. ([#1063](https://github.com/CodesWhat/drydock/pull/1063))
+- **The agents page's paired Gitea registry example had the controller talking HTTPS to an agent serving plain HTTP.** The agent block now mounts its own certificate and sets `DD_SERVER_TLS_ENABLED`, so the example connects as written. ([#1042](https://github.com/CodesWhat/drydock/pull/1042))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#170-rc12--2026-09-06).
+
+</details>
+
+<details open>
 <summary><strong>v1.7.0-rc.11 highlights</strong></summary>
 
 - **OIDC login no longer bounces back to the login page after the identity provider redirects.** The service worker's navigation fallback used to answer every document navigation from the cached app shell except `/api/`, so the OIDC callback never reached Express for its code exchange; it now skips every server-owned route (`/api`, `/auth/`, `/health`, `/metrics`). ([#1016](https://github.com/CodesWhat/drydock/pull/1016))

--- a/README.pl.md
+++ b/README.pl.md
@@ -219,6 +219,21 @@ Zobacz [Przewodnik szybkiego startu](https://getdrydock.com/docs/quickstart) dla
 <h2 align="center" id="recent-updates">Ostatnie aktualizacje</h2>
 
 <details open>
+<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.12</strong></summary>
+
+- **Strona demo nie wysyłała `Cross-Origin-Opener-Policy`, przez co cotygodniowy skan DAST za każdym razem zawodził na regule ZAP 90004.** `apps/demo/vercel.json` wysyła teraz `same-origin` obok istniejącego już nagłówka `Cross-Origin-Embedder-Policy`. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Przebieg arm64 kontroli architektury obrazu wydania kończył się niepowodzeniem przy każdym wieloplatformowym cięciu z `docker: cannot overwrite digest`.** `scripts/check-image-arch.sh` teraz przed sprawdzeniem rozwiązuje własny digest manifestu każdej platformy z indeksu wieloarchitekturowego, zamiast ponownie używać tej samej referencji digestu indeksu, pod którą klasyczny magazyn obrazów dockera nie może przechowywać dwóch wariantów platform. ([#1046](https://github.com/CodesWhat/drydock/pull/1046))
+- **Przeniesienie kontenera do innego agenta albo usunięcie agenta z konfiguracji nie resetuje już jego drzemki, trybu dojrzałości i pominiętych tagów.** Przycinanie przy usuwaniu agenta oraz własne przycinanie przestarzałych kontenerów agenta przekazują teraz również `identityChangeExpected: true` i zapisują politykę aktualizacji odchodzącego wpisu pod jego id Dockera, tak jak robiło to już przycinanie przy starcie. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Ręczne „sprawdź teraz”, które trafiało w momencie, gdy skan już trwał, mogło wysłać to samo powiadomienie dwukrotnie.** Panel, API, webhook oraz kontroler odpytujący agenta przechodzą teraz przez tę samą jednoprzebiegową orkiestrację skanu, której używa harmonogram crona, dzięki czemu nakładające się wywołanie jest włączane w jedno kontynuowanie trwającego skanu (`result.coalesced` w treści JSON, nagłówek `X-Drydock-Watch-Coalesced` na punkcie końcowym agenta), zamiast uruchamiać własny niezależny skan. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Rezerwacja `once=true`, której wyzwalacz nigdy nie odpowiedział, trzymała swój klucz deduplikacji przez cały czas życia procesu.** Handler, który przekroczył swój 30-sekundowy limit czasu, zachowywał rezerwację poza skanem, który ją założył, po cichu pomijając każdą kolejną wysyłkę tego wyniku; każda rezerwacja wygasa teraz według własnego licznika czasu i zapisuje ostrzeżenie z nazwą klucza, jeśli nikt jej wcześniej nie zwolnił. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **DR-121: magazyn sesji i magazyn główny zapisywały ten sam plik `/store/dd.json`, a ten, który zapisał jako ostatni, kasował dane drugiego.** Magazyn sesji zapisuje teraz do własnego pliku siostrzanego, domyślnie `dd-sessions.json`, a magazyn główny odrzuca przestarzałą kolekcję `Sessions` pozostawioną przez starszą wersję, zamiast dalej ją zapisywać. ([#1063](https://github.com/CodesWhat/drydock/pull/1063))
+- **Sparowany przykład rejestru Gitea na stronie agentów sprawiał, że kontroler mówił po HTTPS do agenta obsługującego zwykłe HTTP.** Blok agenta montuje teraz własny certyfikat i ustawia `DD_SERVER_TLS_ENABLED`, dzięki czemu przykład łączy się tak, jak jest napisany. ([#1042](https://github.com/CodesWhat/drydock/pull/1042))
+
+Pełne informacje o wydaniu: [CHANGELOG.md](./CHANGELOG.md#170-rc12--2026-09-06).
+
+</details>
+
+<details open>
 <summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.11</strong></summary>
 
 - **Logowanie OIDC nie wraca już do strony logowania po przekierowaniu przez dostawcę tożsamości.** Nawigacyjny fallback service workera odpowiadał wcześniej na każdą nawigację dokumentu z buforowanej powłoki aplikacji, z wyjątkiem `/api/`, więc callback OIDC nigdy nie docierał do Expressa po wymianę kodu; teraz pomija każdą trasę należącą do serwera (`/api`, `/auth/`, `/health`, `/metrics`). ([#1016](https://github.com/CodesWhat/drydock/pull/1016))

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -219,6 +219,21 @@ Consulte o [Guia de início rápido](https://getdrydock.com/docs/quickstart) par
 <h2 align="center" id="recent-updates">Atualizações recentes</h2>
 
 <details open>
+<summary><strong>Destaques da v1.7.0-rc.12</strong></summary>
+
+- **O site de demonstração não enviava `Cross-Origin-Opener-Policy`, então a varredura DAST semanal falhava na regra 90004 do ZAP em toda execução.** `apps/demo/vercel.json` agora envia `same-origin` ao lado do cabeçalho `Cross-Origin-Embedder-Policy` já existente. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **A etapa arm64 da verificação de arquitetura de imagem do release falhava em todo corte multiplataforma com `docker: cannot overwrite digest`.** `scripts/check-image-arch.sh` agora resolve o digest de manifesto próprio de cada plataforma a partir do índice multiarquitetura antes de sondá-lo, em vez de reutilizar a mesma referência de digest de índice sob a qual o armazenamento de imagens clássico do docker não consegue manter duas variantes de plataforma. ([#1046](https://github.com/CodesWhat/drydock/pull/1046))
+- **Mover um contêiner para outro agente, ou remover um agente da configuração, não reseta mais seu snooze, modo de maturidade e tags ignoradas.** A poda ao remover um agente e a própria poda de contêineres obsoletos do agente agora também passam `identityChangeExpected: true` e guardam a política de atualização do registro que está saindo sob seu id do Docker, do mesmo jeito que a poda de inicialização já fazia. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Um "verificar agora" manual que chegava enquanto uma varredura já estava em execução podia disparar a mesma notificação duas vezes.** O painel, a API, um webhook e o controlador consultando um agente agora passam todos pela mesma orquestração de varredura single-flight que o agendamento cron usa, de modo que uma chamada sobreposta é incorporada ao único acompanhamento da varredura em andamento (`result.coalesced` no corpo JSON, um cabeçalho `X-Drydock-Watch-Coalesced` no endpoint do agente) em vez de iniciar uma varredura independente própria. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **Uma reserva `once=true` cujo gatilho nunca respondeu manteve sua chave de deduplicação pelo tempo de vida do processo.** Um handler que ultrapassava seu limite de 30 segundos mantinha sua reserva além da varredura que a havia tomado, ignorando silenciosamente todo envio posterior para aquele resultado; cada reserva agora expira em seu próprio temporizador e registra um aviso nomeando a chave se ninguém a liberou antes. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **DR-121: o armazenamento de sessões e o armazenamento principal escreviam no mesmo `/store/dd.json`, e quem salvasse por último apagava os dados do outro.** O armazenamento de sessões agora escreve em seu próprio arquivo irmão, `dd-sessions.json` por padrão, e o armazenamento principal descarta uma coleção `Sessions` obsoleta deixada por uma build antiga em vez de continuar salvando-a. ([#1063](https://github.com/CodesWhat/drydock/pull/1063))
+- **O exemplo pareado de registry do Gitea na página de agentes fazia o controlador falar HTTPS com um agente servindo HTTP simples.** O bloco do agente agora monta seu próprio certificado e define `DD_SERVER_TLS_ENABLED`, de modo que o exemplo conecta como está escrito. ([#1042](https://github.com/CodesWhat/drydock/pull/1042))
+
+Notas completas em [CHANGELOG.md](./CHANGELOG.md#170-rc12--2026-09-06).
+
+</details>
+
+<details open>
 <summary><strong>Destaques da v1.7.0-rc.11</strong></summary>
 
 - **O login OIDC não volta mais para a página de login depois do redirecionamento do provedor de identidade.** O fallback de navegação do service worker antes respondia a toda navegação de documento a partir do app shell em cache, exceto `/api/`, então o callback do OIDC nunca chegava ao Express para a troca de código; agora ele ignora toda rota pertencente ao servidor (`/api`, `/auth/`, `/health`, `/metrics`). ([#1016](https://github.com/CodesWhat/drydock/pull/1016))

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -219,6 +219,21 @@ docker run -d \
 <h2 align="center" id="recent-updates">最近更新</h2>
 
 <details open>
+<summary><strong>v1.7.0-rc.12 亮点</strong></summary>
+
+- **演示站点此前没有发送 `Cross-Origin-Opener-Policy`，导致每周的 DAST 扫描每次都在 ZAP 规则 90004 上失败。** `apps/demo/vercel.json` 现在会在已有的 `Cross-Origin-Embedder-Policy` 头旁发送 `same-origin`。([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **发布流程中镜像架构检查的 arm64 环节在每次多平台构建中都会因 `docker: cannot overwrite digest` 而失败。** `scripts/check-image-arch.sh` 现在会在探测之前先从多架构索引中解析出每个平台自己的清单摘要，而不是复用同一个索引摘要引用——docker 的经典镜像存储无法在该引用下保存两个平台变体。([#1046](https://github.com/CodesWhat/drydock/pull/1046))
+- **将容器迁移到另一个代理，或从配置中移除某个代理，都不会再重置它的暂停、成熟度模式和跳过的标签。** 代理移除清理以及代理自身的过期容器清理现在也会传入 `identityChangeExpected: true`，并把离开的记录的更新策略保存在其 Docker id 下，做法与启动清理一致。([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **在扫描已在进行时手动"立即检查"可能会把同一条通知发送两次。** 仪表盘、API、webhook 以及控制器轮询代理现在都通过与定时扫描相同的单飞（single-flight）扫描编排来处理，因此重叠的调用会被并入正在运行的扫描的那一次后续处理（JSON 响应体中的 `result.coalesced`，代理端点上的 `X-Drydock-Watch-Coalesced` 头），而不是各自启动一次独立扫描。([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **一个触发器从未响应的 `once=true` 预留会在进程的整个生命周期内一直占用其去重键。** 超过 30 秒超时的处理程序会让其预留在发起它的那次扫描结束后依然存在，从而悄悄跳过该结果之后的每一次发送；现在每个预留都会按自己的计时器过期，如果没有人提前释放，就会记录一条点名该键的警告日志。([#1050](https://github.com/CodesWhat/drydock/pull/1050))
+- **DR-121：会话存储和主存储此前写入同一个 `/store/dd.json`，谁最后保存就会抹掉另一方的数据。** 会话存储现在会写入自己的同级文件，默认是 `dd-sessions.json`，主存储也会丢弃旧版本遗留下来的过期 `Sessions` 集合，而不是继续保存它。([#1063](https://github.com/CodesWhat/drydock/pull/1063))
+- **代理页面配对的 Gitea registry 示例让控制器以 HTTPS 与只提供纯 HTTP 的代理通信。** 代理侧代码块现在挂载了自己的证书并设置了 `DD_SERVER_TLS_ENABLED`，因此示例可以照原样连接成功。([#1042](https://github.com/CodesWhat/drydock/pull/1042))
+
+完整发布说明见 [CHANGELOG.md](./CHANGELOG.md#170-rc12--2026-09-06)。
+
+</details>
+
+<details open>
 <summary><strong>v1.7.0-rc.11 亮点</strong></summary>
 
 - **OIDC 登录在身份提供方重定向后不会再跳回登录页面。** Service worker 的导航回退此前除 `/api/` 外都会把每次文档导航从缓存的应用外壳中响应，导致 OIDC 回调始终到不了 Express 完成授权码交换；现在它会跳过每个服务器专属路由（`/api`、`/auth/`、`/health`、`/metrics`）。([#1016](https://github.com/CodesWhat/drydock/pull/1016))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.7.0-rc.11',
+    version: '1.7.0-rc.12',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-08-12T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.7.0-rc.11 started',
+    details: 'Drydock v1.7.0-rc.12 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-08-05T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.7.0-rc.11',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.7.0-rc.12',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.7.0-rc.11',
+    tag: '1.7.0-rc.12',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.7.0-rc.11',
+  version: '1.7.0-rc.12',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.7.0-rc.11',
+      version: '1.7.0-rc.12',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.7.0-rc.11', mode: 'demo' },
+        server: { version: '1.7.0-rc.12', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.7.0-rc.11",
+  version: "1.7.0-rc.12",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -294,7 +294,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.7.0-rc.11",
+    version: "v1.7.0-rc.12",
     title: "Smart Updates & UX",
     emoji: "\u{1F680}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.7.0-rc.11",
+      "version": "1.7.0-rc.12",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.7.0-rc.11",
+    "version": "1.7.0-rc.12",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.7.0-rc.11"
+  "version":"1.7.0-rc.12"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.7.0-rc.11",
+    "version": "1.7.0-rc.12",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.7.0-rc.11",
+      "drydockVersion": "1.7.0-rc.12",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.7.0-rc.11` | Immutable release candidate; best for reproducible testing |
+| `1.7.0-rc.12` | Immutable release candidate; best for reproducible testing |
 | `1.7-rc` | Rolling release-candidate channel; moves to the newest `1.7.0-rc.N` |
 | `1.6.0` | Immutable exact GA release; best for reproducible deployments |
 | `1.6` | Rolling stable minor channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,16 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.7.0-rc.12 Highlights — September 6, 2026
+
+- **The demo site was missing `Cross-Origin-Opener-Policy`** — the weekly DAST scan failed on ZAP rule 90004 every run; `apps/demo/vercel.json` now sends `same-origin` next to the existing `Cross-Origin-Embedder-Policy` header ([#1050](https://github.com/CodesWhat/drydock/pull/1050)).
+- **The arm64 pass of the release image-arch check failed on every multi-platform cut** — `scripts/check-image-arch.sh` now resolves each platform's own manifest digest out of the multi-arch index before probing it, instead of reusing a single index-digest reference docker's classic image store can't hold two platform variants under ([#1046](https://github.com/CodesWhat/drydock/pull/1046)).
+- **Moving a container to another agent, or removing an agent from config, no longer resets its update policy** — the agent-removal prune and the agent's own stale-container prune now pass `identityChangeExpected: true` and stash the departing record's snooze, maturity mode, and skipped tags under its Docker id, the same way the startup prune already did ([#1050](https://github.com/CodesWhat/drydock/pull/1050)).
+- **A manual "check now" landing mid-scan could fire the same notification twice** — the dashboard, the API, a webhook, and the controller polling an agent all route through the same single-flight scan orchestration the cron schedule uses, reporting a coalesced call via `result.coalesced` or an `X-Drydock-Watch-Coalesced` header instead of starting an independent scan ([#1050](https://github.com/CodesWhat/drydock/pull/1050)).
+- **A `once=true` notification whose trigger never replied held its dedup key forever** — each reservation now expires on its own timer, four times the handler timeout, and logs a warning naming the key if nothing released it first ([#1050](https://github.com/CodesWhat/drydock/pull/1050)).
+- **DR-121: the session store and the main store wrote the same `/store/dd.json`, and whichever saved last erased the other's data** — the session store now writes to its own sibling file, `dd-sessions.json` by default, and the main store drops a stale `Sessions` collection left behind by an older build ([#1063](https://github.com/CodesWhat/drydock/pull/1063)).
+- **The agents page's paired Gitea registry example had the controller talking HTTPS to an agent serving plain HTTP** — the agent block now mounts its own certificate and sets `DD_SERVER_TLS_ENABLED`, so the example connects as written ([#1042](https://github.com/CodesWhat/drydock/pull/1042)).
+
 ## v1.7.0-rc.11 Highlights — September 5, 2026
 
 - **OIDC login no longer bounces back to the login page** — the service worker's navigation fallback answered every document navigation except `/api/` from the cached app shell, so the identity provider's callback never reached Express for its code exchange; the fallback now skips every server-owned route (`/api`, `/auth/`, `/health`, `/metrics`) ([#1016](https://github.com/CodesWhat/drydock/pull/1016)).

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.7 RC and prior releases have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.7.0-rc.11...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.7.0-rc.12...HEAD`],
+    ['1.7.0-rc.12', `${repositoryUrl}/compare/v1.7.0-rc.11...v1.7.0-rc.12`],
     ['1.7.0-rc.11', `${repositoryUrl}/compare/v1.7.0-rc.10...v1.7.0-rc.11`],
     ['1.7.0-rc.10', `${repositoryUrl}/compare/v1.7.0-rc.9...v1.7.0-rc.10`],
     ['1.7.0-rc.9', `${repositoryUrl}/compare/v1.7.0-rc.8...v1.7.0-rc.9`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.7.0-rc.11';
-const PREV_RC_VERSION = '1.7.0-rc.10';
-const RC_DATE = '2026-09-05';
-const RC_DISPLAY_DATE = 'September 5, 2026';
+const RC_VERSION = '1.7.0-rc.12';
+const PREV_RC_VERSION = '1.7.0-rc.11';
+const RC_DATE = '2026-09-06';
+const RC_DISPLAY_DATE = 'September 6, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.6', 'content/docs/v1.5'];
 const RELEASE_REDIRECT_STATUSES = [301, 302, 303, 307, 308];
 const BROAD_401_CLAIM =
@@ -142,7 +142,7 @@ test('release candidate notes cover the post-promotion fixes', () => {
     `## v${RC_VERSION} Highlights — ${RC_DISPLAY_DATE}`,
   );
 
-  for (const issue of [1021]) {
+  for (const issue of []) {
     const issueLink = `https://github.com/CodesWhat/drydock/issues/${issue}`;
     const pullLink = `https://github.com/CodesWhat/drydock/pull/${issue}`;
     assert.ok(
@@ -155,17 +155,17 @@ test('release candidate notes cover the post-promotion fixes', () => {
     );
   }
 
-  for (const pull of [1010, 1018, 1024, 1037]) {
+  for (const pull of [1042, 1046, 1050, 1063]) {
     const pullLink = `https://github.com/CodesWhat/drydock/pull/${pull}`;
     assert.ok(updates.includes(pullLink), `updates page must link PR #${pull}`);
   }
 
   for (const fragment of [
-    '`/api`',
-    '`/auth/`',
-    '`/health`',
-    '`/metrics`',
-    '`DD_AGENT_REMOTE1_CAFILE`',
+    '`Cross-Origin-Opener-Policy`',
+    '`identityChangeExpected: true`',
+    '`result.coalesced`',
+    '`dd-sessions.json`',
+    '`DD_SERVER_TLS_ENABLED`',
   ]) {
     assert.ok(changelog.includes(fragment), `CHANGELOG.md must include ${fragment}`);
     assert.ok(updates.includes(fragment), `updates page must include ${fragment}`);

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.7.0';
-const RC_VERSION = '1.7.0-rc.11';
+const RC_VERSION = '1.7.0-rc.12';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',

--- a/scripts/release-precut-check.test.mjs
+++ b/scripts/release-precut-check.test.mjs
@@ -328,7 +328,7 @@ test('cli exits 1 and reports pending discussion when strict RC check has an unc
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.11'],
+    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.12'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -345,7 +345,7 @@ test('cli exits 0 when --force is set even with pending replies', () => {
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', '--force', 'v1.7.0-rc.11'],
+    [scriptPath, '--tracker', trackerPath, '--strict', '--force', 'v1.7.0-rc.12'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -360,7 +360,7 @@ test('cli exits 0 with warning when tracker file does not exist', () => {
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.11'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.12'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -377,7 +377,7 @@ test('cli exits 0 for prerelease tags with pending replies (informational only)'
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.11'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.12'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -393,7 +393,7 @@ test('cli exits 1 for prerelease tags with --strict and pending replies', () => 
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.11'],
+    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.12'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -409,7 +409,7 @@ test('cli exits 0 and prints success when tracker has no pending replies', () =>
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.11'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.12'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',


### PR DESCRIPTION
Release-prepare commit for v1.7.0-rc.12, same 25-file shape as the rc.11 one.

Moves the six Unreleased Fixed bullets (demo COOP header, arm64 arch-check digest overwrite, the two once-notification fixes and the prune policy stash from the 1.7 port batch, DR-121 session store file) and the agents-page TLS doc fix under `## [1.7.0-rc.12] — 2026-09-06`, adds the README highlight blocks in all seven languages plus the docs updates page entry, and bumps the version string in the demo mocks, site config, API docs and release tests.
