### PR TITLE
ci(dast): bound the ZAP spider and active scan inside the job budget

### DIFF
--- a/.github/tests/security-dast-web-workflow.test.ts
+++ b/.github/tests/security-dast-web-workflow.test.ts
@@ -89,9 +89,13 @@ test('the ZAP full scan bounds its spider and active scan inside the job budget'
   const scanMinutes = Number(cmdOptions.match(/scanner\.maxScanDurationInMins=(\d+)/u)?.[1]);
   const ruleMinutes = Number(cmdOptions.match(/scanner\.maxRuleDurationInMins=(\d+)/u)?.[1]);
 
-  expect(spiderMinutes).toBeGreaterThan(0);
-  expect(scanMinutes).toBeGreaterThan(0);
-  expect(ruleMinutes).toBeGreaterThan(0);
+  // Floors, not pins: the caps may move as the site grows, but a cap small
+  // enough to skip most of the scan would pass the budget check below while
+  // gutting the gate. 5 minutes of spidering and 20 of active scanning are
+  // the least that still covers the docs site's route set.
+  expect(spiderMinutes).toBeGreaterThanOrEqual(5);
+  expect(scanMinutes).toBeGreaterThanOrEqual(20);
+  expect(ruleMinutes).toBeGreaterThanOrEqual(1);
   expect(ruleMinutes).toBeLessThanOrEqual(scanMinutes);
   // 15 minutes of headroom for ZAP startup, the passive scan and the report.
   expect(spiderMinutes + scanMinutes).toBeLessThanOrEqual(Number(zapTimeout) - 15);

--- a/.github/tests/security-dast-web-workflow.test.ts
+++ b/.github/tests/security-dast-web-workflow.test.ts
@@ -74,6 +74,29 @@ test("ZAP's own budget exceeds the measured full-scan duration", () => {
   expect(typeof nucleiTimeout).toBe('number');
 });
 
+test('the ZAP full scan bounds its spider and active scan inside the job budget', () => {
+  // Both weekly runs to date (32948622205, 33630040351) were cancelled at the
+  // 60-minute job timeout: unbounded, the spider plus the full active scan
+  // against the docs site outgrows the budget and no report is written, so
+  // the gate never fires. The scan step caps each phase and the caps have to
+  // leave room for startup, the passive scan and the report.
+  const workflow = loadWorkflow();
+  const zapTimeout = workflow.jobs?.[ZAP_JOB]?.['timeout-minutes'];
+  const scanStep = getWorkflowStep(ZAP_JOB, 'Run ZAP full scan');
+  const cmdOptions = scanStep?.with?.cmd_options?.toString() ?? '';
+
+  const spiderMinutes = Number(cmdOptions.match(/(?:^|\s)-m\s+(\d+)/u)?.[1]);
+  const scanMinutes = Number(cmdOptions.match(/scanner\.maxScanDurationInMins=(\d+)/u)?.[1]);
+  const ruleMinutes = Number(cmdOptions.match(/scanner\.maxRuleDurationInMins=(\d+)/u)?.[1]);
+
+  expect(spiderMinutes).toBeGreaterThan(0);
+  expect(scanMinutes).toBeGreaterThan(0);
+  expect(ruleMinutes).toBeGreaterThan(0);
+  expect(ruleMinutes).toBeLessThanOrEqual(scanMinutes);
+  // 15 minutes of headroom for ZAP startup, the passive scan and the report.
+  expect(spiderMinutes + scanMinutes).toBeLessThanOrEqual(Number(zapTimeout) - 15);
+});
+
 test('Nuclei steps live in the Nuclei job, not the ZAP job', () => {
   const nucleiScanStep = getWorkflowStep(NUCLEI_JOB, 'Run Nuclei scan');
   expect(nucleiScanStep?.uses).toContain('projectdiscovery/nuclei-action');

--- a/.github/workflows/security-dast-web.yml
+++ b/.github/workflows/security-dast-web.yml
@@ -64,6 +64,18 @@ jobs:
           rules_file_name: .zap/rules.tsv
           allow_issue_writing: false
           fail_action: true
+          # Bound every phase so the scan finishes inside the job budget.
+          # Unbounded, the spider plus the full active scan against the docs
+          # site outgrew 60 minutes and both weekly runs to date (32948622205,
+          # 33630040351) were cancelled at the job timeout with no report
+          # written. -m caps the spider; the two -config values cap the
+          # active scan overall and per rule (ZAP's "Max scan duration" and
+          # "Max rule duration" options). 10 + 35 leaves ~15 minutes for
+          # startup, the passive scan and the report inside the 60-minute
+          # job. The workflow test pins that arithmetic.
+          cmd_options: >-
+            -m 10
+            -z "-config scanner.maxScanDurationInMins=35 -config scanner.maxRuleDurationInMins=5"
 
       - name: Convert ZAP JSON report to SARIF
         if: always() && hashFiles('report_json.json') != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The weekly ZAP full scan of getdrydock.com ran into its 60-minute job timeout on every run, so it never produced a report.** The scan step now caps the spider at 10 minutes and the active scan at 35 minutes (5 per rule), leaving room for startup, the passive scan and the report inside the job budget; a workflow test pins the arithmetic.
+
 ## [1.7.0-rc.12] — 2026-09-06
 
 ### Fixed


### PR DESCRIPTION
CI-14. Both weekly `security-dast-web.yml` runs to date (32948622205, 33630040351) had the `DAST: getdrydock.com (ZAP)` job cancelled at its 60-minute timeout. Unbounded, the spider plus the full active scan against the docs site outgrows the budget, no report gets written, and the gate never fires. The step logs for the cancelled scan aren't retained, so the split between spider and active scan isn't measurable from the runs.

The scan step now passes `cmd_options` capping the spider at 10 minutes and the active scan at 35 minutes overall and 5 per rule (ZAP's `scanner.maxScanDurationInMins` and `scanner.maxRuleDurationInMins`), leaving about 15 minutes for startup, the passive scan and the report. A workflow test parses the options and asserts spider plus scan fits inside the job timeout with that headroom, so lowering the timeout or raising the caps out of proportion fails the test.

This reaches `main` with the GA promotion, where the weekly cron runs; the next weekly run after that is the proof. Same change lands on dev/v1.8 in a sibling PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed ZAP DAST limits:
  - Spider: 10 minutes.
  - Active scan: 35 minutes.
  - Per-rule scan: 5 minutes.
- ✨ Added a regression test for scan limits and the 60-minute job budget.
- 🔒 Prevented ZAP jobs from timing out before report generation and gate evaluation.

## Concerns

- Verify the test parses all `cmd_options` values used by the workflow.
- Verify the 15-minute headroom covers startup, passive scanning, and report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->