### PR TITLE
refactor(store): drop the unused deleteBackup export

### DIFF
--- a/app/store/backup.test.ts
+++ b/app/store/backup.test.ts
@@ -677,28 +677,6 @@ describe('Backup Store', () => {
     expect(result).toBeUndefined();
   });
 
-  test('deleteBackup should remove a backup by id', () => {
-    backup.insertBackup({
-      id: 'b1',
-      containerId: 'c1',
-      containerName: 'nginx',
-      imageName: 'library/nginx',
-      imageTag: '1.24',
-      triggerName: 'docker.default',
-    } as never);
-
-    const deleted = backup.deleteBackup('b1');
-    expect(deleted).toBe(true);
-
-    const result = backup.getBackup('b1');
-    expect(result).toBeUndefined();
-  });
-
-  test('deleteBackup should return false for unknown id', () => {
-    const deleted = backup.deleteBackup('unknown');
-    expect(deleted).toBe(false);
-  });
-
   test('pruneOldBackups should keep only the N most recent backups', () => {
     backup.insertBackup({
       containerId: 'c1',
@@ -908,13 +886,6 @@ describe('Backup Store', () => {
     const freshBackup = await import('./backup.js');
     const result = freshBackup.getBackup('b1');
     expect(result).toBeUndefined();
-  });
-
-  test('deleteBackup should return false when the store is not initialized', async () => {
-    vi.resetModules();
-    const freshBackup = await import('./backup.js');
-    const result = freshBackup.deleteBackup('b1');
-    expect(result).toBe(false);
   });
 
   test('insertBackup should return generated values when the store is not initialized', async () => {

--- a/app/store/backup.ts
+++ b/app/store/backup.ts
@@ -128,18 +128,6 @@ export function getBackup(id: string): ImageBackup | undefined {
 }
 
 /**
- * Delete a backup by id.
- * @param id
- */
-export function deleteBackup(id: string): boolean {
-  if (!db) {
-    return false;
-  }
-  const result = db.prepare('DELETE FROM backups WHERE id = ?').run(id);
-  return result.changes > 0;
-}
-
-/**
  * Prune old backups for a container's canonical identity, keeping only the N
  * most recent.
  * @param scope


### PR DESCRIPTION
DR-87. `deleteBackup()` in `app/store/backup.ts` had no caller in app, ui or e2e beyond its own tests; backups are pruned by retention, not deleted individually. Removed with its three tests. `store/backup.test.ts` 47 green, `backup.ts` at 100% on every metric.

The batch this came from also checked DR-23, DR-24 and DR-25; all three already landed in #1061 and the roadmap has been corrected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🗑️ Removed the unused `deleteBackup(id)` export from `app/store/backup.ts`.
- 🗑️ Removed the three `deleteBackup` tests from `app/store/backup.test.ts`.
- 🔧 Preserved backup retrieval, retention pruning, and uninitialized-store behavior.
- 🔧 `store/backup.test.ts` reports 47 passing tests.
- 🔧 `backup.ts` reports 100% coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->