### PR TITLE
docs: refresh the version table, add an anchor check, and settle the web app version

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -2,6 +2,14 @@ import { createMDX } from "fumadocs-mdx/next";
 
 import { escapeRegExp, versions } from "./scripts/docs-versions.mjs";
 
+// apps/web/package.json's "version" field stays 0.1.0 on purpose and is not
+// bumped alongside the root release. It's a private, never-published npm
+// workspace member (see "private": true in that file), and nothing reads the
+// field: not this config, not Vercel, not any script under scripts/. The
+// version the site actually shows to readers is src/lib/site-config.ts's
+// `version`, which release-precut-check.mjs does keep in step with the root
+// release on every cut.
+
 const withMDX = createMDX();
 
 // Derived from the single source of truth in scripts/docs-versions.mjs.

--- a/apps/web/scripts/docs-anchors.mjs
+++ b/apps/web/scripts/docs-anchors.mjs
@@ -1,0 +1,69 @@
+// Walks content/docs/current/**/*.mdx, computes each page's heading ids with
+// the same remark pipeline the site's MDX build uses (see source.config.ts),
+// and resolves every in-repo anchor link — same-page `#slug` and cross-page
+// `/docs/...#slug` — against those ids. content/docs/v1.x/** is out of scope
+// on purpose: those directories are frozen GA snapshots and are never rebuilt.
+
+import { readdirSync, statSync } from "node:fs";
+import { extname, join, relative, sep } from "node:path";
+import { compile } from "@mdx-js/mdx";
+import { remarkGfm, remarkHeading } from "fumadocs-core/mdx-plugins";
+import remarkCustomHeadingId from "remark-custom-heading-id";
+
+// Same plugin order as apps/web/source.config.ts's defineConfig(), minus the
+// bundler-only image/codeTab/structure plugins that don't affect heading ids.
+const REMARK_PLUGINS = [remarkGfm, [remarkHeading, { generateToc: false }], remarkCustomHeadingId];
+
+export function listMdxFiles(root) {
+  const files = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const target = join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listMdxFiles(target));
+      continue;
+    }
+    if (entry.isFile() && extname(entry.name) === ".mdx") {
+      files.push(target);
+    }
+  }
+  return files;
+}
+
+// content/docs/current/configuration/watchers/index.mdx -> /docs/configuration/watchers
+// content/docs/current/index.mdx                         -> /docs
+export function docsPathForFile(docsRoot, filePath) {
+  const rel = relative(docsRoot, filePath).split(sep).join("/");
+  const withoutIndex = rel.replace(/(^|\/)index\.mdx$/, "").replace(/\.mdx$/, "");
+  return withoutIndex ? `/docs/${withoutIndex}` : "/docs";
+}
+
+export async function headingSlugsForSource(source) {
+  const file = await compile(source, {
+    outputFormat: "function-body",
+    remarkPlugins: REMARK_PLUGINS,
+  });
+  const text = String(file);
+  return [...text.matchAll(/\{\s*id:\s*"([^"]+)"/g)].map((match) => match[1]);
+}
+
+const SAME_PAGE_ANCHOR_RE = /\]\(#([^)\s]+)\)/g;
+const DOCS_ANCHOR_RE = /\]\((\/docs(?:\/[^)#\s]*)?)#([^)\s]+)\)/g;
+
+export function findSamePageAnchors(source) {
+  return [...source.matchAll(SAME_PAGE_ANCHOR_RE)].map((match) => match[1]);
+}
+
+export function findCrossPageDocAnchors(source) {
+  return [...source.matchAll(DOCS_ANCHOR_RE)].map((match) => ({
+    path: match[1],
+    anchor: match[2],
+  }));
+}
+
+export function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/scripts/docs-anchors.mjs
+++ b/apps/web/scripts/docs-anchors.mjs
@@ -1,7 +1,9 @@
 // Walks content/docs/current/**/*.mdx, computes each page's heading ids with
 // the same remark pipeline the site's MDX build uses (see source.config.ts),
 // and resolves every in-repo anchor link — same-page `#slug` and cross-page
-// `/docs/...#slug` — against those ids. content/docs/v1.x/** is out of scope
+// `/docs/...#slug` — against those ids. Links are collected from the parsed
+// mdast tree, not the raw source, so link-shaped text inside code spans and
+// fenced code blocks is never scanned. content/docs/v1.x/** is out of scope
 // on purpose: those directories are frozen GA snapshots and are never rebuilt.
 
 import { readdirSync, statSync } from "node:fs";
@@ -46,18 +48,68 @@ export async function headingSlugsForSource(source) {
   return [...text.matchAll(/\{\s*id:\s*"([^"]+)"/g)].map((match) => match[1]);
 }
 
-const SAME_PAGE_ANCHOR_RE = /\]\(#([^)\s]+)\)/g;
-const DOCS_ANCHOR_RE = /\]\((\/docs(?:\/[^)#\s]*)?)#([^)\s]+)\)/g;
-
-export function findSamePageAnchors(source) {
-  return [...source.matchAll(SAME_PAGE_ANCHOR_RE)].map((match) => match[1]);
+// Walk the mdast tree (not the raw source) for link destinations. `link` is
+// every markdown/MDX link; `definition` is the target of a reference-style
+// link (`[text][ref]` / `[ref]: /target`) — content/docs/current doesn't use
+// that form today, but it's cheap to cover so a future doc that does isn't
+// silently skipped. Recursing into `children` rather than doing a source
+// regex means text inside a fenced code block or inline code span — which
+// mdast represents as `code`/`inlineCode` leaf nodes with a `value`, not as
+// parsed markdown — is never visited, so a link-shaped literal like
+// `` `[example](#missing)` `` in a code sample can't be mistaken for a link.
+function collectLinkUrls(node, urls) {
+  if (node.type === "link" || node.type === "definition") {
+    urls.push(node.url);
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      collectLinkUrls(child, urls);
+    }
+  }
 }
 
-export function findCrossPageDocAnchors(source) {
-  return [...source.matchAll(DOCS_ANCHOR_RE)].map((match) => ({
-    path: match[1],
-    anchor: match[2],
-  }));
+function linkCollectorPlugin(urls) {
+  return () => (tree) => {
+    collectLinkUrls(tree, urls);
+  };
+}
+
+async function linkUrlsForSource(source) {
+  const urls = [];
+  await compile(source, {
+    outputFormat: "function-body",
+    remarkPlugins: [...REMARK_PLUGINS, linkCollectorPlugin(urls)],
+  });
+  return urls;
+}
+
+const DOCS_ANCHOR_URL_RE = /^(\/docs(?:\/[^#]*)?)#(.+)$/;
+
+// Links like /docs/configuration/triggers/#anchor carry a trailing slash
+// that byDocsPath's keys (built from docsPathForFile, which never emits one)
+// don't, so the lookup would silently miss and the anchor would never be
+// checked. Strip it before the lookup, keeping "/docs" itself as the root.
+// A path that still doesn't match any indexed page after normalising is a
+// dead page path — a routing problem outside this anchor check, not
+// something this function decides; callers keep skipping those.
+export function normalizeDocsPath(path) {
+  return path !== "/docs" && path.endsWith("/") ? path.slice(0, -1) : path;
+}
+
+export async function findSamePageAnchors(source) {
+  const urls = await linkUrlsForSource(source);
+  return urls.filter((url) => url.startsWith("#")).map((url) => url.slice(1));
+}
+
+export async function findCrossPageDocAnchors(source) {
+  const urls = await linkUrlsForSource(source);
+  const links = [];
+  for (const url of urls) {
+    const match = url.match(DOCS_ANCHOR_URL_RE);
+    if (!match) continue;
+    links.push({ path: normalizeDocsPath(match[1]), anchor: match[2] });
+  }
+  return links;
 }
 
 export function isDirectory(path) {

--- a/apps/web/scripts/docs-anchors.test.mjs
+++ b/apps/web/scripts/docs-anchors.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  docsPathForFile,
+  findCrossPageDocAnchors,
+  findSamePageAnchors,
+  headingSlugsForSource,
+  isDirectory,
+  listMdxFiles,
+} from "./docs-anchors.mjs";
+
+const scriptDir = fileURLToPath(new URL(".", import.meta.url));
+const docsRoot = join(scriptDir, "..", "..", "..", "content", "docs", "current");
+
+async function buildSlugIndex() {
+  const files = listMdxFiles(docsRoot);
+  const bySourcePath = new Map();
+  const byDocsPath = new Map();
+
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    const slugs = new Set(await headingSlugsForSource(source));
+    const docsPath = docsPathForFile(docsRoot, file);
+    bySourcePath.set(file, { source, slugs, docsPath });
+    byDocsPath.set(docsPath, slugs);
+  }
+
+  return { files, bySourcePath, byDocsPath };
+}
+
+// Every /docs/... target that isn't itself a page (e.g. /docs/configuration
+// resolves fine, but a target that 404s isn't an anchor problem this check
+// owns) still needs to resolve to a real page before its anchor is checkable.
+// Assets and off-site links never carry a same-page-checkable anchor.
+function isCheckableDocsPath(path) {
+  return path !== "/docs/assets" && !path.startsWith("/docs/assets/");
+}
+
+test("every same-page #anchor link resolves to a real heading id", async () => {
+  const { bySourcePath } = await buildSlugIndex();
+  const failures = [];
+
+  for (const [file, { source, slugs }] of bySourcePath) {
+    for (const anchor of findSamePageAnchors(source)) {
+      if (!slugs.has(anchor)) {
+        failures.push(`${file}: #${anchor} has no matching heading on the same page`);
+      }
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});
+
+test("every cross-page /docs/...#anchor link resolves to a heading id on the target page", async () => {
+  const { bySourcePath, byDocsPath } = await buildSlugIndex();
+  const failures = [];
+
+  for (const [file, { source }] of bySourcePath) {
+    for (const { path, anchor } of findCrossPageDocAnchors(source)) {
+      if (!isCheckableDocsPath(path)) continue;
+
+      const targetSlugs = byDocsPath.get(path);
+      if (!targetSlugs) {
+        // A dead /docs/... path is a routing problem, not an anchor problem —
+        // out of scope for this check.
+        continue;
+      }
+      if (!targetSlugs.has(anchor)) {
+        failures.push(`${file}: ${path}#${anchor} has no matching heading on ${path}`);
+      }
+    }
+  }
+
+  assert.deepEqual(failures, []);
+});
+
+// Regression cases for the three anchors DOC-3 found dead: the heading text
+// contains "&" or "/", which github-slugger turns into a double hyphen
+// (adjacent-whitespace collapse around a stripped punctuation character), not
+// the single hyphen a naive slug guess would produce.
+test("DOC-3 regression: docker-compose links to the docker trigger's Image Backup & Rollback heading", async () => {
+  const file = join(docsRoot, "configuration", "triggers", "docker-compose", "index.mdx");
+  const source = readFileSync(file, "utf8");
+  const links = findCrossPageDocAnchors(source);
+  assert.ok(
+    links.some(
+      (link) =>
+        link.path === "/docs/configuration/triggers/docker" &&
+        link.anchor === "image-backup--rollback",
+    ),
+    "expected docker-compose/index.mdx to link to /docs/configuration/triggers/docker#image-backup--rollback",
+  );
+
+  const targetSource = readFileSync(
+    join(docsRoot, "configuration", "triggers", "docker", "index.mdx"),
+    "utf8",
+  );
+  const targetSlugs = await headingSlugsForSource(targetSource);
+  assert.ok(targetSlugs.includes("image-backup--rollback"));
+});
+
+test("DOC-3 regression: watchers links to its own WATCHALL / WATCHBYDEFAULT behavior matrix heading", async () => {
+  const file = join(docsRoot, "configuration", "watchers", "index.mdx");
+  const source = readFileSync(file, "utf8");
+  assert.ok(findSamePageAnchors(source).includes("watchall--watchbydefault-behavior-matrix"));
+
+  const slugs = await headingSlugsForSource(source);
+  assert.ok(slugs.includes("watchall--watchbydefault-behavior-matrix"));
+});
+
+test("DOC-3 regression: updates links to the ui config's Language / Locale heading", async () => {
+  const file = join(docsRoot, "updates", "index.mdx");
+  const source = readFileSync(file, "utf8");
+  const links = findCrossPageDocAnchors(source);
+  assert.ok(
+    links.some(
+      (link) => link.path === "/docs/configuration/ui" && link.anchor === "language--locale",
+    ),
+    "expected updates/index.mdx to link to /docs/configuration/ui#language--locale",
+  );
+
+  const targetSource = readFileSync(join(docsRoot, "configuration", "ui", "index.mdx"), "utf8");
+  const targetSlugs = await headingSlugsForSource(targetSource);
+  assert.ok(targetSlugs.includes("language--locale"));
+});
+
+test("docsPathForFile derives the site path the sync step publishes", () => {
+  assert.equal(
+    docsPathForFile(docsRoot, join(docsRoot, "configuration", "watchers", "index.mdx")),
+    "/docs/configuration/watchers",
+  );
+  assert.equal(docsPathForFile(docsRoot, join(docsRoot, "index.mdx")), "/docs");
+});
+
+test("docsRoot exists and is a directory", () => {
+  assert.ok(isDirectory(docsRoot));
+});

--- a/apps/web/scripts/docs-anchors.test.mjs
+++ b/apps/web/scripts/docs-anchors.test.mjs
@@ -45,7 +45,7 @@ test("every same-page #anchor link resolves to a real heading id", async () => {
   const failures = [];
 
   for (const [file, { source, slugs }] of bySourcePath) {
-    for (const anchor of findSamePageAnchors(source)) {
+    for (const anchor of await findSamePageAnchors(source)) {
       if (!slugs.has(anchor)) {
         failures.push(`${file}: #${anchor} has no matching heading on the same page`);
       }
@@ -60,7 +60,7 @@ test("every cross-page /docs/...#anchor link resolves to a heading id on the tar
   const failures = [];
 
   for (const [file, { source }] of bySourcePath) {
-    for (const { path, anchor } of findCrossPageDocAnchors(source)) {
+    for (const { path, anchor } of await findCrossPageDocAnchors(source)) {
       if (!isCheckableDocsPath(path)) continue;
 
       const targetSlugs = byDocsPath.get(path);
@@ -85,7 +85,7 @@ test("every cross-page /docs/...#anchor link resolves to a heading id on the tar
 test("DOC-3 regression: docker-compose links to the docker trigger's Image Backup & Rollback heading", async () => {
   const file = join(docsRoot, "configuration", "triggers", "docker-compose", "index.mdx");
   const source = readFileSync(file, "utf8");
-  const links = findCrossPageDocAnchors(source);
+  const links = await findCrossPageDocAnchors(source);
   assert.ok(
     links.some(
       (link) =>
@@ -106,7 +106,8 @@ test("DOC-3 regression: docker-compose links to the docker trigger's Image Backu
 test("DOC-3 regression: watchers links to its own WATCHALL / WATCHBYDEFAULT behavior matrix heading", async () => {
   const file = join(docsRoot, "configuration", "watchers", "index.mdx");
   const source = readFileSync(file, "utf8");
-  assert.ok(findSamePageAnchors(source).includes("watchall--watchbydefault-behavior-matrix"));
+  const anchors = await findSamePageAnchors(source);
+  assert.ok(anchors.includes("watchall--watchbydefault-behavior-matrix"));
 
   const slugs = await headingSlugsForSource(source);
   assert.ok(slugs.includes("watchall--watchbydefault-behavior-matrix"));
@@ -115,7 +116,7 @@ test("DOC-3 regression: watchers links to its own WATCHALL / WATCHBYDEFAULT beha
 test("DOC-3 regression: updates links to the ui config's Language / Locale heading", async () => {
   const file = join(docsRoot, "updates", "index.mdx");
   const source = readFileSync(file, "utf8");
-  const links = findCrossPageDocAnchors(source);
+  const links = await findCrossPageDocAnchors(source);
   assert.ok(
     links.some(
       (link) => link.path === "/docs/configuration/ui" && link.anchor === "language--locale",
@@ -126,6 +127,65 @@ test("DOC-3 regression: updates links to the ui config's Language / Locale headi
   const targetSource = readFileSync(join(docsRoot, "configuration", "ui", "index.mdx"), "utf8");
   const targetSlugs = await headingSlugsForSource(targetSource);
   assert.ok(targetSlugs.includes("language--locale"));
+});
+
+// Link-shaped text inside a fenced code block or an inline code span must
+// never be treated as a real link — those are literal MDX text nodes, not
+// parsed markdown — while a genuinely broken anchor elsewhere on the same
+// page is still caught.
+test("code spans and fenced code blocks are not scanned for anchors, but a real broken link in the same fixture still is", async () => {
+  const source = [
+    "# Heading",
+    "",
+    "Real anchor: [real](#heading).",
+    "",
+    "Fenced block with a link-shaped literal that must not be treated as a link:",
+    "",
+    "```md",
+    "[example](#missing)",
+    "```",
+    "",
+    "Inline code span with a link-shaped literal: `[example](#missing)`.",
+    "",
+    "Broken anchor: [broken](#definitely-missing).",
+    "",
+  ].join("\n");
+
+  const slugs = new Set(await headingSlugsForSource(source));
+  const anchors = await findSamePageAnchors(source);
+
+  assert.deepEqual(anchors, ["heading", "definitely-missing"]);
+  assert.ok(
+    !anchors.includes("missing"),
+    "the code-block/code-span literal must not surface as a link",
+  );
+
+  const failures = anchors.filter((anchor) => !slugs.has(anchor));
+  assert.deepEqual(failures, ["definitely-missing"]);
+});
+
+// /docs/configuration/watchers/#anchor (trailing slash) must resolve against
+// the same indexed page as /docs/configuration/watchers#anchor.
+test("a trailing slash on a cross-page /docs/.../ link still resolves against the indexed page", async () => {
+  const { byDocsPath } = await buildSlugIndex();
+
+  const missingAnchorSource = "[broken](/docs/configuration/watchers/#definitely-missing-anchor)\n";
+  const missingAnchorLinks = await findCrossPageDocAnchors(missingAnchorSource);
+  assert.deepEqual(missingAnchorLinks, [
+    { path: "/docs/configuration/watchers", anchor: "definitely-missing-anchor" },
+  ]);
+  const missingAnchorTarget = byDocsPath.get(missingAnchorLinks[0].path);
+  assert.ok(missingAnchorTarget, "trailing-slash link must still resolve to the indexed page");
+  assert.ok(!missingAnchorTarget.has(missingAnchorLinks[0].anchor));
+
+  const validAnchorSource =
+    "[valid](/docs/configuration/watchers/#watchall--watchbydefault-behavior-matrix)\n";
+  const validAnchorLinks = await findCrossPageDocAnchors(validAnchorSource);
+  assert.deepEqual(validAnchorLinks, [
+    { path: "/docs/configuration/watchers", anchor: "watchall--watchbydefault-behavior-matrix" },
+  ]);
+  const validAnchorTarget = byDocsPath.get(validAnchorLinks[0].path);
+  assert.ok(validAnchorTarget.has(validAnchorLinks[0].anchor));
 });
 
 test("docsPathForFile derives the site path the sync step publishes", () => {

--- a/content/docs/current/api/approvals.mdx
+++ b/content/docs/current/api/approvals.mdx
@@ -128,4 +128,4 @@ curl -X POST http://drydock:3000/api/v1/approvals/6f2a1e3c-9b7d-4a2e-8c1f-3d4e5f
 
 ## Events
 
-Every reconciler and decision writes an SSE event: `dd:approval-created` when a row is minted, `dd:approval-decided` on approve/reject/defer, and `dd:approval-resolved` when a row leaves the queue by any other path (candidate withdrawn or superseded, container removed). All three carry `{ id, containerId, containerName, decision, pendingCount }` — `pendingCount` is the post-write count, so a client can update a badge directly without a follow-up request. See the [SSE event list](/docs/api#server-sent-events).
+Every reconciler and decision writes an SSE event: `dd:approval-created` when a row is minted, `dd:approval-decided` on approve/reject/defer, and `dd:approval-resolved` when a row leaves the queue by any other path (candidate withdrawn or superseded, container removed). All three carry `{ id, containerId, containerName, decision, pendingCount }` — `pendingCount` is the post-write count, so a client can update a badge directly without a follow-up request. See the [SSE event list](/docs/api#server-sent-events-sse).

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,3 +12,14 @@ Documentation content is versioned under `/content/docs`:
 The version list itself lives in `apps/web/scripts/docs-versions.mjs`. Its first entry maps the `current` source directory to the active public slug, and every other entry maps a snapshot source directory to its slug. Update that file, not this one, when a line ships or retires.
 
 The site/docs app lives in `/apps/web` and uses `npm run sync:docs` to copy each entry from `docs-versions.mjs` into `apps/web/content/docs/<slug>`. The synced copy is gitignored.
+
+## Where the live lines stand right now
+
+| Line | Status | Maps to |
+|---|---|---|
+| v1.8 | next, in development on `dev/v1.8` | still `current` — there is no `content/docs/v1.8` yet. It's cut from `current` at v1.8 GA, the same way `content/docs/v1.6` was cut from `current` at v1.6 GA. |
+| v1.7 | current (`docs-versions.mjs`'s first entry, `slug: "v1.7"`) | `content/docs/current` |
+| v1.6 | maintenance (previous line) | `content/docs/v1.6`, a frozen snapshot |
+| v1.5 and earlier | archived, no longer maintained | `content/docs/v1.5`, `v1.4`, `v1.3`, frozen snapshots |
+
+`current` always holds the docs for whichever line is actively being written, which is why v1.8 work already lands there even before `docs-versions.mjs` is bumped at the release cut. Reread `apps/web/scripts/docs-versions.mjs` for the exact mapping — this table is a snapshot of it, not a replacement.


### PR DESCRIPTION
Three roadmap docs items, one commit each.

DOC-2: `docs/README.md` gains a table of where the live lines stand (v1.8 next, v1.7 current, v1.6 maintenance, earlier archived) and which `content/docs/` directory each maps to, checked against the directories and `apps/web/scripts/docs-versions.mjs`.

DOC-3: the three anchors the roadmap called dead turned out to resolve already. The double hyphens are what github-slugger produces for a stripped `&` or `/`, so `image-backup--rollback`, `watchall--watchbydefault-behavior-matrix` and `language--locale` are the correct ids. What was missing was a check, so `apps/web/scripts/docs-anchors.mjs` plus its test now walks `content/docs/current/**/*.mdx`, resolves same-page and cross-page `/docs/...#anchor` links against heading ids computed through the site's own remark pipeline, and carries those three as regression cases. It found one real break: `api/approvals.mdx` linked `#server-sent-events` where the heading slugs to `server-sent-events-sse`. Fixed. Frozen `v1.x` snapshots untouched.

DOC-4: `apps/web/package.json` stays at `0.1.0` on purpose and `next.config.mjs` now says so. It is private, never published, never bumped in its history, and nothing reads the field; the displayed site version comes from `site-config.ts`, which the precut check keeps in step with the release. The portwing `SERVER_COMPAT_LEVEL` claim the roadmap wanted verified does not exist anywhere in the changelog or docs; the only statement of the value is the portwing API page's `1.4.0`, which matches both `app/api/portwing-ws.ts` and portwing's `COMPATIBILITY.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- ✨ Added documentation version mapping in `docs/README.md`.
- ✨ Added current MDX anchor validation script and tests.
- 🔧 Documented intentional `0.1.0` handling in `apps/web/next.config.mjs`.
- 🐛 Fixed the Approvals API link to `#server-sent-events-sse`.
- 🔧 Confirmed portwing compatibility value `1.4.0`.
- 🔒 Kept frozen `v1.x` documentation snapshots unchanged.

## Concerns

- Verify that `docs-anchors.test.mjs` runs in CI or the standard test command.
- Confirm that the documented `1.4.0` portwing value matches the final implementation and compatibility documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->