### PR TITLE
ci: narrow scorecard permissions, bound the ui coverage step, and time-box the soak-override test

### DIFF
--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -564,6 +564,19 @@ test('load-test processor only exports Artillery hooks used by scenarios', () =>
   expect(processorSource).not.toContain('ensureContainerId');
 });
 
+test('the ui coverage step bounds memory and worker count so the runner cannot kill it', () => {
+  // CI-17: three runs on 2026-09-07 (plus #1102) saw "Run ui tests" marked
+  // `cancelled` after 2.5-6 min with no timeout hit and no concurrency
+  // group -- the 7 GB runner most likely OOM'd under the vitest coverage
+  // pass and GitHub reported the runner service's death as a cancel. An
+  // explicit heap cap and worker cap keep worst-case memory well inside the
+  // runner's budget so nobody can silently drop them later.
+  const step = getTestJobStep('Run ui tests');
+
+  expect(step?.env?.NODE_OPTIONS).toContain('--max-old-space-size=');
+  expect(step?.run).toContain('--maxWorkers=1');
+});
+
 test('build job checks base image pins before building, for the platforms it smoke-builds', () => {
   const workflow = loadWorkflow();
   const steps = workflow.jobs?.build?.steps ?? [];

--- a/.github/tests/ci-verify-workflow.test.ts
+++ b/.github/tests/ci-verify-workflow.test.ts
@@ -573,8 +573,8 @@ test('the ui coverage step bounds memory and worker count so the runner cannot k
   // runner's budget so nobody can silently drop them later.
   const step = getTestJobStep('Run ui tests');
 
-  expect(step?.env?.NODE_OPTIONS).toContain('--max-old-space-size=');
-  expect(step?.run).toContain('--maxWorkers=1');
+  expect(step?.env?.NODE_OPTIONS).toContain('--max-old-space-size=1536');
+  expect(step?.run).toMatch(/(?:^|\s)--maxWorkers=1(?:\s|$)/);
 });
 
 test('build job checks base image pins before building, for the platforms it smoke-builds', () => {

--- a/.github/tests/release-cut-soak-override.test.ts
+++ b/.github/tests/release-cut-soak-override.test.ts
@@ -200,6 +200,11 @@ function runSourceStep(options: {
   }
 }
 
+// CA-11: each test here shells out to git and a real bash script and is the
+// slowest file in .github/tests, so it flakes first under load. 60s: two
+// pre-push gates plus a docker build running alongside on the same machine.
+vi.setConfig({ testTimeout: 60_000 });
+
 test('a blank soak_override_reason still hard-fails with the unchanged error message', () => {
   const result = runSourceStep({
     isPrerelease: false,

--- a/.github/workflows/ci-verify.yml
+++ b/.github/workflows/ci-verify.yml
@@ -626,7 +626,18 @@ jobs:
         working-directory: ui
 
       - name: Run ui tests
-        run: npm run test:unit
+        # CI-17: three runs on 2026-09-07 (plus #1102) had this step marked
+        # `cancelled` after 2.5-6 min with no timeout hit and no concurrency
+        # group -- the 7 GB ubuntu-latest runner most likely ran the vitest
+        # coverage pass out of memory and the runner service died, which
+        # GitHub reports as a cancel rather than an OOM. Budget: 1536 MiB
+        # heap cap * 2 processes (the main vitest process plus the single
+        # worker fork --maxWorkers=1 allows) = 3 GiB worst case, comfortably
+        # under the 7 GiB runner with headroom left for non-heap V8
+        # overhead, npm, and the OS.
+        env:
+          NODE_OPTIONS: --max-old-space-size=1536
+        run: npm run test:unit -- --maxWorkers=1
         working-directory: ui
 
       - name: Normalize coverage paths

--- a/.github/workflows/security-scorecard.yml
+++ b/.github/workflows/security-scorecard.yml
@@ -16,7 +16,7 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Weekly on Monday at 06:00 UTC
 
-permissions: read-all
+permissions: {}
 
 concurrency:
   group: scorecard-${{ github.workflow }}


### PR DESCRIPTION
Three small CI roadmap items, one commit each.

CI-4: `security-scorecard.yml` was the one workflow with `permissions: read-all` at the top level. The job below already grants every scope it needs, so the top level is now `{}` like the other eleven workflows. That was the only `excessive-permissions` finding under zizmor's pedantic persona. CI-3 (SHA pins plus the Renovate digest rule) turned out to be already satisfied: every `uses:` is a 40-char SHA and `renovate.json` inherits `helpers:pinGitHubActionDigests` through `config:best-practices`, so nothing to change there.

CI-17: the ui coverage step in `ci-verify.yml` got cancelled mid-run four times on 2026-09-07 with "The operation was canceled", no timeout hit and the same SHA green on rerun, which is what a runner dying under memory pressure looks like. The step now sets `NODE_OPTIONS=--max-old-space-size=1536` and runs with `--maxWorkers=1`, so the worst case is two processes at 1.5 GiB heap each, well inside the 7 GiB runner. The app step already carried its own worker cap. A workflow test asserts both settings stay on the step.

CA-11: `release-cut-soak-override.test.ts` shells out and ran on the default vitest timeout. It now declares a 60 s `testTimeout` with a comment naming the load it tolerates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changelog

- 🔒 Set workflow-level permissions to `{}` in `security-scorecard.yml`.
- 🔧 Limited UI coverage to 1536 MiB and one worker.
- ✨ Added workflow coverage for the UI resource limits.
- 🔧 Set a 60-second timeout for `release-cut-soak-override.test.ts`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->