### PR TITLE
fix(watcher): re-derive digest watching on every scan so stale rows flag updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Containers on a floating tag that drydock first saw before v1.5.0-rc.17 could stay marked Current forever, even when the registry had a newer digest.** `image.digest.watch` was written once at first discovery and never revisited, so a row discovered before the digest-watch default changed from `!isDockerHubDomain(domain)` to "watch when the tag is meaningful" (v1.5.0-rc.17) kept the old `false` default permanently; only recreating the container picked up the new one. It is now re-derived every scan, the same way `isLocalImage` and `digest.repoDigests` already are, and an explicit `dd.watch.digest` label or imgset override still wins. ([#1070](https://github.com/CodesWhat/drydock/issues/1070))
 - **The weekly ZAP full scan of getdrydock.com ran into its 60-minute job timeout on every run, so it never produced a report.** The scan step now caps the spider at 10 minutes and the active scan at 35 minutes (5 per rule), leaving room for startup, the passive scan and the report inside the job budget; a workflow test pins the arithmetic.
 
 ## [1.7.0-rc.12] — 2026-09-06

--- a/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.test.ts
@@ -704,10 +704,15 @@ describe('docker image details orchestration module', () => {
       env: [{ key: 'APP_ENV', value: 'prod' }],
     });
     expect(containerInStore.image.id).toBe('image-new');
+    // digest.watch is re-derived every cycle (#1070): the default helpers'
+    // resolveTagName('1.2.3') resolves as a meaningful specific-precision
+    // semver tag with no dd.watch.digest label, so isDigestToWatch's default
+    // is true.
     expect(containerInStore.image.digest).toEqual({
       repo: 'sha256:new',
       repoDigests: ['sha256:new'],
       value: 'sha256:new',
+      watch: true,
     });
     expect(containerInStore.image.created).toBe('2026-03-01T00:00:00.000Z');
   });
@@ -1807,6 +1812,132 @@ describe('docker image details orchestration module', () => {
         repo: 'sha256:mine',
         repoDigests: ['sha256:mine'],
       });
+    });
+  });
+
+  describe('digest.watch re-derivation on every scan (#1070)', () => {
+    function createStoredContainerForRederivation(overrides: Record<string, any> = {}) {
+      return {
+        id: 'container-1',
+        name: 'service',
+        error: undefined,
+        details: { ports: [], volumes: [], env: [] },
+        image: {
+          id: 'image-new',
+          name: 'acme/service',
+          registry: { name: 'hub', url: 'https://registry-1.docker.io/v2' },
+          tag: { value: 'latest', semver: false },
+          digest: { repo: 'sha256:new', value: 'sha256:new', watch: false },
+          created: '2025-01-01T00:00:00.000Z',
+        },
+        ...overrides,
+      };
+    }
+
+    test('a stale watch:false row for a non-semver Docker Hub tag flips to true with no label', async () => {
+      const containerInStore = createStoredContainerForRederivation();
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(containerInStore as any);
+
+      const { watcher } = createWatcher();
+      const helpers = createHelpers({
+        resolveImageName: vi.fn().mockReturnValue({ domain: 'docker.io', path: 'acme/service' }),
+        resolveTagName: vi.fn().mockReturnValue('latest'),
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer({ Image: 'acme/service:latest' }),
+        {},
+        helpers as any,
+      );
+
+      expect(containerInStore.image.digest.watch).toBe(true);
+    });
+
+    test('a live dd.watch.digest=false label keeps a non-semver Docker Hub tag from flipping', async () => {
+      const containerInStore = createStoredContainerForRederivation();
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(containerInStore as any);
+
+      const { watcher } = createWatcher();
+      const helpers = createHelpers({
+        resolveImageName: vi.fn().mockReturnValue({ domain: 'docker.io', path: 'acme/service' }),
+        resolveTagName: vi.fn().mockReturnValue('latest'),
+        mergeConfigWithImgset: vi.fn(() => ({
+          includeTags: undefined,
+          excludeTags: undefined,
+          transformTags: undefined,
+          tagFamily: undefined,
+          linkTemplate: undefined,
+          displayName: undefined,
+          displayIcon: undefined,
+          triggerInclude: undefined,
+          triggerExclude: undefined,
+          watchDigest: 'false',
+          inspectTagPath: undefined,
+          lookupImage: undefined,
+        })),
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer({
+          Image: 'acme/service:latest',
+          Labels: { 'dd.watch.digest': 'false' },
+        }),
+        {},
+        helpers as any,
+      );
+
+      expect(containerInStore.image.digest.watch).toBe(false);
+    });
+
+    // isDigestToWatch's auto-derived default treats a meaningful semver tag
+    // the same as a floating one (#498), so an unlabeled semver row would
+    // also flip to true here — the "stays false" case for a semver tag is an
+    // explicit dd.watch.digest=false override, same override mechanism as
+    // the non-semver case above, proven separately here because it is the
+    // scenario #1070 must not regress: the override still wins after the
+    // fix, whatever the tag's shape.
+    test('a live dd.watch.digest=false label keeps a semver tag row from flipping', async () => {
+      const containerInStore = createStoredContainerForRederivation({
+        image: {
+          ...createStoredContainerForRederivation().image,
+          tag: { value: '1.4.5', semver: true },
+        },
+      });
+      vi.spyOn(storeContainer, 'getContainer').mockReturnValue(containerInStore as any);
+
+      const { watcher } = createWatcher();
+      const helpers = createHelpers({
+        resolveImageName: vi.fn().mockReturnValue({ domain: 'docker.io', path: 'acme/service' }),
+        resolveTagName: vi.fn().mockReturnValue('1.4.5'),
+        mergeConfigWithImgset: vi.fn(() => ({
+          includeTags: undefined,
+          excludeTags: undefined,
+          transformTags: undefined,
+          tagFamily: undefined,
+          linkTemplate: undefined,
+          displayName: undefined,
+          displayIcon: undefined,
+          triggerInclude: undefined,
+          triggerExclude: undefined,
+          watchDigest: 'false',
+          inspectTagPath: undefined,
+          lookupImage: undefined,
+        })),
+      });
+
+      await addImageDetailsToContainerOrchestration(
+        watcher as any,
+        createDockerSummaryContainer({
+          Image: 'acme/service:1.4.5',
+          Labels: { 'dd.watch.digest': 'false' },
+        }),
+        {},
+        helpers as any,
+      );
+
+      expect(containerInStore.image.digest.watch).toBe(false);
     });
   });
 

--- a/app/watchers/providers/docker/docker-image-details-orchestration.ts
+++ b/app/watchers/providers/docker/docker-image-details-orchestration.ts
@@ -358,17 +358,20 @@ async function refreshStoredContainerImageFields(
     // when the old digest.repo isn't among the freshly derived entries (#669).
     containerInStore.image.digest.repoDigests = freshOrderedRepoDigests;
 
-    if (shouldRepairStoredImageReference(containerInStore)) {
-      const resolvedImageState = resolveContainerImageState({
-        watcher,
-        container,
-        dockerContainerName,
-        labelOverrides,
-        image: currentImage,
-        containerInspect,
-        helpers,
-      });
+    // Re-resolved every cycle (not just inside the repair branch below) so
+    // digest.watch can be re-derived unconditionally — see the re-derivation
+    // block after the repair branch for why (#1070).
+    const resolvedImageState = resolveContainerImageState({
+      watcher,
+      container,
+      dockerContainerName,
+      labelOverrides,
+      image: currentImage,
+      containerInspect,
+      helpers,
+    });
 
+    if (shouldRepairStoredImageReference(containerInStore)) {
       if (resolvedImageState) {
         const refreshedContainer = helpers.normalizeContainer({
           ...containerInStore,
@@ -417,6 +420,20 @@ async function refreshStoredContainerImageFields(
         containerInStore.sourceRepo = refreshedContainer.sourceRepo;
         return;
       }
+    }
+
+    // Re-derive digest.watch every cycle — independent of
+    // shouldRepairStoredImageReference above, same as isLocalImage and
+    // digest.repoDigests further up. A row discovered before the
+    // isDigestToWatch default changed from `!isDockerHubDomain(domain)` to
+    // "watch when the tag is meaningful" (dd6c4ae37, v1.5.0-rc.17) had
+    // `watch: false` written once at discovery and never revisited, so it
+    // stayed stuck on the old default forever. resolveContainerImageState
+    // already re-reads the live dd.watch.digest label/imgset value ahead of
+    // the auto-derived default, so an explicit override still wins; only the
+    // stale auto-derived default gets replaced (#1070).
+    if (resolvedImageState) {
+      containerInStore.image.digest.watch = resolvedImageState.watchDigest;
     }
 
     // Keep local digest value populated for digest-watch containers, even when


### PR DESCRIPTION
Fixes #1070.

`image.digest.watch` was written once at discovery and only rewritten by the unresolved-tag repair path. The default for a non-semver Docker Hub tag flipped from off to on in v1.5.0-rc.17, so any `something:latest` container drydock had been watching since before May still carried `watch: false`, `findNewVersion` skipped the digest block, and the row said Current no matter what the registry served. Containers recreated after that release got a fresh row and worked, which is why the reporter saw two of five `portainer/agent:latest` flag the 2.45.0 digest and two stay Current.

`refreshStoredContainerImageFields` now runs `resolveContainerImageState` every cycle and writes the derived `watchDigest` back, the same way `isLocalImage` and `repoDigests` are already refreshed for #669. An explicit `dd.watch.digest` label or imgset value is read from the live container each cycle, so an operator's choice still wins; only the stale auto-derived default is replaced. Three tests cover the stale-false row, the label override on a floating tag, and the label override on a semver tag. CHANGELOG entry included.

Forward-port to dev/v1.8 and port to dev/v1.6 follow.
