### PR TITLE
chore(release): prepare v1.7.0-rc.13

### DIFF
--- a/.github/tests/readme-translations.test.ts
+++ b/.github/tests/readme-translations.test.ts
@@ -66,123 +66,90 @@ const localizedSurfaceFragments: Record<
     featureTableHeader: '| | Funktion | Beschreibung |',
     builtWithHeading: '<h2 align="center" id="built-with">Gebaut mit</h2>',
     communityQaHeading: '### Community-QA',
-    releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.12</strong></summary>',
+    releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.13</strong></summary>',
   },
   'README.es.md': {
     featureTableHeader: '| | Característica | Descripción |',
     builtWithHeading: '<h2 align="center" id="built-with">Construido con</h2>',
     communityQaHeading: '### Control de calidad de la comunidad',
-    releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.12</strong></summary>',
+    releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.13</strong></summary>',
   },
   'README.fr.md': {
     featureTableHeader: '| | Fonctionnalité | Descriptif |',
     builtWithHeading: '<h2 align="center" id="built-with">Construit avec</h2>',
     communityQaHeading: '### Contrôle qualité de la communauté',
-    releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.12</strong></summary>',
+    releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.13</strong></summary>',
   },
   'README.pl.md': {
     featureTableHeader: '| | Funkcja | Opis |',
     builtWithHeading: '<h2 align="center" id="built-with">Zbudowany z</h2>',
     communityQaHeading: '### Kontrola jakości społeczności',
     releaseHeading:
-      '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.12</strong></summary>',
+      '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.13</strong></summary>',
   },
   'README.pt-BR.md': {
     featureTableHeader: '| | Recurso | Descrição |',
     builtWithHeading: '<h2 align="center" id="built-with">Construído com</h2>',
     communityQaHeading: '### Controle de qualidade da comunidade',
-    releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.12</strong></summary>',
+    releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.13</strong></summary>',
   },
   'README.zh-CN.md': {
     featureTableHeader: '| |特色|描述 |',
     builtWithHeading: '<h2 align="center" id="built-with">技术栈</h2>',
     communityQaHeading: '### 社区质量检查',
-    releaseHeading: '<summary><strong>v1.7.0-rc.12 亮点</strong></summary>',
+    releaseHeading: '<summary><strong>v1.7.0-rc.13 亮点</strong></summary>',
   },
 };
 
 const localizedReleaseFragments: Record<
   string,
   {
-    coopHeader: string;
-    embedderHeader: string;
-    archDigestProbe: string;
-    sessionStoreSplit: string;
-    sessionsCollectionMention: string;
-    agentsTlsMismatch: string;
+    digestWatchHeader: string;
+    dastTimeoutHeader: string;
+    dastBudgetMention: string;
   }
 > = {
   'README.de.md': {
-    coopHeader:
-      '**Die Demo-Site sendete kein `Cross-Origin-Opener-Policy`, sodass der wöchentliche DAST-Scan bei jeder Ausführung an ZAP-Regel 90004 scheiterte.**',
-    embedderHeader: 'bereits vorhandenen `Cross-Origin-Embedder-Policy`-Header',
-    archDigestProbe:
-      '**Der arm64-Durchlauf der Image-Arch-Prüfung im Release schlug bei jedem Multi-Plattform-Cut mit `docker: cannot overwrite digest` fehl.**',
-    sessionStoreSplit:
-      '**DR-121: Der Session-Store und der Haupt-Store schrieben dieselbe `/store/dd.json`, und wer zuletzt speicherte, löschte die Daten des anderen.**',
-    sessionsCollectionMention: 'verwirft eine veraltete `Sessions`-Collection',
-    agentsTlsMismatch:
-      '**Das gepaarte Gitea-Registry-Beispiel der Agents-Seite ließ den Controller HTTPS mit einem Agent sprechen, der nur HTTP anbot.**',
+    digestWatchHeader:
+      '**Container auf einem Floating-Tag, die Drydock erstmals vor v1.5.0-rc.17 gesehen hat, konnten für immer als Current markiert bleiben, selbst wenn die Registry einen neueren Digest hatte.**',
+    dastTimeoutHeader:
+      '**Der wöchentliche vollständige ZAP-Scan von getdrydock.com lief bei jedem Durchlauf in sein 60-Minuten-Job-Timeout und lieferte nie einen Bericht.**',
+    dastBudgetMention: 'im Job-Budget',
   },
   'README.es.md': {
-    coopHeader:
-      '**El sitio de demostración no enviaba `Cross-Origin-Opener-Policy`, por lo que el escaneo DAST semanal fallaba en la regla 90004 de ZAP en cada ejecución.**',
-    embedderHeader: 'cabecera `Cross-Origin-Embedder-Policy` ya existente',
-    archDigestProbe:
-      '**El paso arm64 de la comprobación de arquitectura de imagen del release fallaba en cada corte multiplataforma con `docker: cannot overwrite digest`.**',
-    sessionStoreSplit:
-      '**DR-121: el almacén de sesiones y el almacén principal escribían el mismo `/store/dd.json`, y el que guardaba último borraba los datos del otro.**',
-    sessionsCollectionMention: 'descarta una colección `Sessions` obsoleta',
-    agentsTlsMismatch:
-      '**El ejemplo emparejado de registry de Gitea de la página de agentes hacía que el controlador hablara HTTPS con un agente que servía HTTP simple.**',
+    digestWatchHeader:
+      '**Los contenedores en una etiqueta flotante que drydock vio por primera vez antes de v1.5.0-rc.17 podían quedar marcados como Actuales para siempre, incluso con un digest más reciente disponible.**',
+    dastTimeoutHeader:
+      '**El escaneo ZAP completo semanal de getdrydock.com llegaba a su tiempo de espera de 60 minutos en cada ejecución y nunca producía un informe.**',
+    dastBudgetMention: 'presupuesto del job',
   },
   'README.fr.md': {
-    coopHeader:
-      "**Le site de démonstration n'envoyait pas `Cross-Origin-Opener-Policy`, si bien que le scan DAST hebdomadaire échouait sur la règle ZAP 90004 à chaque exécution.**",
-    embedderHeader: "l'en-tête `Cross-Origin-Embedder-Policy` déjà présent",
-    archDigestProbe:
-      "**Le passage arm64 du contrôle d'architecture d'image du release échouait à chaque coupe multiplateforme avec `docker: cannot overwrite digest`.**",
-    sessionStoreSplit:
-      "**DR-121 : le magasin de sessions et le magasin principal écrivaient dans le même `/store/dd.json`, et celui qui enregistrait en dernier effaçait les données de l'autre.**",
-    sessionsCollectionMention: 'abandonne une collection `Sessions` obsolète',
-    agentsTlsMismatch:
-      "**L'exemple apparié de registre Gitea de la page des agents faisait parler HTTPS au contrôleur avec un agent servant du HTTP simple.**",
+    digestWatchHeader:
+      '**Les conteneurs sur un tag flottant que drydock avait vu pour la première fois avant v1.5.0-rc.17 pouvaient rester marqués Current pour toujours, même avec un digest plus récent disponible.**',
+    dastTimeoutHeader:
+      "**Le scan ZAP complet hebdomadaire de getdrydock.com atteignait son délai d'expiration de 60 minutes à chaque exécution et ne produisait jamais de rapport.**",
+    dastBudgetMention: 'budget du job',
   },
   'README.pl.md': {
-    coopHeader:
-      '**Strona demo nie wysyłała `Cross-Origin-Opener-Policy`, przez co cotygodniowy skan DAST za każdym razem zawodził na regule ZAP 90004.**',
-    embedderHeader: 'istniejącego już nagłówka `Cross-Origin-Embedder-Policy`',
-    archDigestProbe:
-      '**Przebieg arm64 kontroli architektury obrazu wydania kończył się niepowodzeniem przy każdym wieloplatformowym cięciu z `docker: cannot overwrite digest`.**',
-    sessionStoreSplit:
-      '**DR-121: magazyn sesji i magazyn główny zapisywały ten sam plik `/store/dd.json`, a ten, który zapisał jako ostatni, kasował dane drugiego.**',
-    sessionsCollectionMention: 'odrzuca przestarzałą kolekcję `Sessions`',
-    agentsTlsMismatch:
-      '**Sparowany przykład rejestru Gitea na stronie agentów sprawiał, że kontroler mówił po HTTPS do agenta obsługującego zwykłe HTTP.**',
+    digestWatchHeader:
+      '**Kontenery na płynnym tagu, które drydock po raz pierwszy zobaczył przed v1.5.0-rc.17, mogły zostać oznaczone jako Current na zawsze, nawet gdy registry miało nowszy digest.**',
+    dastTimeoutHeader:
+      '**Cotygodniowy pełny skan ZAP dla getdrydock.com za każdym razem trafiał w swój 60-minutowy limit czasu zadania i nigdy nie tworzył raportu.**',
+    dastBudgetMention: 'budżecie zadania',
   },
   'README.pt-BR.md': {
-    coopHeader:
-      '**O site de demonstração não enviava `Cross-Origin-Opener-Policy`, então a varredura DAST semanal falhava na regra 90004 do ZAP em toda execução.**',
-    embedderHeader: 'cabeçalho `Cross-Origin-Embedder-Policy` já existente',
-    archDigestProbe:
-      '**A etapa arm64 da verificação de arquitetura de imagem do release falhava em todo corte multiplataforma com `docker: cannot overwrite digest`.**',
-    sessionStoreSplit:
-      '**DR-121: o armazenamento de sessões e o armazenamento principal escreviam no mesmo `/store/dd.json`, e quem salvasse por último apagava os dados do outro.**',
-    sessionsCollectionMention: 'descarta uma coleção `Sessions` obsoleta',
-    agentsTlsMismatch:
-      '**O exemplo pareado de registry do Gitea na página de agentes fazia o controlador falar HTTPS com um agente servindo HTTP simples.**',
+    digestWatchHeader:
+      '**Contêineres em uma tag flutuante que o drydock viu pela primeira vez antes da v1.5.0-rc.17 podiam ficar marcados como Current para sempre, mesmo com um digest mais novo disponível.**',
+    dastTimeoutHeader:
+      '**A varredura ZAP completa semanal do getdrydock.com atingia seu tempo limite de 60 minutos em toda execução e nunca produzia um relatório.**',
+    dastBudgetMention: 'orçamento do job',
   },
   'README.zh-CN.md': {
-    coopHeader:
-      '**演示站点此前没有发送 `Cross-Origin-Opener-Policy`，导致每周的 DAST 扫描每次都在 ZAP 规则 90004 上失败。**',
-    embedderHeader: '已有的 `Cross-Origin-Embedder-Policy` 头',
-    archDigestProbe:
-      '**发布流程中镜像架构检查的 arm64 环节在每次多平台构建中都会因 `docker: cannot overwrite digest` 而失败。**',
-    sessionStoreSplit:
-      '**DR-121：会话存储和主存储此前写入同一个 `/store/dd.json`，谁最后保存就会抹掉另一方的数据。**',
-    sessionsCollectionMention: '丢弃旧版本遗留下来的过期 `Sessions` 集合',
-    agentsTlsMismatch:
-      '**代理页面配对的 Gitea registry 示例让控制器以 HTTPS 与只提供纯 HTTP 的代理通信。**',
+    digestWatchHeader:
+      '**drydock 在 v1.5.0-rc.17 之前首次发现的浮动标签容器，即使镜像仓库中已有更新的 digest，也可能永远被标记为 Current。**',
+    dastTimeoutHeader:
+      '**getdrydock.com 每周的完整 ZAP 扫描每次都会触及 60 分钟的任务超时，从未生成过报告。**',
+    dastBudgetMention: '任务预算',
   },
 };
 
@@ -243,6 +210,7 @@ const requiredFragments = [
   './CHANGELOG.md#170-rc10--2026-09-04',
   './CHANGELOG.md#170-rc11--2026-09-05',
   './CHANGELOG.md#170-rc12--2026-09-06',
+  './CHANGELOG.md#170-rc13--2026-09-08',
   'Portwing 0.9.0+',
   'Standard HTTP',
   '`DD_EXPERIMENTAL_PORTWING=false`',
@@ -296,26 +264,21 @@ describe.each(translatedReadmes)('%s', (readme) => {
     const surface = localizedSurfaceFragments[readme];
     const release = localizedReleaseFragments[readme];
     const releaseBlock = getReleaseBlock(content, surface.releaseHeading);
-    const releaseBullets = [
-      release.coopHeader,
-      release.archDigestProbe,
-      release.sessionStoreSplit,
-      release.agentsTlsMismatch,
-    ].map((fragment) => getBullet(releaseBlock, fragment));
+    const releaseBullets = [release.digestWatchHeader, release.dastTimeoutHeader].map((fragment) =>
+      getBullet(releaseBlock, fragment),
+    );
     const getUrls = (bullet: string | undefined) =>
       [...(bullet ?? '').matchAll(/https?:\/\/[^)<>"\s]+/g)].map(([url]) => url);
 
     expect(releaseBullets.every(Boolean)).toBe(true);
-    expect(releaseBullets[0]).toContain(release.embedderHeader);
-    expect(releaseBullets[2]).toContain(release.sessionsCollectionMention);
+    expect(releaseBullets[0]).toContain('`isLocalImage`');
+    expect(releaseBullets[1]).toContain(release.dastBudgetMention);
     expect(releaseBullets.flatMap(getUrls).sort()).toEqual([
-      'https://github.com/CodesWhat/drydock/pull/1042',
-      'https://github.com/CodesWhat/drydock/pull/1046',
-      'https://github.com/CodesWhat/drydock/pull/1050',
-      'https://github.com/CodesWhat/drydock/pull/1063',
+      'https://github.com/CodesWhat/drydock/pull/1080',
+      'https://github.com/CodesWhat/drydock/pull/1108',
     ]);
     expect(getUrls(releaseBullets[0]).sort()).toEqual([
-      'https://github.com/CodesWhat/drydock/pull/1050',
+      'https://github.com/CodesWhat/drydock/pull/1108',
     ]);
   });
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0-rc.13] — 2026-09-08
+
 ### Fixed
 
 - **Containers on a floating tag that drydock first saw before v1.5.0-rc.17 could stay marked Current forever, even when the registry had a newer digest.** `image.digest.watch` was written once at first discovery and never revisited, so a row discovered before the digest-watch default changed from `!isDockerHubDomain(domain)` to "watch when the tag is meaningful" (v1.5.0-rc.17) kept the old `false` default permanently; only recreating the container picked up the new one. It is now re-derived every scan, the same way `isLocalImage` and `digest.repoDigests` already are, and an explicit `dd.watch.digest` label or imgset override still wins. ([#1070](https://github.com/CodesWhat/drydock/issues/1070))
@@ -2729,7 +2731,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.12...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.13...HEAD
+[1.7.0-rc.13]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.12...v1.7.0-rc.13
 [1.7.0-rc.12]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.11...v1.7.0-rc.12
 [1.7.0-rc.11]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.10...v1.7.0-rc.11
 [1.7.0-rc.10]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.9...v1.7.0-rc.10

--- a/README.de.md
+++ b/README.de.md
@@ -219,6 +219,16 @@ Weitere Informationen zu Docker Compose, Socket-Sicherheit, Reverse-Proxy und al
 <h2 align="center" id="recent-updates">Aktuelle Updates</h2>
 
 <details open>
+<summary><strong>Highlights von v1.7.0-rc.13</strong></summary>
+
+- **Container auf einem Floating-Tag, die Drydock erstmals vor v1.5.0-rc.17 gesehen hat, konnten für immer als Current markiert bleiben, selbst wenn die Registry einen neueren Digest hatte.** `image.digest.watch` wird jetzt bei jedem Scan neu ermittelt, statt einmalig bei der ersten Erkennung festgeschrieben zu werden, genau wie `isLocalImage` und `digest.repoDigests` es bereits tun. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))
+- **Der wöchentliche vollständige ZAP-Scan von getdrydock.com lief bei jedem Durchlauf in sein 60-Minuten-Job-Timeout und lieferte nie einen Bericht.** Der Scan-Schritt begrenzt jetzt den Spider auf 10 Minuten und den aktiven Scan auf 35 Minuten, sodass Platz für den passiven Scan und den Bericht im Job-Budget bleibt. ([#1080](https://github.com/CodesWhat/drydock/pull/1080))
+
+Vollständige Release-Notes in [CHANGELOG.md](./CHANGELOG.md#170-rc13--2026-09-08).
+
+</details>
+
+<details open>
 <summary><strong>Highlights von v1.7.0-rc.12</strong></summary>
 
 - **Die Demo-Site sendete kein `Cross-Origin-Opener-Policy`, sodass der wöchentliche DAST-Scan bei jeder Ausführung an ZAP-Regel 90004 scheiterte.** `apps/demo/vercel.json` sendet jetzt `same-origin` neben dem bereits vorhandenen `Cross-Origin-Embedder-Policy`-Header. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))

--- a/README.es.md
+++ b/README.es.md
@@ -219,6 +219,16 @@ Consulte la [guía de inicio rápido](https://getdrydock.com/docs/quickstart) pa
 <h2 align="center" id="recent-updates">Actualizaciones recientes</h2>
 
 <details open>
+<summary><strong>Aspectos destacados de v1.7.0-rc.13</strong></summary>
+
+- **Los contenedores en una etiqueta flotante que drydock vio por primera vez antes de v1.5.0-rc.17 podían quedar marcados como Actuales para siempre, incluso con un digest más reciente disponible.** `image.digest.watch` ahora se vuelve a derivar en cada escaneo en lugar de fijarse en el primer descubrimiento, igual que ya hacen `isLocalImage` y `digest.repoDigests`. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))
+- **El escaneo ZAP completo semanal de getdrydock.com llegaba a su tiempo de espera de 60 minutos en cada ejecución y nunca producía un informe.** El paso de escaneo ahora limita el spider a 10 minutos y el escaneo activo a 35, dejando espacio para el escaneo pasivo y el informe dentro del presupuesto del job. ([#1080](https://github.com/CodesWhat/drydock/pull/1080))
+
+Notas completas de la versión en [CHANGELOG.md](./CHANGELOG.md#170-rc13--2026-09-08).
+
+</details>
+
+<details open>
 <summary><strong>Aspectos destacados de v1.7.0-rc.12</strong></summary>
 
 - **El sitio de demostración no enviaba `Cross-Origin-Opener-Policy`, por lo que el escaneo DAST semanal fallaba en la regla 90004 de ZAP en cada ejecución.** `apps/demo/vercel.json` ahora envía `same-origin` junto a la cabecera `Cross-Origin-Embedder-Policy` ya existente. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))

--- a/README.fr.md
+++ b/README.fr.md
@@ -219,6 +219,16 @@ Consultez le [Guide de démarrage rapide](https://getdrydock.com/docs/quickstart
 <h2 align="center" id="recent-updates">Mises à jour récentes</h2>
 
 <details open>
+<summary><strong>Points forts de la v1.7.0-rc.13</strong></summary>
+
+- **Les conteneurs sur un tag flottant que drydock avait vu pour la première fois avant v1.5.0-rc.17 pouvaient rester marqués Current pour toujours, même avec un digest plus récent disponible.** `image.digest.watch` est désormais recalculé à chaque scan au lieu d'être fixé lors de la première découverte, de la même façon que le font déjà `isLocalImage` et `digest.repoDigests`. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))
+- **Le scan ZAP complet hebdomadaire de getdrydock.com atteignait son délai d'expiration de 60 minutes à chaque exécution et ne produisait jamais de rapport.** L'étape de scan limite désormais le spider à 10 minutes et le scan actif à 35, laissant de la place pour le scan passif et le rapport dans le budget du job. ([#1080](https://github.com/CodesWhat/drydock/pull/1080))
+
+Notes complètes dans [CHANGELOG.md](./CHANGELOG.md#170-rc13--2026-09-08).
+
+</details>
+
+<details open>
 <summary><strong>Points forts de la v1.7.0-rc.12</strong></summary>
 
 - **Le site de démonstration n'envoyait pas `Cross-Origin-Opener-Policy`, si bien que le scan DAST hebdomadaire échouait sur la règle ZAP 90004 à chaque exécution.** `apps/demo/vercel.json` envoie désormais `same-origin` à côté de l'en-tête `Cross-Origin-Embedder-Policy` déjà présent. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))

--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.7.0-rc.13 highlights</strong></summary>
+
+- **Containers on a floating tag that drydock first saw before v1.5.0-rc.17 could stay marked Current forever, even with a newer digest available.** `image.digest.watch` is now re-derived every scan instead of being fixed at first discovery, the same way `isLocalImage` and `digest.repoDigests` already are. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))
+- **The weekly ZAP full scan of getdrydock.com ran into its 60-minute job timeout on every run and never produced a report.** The scan step now caps the spider at 10 minutes and the active scan at 35, leaving room for the passive scan and report inside the job budget. ([#1080](https://github.com/CodesWhat/drydock/pull/1080))
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#170-rc13--2026-09-08).
+
+</details>
+
+<details open>
 <summary><strong>v1.7.0-rc.12 highlights</strong></summary>
 
 - **The demo site was missing `Cross-Origin-Opener-Policy`, so the weekly DAST scan failed on ZAP rule 90004 every run.** `apps/demo/vercel.json` now sends `same-origin` next to the existing `Cross-Origin-Embedder-Policy` header. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))

--- a/README.pl.md
+++ b/README.pl.md
@@ -219,6 +219,16 @@ Zobacz [Przewodnik szybkiego startu](https://getdrydock.com/docs/quickstart) dla
 <h2 align="center" id="recent-updates">Ostatnie aktualizacje</h2>
 
 <details open>
+<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.13</strong></summary>
+
+- **Kontenery na płynnym tagu, które drydock po raz pierwszy zobaczył przed v1.5.0-rc.17, mogły zostać oznaczone jako Current na zawsze, nawet gdy registry miało nowszy digest.** `image.digest.watch` jest teraz wyznaczane na nowo przy każdym skanowaniu zamiast być ustalane raz przy pierwszym wykryciu, tak samo jak już robią to `isLocalImage` i `digest.repoDigests`. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))
+- **Cotygodniowy pełny skan ZAP dla getdrydock.com za każdym razem trafiał w swój 60-minutowy limit czasu zadania i nigdy nie tworzył raportu.** Krok skanowania ogranicza teraz spidera do 10 minut, a aktywny skan do 35, zostawiając miejsce na skan pasywny i raport w budżecie zadania. ([#1080](https://github.com/CodesWhat/drydock/pull/1080))
+
+Pełne informacje o wydaniu: [CHANGELOG.md](./CHANGELOG.md#170-rc13--2026-09-08).
+
+</details>
+
+<details open>
 <summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.12</strong></summary>
 
 - **Strona demo nie wysyłała `Cross-Origin-Opener-Policy`, przez co cotygodniowy skan DAST za każdym razem zawodził na regule ZAP 90004.** `apps/demo/vercel.json` wysyła teraz `same-origin` obok istniejącego już nagłówka `Cross-Origin-Embedder-Policy`. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -219,6 +219,16 @@ Consulte o [Guia de início rápido](https://getdrydock.com/docs/quickstart) par
 <h2 align="center" id="recent-updates">Atualizações recentes</h2>
 
 <details open>
+<summary><strong>Destaques da v1.7.0-rc.13</strong></summary>
+
+- **Contêineres em uma tag flutuante que o drydock viu pela primeira vez antes da v1.5.0-rc.17 podiam ficar marcados como Current para sempre, mesmo com um digest mais novo disponível.** `image.digest.watch` agora é recalculado a cada varredura, em vez de ser fixado na primeira descoberta, da mesma forma que `isLocalImage` e `digest.repoDigests` já fazem. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))
+- **A varredura ZAP completa semanal do getdrydock.com atingia seu tempo limite de 60 minutos em toda execução e nunca produzia um relatório.** A etapa de varredura agora limita o spider a 10 minutos e a varredura ativa a 35, deixando espaço para a varredura passiva e o relatório dentro do orçamento do job. ([#1080](https://github.com/CodesWhat/drydock/pull/1080))
+
+Notas completas em [CHANGELOG.md](./CHANGELOG.md#170-rc13--2026-09-08).
+
+</details>
+
+<details open>
 <summary><strong>Destaques da v1.7.0-rc.12</strong></summary>
 
 - **O site de demonstração não enviava `Cross-Origin-Opener-Policy`, então a varredura DAST semanal falhava na regra 90004 do ZAP em toda execução.** `apps/demo/vercel.json` agora envia `same-origin` ao lado do cabeçalho `Cross-Origin-Embedder-Policy` já existente. ([#1050](https://github.com/CodesWhat/drydock/pull/1050))

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -219,6 +219,16 @@ docker run -d \
 <h2 align="center" id="recent-updates">最近更新</h2>
 
 <details open>
+<summary><strong>v1.7.0-rc.13 亮点</strong></summary>
+
+- **drydock 在 v1.5.0-rc.17 之前首次发现的浮动标签容器，即使镜像仓库中已有更新的 digest，也可能永远被标记为 Current。** `image.digest.watch` 现在会在每次扫描时重新计算，而不是在首次发现时一次性写死，`isLocalImage` 和 `digest.repoDigests` 早已是这样处理的。([#1108](https://github.com/CodesWhat/drydock/pull/1108))
+- **getdrydock.com 每周的完整 ZAP 扫描每次都会触及 60 分钟的任务超时，从未生成过报告。** 扫描步骤现在将爬虫阶段限制在 10 分钟内，主动扫描限制在 35 分钟内，为被动扫描和报告留出任务预算空间。([#1080](https://github.com/CodesWhat/drydock/pull/1080))
+
+完整发布说明见 [CHANGELOG.md](./CHANGELOG.md#170-rc13--2026-09-08)。
+
+</details>
+
+<details open>
 <summary><strong>v1.7.0-rc.12 亮点</strong></summary>
 
 - **演示站点此前没有发送 `Cross-Origin-Opener-Policy`，导致每周的 DAST 扫描每次都在 ZAP 规则 90004 上失败。** `apps/demo/vercel.json` 现在会在已有的 `Cross-Origin-Embedder-Policy` 头旁发送 `same-origin`。([#1050](https://github.com/CodesWhat/drydock/pull/1050))

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.7.0-rc.12',
+    version: '1.7.0-rc.13',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-08-12T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.7.0-rc.12 started',
+    details: 'Drydock v1.7.0-rc.13 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-08-05T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.7.0-rc.12',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.7.0-rc.13',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.7.0-rc.12',
+    tag: '1.7.0-rc.13',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.7.0-rc.12',
+  version: '1.7.0-rc.13',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.7.0-rc.12',
+      version: '1.7.0-rc.13',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.7.0-rc.12', mode: 'demo' },
+        server: { version: '1.7.0-rc.13', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.7.0-rc.12",
+  version: "1.7.0-rc.13",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -294,7 +294,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.7.0-rc.12",
+    version: "v1.7.0-rc.13",
     title: "Smart Updates & UX",
     emoji: "\u{1F680}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.7.0-rc.12",
+      "version": "1.7.0-rc.13",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.7.0-rc.12",
+    "version": "1.7.0-rc.13",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.7.0-rc.12"
+  "version":"1.7.0-rc.13"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.7.0-rc.12",
+    "version": "1.7.0-rc.13",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.7.0-rc.12",
+      "drydockVersion": "1.7.0-rc.13",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.7.0-rc.12` | Immutable release candidate; best for reproducible testing |
+| `1.7.0-rc.13` | Immutable release candidate; best for reproducible testing |
 | `1.7-rc` | Rolling release-candidate channel; moves to the newest `1.7.0-rc.N` |
 | `1.6.0` | Immutable exact GA release; best for reproducible deployments |
 | `1.6` | Rolling stable minor channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,11 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.7.0-rc.13 Highlights — September 8, 2026
+
+- **Containers on a floating tag from before v1.5.0-rc.17 could stay marked Current forever, even with a newer digest available** — `image.digest.watch` is now re-derived every scan instead of being fixed at first discovery ([#1108](https://github.com/CodesWhat/drydock/pull/1108)).
+- **The weekly ZAP full scan of getdrydock.com hit its 60-minute job timeout on every run and never produced a report** — the scan step now caps the spider at 10 minutes and the active scan at 35, leaving room for the passive scan and report inside the job budget ([#1080](https://github.com/CodesWhat/drydock/pull/1080)).
+
 ## v1.7.0-rc.12 Highlights — September 6, 2026
 
 - **The demo site was missing `Cross-Origin-Opener-Policy`** — the weekly DAST scan failed on ZAP rule 90004 every run; `apps/demo/vercel.json` now sends `same-origin` next to the existing `Cross-Origin-Embedder-Policy` header ([#1050](https://github.com/CodesWhat/drydock/pull/1050)).

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.7 RC and prior releases have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.7.0-rc.12...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.7.0-rc.13...HEAD`],
+    ['1.7.0-rc.13', `${repositoryUrl}/compare/v1.7.0-rc.12...v1.7.0-rc.13`],
     ['1.7.0-rc.12', `${repositoryUrl}/compare/v1.7.0-rc.11...v1.7.0-rc.12`],
     ['1.7.0-rc.11', `${repositoryUrl}/compare/v1.7.0-rc.10...v1.7.0-rc.11`],
     ['1.7.0-rc.10', `${repositoryUrl}/compare/v1.7.0-rc.9...v1.7.0-rc.10`],

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.7.0-rc.12';
-const PREV_RC_VERSION = '1.7.0-rc.11';
-const RC_DATE = '2026-09-06';
-const RC_DISPLAY_DATE = 'September 6, 2026';
+const RC_VERSION = '1.7.0-rc.13';
+const PREV_RC_VERSION = '1.7.0-rc.12';
+const RC_DATE = '2026-09-08';
+const RC_DISPLAY_DATE = 'September 8, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.6', 'content/docs/v1.5'];
 const RELEASE_REDIRECT_STATUSES = [301, 302, 303, 307, 308];
 const BROAD_401_CLAIM =
@@ -155,17 +155,14 @@ test('release candidate notes cover the post-promotion fixes', () => {
     );
   }
 
-  for (const pull of [1042, 1046, 1050, 1063]) {
+  for (const pull of [1080, 1108]) {
     const pullLink = `https://github.com/CodesWhat/drydock/pull/${pull}`;
     assert.ok(updates.includes(pullLink), `updates page must link PR #${pull}`);
   }
 
   for (const fragment of [
-    '`Cross-Origin-Opener-Policy`',
-    '`identityChangeExpected: true`',
-    '`result.coalesced`',
-    '`dd-sessions.json`',
-    '`DD_SERVER_TLS_ENABLED`',
+    '`image.digest.watch`',
+    'caps the spider at 10 minutes and the active scan at 35',
   ]) {
     assert.ok(changelog.includes(fragment), `CHANGELOG.md must include ${fragment}`);
     assert.ok(updates.includes(fragment), `updates page must include ${fragment}`);

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.7.0';
-const RC_VERSION = '1.7.0-rc.12';
+const RC_VERSION = '1.7.0-rc.13';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',

--- a/scripts/release-precut-check.test.mjs
+++ b/scripts/release-precut-check.test.mjs
@@ -328,7 +328,7 @@ test('cli exits 1 and reports pending discussion when strict RC check has an unc
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.12'],
+    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.13'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -345,7 +345,7 @@ test('cli exits 0 when --force is set even with pending replies', () => {
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', '--force', 'v1.7.0-rc.12'],
+    [scriptPath, '--tracker', trackerPath, '--strict', '--force', 'v1.7.0-rc.13'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -360,7 +360,7 @@ test('cli exits 0 with warning when tracker file does not exist', () => {
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.12'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.13'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -377,7 +377,7 @@ test('cli exits 0 for prerelease tags with pending replies (informational only)'
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.12'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.13'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -393,7 +393,7 @@ test('cli exits 1 for prerelease tags with --strict and pending replies', () => 
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.12'],
+    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.13'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -409,7 +409,7 @@ test('cli exits 0 and prints success when tracker has no pending replies', () =>
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.12'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.13'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',


### PR DESCRIPTION
Release metadata for v1.7.0-rc.13, same shape as the rc.12 prepare (#1066): CHANGELOG heading and link reference, README highlights block in all seven languages, site config and demo mock versions, the docs pages that quote the version, and the script and workflow tests that pin it. Package versions stay at 1.7.0.

Two entries since rc.12: the digest-watch re-derivation fix (#1108, fixes #1070) and the DAST scan bound (#1080).

`npm run release:precheck v1.7.0-rc.13` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Changed release metadata from `v1.7.0-rc.12` to `v1.7.0-rc.13`.
- ✨ Added release highlights in seven README translations and the updates documentation.
- 🐛 Fixed floating-tag update detection by re-deriving `image.digest.watch` on every scan.
- 🔒 Bound the ZAP DAST scan to a 10-minute spider and 35-minute active scan.
- 🔧 Updated demo mocks, site configuration, API documentation, quickstart documentation, and release tests.
- 🔧 Preserved package versions at `1.7.0`.
- 🔧 Updated changelog comparison links and release date metadata.
- ✅ Release precheck passes.

## Concerns

- Verify that the digest-watch fix resolves issue `#1070` for all affected `portainer_agent` containers.
- Confirm that all seven translated README highlights use the correct localized release-link format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->