### PR TITLE
docs(rollback): document the backup and rollback endpoints in full

### DIFF
--- a/content/docs/current/api/container.mdx
+++ b/content/docs/current/api/container.mdx
@@ -805,7 +805,7 @@ curl -X POST http://drydock:3000/api/v1/containers/31a61a8305ef1fc9a71fa4f20a68d
   -d '{"backupId": "abc123"}'
 ```
 
-Returns 200 on success, 404 if the container/backup/trigger is not found, or 428 if confirmation is missing.
+Returns 200 on success, 404 if the container, the requested backup, or a matching Docker/Docker Compose trigger is not found, 409 if the backup was recorded by a Portainer action trigger (manual rollback needs a Docker or Docker Compose action instead) or the rollback would otherwise require an immutable digest reference that cannot be established, 428 if confirmation is missing, 501 if the container's agent connection does not support lifecycle actions, or 500 if the rollback fails.
 
 ## Get update/rollback history
 

--- a/content/docs/current/api/index.mdx
+++ b/content/docs/current/api/index.mdx
@@ -103,6 +103,8 @@ If the header is missing or does not match the expected token, the API responds 
 | `/api/v1/portwing/ws` | `WS` | Stable Portwing edge-agent WebSocket endpoint using the `portwing/1.0` protocol |
 | `/api/v1/containers/update` | `POST` | Bulk queue updates for multiple containers (see [Container API](/docs/api/container#bulk-update-containers)) |
 | `/api/v1/containers/backups` | `GET` | [All image backups](/docs/api/container#list-all-backups) (optionally filter by `containerName`) |
+| `/api/v1/containers/:id/backups` | `GET` | [Image backups for one container](/docs/api/container#get-container-backups), sorted by most recent first |
+| `/api/v1/containers/:id/rollback` | `POST` | [Roll back a container](/docs/api/container#rollback-a-container) to a previous backup image (defaults to the most recent when `backupId` is omitted); requires `X-DD-Confirm-Action: container-rollback` |
 | `/api/v1/icons/:provider/:slug` | `GET` | Proxy and cache registry icon images |
 | `/api/v1/icons/cache` | `DELETE` | Clear the icon proxy cache |
 | `/api/v1/auth/status` | `GET` | Authentication status check |

--- a/content/docs/current/configuration/rollback/index.mdx
+++ b/content/docs/current/configuration/rollback/index.mdx
@@ -19,8 +19,9 @@ The number of backups retained per container is configurable via a trigger envir
 | Env var | Required | Description | Supported values | Default value when missing |
 | -------------------------------------------------- | :--------------: | ---------------------------------------- | ---------------- | -------------------------- |
 | `DD_ACTION_DOCKER_{trigger_name}_BACKUPCOUNT` | ⚪ | Number of backups to retain per container | integer | `3` |
+| `DD_ACTION_DOCKERCOMPOSE_{trigger_name}_BACKUPCOUNT` | ⚪ | Number of backups to retain per container | integer | `3` |
 
-<Callout type="info">This variable is set on the [Docker trigger](/docs/configuration/triggers/docker), not on the target container.</Callout>
+<Callout type="info">This variable is set on the [Docker](/docs/configuration/triggers/docker) or [Docker Compose](/docs/configuration/triggers/docker-compose) action trigger, not on the target container. The Docker Compose trigger inherits its configuration schema from Docker, so the same variable and default apply.</Callout>
 
 ## Manual Rollback
 


### PR DESCRIPTION
Roadmap DOC-5, third item. The backup and rollback surface was mostly documented already, so this closes the three gaps an audit of `app/api/backup.ts`, the OpenAPI paths and the docs turned up: the rollback endpoint's 409 (Portainer-originated backup, or an immutable-digest rollback that can't be resolved), 501 (agent lifecycle unsupported) and 500 responses were missing from the container API page; the endpoint overview table had no rows for `GET /api/v1/containers/:id/backups` or `POST /api/v1/containers/:id/rollback`; and the retention table only named `DD_ACTION_DOCKER_{name}_BACKUPCOUNT` even though the Docker Compose action shares the same schema and honours `DD_ACTION_DOCKERCOMPOSE_{name}_BACKUPCOUNT`.
