### PR TITLE
test(store): kill the compose lock and startup migration mutants

### DIFF
--- a/app/store/app.test.ts
+++ b/app/store/app.test.ts
@@ -99,4 +99,30 @@ describe('App store', () => {
 
     expect(app.isUpgrade()).toBe(true);
   });
+
+  test('completeStartupInitialization propagates when migrate throws and never advances the stored version', () => {
+    db.prepare('INSERT INTO app_info (id, name, version) VALUES (1, ?, ?)').run('drydock', '1.0.0');
+    vi.mocked(migrate.migrate).mockImplementation(() => {
+      throw new Error('migrate failed');
+    });
+
+    app.createCollections(db);
+
+    expect(() => app.completeStartupInitialization()).toThrow('migrate failed');
+    expect(migrate.repairDataOnStartup).not.toHaveBeenCalled();
+    expect(app.getAppInfos()).toStrictEqual({ name: 'drydock', version: '1.0.0' });
+  });
+
+  test('completeStartupInitialization propagates when repairDataOnStartup throws and never advances the stored version', () => {
+    db.prepare('INSERT INTO app_info (id, name, version) VALUES (1, ?, ?)').run('drydock', '1.0.0');
+    vi.mocked(migrate.repairDataOnStartup).mockImplementation(() => {
+      throw new Error('repair failed');
+    });
+
+    app.createCollections(db);
+
+    expect(() => app.completeStartupInitialization()).toThrow('repair failed');
+    expect(migrate.migrate).toHaveBeenCalledWith('1.0.0', '2.0.0');
+    expect(app.getAppInfos()).toStrictEqual({ name: 'drydock', version: '1.0.0' });
+  });
 });

--- a/app/triggers/providers/dockercompose/ComposeFileLockManager.test.ts
+++ b/app/triggers/providers/dockercompose/ComposeFileLockManager.test.ts
@@ -20,9 +20,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 describe('ComposeFileLockManager', () => {
   test('withComposeFileLock should not reacquire lock when operation nests on the same file', async () => {
     const manager = new ComposeFileLockManager({
-      log: {
-        warn: vi.fn(),
-      },
+      getLog: () => ({ warn: vi.fn() }),
     });
 
     const nestedOperation = vi.fn(async () => 'ok');
@@ -41,14 +39,10 @@ describe('ComposeFileLockManager', () => {
     const lockBusyError: any = new Error('lock exists');
     lockBusyError.code = 'EEXIST';
     const managerA = new ComposeFileLockManager({
-      log: {
-        warn: vi.fn(),
-      },
+      getLog: () => ({ warn: vi.fn() }),
     });
     const managerB = new ComposeFileLockManager({
-      log: {
-        warn: vi.fn(),
-      },
+      getLog: () => ({ warn: vi.fn() }),
     });
     let firstOperationActive = false;
     let markFirstOperationStarted: () => void = () => {};
@@ -113,5 +107,76 @@ describe('ComposeFileLockManager', () => {
     expect(secondResult).toBe('second');
     expect(lockCreateAttemptCountBeforeRelease).toBe(1);
     expect(lockWaitCallCountBeforeRelease).toBe(0);
+  });
+
+  test('withComposeFileLock should release the lock when the operation throws, so a subsequent acquisition succeeds immediately', async () => {
+    const filePath = '/opt/drydock/test/compose.yml';
+    const lockFilePath = `${filePath}.drydock.lock`;
+    let lockFileExists = false;
+
+    fs.writeFile
+      .mockReset()
+      .mockImplementation(async (target: unknown, _data: unknown, opts?: { flag?: string }) => {
+        if (opts?.flag === 'wx') {
+          if (lockFileExists) {
+            const lockBusyError: any = new Error('lock exists');
+            lockBusyError.code = 'EEXIST';
+            throw lockBusyError;
+          }
+          lockFileExists = true;
+        }
+        return undefined;
+      });
+    fs.unlink.mockReset().mockImplementation(async () => {
+      lockFileExists = false;
+    });
+
+    const manager = new ComposeFileLockManager({ getLog: () => ({ warn: vi.fn() }) });
+    const waitForLockChangeSpy = vi.spyOn(manager, 'waitForComposeFileLockChange');
+
+    await expect(
+      manager.withComposeFileLock(filePath, async () => {
+        throw new Error('operation failed');
+      }),
+    ).rejects.toThrow('operation failed');
+
+    expect(fs.unlink).toHaveBeenCalledTimes(1);
+    expect(fs.unlink).toHaveBeenCalledWith(lockFilePath);
+    expect(lockFileExists).toBe(false);
+
+    const secondOperation = vi.fn(async () => 'second');
+    const secondResult = await manager.withComposeFileLock(filePath, secondOperation);
+
+    expect(secondResult).toBe('second');
+    // If the release were skipped on throw (release moved out of `finally`),
+    // the lock file would still be present and this second acquisition would
+    // hit EEXIST and have to wait for it, instead of succeeding immediately.
+    expect(waitForLockChangeSpy).not.toHaveBeenCalled();
+  });
+
+  test('withComposeFileLock should clear the held-lock fast-path entry when the operation throws', async () => {
+    const filePath = '/opt/drydock/test/compose.yml';
+    fs.writeFile.mockReset().mockResolvedValue(undefined);
+
+    const manager = new ComposeFileLockManager({ getLog: () => ({ warn: vi.fn() }) });
+
+    await expect(
+      manager.withComposeFileLock(filePath, async () => {
+        throw new Error('operation failed');
+      }),
+    ).rejects.toThrow('operation failed');
+
+    expect(manager._composeFileLocksHeld.has(filePath)).toBe(false);
+
+    const secondOperation = vi.fn(async () => 'second');
+    const secondResult = await manager.withComposeFileLock(filePath, secondOperation);
+
+    expect(secondResult).toBe('second');
+    expect(secondOperation).toHaveBeenCalledWith(filePath);
+    // If the held-set delete were removed, the entry would leak and the
+    // second call would take the in-process fast path without reacquiring
+    // the lock, so fs.writeFile would only have been called once (the first
+    // acquisition) instead of twice.
+    expect(fs.writeFile).toHaveBeenCalledTimes(2);
   });
 });

--- a/app/triggers/providers/dockercompose/Dockercompose.file-ops-and-trigger-batch.test.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.file-ops-and-trigger-batch.test.ts
@@ -118,7 +118,7 @@ describe('Dockercompose Trigger', () => {
     expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('copy failed'));
   });
 
-  test('writeComposeFile should log error and throw on write failure', async () => {
+  test('writeComposeFile should log error and throw when lock acquisition fails outright', async () => {
     fs.writeFile.mockRejectedValueOnce(new Error('write failed'));
 
     await expect(trigger.writeComposeFile('/opt/drydock/test/compose.yml', 'data')).rejects.toThrow(
@@ -126,6 +126,20 @@ describe('Dockercompose Trigger', () => {
     );
 
     expect(mockLog.error).toHaveBeenCalledWith(expect.stringContaining('write failed'));
+  });
+
+  test('writeComposeFile should propagate and leave the compose file untouched when the temp file write fails', async () => {
+    const temporaryWriteError = new Error('temp write failed');
+    // First fs.writeFile call is the lock file (wx flag); it must succeed so
+    // the failure below is attributed to the temp-file write, not the lock.
+    fs.writeFile.mockResolvedValueOnce(undefined).mockRejectedValueOnce(temporaryWriteError);
+
+    await expect(trigger.writeComposeFile('/opt/drydock/test/compose.yml', 'data')).rejects.toThrow(
+      'temp write failed',
+    );
+
+    expect(fs.rename).not.toHaveBeenCalled();
+    expect(mockLog.error).toHaveBeenCalledWith(expect.stringContaining('temp write failed'));
   });
 
   test('writeComposeFile should stringify non-object write failures in logs', async () => {

--- a/app/triggers/providers/dockercompose/Dockercompose.file-ops-and-trigger-batch.test.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.file-ops-and-trigger-batch.test.ts
@@ -129,15 +129,19 @@ describe('Dockercompose Trigger', () => {
   });
 
   test('writeComposeFile should propagate and leave the compose file untouched when the temp file write fails', async () => {
+    const composeFilePath = '/opt/drydock/test/compose.yml';
     const temporaryWriteError = new Error('temp write failed');
     // First fs.writeFile call is the lock file (wx flag); it must succeed so
     // the failure below is attributed to the temp-file write, not the lock.
     fs.writeFile.mockResolvedValueOnce(undefined).mockRejectedValueOnce(temporaryWriteError);
 
-    await expect(trigger.writeComposeFile('/opt/drydock/test/compose.yml', 'data')).rejects.toThrow(
+    await expect(trigger.writeComposeFile(composeFilePath, 'data')).rejects.toThrow(
       'temp write failed',
     );
 
+    // The rejected write must be the temp file, not a direct write to the
+    // final compose path that happened to fail before the rename.
+    expect(fs.writeFile.mock.calls[1]![0]).not.toBe(composeFilePath);
     expect(fs.rename).not.toHaveBeenCalled();
     expect(mockLog.error).toHaveBeenCalledWith(expect.stringContaining('temp write failed'));
   });


### PR DESCRIPTION
Roadmap DR-28 and DR-29, test debt that survived 100% coverage.

DR-28, compose file lock: three new tests each turn a named mutant red (verified by applying the mutant by hand and reverting): the release-on-throw test fails if the release leaves the `finally`, the held-set test fails if the `_composeFileLocksHeld.delete` goes, and a temp-write-failure test fails if `writeComposeFileAtomic` stops propagating. `ComposeFileLockManager.test.ts` passed `{ log }` to a constructor that takes `{ getLog }`; fixed on all four instantiations. The test at the old `:121` that claimed to cover a write failure but exercised lock acquisition is renamed to what it tests.

DR-29, startup migration: `completeStartupInitialization` now has a throwing `migrate.migrate` case and a throwing `repairDataOnStartup` case, each asserting the error propagates and the stored version never advances (on the SQLite store that is one `writeAppInfoRow` upsert, so the assertion reads back `getAppInfos()` instead of counting insert/remove calls). A swallowing try/catch on either call, or the version write moved above the migrate call, fails them.

Touched source files stay at 100% coverage. One neighbour, the "stringify non-object write failures" test in the file-ops batch file, has the same first-call mislabel and is left for a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

### ✨ Added
- Added startup migration tests for migration and repair failures.
- Added compose lock tests for error release and held-lock tracking.
- Added temporary write failure coverage.

### 🔧 Changed
- Updated `ComposeFileLockManager` tests to use `{ getLog }`.
- Renamed the lock-acquisition failure test for accuracy.
- Verified that startup failures preserve the stored `app_info` version.
- Verified that temporary write failures prevent rename and propagate errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->