### PR TITLE
test(api): make the integration tests deterministic under load

### DIFF
--- a/app/api/api-key-enforcement.integration.test.ts
+++ b/app/api/api-key-enforcement.integration.test.ts
@@ -202,10 +202,25 @@ function createTestApp(store: SessionStore): Application {
   return app;
 }
 
+/**
+ * Bind the loopback address, never the wildcard.
+ *
+ * `listen(0)` binds `::` dual-stack, and libuv sets SO_REUSEADDR, which makes
+ * the kernel's ephemeral-port picker check for an *exact* address+port conflict
+ * only. A wildcard listener can be handed a port another process already holds
+ * on `127.0.0.1` (`healthcheck.binary.test.ts` and
+ * `agent/PortwingDockerBridge.ts` both bind that address), and the more
+ * specific binding wins every connection to `127.0.0.1`, so the requests below
+ * answer from a foreign server carrying none of this app's routes or
+ * middleware. That is how the limiter case a few hundred lines down came back
+ * with an empty RateLimit header set (DR-74), and the same collision reading as
+ * a 404 is DR-57.
+ * @param app
+ */
 function startServer(app: Application): Promise<RunningServer> {
   return new Promise((resolve) => {
     const server = http.createServer(app);
-    server.listen(0, () => {
+    server.listen(0, '127.0.0.1', () => {
       const address = server.address();
       const port = typeof address === 'object' && address ? address.port : 0;
       resolve({ server, port });
@@ -542,6 +557,7 @@ describe('API key enforcement', () => {
  */
 describe('the pre-authentication limiter is not an existence oracle', () => {
   const OUTER_LIMIT = 3;
+  const WINDOW_MS = 60 * 1000;
   const openServers: http.Server[] = [];
 
   function buildLimiterApp(): Application {
@@ -549,7 +565,7 @@ describe('the pre-authentication limiter is not an existence oracle', () => {
     app.set('trust proxy', 1);
     app.use(
       rateLimit({
-        windowMs: 60 * 1000,
+        windowMs: WINDOW_MS,
         max: OUTER_LIMIT,
         standardHeaders: true,
         legacyHeaders: false,
@@ -621,11 +637,28 @@ describe('the pre-authentication limiter is not an existence oracle', () => {
       return rateLimitHeaders(await probe(limiterPort, credential));
     }
 
-    const unknownHeaders = await probeAfterPriming(unknownIdCredential);
-    const wrongSecretHeaders = await probeAfterPriming(wrongSecretCredential);
+    // `RateLimit-Reset` counts whole seconds down from the moment its window
+    // opened, so the two probes read 60 and 59 as soon as CPU contention puts
+    // more than a second between one pair's priming request and its probe.
+    // That is a difference in the wall clock, not in anything the limiter
+    // revealed about the credential, and comparing it as-is is DR-74. Freezing
+    // Date — and only Date, so the sockets underneath keep their real timers —
+    // pins both windows to the same reading and leaves every other header,
+    // `ratelimit-remaining` above all, doing the real work of the comparison.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    try {
+      const unknownHeaders = await probeAfterPriming(unknownIdCredential);
+      const wrongSecretHeaders = await probeAfterPriming(wrongSecretCredential);
 
-    expect(Object.keys(unknownHeaders).length).toBeGreaterThan(0);
-    expect(wrongSecretHeaders).toStrictEqual(unknownHeaders);
+      expect(Object.keys(unknownHeaders).length).toBeGreaterThan(0);
+      // The full window, proving the clock really is frozen: without it this
+      // reads 60 or 59 depending on load, and the freeze could stop working
+      // without the comparison below ever noticing.
+      expect(unknownHeaders['ratelimit-reset']).toBe(String(WINDOW_MS / 1000));
+      expect(wrongSecretHeaders).toStrictEqual(unknownHeaders);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test('every failing credential is charged to one bucket, so probing cannot mint budgets', async () => {

--- a/app/api/auth-session-persistence.integration.test.ts
+++ b/app/api/auth-session-persistence.integration.test.ts
@@ -146,10 +146,26 @@ async function createTestApp(store: SessionStore): Promise<Application> {
   return app;
 }
 
+/**
+ * Bind the loopback address, never the wildcard.
+ *
+ * `listen(0)` binds `::` dual-stack, and libuv sets SO_REUSEADDR on every
+ * listening socket, which makes the kernel's ephemeral-port picker check for an
+ * *exact* address+port conflict only. A wildcard listener can therefore be
+ * handed a port another process already holds on `127.0.0.1` — the app suite
+ * has two such binders, `healthcheck.binary.test.ts` and
+ * `agent/PortwingDockerBridge.ts`, and a second concurrent gate is running them
+ * — and the more specific binding wins every connection to `127.0.0.1`. Every
+ * request below then lands on that other server and comes back 404, which is
+ * DR-57. Naming `127.0.0.1` makes this server the most specific match for the
+ * address the tests fetch, and an exact conflict is the one case the picker
+ * does skip, so it cannot be handed a squatted port either.
+ * @param app
+ */
 function startServer(app: Application): Promise<RunningServer> {
   return new Promise((resolve) => {
     const server = http.createServer(app);
-    server.listen(0, () => {
+    server.listen(0, '127.0.0.1', () => {
       const address = server.address();
       const port = typeof address === 'object' && address ? address.port : 0;
       resolve({ server, port });

--- a/app/api/compat/wudcard.test.ts
+++ b/app/api/compat/wudcard.test.ts
@@ -17,7 +17,7 @@ function runMiddleware(method: string, path: string, internalApiRouter = vi.fn()
 async function startServer(app: express.Express) {
   const server = http.createServer(app);
   await new Promise<void>((resolve) => {
-    server.listen(0, resolve);
+    server.listen(0, '127.0.0.1', resolve);
   });
   const address = server.address() as AddressInfo;
   return { server, baseUrl: `http://127.0.0.1:${address.port}` };

--- a/app/api/config-validate.integration.test.ts
+++ b/app/api/config-validate.integration.test.ts
@@ -38,7 +38,7 @@ function createTestApp(): Application {
 function startServer(app: Application): Promise<RunningServer> {
   return new Promise((resolve) => {
     const server = http.createServer(app);
-    server.listen(0, () => {
+    server.listen(0, '127.0.0.1', () => {
       const address = server.address();
       const port = typeof address === 'object' && address ? address.port : 0;
       resolve({ server, port });

--- a/app/api/index.test.ts
+++ b/app/api/index.test.ts
@@ -856,7 +856,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -898,7 +898,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -967,7 +967,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1024,7 +1024,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1069,7 +1069,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1122,7 +1122,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1165,7 +1165,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;

--- a/app/api/webhooks/registry.e2e.test.ts
+++ b/app/api/webhooks/registry.e2e.test.ts
@@ -69,7 +69,7 @@ describe('api/webhooks/registry E2E', () => {
     app.use('/api/webhooks/registry', registryWebhookRouter.init());
 
     const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
-      const startedServer = app.listen(0, () => resolve(startedServer));
+      const startedServer = app.listen(0, '127.0.0.1', () => resolve(startedServer));
     });
 
     try {

--- a/app/authentications/providers/oidc/Oidc.test.ts
+++ b/app/authentications/providers/oidc/Oidc.test.ts
@@ -440,7 +440,7 @@ test('getAuthenticator should enforce OIDC route rate limiting in express integr
   oidc.getAuthenticator(integrationApp);
 
   const server = await new Promise<any>((resolve) => {
-    const startedServer = integrationApp.listen(0, () => resolve(startedServer));
+    const startedServer = integrationApp.listen(0, '127.0.0.1', () => resolve(startedServer));
   });
   const address = server.address();
   if (!address || typeof address === 'string') {
@@ -489,7 +489,7 @@ async function runOidcRememberFlow(remember: boolean): Promise<Response> {
   oidc.getAuthenticator(integrationApp);
 
   const server = await new Promise<any>((resolve) => {
-    const startedServer = integrationApp.listen(0, () => resolve(startedServer));
+    const startedServer = integrationApp.listen(0, '127.0.0.1', () => resolve(startedServer));
   });
   const address = server.address();
   if (!address || typeof address === 'string') {
@@ -555,7 +555,7 @@ test('OIDC remember route rejects malformed preferences before creating a sessio
   integrationApp.post('/auth/remember', requireSameOriginForMutations, setRememberMe);
 
   const server = await new Promise<any>((resolve) => {
-    const startedServer = integrationApp.listen(0, () => resolve(startedServer));
+    const startedServer = integrationApp.listen(0, '127.0.0.1', () => resolve(startedServer));
   });
   const address = server.address();
   if (!address || typeof address === 'string') {


### PR DESCRIPTION
Roadmap DR-57 and DR-74. Both flaked only when two pre-push gates ran at once, and the cause is not the wall clock.

`server.listen(0)` with no host binds the IPv6 wildcard. libuv sets `SO_REUSEADDR` on every listener, and on Darwin the ephemeral-port picker then rejects only an exact address-plus-port match, so a wildcard listener can be handed a port another test already holds on `127.0.0.1` (the healthcheck binary test and the Portwing bridge both bind loopback). The kernel routes `127.0.0.1:P` to the more specific socket, so the test's request answers from the other test's server: `expected 404 to be 200` in the session-persistence test, and an empty RateLimit header map in the api-key test (the response never went through the limiter app). Measured on a 14-core Mac: an explicit loopback bind over a live wildcard listener succeeds and wins the connection.

Fix: every test listener binds `listen(0, '127.0.0.1')`. The two flaking files first, then the same one-token change at the other twelve `listen(0` sites in app tests (wudcard, config-validate, api/index, registry webhook, Oidc). The rate-limit case also had a second, latent defect: `RateLimit-Reset` drifts by a second between two independently timed limiters under contention, so the probes now run with `Date` frozen and the reset value is asserted, with `ratelimit-remaining` still doing the discriminating work.

Verified: each fixed file 5 of 5 alone, and `npx vitest run api/` 3 of 3 under 14 CPU burners with a loop churning loopback ports and a full coverage gate running in another worktree. No production code changed. The 1.7 and 1.6 lines get the same change as a port.
