### PR TITLE
test(api): make the integration tests deterministic under load

### DIFF
--- a/app/api/auth-session-persistence.integration.test.ts
+++ b/app/api/auth-session-persistence.integration.test.ts
@@ -137,10 +137,26 @@ function createTestApp(store: LokiSessionStore): Application {
   return app;
 }
 
+/**
+ * Bind the loopback address, never the wildcard.
+ *
+ * `listen(0)` binds `::` dual-stack, and libuv sets SO_REUSEADDR on every
+ * listening socket, which makes the kernel's ephemeral-port picker check for an
+ * *exact* address+port conflict only. A wildcard listener can therefore be
+ * handed a port another process already holds on `127.0.0.1` — the app suite
+ * has two such binders, `healthcheck.binary.test.ts` and
+ * `agent/PortwingDockerBridge.ts`, and a second concurrent gate is running them
+ * — and the more specific binding wins every connection to `127.0.0.1`. Every
+ * request below then lands on that other server and comes back 404, which is
+ * DR-57. Naming `127.0.0.1` makes this server the most specific match for the
+ * address the tests fetch, and an exact conflict is the one case the picker
+ * does skip, so it cannot be handed a squatted port either.
+ * @param app
+ */
 function startServer(app: Application): Promise<RunningServer> {
   return new Promise((resolve) => {
     const server = http.createServer(app);
-    server.listen(0, () => {
+    server.listen(0, '127.0.0.1', () => {
       const address = server.address();
       const port = typeof address === 'object' && address ? address.port : 0;
       resolve({ server, port });

--- a/app/api/compat/wudcard.test.ts
+++ b/app/api/compat/wudcard.test.ts
@@ -17,7 +17,7 @@ function runMiddleware(method: string, path: string, internalApiRouter = vi.fn()
 async function startServer(app: express.Express) {
   const server = http.createServer(app);
   await new Promise<void>((resolve) => {
-    server.listen(0, resolve);
+    server.listen(0, '127.0.0.1', resolve);
   });
   const address = server.address() as AddressInfo;
   return { server, baseUrl: `http://127.0.0.1:${address.port}` };

--- a/app/api/index.test.ts
+++ b/app/api/index.test.ts
@@ -848,7 +848,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -890,7 +890,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -959,7 +959,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1016,7 +1016,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1061,7 +1061,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1114,7 +1114,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1157,7 +1157,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;

--- a/app/api/webhooks/registry.e2e.test.ts
+++ b/app/api/webhooks/registry.e2e.test.ts
@@ -69,7 +69,7 @@ describe('api/webhooks/registry E2E', () => {
     app.use('/api/webhooks/registry', registryWebhookRouter.init());
 
     const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
-      const startedServer = app.listen(0, () => resolve(startedServer));
+      const startedServer = app.listen(0, '127.0.0.1', () => resolve(startedServer));
     });
 
     try {

--- a/app/authentications/providers/oidc/Oidc.test.ts
+++ b/app/authentications/providers/oidc/Oidc.test.ts
@@ -348,7 +348,7 @@ test('getStrategy should enforce OIDC route rate limiting in express integration
   oidc.getStrategy(integrationApp);
 
   const server = await new Promise<any>((resolve) => {
-    const startedServer = integrationApp.listen(0, () => resolve(startedServer));
+    const startedServer = integrationApp.listen(0, '127.0.0.1', () => resolve(startedServer));
   });
   const address = server.address();
   if (!address || typeof address === 'string') {


### PR DESCRIPTION
Port of #1123 to dev/v1.7.

Every test listener now binds 127.0.0.1 instead of the wildcard address. On Darwin, `listen(0)` on `::` can be handed a port another test already holds on 127.0.0.1 (libuv sets SO_REUSEADDR and the kernel's port check only rejects exact matches), so requests hit a foreign server and the session-persistence assertions fail under load with a 404 and no RateLimit headers.

The api-key-enforcement and config-validate suites do not exist on this line, so those hunks are left out. Roadmap DR-57.
