### PR TITLE
test(api): bind every test listener to loopback

### DIFF
--- a/app/api/compat/wudcard.test.ts
+++ b/app/api/compat/wudcard.test.ts
@@ -17,7 +17,7 @@ function runMiddleware(method: string, path: string, internalApiRouter = vi.fn()
 async function startServer(app: express.Express) {
   const server = http.createServer(app);
   await new Promise<void>((resolve) => {
-    server.listen(0, resolve);
+    server.listen(0, '127.0.0.1', resolve);
   });
   const address = server.address() as AddressInfo;
   return { server, baseUrl: `http://127.0.0.1:${address.port}` };

--- a/app/api/index.test.ts
+++ b/app/api/index.test.ts
@@ -847,7 +847,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -889,7 +889,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -958,7 +958,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1017,7 +1017,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1063,7 +1063,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1116,7 +1116,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;
@@ -1159,7 +1159,7 @@ describe('API Index', () => {
 
     const server = http.createServer(app);
     await new Promise<void>((resolve) => {
-      server.listen(0, resolve);
+      server.listen(0, '127.0.0.1', resolve);
     });
     const address = server.address() as AddressInfo;
     const baseUrl = `http://127.0.0.1:${address.port}`;

--- a/app/api/webhooks/registry.e2e.test.ts
+++ b/app/api/webhooks/registry.e2e.test.ts
@@ -69,7 +69,7 @@ describe('api/webhooks/registry E2E', () => {
     app.use('/api/webhooks/registry', registryWebhookRouter.init());
 
     const server = await new Promise<ReturnType<typeof app.listen>>((resolve) => {
-      const startedServer = app.listen(0, () => resolve(startedServer));
+      const startedServer = app.listen(0, '127.0.0.1', () => resolve(startedServer));
     });
 
     try {

--- a/app/authentications/providers/oidc/Oidc.test.ts
+++ b/app/authentications/providers/oidc/Oidc.test.ts
@@ -348,7 +348,7 @@ test('getStrategy should enforce OIDC route rate limiting in express integration
   oidc.getStrategy(integrationApp);
 
   const server = await new Promise<any>((resolve) => {
-    const startedServer = integrationApp.listen(0, () => resolve(startedServer));
+    const startedServer = integrationApp.listen(0, '127.0.0.1', () => resolve(startedServer));
   });
   const address = server.address();
   if (!address || typeof address === 'string') {


### PR DESCRIPTION
Port of #1123 to dev/v1.6.

Every test listener now binds 127.0.0.1 instead of the wildcard address. On Darwin, `listen(0)` on `::` can be handed a port another test already holds on 127.0.0.1 (libuv sets SO_REUSEADDR and the kernel's port check only rejects exact matches), so requests hit a foreign server and assertions fail under load.

This line has no session-persistence suite, so only the listener binds are ported. Roadmap DR-57.
