### PR TITLE
ci(release): label the image with the cut's source commit

### DIFF
--- a/.github/tests/release-cut-retry-workflow.test.ts
+++ b/.github/tests/release-cut-retry-workflow.test.ts
@@ -158,6 +158,26 @@ test('release-cut delegates image tags and labels to docker metadata-action', ()
   expect(shellTagComputations).toStrictEqual([]);
 });
 
+// DR-119: docker/metadata-action defaults org.opencontainers.image.revision
+// to github.sha, which is the run's own checkout (main's head at cut time),
+// not the release source SHA. For a maintenance cut those differ, so the
+// shipped image labeled the wrong commit (v1.6.1-rc.9 carried main's head
+// instead of the dev-branch commit it was actually built from). Both
+// metadata-action invocations must override the label explicitly.
+test('release-cut pins the revision label to the release source SHA, not github.sha', () => {
+  const metadataStep = getStep('Docker metadata');
+  const stagingMetadataStep = getStep('Docker staging metadata');
+
+  for (const step of [metadataStep, stagingMetadataStep]) {
+    expect(blockLines(step?.with?.labels)).toStrictEqual([
+      'org.opencontainers.image.revision=${{ steps.source.outputs.source_sha }}',
+    ]);
+  }
+
+  const releaseStepText = JSON.stringify(loadReleaseSteps());
+  expect(releaseStepText).not.toContain('org.opencontainers.image.revision=${{ github.sha }}');
+});
+
 test('release-cut defines external registry repositories once at job scope', () => {
   const workflow = loadWorkflow(workflowPath);
   const releaseJob = workflow.jobs?.release;

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -710,6 +710,13 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.next.outputs.release_tag }},enable=${{ steps.tag.outputs.is_prerelease == 'false' }}
             type=semver,pattern={{major}},value=${{ steps.next.outputs.release_tag }},enable=${{ steps.tag.outputs.is_prerelease == 'false' }}
             type=raw,value=latest,enable=${{ steps.tag.outputs.is_prerelease == 'false' }}
+          # docker/metadata-action defaults org.opencontainers.image.revision to
+          # github.sha, which is the workflow run's own checkout commit
+          # (main's head at RC-cut time), not SOURCE_SHA (the dev-branch commit
+          # actually built). Override it explicitly so the shipped label names
+          # the true source commit on every maintenance cut where they differ.
+          labels: |
+            org.opencontainers.image.revision=${{ steps.source.outputs.source_sha }}
 
       - name: Docker staging metadata
         id: staging_meta
@@ -724,6 +731,10 @@ jobs:
             latest=false
           tags: |
             type=raw,value=release-staging-${{ github.run_id }}-${{ github.run_attempt }}
+          # Same override as the "Docker metadata" step above: pin the
+          # revision label to SOURCE_SHA, not github.sha.
+          labels: |
+            org.opencontainers.image.revision=${{ steps.source.outputs.source_sha }}
 
       - name: Validate GA candidate digest in every registry
         if: steps.tag.outputs.is_prerelease == 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A maintenance cut labeled the shipped image with `main`'s commit instead of the commit it was built from.** Both `docker/metadata-action` steps in `release-cut.yml` left `org.opencontainers.image.revision` at its default, `github.sha`, which is the workflow run's own checkout rather than the dev-branch source commit the build used. The v1.6.1-rc.9 staging image carried `5ae315227` in that label instead of `2969675ef`. Both steps now set the label from the release source SHA.
+
 ## [1.7.0-rc.13] — 2026-09-08
 
 ### Fixed


### PR DESCRIPTION
Roadmap DR-119.

A maintenance cut checks out SOURCE_SHA for the build, but both docker/metadata-action steps left `org.opencontainers.image.revision` at its default of `github.sha`, so the shipped image was labeled with main's head instead of the dev-branch commit it was built from. The v1.6.1-rc.9 staging image carried `5ae315227` where `2969675ef` belonged.

Both steps now set the label explicitly from `steps.source.outputs.source_sha`. A workflow test pins that. Prerelease cuts are unaffected since SOURCE_SHA equals the checkout there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

- 🔧 Set the revision label for published and staging images to `steps.source.outputs.source_sha`.
- ✨ Added workflow tests for the revision label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->