### PR TITLE
chore(release): prepare v1.6.1-rc.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1-rc.11] — 2026-09-08
+
 ### Fixed
 
 - **Containers on a floating tag that drydock first saw before v1.5.0-rc.17 could stay marked Current forever, even when the registry had a newer digest.** `image.digest.watch` was written once at first discovery and never revisited, so a row discovered before the digest-watch default changed from `!isDockerHubDomain(domain)` to "watch when the tag is meaningful" (v1.5.0-rc.17) kept the old `false` default permanently; only recreating the container picked up the new one. It is now re-derived every scan, the same way `isLocalImage` and `digest.repoDigests` already are, and an explicit `dd.watch.digest` label or imgset override still wins. Ported from the v1.7 line ([#1108](https://github.com/CodesWhat/drydock/pull/1108)). ([#1070](https://github.com/CodesWhat/drydock/issues/1070))
@@ -2499,7 +2501,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.10...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.11...HEAD
+[1.6.1-rc.11]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.10...v1.6.1-rc.11
 [1.6.1-rc.10]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.9...v1.6.1-rc.10
 [1.6.1-rc.9]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.8...v1.6.1-rc.9
 [1.6.1-rc.8]: https://github.com/CodesWhat/drydock/compare/v1.6.1-rc.7...v1.6.1-rc.8

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 <p align="center">
-  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.10-blue" alt="Version"></a>
+  <a href="https://github.com/CodesWhat/drydock/releases"><img src="https://img.shields.io/badge/version-1.6.1--rc.11-blue" alt="Version"></a>
   <a href="https://github.com/orgs/CodesWhat/packages/container/package/drydock"><img src="https://img.shields.io/badge/platforms-amd64%20%7C%20arm64-informational?logo=linux&logoColor=white" alt="Multi-arch"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-C9A227" alt="License AGPL-3.0"></a>
   <br>
@@ -179,6 +179,17 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">🆕 Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.6.1-rc.11 highlights</strong></summary>
+
+Long-lived containers on floating tags now detect new registry digests without
+needing to be recreated. Every scan rechecks the digest-watch default while
+preserving explicit label and image-set overrides.
+
+[Full changelog](CHANGELOG.md#161-rc11--2026-09-08)
+
+</details>
+
+<details>
 <summary><strong>v1.6.1-rc.10 highlights</strong></summary>
 
 - **The demo site no longer fails the weekly DAST scan on ZAP rule 90004** — it never sent `Cross-Origin-Opener-Policy`, and `apps/demo/vercel.json` now sends `same-origin`.

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.6.1-rc.10',
+    version: '1.6.1-rc.11',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-03-10T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.6.1-rc.10 started',
+    details: 'Drydock v1.6.1-rc.11 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-03-03T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.10',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.6.1-rc.11',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.6.1-rc.10',
+    tag: '1.6.1-rc.11',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.6.1-rc.10',
+  version: '1.6.1-rc.11',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.6.1-rc.10',
+      version: '1.6.1-rc.11',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.6.1-rc.10', mode: 'demo' },
+        server: { version: '1.6.1-rc.11', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.6.1-rc.10",
+  version: "1.6.1-rc.11",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -281,7 +281,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.6.1-rc.10",
+    version: "v1.6.1-rc.11",
     title: "Notifications, Policy & Release Intel",
     emoji: "\u{1F4E8}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.6.1-rc.10",
+      "version": "1.6.1-rc.11",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.6.1-rc.10",
+    "version": "1.6.1-rc.11",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.6.1-rc.10"
+  "version":"1.6.1-rc.11"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.6.1-rc.10",
+    "version": "1.6.1-rc.11",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.6.1-rc.10",
+      "drydockVersion": "1.6.1-rc.11",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.6.1-rc.10` | Immutable release candidate; best for reproducible testing |
+| `1.6.1-rc.11` | Immutable release candidate; best for reproducible testing |
 | `1.6-rc` | Rolling release-candidate channel; moves to the newest `1.6.1-rc.N` |
 | `1.6` | Rolling stable minor channel; published only for GA releases |
 | `1` | Rolling stable major channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,14 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.6.1-rc.11 Highlights — September 8, 2026
+
+Long-lived containers on floating tags now detect new registry digests without
+needing to be recreated. Every scan rechecks the digest-watch default while
+preserving explicit label and image-set overrides. See
+[CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#161-rc11--2026-09-08)
+for the full release notes.
+
 ## v1.6.1-rc.10 Highlights — September 6, 2026
 
 Three fixes: the demo site no longer fails the weekly DAST scan on ZAP rule

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "drydock-e2e",
       "version": "1.6.1",
+      "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@cucumber/cucumber": "12.9.0",
@@ -3762,9 +3763,9 @@
       }
     },
     "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-7.0.2.tgz",
+      "integrity": "sha512-uKZghv9UmPkMVLYy//KZ9HFAIJsl7wkhoEdIL0+rhuSY9pZQlhaeGEDPIe+/w7eh81MOql8Q/9+inAGWG6ZHYA==",
       "dev": true,
       "license": "MIT"
     },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
+    "postinstall": "node ../scripts/patch-artillery-csv.mjs",
     "format": "biome format --write .",
     "lint:fix": "biome check --fix .",
     "lint": "biome check .",
@@ -37,6 +38,7 @@
     "lodash": "4.18.1"
   },
   "overrides": {
+    "csv-parse": "7.0.2",
     "brace-expansion": "5.0.9",
     "js-yaml": "3.15.1",
     "fast-xml-parser": "5.10.1",

--- a/e2e/tests/artillery-csv.test.js
+++ b/e2e/tests/artillery-csv.test.js
@@ -1,0 +1,48 @@
+const assert = require('node:assert/strict');
+const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const test = require('node:test');
+const { promisify } = require('node:util');
+const { parse } = require('csv-parse');
+
+test('duplicate CSV headers remain own properties without replacing the record prototype', async () => {
+  const [record] = await promisify(parse)('__proto__,__proto__,name\na,b,example\n', {
+    columns: true,
+    group_columns_by_name: true,
+  });
+  assert.equal(Object.getPrototypeOf(record), Object.prototype);
+  assert.equal(Object.hasOwn(record, '__proto__'), true);
+  assert.deepEqual(Object.getOwnPropertyDescriptor(record, '__proto__').value, ['a', 'b']);
+  assert.equal(record.name, 'example');
+});
+
+test('Artillery prepares a CSV payload using the patched parser', async (t) => {
+  const directory = mkdtempSync(join(tmpdir(), 'drydock-csv-payload-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const previous = global.artillery;
+  global.artillery = { testRunId: 'csv-compatibility' };
+  t.after(() => {
+    if (previous === undefined) delete global.artillery;
+    else global.artillery = previous;
+  });
+  const csvPath = join(directory, 'users.csv');
+  const configPath = join(directory, 'scenario.json');
+  writeFileSync(csvPath, 'name,count\n"Doe, Jane",2\n\n');
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      config: {
+        target: 'http://127.0.0.1:1',
+        phases: [{ duration: 1, arrivalCount: 1 }],
+        payload: { path: csvPath, fields: ['name', 'count'], skipHeader: true },
+      },
+      scenarios: [{ flow: [{ get: { url: '/' } }] }],
+    }),
+  );
+  const { default: prepare } = await import(
+    '../node_modules/artillery/dist/lib/util/prepare-test-execution-plan.js'
+  );
+  const plan = await prepare([configPath], {});
+  assert.deepEqual(plan.config.payload[0].data, [['Doe, Jane', 2]]);
+});

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.6.1 RC, v1.6.0 GA, and v1.5.2 GA have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.10...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.6.1-rc.11...HEAD`],
+    ['1.6.1-rc.11', `${repositoryUrl}/compare/v1.6.1-rc.10...v1.6.1-rc.11`],
     ['1.6.1-rc.10', `${repositoryUrl}/compare/v1.6.1-rc.9...v1.6.1-rc.10`],
     ['1.6.1-rc.9', `${repositoryUrl}/compare/v1.6.1-rc.8...v1.6.1-rc.9`],
     ['1.6.1-rc.8', `${repositoryUrl}/compare/v1.6.1-rc.7...v1.6.1-rc.8`],

--- a/scripts/patch-artillery-csv.mjs
+++ b/scripts/patch-artillery-csv.mjs
@@ -1,0 +1,28 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Artillery 2.0.34 still imports the default export removed by csv-parse 5.
+// Keep its CSV payload support while overriding the vulnerable parser to 7.0.2.
+const directory =
+  process.argv[2] ?? fileURLToPath(new URL('../e2e/node_modules/artillery', import.meta.url));
+const imports = [
+  ['dist/lib/cmds/run.js', '_csv'],
+  ['dist/lib/util/prepare-test-execution-plan.js', 'csv'],
+];
+const changes = imports.map(([file, alias]) => {
+  const path = join(directory, file);
+  const source = readFileSync(path, 'utf8');
+  const before = `import ${alias} from 'csv-parse';`;
+  const after = `import { parse as ${alias} } from 'csv-parse';`;
+  if (source.includes(after)) return { path, source, patched: source };
+  if (!source.includes(before)) {
+    throw new Error(
+      `Unexpected Artillery csv-parse import in ${file}; review the compatibility patch`,
+    );
+  }
+  return { path, source, patched: source.replace(before, after) };
+});
+for (const { path, source, patched } of changes) {
+  if (source !== patched) writeFileSync(path, patched);
+}

--- a/scripts/patch-artillery-csv.test.mjs
+++ b/scripts/patch-artillery-csv.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(new URL('./patch-artillery-csv.mjs', import.meta.url));
+const files = ['dist/lib/cmds/run.js', 'dist/lib/util/prepare-test-execution-plan.js'];
+const aliases = ['_csv', 'csv'];
+
+function fixture(t) {
+  const directory = mkdtempSync(join(tmpdir(), 'drydock-artillery-csv-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  for (const [index, file] of files.entries()) {
+    mkdirSync(dirname(join(directory, file)), { recursive: true });
+    writeFileSync(join(directory, file), `import ${aliases[index]} from 'csv-parse';\n`);
+  }
+  return directory;
+}
+
+test('adapts both Artillery runtime imports to the patched parser and is idempotent', (t) => {
+  const directory = fixture(t);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const result = spawnSync(process.execPath, [script, directory], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    for (const [index, file] of files.entries()) {
+      assert.equal(
+        readFileSync(join(directory, file), 'utf8'),
+        `import { parse as ${aliases[index]} } from 'csv-parse';\n`,
+      );
+    }
+  }
+});
+
+test('an unexpected upstream import fails before either runtime file is changed', (t) => {
+  const directory = fixture(t);
+  writeFileSync(join(directory, files[1]), 'unexpected upstream layout\n');
+  const result = spawnSync(process.execPath, [script, directory], { encoding: 'utf8' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unexpected Artillery csv-parse import/u);
+  assert.equal(readFileSync(join(directory, files[0]), 'utf8'), "import _csv from 'csv-parse';\n");
+});

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,10 +2,10 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.6.1-rc.10';
-const PREV_RC_VERSION = '1.6.1-rc.9';
-const RC_DATE = '2026-09-06';
-const RC_DISPLAY_DATE = 'September 6, 2026';
+const RC_VERSION = '1.6.1-rc.11';
+const PREV_RC_VERSION = '1.6.1-rc.10';
+const RC_DATE = '2026-09-08';
+const RC_DISPLAY_DATE = 'September 8, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.5'];
 const BROAD_401_CLAIM =
   /(?:all|every) API (?:call|request)s?(?: (?:is|are) rejected with| returns?) `401`/iu;

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.6.1';
-const RC_VERSION = '1.6.1-rc.10';
+const RC_VERSION = '1.6.1-rc.11';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -22,6 +22,14 @@ function resolvedVersion(lockfile, packageName) {
   return lockfile.packages?.[`node_modules/${packageName}`]?.version;
 }
 
+test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
+  const manifest = readJson('e2e/package.json');
+  const lockfile = readJson('e2e/package-lock.json');
+  assert.equal(manifest.overrides?.['csv-parse'], '7.0.2');
+  assert.equal(resolvedVersion(lockfile, 'csv-parse'), '7.0.2');
+  assert.equal(manifest.scripts.postinstall, 'node ../scripts/patch-artillery-csv.mjs');
+});
+
 // Only the 4.x line is vetted now: 4.1.3 carries the August 2026 host-confusion
 // and SSRF fixes in addition to the earlier CVE-2026-16221 fix.
 // The transitional 3.1.4 branch was dropped once the override moved to 4.x,


### PR DESCRIPTION
Prepare v1.6.1-rc.11 with the floating-tag digest-watch fix already merged into dev/v1.6. Move its release notes out of Unreleased and update the release identity, demo fixtures, docs and comparison links.

The release gate found CVE-2026-85063 in Artillery's csv-parse dependency. Pin the patched 7.0.2 and adapt Artillery's two runtime imports during installation so CSV payloads keep working. The patch checks the upstream imports before changing either file and is safe to run twice.

Validation: release identity checks, a clean e2e install, all 15 e2e support tests, the dependency and compatibility-patch tests, and Artillery CLI startup pass. The regression test exercises duplicate CSV headers, and the integration test prepares a real CSV payload through Artillery.

The full pre-push gate passed in 284 seconds, including backend and frontend coverage, builds, static analysis, workflow checks and website script tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changelog

🔧 **Changed**
- Prepared release `v1.6.1-rc.11`.
- Updated release identity in README, demo fixtures, web configuration, and API documentation.
- Added release highlights and updated changelog comparison links.
- Added Artillery `postinstall` patching.

🐛 **Fixed**
- Added duplicate CSV header regression coverage.
- Added CSV payload integration coverage.
- Made the Artillery import patch idempotent and fail on unexpected upstream imports.

🔒 **Security**
- Pinned `csv-parse` to `7.0.2`.
- Patched Artillery runtime imports to use the named `parse` export.
- Added dependency-version and patch-behavior tests.

## Concerns

- Confirm the lockfile resolves `csv-parse` to `7.0.2`.
- Re-run the Artillery patch after Artillery dependency upgrades and update expected import patterns if required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->