### PR TITLE
chore(release): prepare v1.7.0-rc.14

### DIFF
--- a/.github/tests/readme-translations.test.ts
+++ b/.github/tests/readme-translations.test.ts
@@ -66,38 +66,38 @@ const localizedSurfaceFragments: Record<
     featureTableHeader: '| | Funktion | Beschreibung |',
     builtWithHeading: '<h2 align="center" id="built-with">Gebaut mit</h2>',
     communityQaHeading: '### Community-QA',
-    releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.13</strong></summary>',
+    releaseHeading: '<summary><strong>Highlights von v1.7.0-rc.14</strong></summary>',
   },
   'README.es.md': {
     featureTableHeader: '| | Característica | Descripción |',
     builtWithHeading: '<h2 align="center" id="built-with">Construido con</h2>',
     communityQaHeading: '### Control de calidad de la comunidad',
-    releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.13</strong></summary>',
+    releaseHeading: '<summary><strong>Aspectos destacados de v1.7.0-rc.14</strong></summary>',
   },
   'README.fr.md': {
     featureTableHeader: '| | Fonctionnalité | Descriptif |',
     builtWithHeading: '<h2 align="center" id="built-with">Construit avec</h2>',
     communityQaHeading: '### Contrôle qualité de la communauté',
-    releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.13</strong></summary>',
+    releaseHeading: '<summary><strong>Points forts de la v1.7.0-rc.14</strong></summary>',
   },
   'README.pl.md': {
     featureTableHeader: '| | Funkcja | Opis |',
     builtWithHeading: '<h2 align="center" id="built-with">Zbudowany z</h2>',
     communityQaHeading: '### Kontrola jakości społeczności',
     releaseHeading:
-      '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.13</strong></summary>',
+      '<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.14</strong></summary>',
   },
   'README.pt-BR.md': {
     featureTableHeader: '| | Recurso | Descrição |',
     builtWithHeading: '<h2 align="center" id="built-with">Construído com</h2>',
     communityQaHeading: '### Controle de qualidade da comunidade',
-    releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.13</strong></summary>',
+    releaseHeading: '<summary><strong>Destaques da v1.7.0-rc.14</strong></summary>',
   },
   'README.zh-CN.md': {
     featureTableHeader: '| |特色|描述 |',
     builtWithHeading: '<h2 align="center" id="built-with">技术栈</h2>',
     communityQaHeading: '### 社区质量检查',
-    releaseHeading: '<summary><strong>v1.7.0-rc.13 亮点</strong></summary>',
+    releaseHeading: '<summary><strong>v1.7.0-rc.14 亮点</strong></summary>',
   },
 };
 
@@ -211,6 +211,7 @@ const requiredFragments = [
   './CHANGELOG.md#170-rc11--2026-09-05',
   './CHANGELOG.md#170-rc12--2026-09-06',
   './CHANGELOG.md#170-rc13--2026-09-08',
+  './CHANGELOG.md#170-rc14--2026-09-08',
   'Portwing 0.9.0+',
   'Standard HTTP',
   '`DD_EXPERIMENTAL_PORTWING=false`',
@@ -260,10 +261,13 @@ describe.each(translatedReadmes)('%s', (readme) => {
     expect(content).toContain(surface.releaseHeading);
   });
 
-  test('maps localized v1.7 release bullets to their source links', () => {
+  test('maps archived rc.13 release bullets to their source links', () => {
     const surface = localizedSurfaceFragments[readme];
     const release = localizedReleaseFragments[readme];
-    const releaseBlock = getReleaseBlock(content, surface.releaseHeading);
+    const releaseBlock = getReleaseBlock(
+      content,
+      surface.releaseHeading.replace('v1.7.0-rc.14', 'v1.7.0-rc.13'),
+    );
     const releaseBullets = [release.digestWatchHeader, release.dastTimeoutHeader].map((fragment) =>
       getBullet(releaseBlock, fragment),
     );

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0-rc.14] — 2026-09-08
+
 ### Fixed
 
 - **A maintenance cut labeled the shipped image with `main`'s commit instead of the commit it was built from.** Both `docker/metadata-action` steps in `release-cut.yml` left `org.opencontainers.image.revision` at its default, `github.sha`, which is the workflow run's own checkout rather than the dev-branch source commit the build used. The v1.6.1-rc.9 staging image carried `5ae315227` in that label instead of `2969675ef`. Both steps now set the label from the release source SHA.
@@ -2738,7 +2740,8 @@ Remaining upstream-only changes (not ported — not applicable to drydock):
 | Fix codeberg tests | Covered by drydock's own tests |
 | Update changelog | Upstream-specific |
 
-[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.13...HEAD
+[Unreleased]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.14...HEAD
+[1.7.0-rc.14]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.13...v1.7.0-rc.14
 [1.7.0-rc.13]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.12...v1.7.0-rc.13
 [1.7.0-rc.12]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.11...v1.7.0-rc.12
 [1.7.0-rc.11]: https://github.com/CodesWhat/drydock/compare/v1.7.0-rc.10...v1.7.0-rc.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Rolling back a container (auto-rollback on an unhealthy update, or a manual restore) now runs the same runtime-config sanitization as an update, so an entrypoint or command the newer image introduced is no longer copied onto the older image and the rolled-back container starts.**
 - **Tag family matching now requires the candidate's variant suffix to match the current tag's exactly, so a container on 1.27.3-alpine is no longer offered 1.28.0-alpine-perl (or 1.28.0-alpine from -alpine-slim) under dd.tag.family=loose or a dd.tag.include filter.**
 - Precision-only suffix carve-out now requires at least one digit placeholder, so a trailing dot (`1.3.0-alpine.`) no longer counts as the same tag family as `1.3.0-alpine`.
+- **Monthly and longer watcher schedules could expire scans after 1 ms.** The scan deadline was twice the cron interval, which overflowed Node's timer limit and cleared the in-flight scan guard almost immediately. Deadlines now stop at the largest supported delay, preserving the existing ten-minute floor and shorter schedule behavior.
 
 ## [1.7.0-rc.13] — 2026-09-08
 

--- a/README.de.md
+++ b/README.de.md
@@ -219,6 +219,15 @@ Weitere Informationen zu Docker Compose, Socket-Sicherheit, Reverse-Proxy und al
 <h2 align="center" id="recent-updates">Aktuelle Updates</h2>
 
 <details open>
+<summary><strong>Highlights von v1.7.0-rc.14</strong></summary>
+
+Rollbacks entfernen jetzt geerbte Entrypoints und Befehle, die das gesicherte Image nicht ausführen kann. Der Tag-Abgleich hält Varianten wie `alpine` und `alpine-perl` getrennt. Image-Labels von Wartungsreleases nennen den tatsächlichen Quell-Commit.
+
+Vollständige Versionshinweise in [CHANGELOG.md](./CHANGELOG.md#170-rc14--2026-09-08).
+
+</details>
+
+<details>
 <summary><strong>Highlights von v1.7.0-rc.13</strong></summary>
 
 - **Container auf einem Floating-Tag, die Drydock erstmals vor v1.5.0-rc.17 gesehen hat, konnten für immer als Current markiert bleiben, selbst wenn die Registry einen neueren Digest hatte.** `image.digest.watch` wird jetzt bei jedem Scan neu ermittelt, statt einmalig bei der ersten Erkennung festgeschrieben zu werden, genau wie `isLocalImage` und `digest.repoDigests` es bereits tun. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))

--- a/README.es.md
+++ b/README.es.md
@@ -219,6 +219,15 @@ Consulte la [guía de inicio rápido](https://getdrydock.com/docs/quickstart) pa
 <h2 align="center" id="recent-updates">Actualizaciones recientes</h2>
 
 <details open>
+<summary><strong>Aspectos destacados de v1.7.0-rc.14</strong></summary>
+
+Las reversiones eliminan los puntos de entrada y comandos heredados que la imagen de respaldo no puede ejecutar. La comparación de etiquetas mantiene separadas variantes como `alpine` y `alpine-perl`. Las etiquetas de las imágenes de mantenimiento identifican el commit de origen real.
+
+Notas completas en [CHANGELOG.md](./CHANGELOG.md#170-rc14--2026-09-08).
+
+</details>
+
+<details>
 <summary><strong>Aspectos destacados de v1.7.0-rc.13</strong></summary>
 
 - **Los contenedores en una etiqueta flotante que drydock vio por primera vez antes de v1.5.0-rc.17 podían quedar marcados como Actuales para siempre, incluso con un digest más reciente disponible.** `image.digest.watch` ahora se vuelve a derivar en cada escaneo en lugar de fijarse en el primer descubrimiento, igual que ya hacen `isLocalImage` y `digest.repoDigests`. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))

--- a/README.fr.md
+++ b/README.fr.md
@@ -219,6 +219,15 @@ Consultez le [Guide de démarrage rapide](https://getdrydock.com/docs/quickstart
 <h2 align="center" id="recent-updates">Mises à jour récentes</h2>
 
 <details open>
+<summary><strong>Points forts de la v1.7.0-rc.14</strong></summary>
+
+Les restaurations suppriment les points d’entrée et commandes hérités que l’image sauvegardée ne peut pas exécuter. La comparaison des tags distingue les variantes comme `alpine` et `alpine-perl`. Les labels des images de maintenance indiquent le véritable commit source.
+
+Notes de version complètes dans [CHANGELOG.md](./CHANGELOG.md#170-rc14--2026-09-08).
+
+</details>
+
+<details>
 <summary><strong>Points forts de la v1.7.0-rc.13</strong></summary>
 
 - **Les conteneurs sur un tag flottant que drydock avait vu pour la première fois avant v1.5.0-rc.17 pouvaient rester marqués Current pour toujours, même avec un digest plus récent disponible.** `image.digest.watch` est désormais recalculé à chaque scan au lieu d'être fixé lors de la première découverte, de la même façon que le font déjà `isLocalImage` et `digest.repoDigests`. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))

--- a/README.md
+++ b/README.md
@@ -222,6 +222,15 @@ See the [Quick Start guide](https://getdrydock.com/docs/quickstart) for Docker C
 <h2 align="center" id="recent-updates">Recent Updates</h2>
 
 <details open>
+<summary><strong>v1.7.0-rc.14 highlights</strong></summary>
+
+Rollback now removes inherited entrypoints and commands that the backup image cannot run. Tag matching keeps variants such as `alpine` and `alpine-perl` separate, and maintenance image labels identify the actual source commit.
+
+Full release notes in [CHANGELOG.md](./CHANGELOG.md#170-rc14--2026-09-08).
+
+</details>
+
+<details>
 <summary><strong>v1.7.0-rc.13 highlights</strong></summary>
 
 - **Containers on a floating tag that drydock first saw before v1.5.0-rc.17 could stay marked Current forever, even with a newer digest available.** `image.digest.watch` is now re-derived every scan instead of being fixed at first discovery, the same way `isLocalImage` and `digest.repoDigests` already are. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))

--- a/README.pl.md
+++ b/README.pl.md
@@ -219,6 +219,15 @@ Zobacz [Przewodnik szybkiego startu](https://getdrydock.com/docs/quickstart) dla
 <h2 align="center" id="recent-updates">Ostatnie aktualizacje</h2>
 
 <details open>
+<summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.14</strong></summary>
+
+Przywracanie usuwa teraz odziedziczone punkty wejścia i polecenia, których zapisany obraz nie może uruchomić. Dopasowanie tagów rozróżnia warianty takie jak `alpine` i `alpine-perl`. Etykiety obrazów wydań serwisowych wskazują właściwy commit źródłowy.
+
+Pełne informacje o wydaniu w [CHANGELOG.md](./CHANGELOG.md#170-rc14--2026-09-08).
+
+</details>
+
+<details>
 <summary><strong>Najważniejsze informacje w wersji v1.7.0-rc.13</strong></summary>
 
 - **Kontenery na płynnym tagu, które drydock po raz pierwszy zobaczył przed v1.5.0-rc.17, mogły zostać oznaczone jako Current na zawsze, nawet gdy registry miało nowszy digest.** `image.digest.watch` jest teraz wyznaczane na nowo przy każdym skanowaniu zamiast być ustalane raz przy pierwszym wykryciu, tak samo jak już robią to `isLocalImage` i `digest.repoDigests`. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -219,6 +219,15 @@ Consulte o [Guia de início rápido](https://getdrydock.com/docs/quickstart) par
 <h2 align="center" id="recent-updates">Atualizações recentes</h2>
 
 <details open>
+<summary><strong>Destaques da v1.7.0-rc.14</strong></summary>
+
+A reversão agora remove pontos de entrada e comandos herdados que a imagem de backup não pode executar. A comparação de tags mantém variantes como `alpine` e `alpine-perl` separadas. Os rótulos das imagens de manutenção identificam o commit de origem correto.
+
+Notas completas em [CHANGELOG.md](./CHANGELOG.md#170-rc14--2026-09-08).
+
+</details>
+
+<details>
 <summary><strong>Destaques da v1.7.0-rc.13</strong></summary>
 
 - **Contêineres em uma tag flutuante que o drydock viu pela primeira vez antes da v1.5.0-rc.17 podiam ficar marcados como Current para sempre, mesmo com um digest mais novo disponível.** `image.digest.watch` agora é recalculado a cada varredura, em vez de ser fixado na primeira descoberta, da mesma forma que `isLocalImage` e `digest.repoDigests` já fazem. ([#1108](https://github.com/CodesWhat/drydock/pull/1108))

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -219,6 +219,15 @@ docker run -d \
 <h2 align="center" id="recent-updates">最近更新</h2>
 
 <details open>
+<summary><strong>v1.7.0-rc.14 亮点</strong></summary>
+
+回滚现在会移除备份镜像无法运行的继承入口点和命令。标签匹配会区分 `alpine` 和 `alpine-perl` 等变体。维护版本的镜像标签现在会标明实际的源代码提交。
+
+完整发布说明见 [CHANGELOG.md](./CHANGELOG.md#170-rc14--2026-09-08).
+
+</details>
+
+<details>
 <summary><strong>v1.7.0-rc.13 亮点</strong></summary>
 
 - **drydock 在 v1.5.0-rc.17 之前首次发现的浮动标签容器，即使镜像仓库中已有更新的 digest，也可能永远被标记为 Current。** `image.digest.watch` 现在会在每次扫描时重新计算，而不是在首次发现时一次性写死，`isLocalImage` 和 `digest.repoDigests` 早已是这样处理的。([#1108](https://github.com/CodesWhat/drydock/pull/1108))

--- a/app/watchers/providers/docker/docker-cron-watch.test.ts
+++ b/app/watchers/providers/docker/docker-cron-watch.test.ts
@@ -186,6 +186,26 @@ describe('watchFromCronOrchestration', () => {
     expect(watcher.queueMaintenanceWindowWatch).not.toHaveBeenCalled();
   });
 
+  test('keeps a monthly scan pending instead of overflowing the real deadline timer', async () => {
+    const deferred = createDeferred<ContainerReport[]>();
+    const watcher = createWatcher({
+      watch: vi.fn().mockReturnValue(deferred.promise),
+      getNextScheduledRunDate: vi.fn((fromDate?: Date) =>
+        fromDate ? new Date('2026-02-01T00:00:00Z') : new Date('2026-01-01T00:00:00Z'),
+      ),
+    });
+    const call = watchFromCronOrchestration(watcher, { reason: 'schedule' });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(watcher.log?.warn).not.toHaveBeenCalled();
+      expect(watcher.cronWatchInFlight).toBeDefined();
+    } finally {
+      deferred.resolve([]);
+      await call;
+      resetCronWatchState(watcher);
+    }
+  });
+
   test.each([
     {
       label: 'no interval is available',
@@ -206,6 +226,21 @@ describe('watchFromCronOrchestration', () => {
       label: "the interval's multiple exceeds the floor",
       intervalMs: 20 * 60 * 1000,
       expectedDeadlineMs: 40 * 60 * 1000,
+    },
+    {
+      label: "the interval's multiple is below Node's timer ceiling",
+      intervalMs: 1073741823,
+      expectedDeadlineMs: 2147483646,
+    },
+    {
+      label: "the interval's multiple exceeds Node's timer ceiling",
+      intervalMs: 1073741824,
+      expectedDeadlineMs: 2147483647,
+    },
+    {
+      label: 'the interval spans a month',
+      intervalMs: 31 * 24 * 60 * 60 * 1000,
+      expectedDeadlineMs: 2147483647,
     },
   ])('sizes the in-flight deadline when $label', async ({ intervalMs, expectedDeadlineMs }) => {
     vi.useFakeTimers();

--- a/app/watchers/providers/docker/docker-cron-watch.ts
+++ b/app/watchers/providers/docker/docker-cron-watch.ts
@@ -122,15 +122,16 @@ export function resetCronWatchState(watcher: CronWatchOrchestrationWatcher): voi
  */
 const CRON_WATCH_DEADLINE_INTERVAL_MULTIPLIER = 2;
 const CRON_WATCH_DEADLINE_FLOOR_MS = 10 * 60 * 1000; // 10 minutes
+const CRON_WATCH_DEADLINE_CEILING_MS = 2147483647; // Larger Node timers expire after 1ms.
 
 function getCronWatchDeadlineMs(watcher: CronWatchOrchestrationWatcher): number {
   const intervalMs = getCronIntervalMs(watcher);
   if (!intervalMs || intervalMs <= 0) {
     return CRON_WATCH_DEADLINE_FLOOR_MS;
   }
-  return Math.max(
-    intervalMs * CRON_WATCH_DEADLINE_INTERVAL_MULTIPLIER,
-    CRON_WATCH_DEADLINE_FLOOR_MS,
+  return Math.min(
+    CRON_WATCH_DEADLINE_CEILING_MS,
+    Math.max(intervalMs * CRON_WATCH_DEADLINE_INTERVAL_MULTIPLIER, CRON_WATCH_DEADLINE_FLOOR_MS),
   );
 }
 

--- a/apps/demo/src/mocks/data/agents.ts
+++ b/apps/demo/src/mocks/data/agents.ts
@@ -4,7 +4,7 @@ export const agents = [
     host: '192.168.1.50',
     port: 3001,
     connected: true,
-    version: '1.7.0-rc.13',
+    version: '1.7.0-rc.14',
     os: 'linux',
     arch: 'amd64',
     cpus: 4,

--- a/apps/demo/src/mocks/data/audit.ts
+++ b/apps/demo/src/mocks/data/audit.ts
@@ -3,7 +3,7 @@ export const auditEntries = [
     id: 'aud-001',
     timestamp: '2026-08-12T08:00:00.000Z',
     action: 'system:start',
-    details: 'Drydock v1.7.0-rc.13 started',
+    details: 'Drydock v1.7.0-rc.14 started',
   },
   {
     id: 'aud-002',
@@ -207,6 +207,6 @@ export const auditEntries = [
     timestamp: '2026-08-05T18:00:00.000Z',
     action: 'container:watch',
     container: 'drydock',
-    details: 'Started watching ghcr.io/codeswhat/drydock:1.7.0-rc.13',
+    details: 'Started watching ghcr.io/codeswhat/drydock:1.7.0-rc.14',
   },
 ];

--- a/apps/demo/src/mocks/data/containers.ts
+++ b/apps/demo/src/mocks/data/containers.ts
@@ -330,7 +330,7 @@ export const containers = [
     displayName: 'Drydock',
     displayIcon: 'sh-drydock',
     image: 'codeswhat/drydock',
-    tag: '1.7.0-rc.13',
+    tag: '1.7.0-rc.14',
     registryType: 'ghcr',
     registryUrl: 'https://ghcr.io',
     scanStatus: 'scanned',

--- a/apps/demo/src/mocks/data/server.ts
+++ b/apps/demo/src/mocks/data/server.ts
@@ -1,5 +1,5 @@
 export const serverInfo = {
-  version: '1.7.0-rc.13',
+  version: '1.7.0-rc.14',
   uptime: 864000,
   hostname: 'drydock-demo',
   platform: 'linux',

--- a/apps/demo/src/mocks/handlers/app.ts
+++ b/apps/demo/src/mocks/handlers/app.ts
@@ -4,7 +4,7 @@ export const appHandlers = [
   http.get('/api/v1/app', () =>
     HttpResponse.json({
       name: 'Drydock',
-      version: '1.7.0-rc.13',
+      version: '1.7.0-rc.14',
       description: 'Docker container update manager',
       repository: 'https://github.com/CodesWhat/drydock',
       documentation: 'https://getdrydock.com/docs',
@@ -16,7 +16,7 @@ export const appHandlers = [
     return HttpResponse.json(
       {
         generatedAt: new Date().toISOString(),
-        server: { version: '1.7.0-rc.13', mode: 'demo' },
+        server: { version: '1.7.0-rc.14', mode: 'demo' },
         summary: {
           containers: 25,
           watchers: 2,

--- a/apps/web/src/lib/site-config.ts
+++ b/apps/web/src/lib/site-config.ts
@@ -15,7 +15,7 @@ export const SITE_CONFIG = {
   /** Brand name shown in the header, footer, and metadata. */
   name: "Drydock",
   /** Current release version shown in the hero badge. */
-  version: "1.7.0-rc.13",
+  version: "1.7.0-rc.14",
   /** Short product tagline used in page titles and OG metadata. */
   tagline: "Container Update Monitoring",
   /** Default meta / OpenGraph / Twitter description. */

--- a/apps/web/src/lib/site-content.ts
+++ b/apps/web/src/lib/site-content.ts
@@ -294,7 +294,7 @@ export const roadmap: Milestone[] = [
     ],
   },
   {
-    version: "v1.7.0-rc.13",
+    version: "v1.7.0-rc.14",
     title: "Smart Updates & UX",
     emoji: "\u{1F680}",
     status: "next",

--- a/content/docs/current/api/agent.mdx
+++ b/content/docs/current/api/agent.mdx
@@ -23,7 +23,7 @@ curl http://drydock:3000/api/v1/agents
       "host": "192.168.1.50",
       "port": 3000,
       "connected": true,
-      "version": "1.7.0-rc.13",
+      "version": "1.7.0-rc.14",
       "os": "linux",
       "arch": "amd64",
       "cpus": 4,
@@ -153,7 +153,7 @@ Sent immediately upon connection to confirm the handshake.
 {
   "type": "dd:ack",
   "data": {
-    "version": "1.7.0-rc.13",
+    "version": "1.7.0-rc.14",
     "os": "linux",
     "arch": "amd64",
     "cpus": 4,

--- a/content/docs/current/api/app.mdx
+++ b/content/docs/current/api/app.mdx
@@ -12,7 +12,7 @@ curl http://drydock:3000/api/v1/app
 
 {
   "name":"drydock",
-  "version":"1.7.0-rc.13"
+  "version":"1.7.0-rc.14"
 }
 ```
 

--- a/content/docs/current/api/portwing.mdx
+++ b/content/docs/current/api/portwing.mdx
@@ -197,7 +197,7 @@ A versioned alias `/api/v1/portwing/ws` is also accepted and is signature-equiva
     "agentId": "edge-host-01",
     "agentName": "edge-host-01",
     "protocol": "portwing/1.0",
-    "version": "1.7.0-rc.13",
+    "version": "1.7.0-rc.14",
     "pubKeyId": "3f8a1c2e9b047d56",
     "timestamp": 1780329600,
     "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
@@ -220,7 +220,7 @@ A name collision with an already-connected agent under the same key (or the in-f
   "data": {
     "pollInterval": 300,
     "config": {
-      "drydockVersion": "1.7.0-rc.13",
+      "drydockVersion": "1.7.0-rc.14",
       "supportedProtocols": "portwing/1.0",
       "serverCompatLevel": "1.4.0"
     }

--- a/content/docs/current/quickstart/index.mdx
+++ b/content/docs/current/quickstart/index.mdx
@@ -108,7 +108,7 @@ Release tags use the same channel names in every registry:
 
 | Tag | Behavior |
 | --- | --- |
-| `1.7.0-rc.13` | Immutable release candidate; best for reproducible testing |
+| `1.7.0-rc.14` | Immutable release candidate; best for reproducible testing |
 | `1.7-rc` | Rolling release-candidate channel; moves to the newest `1.7.0-rc.N` |
 | `1.6.0` | Immutable exact GA release; best for reproducible deployments |
 | `1.6` | Rolling stable minor channel; published only for GA releases |

--- a/content/docs/current/updates/index.mdx
+++ b/content/docs/current/updates/index.mdx
@@ -5,6 +5,13 @@ description: "Release update notes and feature highlights, with direct links to 
 
 ## Unreleased
 
+## v1.7.0-rc.14 Highlights — September 8, 2026
+
+- Rollback now applies the same runtime-config sanitization as an update, so an entrypoint or command introduced by the newer image is not copied onto an older image that cannot run it. Tag family matching requires an exact variant suffix, with a digit-only precision exception; a trailing dot no longer qualifies ([#1134](https://github.com/CodesWhat/drydock/pull/1134)).
+- Maintenance image labels now name the release source SHA instead of the workflow's main-branch commit ([#1126](https://github.com/CodesWhat/drydock/pull/1126)).
+
+Full release notes are in [CHANGELOG.md](https://github.com/CodesWhat/drydock/blob/main/CHANGELOG.md#170-rc14--2026-09-08).
+
 ## v1.7.0-rc.13 Highlights — September 8, 2026
 
 - **Containers on a floating tag from before v1.5.0-rc.17 could stay marked Current forever, even with a newer digest available** — `image.digest.watch` is now re-derived every scan instead of being fixed at first discovery ([#1108](https://github.com/CodesWhat/drydock/pull/1108)).

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "drydock-e2e",
       "version": "1.7.0",
+      "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@cucumber/cucumber": "12.9.0",
@@ -3847,9 +3848,9 @@
       }
     },
     "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-7.0.2.tgz",
+      "integrity": "sha512-uKZghv9UmPkMVLYy//KZ9HFAIJsl7wkhoEdIL0+rhuSY9pZQlhaeGEDPIe+/w7eh81MOql8Q/9+inAGWG6ZHYA==",
       "dev": true,
       "license": "MIT"
     },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
+    "postinstall": "node ../scripts/patch-artillery-csv.mjs",
     "format": "biome format --write .",
     "lint:fix": "biome check --fix .",
     "lint": "biome check .",
@@ -37,6 +38,7 @@
     "lodash": "4.18.1"
   },
   "overrides": {
+    "csv-parse": "7.0.2",
     "brace-expansion": "5.0.9",
     "fflate": "0.8.3",
     "js-yaml": "3.15.2",

--- a/e2e/tests/artillery-csv.test.js
+++ b/e2e/tests/artillery-csv.test.js
@@ -1,0 +1,48 @@
+const assert = require('node:assert/strict');
+const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const test = require('node:test');
+const { promisify } = require('node:util');
+const { parse } = require('csv-parse');
+
+test('duplicate CSV headers remain own properties without replacing the record prototype', async () => {
+  const [record] = await promisify(parse)('__proto__,__proto__,name\na,b,example\n', {
+    columns: true,
+    group_columns_by_name: true,
+  });
+  assert.equal(Object.getPrototypeOf(record), Object.prototype);
+  assert.equal(Object.hasOwn(record, '__proto__'), true);
+  assert.deepEqual(Object.getOwnPropertyDescriptor(record, '__proto__').value, ['a', 'b']);
+  assert.equal(record.name, 'example');
+});
+
+test('Artillery prepares a CSV payload using the patched parser', async (t) => {
+  const directory = mkdtempSync(join(tmpdir(), 'drydock-csv-payload-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const previous = global.artillery;
+  global.artillery = { testRunId: 'csv-compatibility' };
+  t.after(() => {
+    if (previous === undefined) delete global.artillery;
+    else global.artillery = previous;
+  });
+  const csvPath = join(directory, 'users.csv');
+  const configPath = join(directory, 'scenario.json');
+  writeFileSync(csvPath, 'name,count\n"Doe, Jane",2\n\n');
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      config: {
+        target: 'http://127.0.0.1:1',
+        phases: [{ duration: 1, arrivalCount: 1 }],
+        payload: { path: csvPath, fields: ['name', 'count'], skipHeader: true },
+      },
+      scenarios: [{ flow: [{ get: { url: '/' } }] }],
+    }),
+  );
+  const { default: prepare } = await import(
+    '../node_modules/artillery/dist/lib/util/prepare-test-execution-plan.js'
+  );
+  const plan = await prepare([configPath], {});
+  assert.deepEqual(plan.config.payload[0].data, [['Doe, Jane', 2]]);
+});

--- a/e2e/tests/artillery-csv.test.js
+++ b/e2e/tests/artillery-csv.test.js
@@ -1,10 +1,14 @@
 const assert = require('node:assert/strict');
 const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
+const { createRequire } = require('node:module');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 const test = require('node:test');
 const { promisify } = require('node:util');
-const { parse } = require('csv-parse');
+const artilleryRequire = createRequire(
+  join(__dirname, '../node_modules/artillery/dist/lib/util/prepare-test-execution-plan.js'),
+);
+const { parse } = artilleryRequire('csv-parse');
 
 test('duplicate CSV headers remain own properties without replacing the record prototype', async () => {
   const [record] = await promisify(parse)('__proto__,__proto__,name\na,b,example\n', {

--- a/scripts/changelog-links.test.mjs
+++ b/scripts/changelog-links.test.mjs
@@ -56,7 +56,8 @@ test('every linked changelog heading has exactly one link definition', () => {
 test('v1.7 RC and prior releases have a complete chronological comparison-link chain', () => {
   const definitions = new Map(getLinkDefinitions(changelog).map(({ label, url }) => [label, url]));
   const expected = new Map([
-    ['Unreleased', `${repositoryUrl}/compare/v1.7.0-rc.13...HEAD`],
+    ['Unreleased', `${repositoryUrl}/compare/v1.7.0-rc.14...HEAD`],
+    ['1.7.0-rc.14', `${repositoryUrl}/compare/v1.7.0-rc.13...v1.7.0-rc.14`],
     ['1.7.0-rc.13', `${repositoryUrl}/compare/v1.7.0-rc.12...v1.7.0-rc.13`],
     ['1.7.0-rc.12', `${repositoryUrl}/compare/v1.7.0-rc.11...v1.7.0-rc.12`],
     ['1.7.0-rc.11', `${repositoryUrl}/compare/v1.7.0-rc.10...v1.7.0-rc.11`],

--- a/scripts/patch-artillery-csv.mjs
+++ b/scripts/patch-artillery-csv.mjs
@@ -1,0 +1,28 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Artillery 2.0.34 still imports the default export removed by csv-parse 5.
+// Keep its CSV payload support while overriding the vulnerable parser to 7.0.2.
+const directory =
+  process.argv[2] ?? fileURLToPath(new URL('../e2e/node_modules/artillery', import.meta.url));
+const imports = [
+  ['dist/lib/cmds/run.js', '_csv'],
+  ['dist/lib/util/prepare-test-execution-plan.js', 'csv'],
+];
+const changes = imports.map(([file, alias]) => {
+  const path = join(directory, file);
+  const source = readFileSync(path, 'utf8');
+  const before = `import ${alias} from 'csv-parse';`;
+  const after = `import { parse as ${alias} } from 'csv-parse';`;
+  if (source.includes(after)) return { path, source, patched: source };
+  if (!source.includes(before)) {
+    throw new Error(
+      `Unexpected Artillery csv-parse import in ${file}; review the compatibility patch`,
+    );
+  }
+  return { path, source, patched: source.replace(before, after) };
+});
+for (const { path, source, patched } of changes) {
+  if (source !== patched) writeFileSync(path, patched);
+}

--- a/scripts/patch-artillery-csv.test.mjs
+++ b/scripts/patch-artillery-csv.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(new URL('./patch-artillery-csv.mjs', import.meta.url));
+const files = ['dist/lib/cmds/run.js', 'dist/lib/util/prepare-test-execution-plan.js'];
+const aliases = ['_csv', 'csv'];
+
+function fixture(t) {
+  const directory = mkdtempSync(join(tmpdir(), 'drydock-artillery-csv-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  for (const [index, file] of files.entries()) {
+    mkdirSync(dirname(join(directory, file)), { recursive: true });
+    writeFileSync(join(directory, file), `import ${aliases[index]} from 'csv-parse';\n`);
+  }
+  return directory;
+}
+
+test('adapts both Artillery runtime imports to the patched parser and is idempotent', (t) => {
+  const directory = fixture(t);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const result = spawnSync(process.execPath, [script, directory], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    for (const [index, file] of files.entries()) {
+      assert.equal(
+        readFileSync(join(directory, file), 'utf8'),
+        `import { parse as ${aliases[index]} } from 'csv-parse';\n`,
+      );
+    }
+  }
+});
+
+test('an unexpected upstream import fails before either runtime file is changed', (t) => {
+  const directory = fixture(t);
+  writeFileSync(join(directory, files[1]), 'unexpected upstream layout\n');
+  const result = spawnSync(process.execPath, [script, directory], { encoding: 'utf8' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unexpected Artillery csv-parse import/u);
+  assert.equal(readFileSync(join(directory, files[0]), 'utf8'), "import _csv from 'csv-parse';\n");
+});

--- a/scripts/release-docs-identity.test.mjs
+++ b/scripts/release-docs-identity.test.mjs
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const RC_VERSION = '1.7.0-rc.13';
-const PREV_RC_VERSION = '1.7.0-rc.12';
+const RC_VERSION = '1.7.0-rc.14';
+const PREV_RC_VERSION = '1.7.0-rc.13';
 const RC_DATE = '2026-09-08';
 const RC_DISPLAY_DATE = 'September 8, 2026';
 const DOC_ROOTS = ['content/docs/current', 'content/docs/v1.6', 'content/docs/v1.5'];
@@ -155,15 +155,12 @@ test('release candidate notes cover the post-promotion fixes', () => {
     );
   }
 
-  for (const pull of [1080, 1108]) {
+  for (const pull of [1126, 1134]) {
     const pullLink = `https://github.com/CodesWhat/drydock/pull/${pull}`;
     assert.ok(updates.includes(pullLink), `updates page must link PR #${pull}`);
   }
 
-  for (const fragment of [
-    '`image.digest.watch`',
-    'caps the spider at 10 minutes and the active scan at 35',
-  ]) {
+  for (const fragment of ['runtime-config sanitization', 'variant suffix', 'release source SHA']) {
     assert.ok(changelog.includes(fragment), `CHANGELOG.md must include ${fragment}`);
     assert.ok(updates.includes(fragment), `updates page must include ${fragment}`);
   }

--- a/scripts/release-identity.test.mjs
+++ b/scripts/release-identity.test.mjs
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const BASE_VERSION = '1.7.0';
-const RC_VERSION = '1.7.0-rc.13';
+const RC_VERSION = '1.7.0-rc.14';
 const DEMO_RELEASE_FIXTURES = [
   {
     path: 'apps/demo/src/mocks/data/server.ts',

--- a/scripts/release-precut-check.test.mjs
+++ b/scripts/release-precut-check.test.mjs
@@ -328,7 +328,7 @@ test('cli exits 1 and reports pending discussion when strict RC check has an unc
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.13'],
+    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.14'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -345,7 +345,7 @@ test('cli exits 0 when --force is set even with pending replies', () => {
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', '--force', 'v1.7.0-rc.13'],
+    [scriptPath, '--tracker', trackerPath, '--strict', '--force', 'v1.7.0-rc.14'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -360,7 +360,7 @@ test('cli exits 0 with warning when tracker file does not exist', () => {
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.13'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.14'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -377,7 +377,7 @@ test('cli exits 0 for prerelease tags with pending replies (informational only)'
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.13'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.14'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -393,7 +393,7 @@ test('cli exits 1 for prerelease tags with --strict and pending replies', () => 
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.13'],
+    [scriptPath, '--tracker', trackerPath, '--strict', 'v1.7.0-rc.14'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',
@@ -409,7 +409,7 @@ test('cli exits 0 and prints success when tracker has no pending replies', () =>
 
   const result = spawnSync(
     process.execPath,
-    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.13'],
+    [scriptPath, '--tracker', trackerPath, 'v1.7.0-rc.14'],
     {
       cwd: process.cwd(),
       encoding: 'utf8',

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -26,7 +26,10 @@ test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
   const manifest = readJson('e2e/package.json');
   const lockfile = readJson('e2e/package-lock.json');
   assert.equal(manifest.overrides?.['csv-parse'], '7.0.2');
-  assert.equal(resolvedVersion(lockfile, 'csv-parse'), '7.0.2');
+  const artilleryCsv =
+    resolvedVersion(lockfile, 'artillery/node_modules/csv-parse') ??
+    resolvedVersion(lockfile, 'csv-parse');
+  assert.equal(artilleryCsv, '7.0.2');
   assert.equal(manifest.scripts.postinstall, 'node ../scripts/patch-artillery-csv.mjs');
 });
 

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -22,6 +22,14 @@ function resolvedVersion(lockfile, packageName) {
   return lockfile.packages?.[`node_modules/${packageName}`]?.version;
 }
 
+test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
+  const manifest = readJson('e2e/package.json');
+  const lockfile = readJson('e2e/package-lock.json');
+  assert.equal(manifest.overrides?.['csv-parse'], '7.0.2');
+  assert.equal(resolvedVersion(lockfile, 'csv-parse'), '7.0.2');
+  assert.equal(manifest.scripts.postinstall, 'node ../scripts/patch-artillery-csv.mjs');
+});
+
 // Only the 4.x line is vetted now: 4.1.3 carries the August 2026 host-confusion
 // and SSRF fixes in addition to the earlier CVE-2026-16221 fix.
 // The transitional 3.1.4 branch was dropped once the override moved to 4.x,


### PR DESCRIPTION
Prepare v1.7.0-rc.14 with the rollback runtime-config, tag-variant matching and maintenance image revision-label fixes already merged into dev/v1.7. Move those notes out of Unreleased and update release identities, demo fixtures, API examples, highlights and all six translated READMEs.

Carry forward the tested Artillery CSV fix from the v1.6 release preparation: csv-parse 7.0.2 with a guarded postinstall adaptation for Artillery 2.0.34's two runtime imports. This clears CVE-2026-85063 while preserving CSV payload parsing.

Validation: 55 release checks, 249 workflow tests, 18 e2e support tests after a clean install, and the full pre-push gate, including backend/frontend coverage and builds. Release precheck reports matching metadata and no pending discussion replies.

This prepares the candidate only. Merge and cut v1.6.1-rc.11 first, then promote the reviewed v1.7 tree to main and cut rc.14. The new candidate starts a fresh seven-day soak.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added v1.7.0-rc.14 release notes and highlights in the changelog, updates page, and six translated READMEs.
- 🔧 Updated release identity, demo fixtures, API examples, quickstart tags, roadmap data, and release-link tests.
- 🐛 Documented rollback runtime-config sanitization, tag-variant matching, and maintenance image source-SHA labels.
- 🐛 Added Artillery CSV parsing compatibility for `csv-parse` 7.0.2.
- 🐛 Capped Docker cron deadlines at Node’s `2,147,483,647` ms timer limit.
- 🔒 Addressed CVE-2026-85063 with a pinned dependency and guarded Artillery postinstall patch.
- ✨ Added CSV parsing, Artillery integration, patch-script, and cron deadline tests.

## Concerns

- Verify `v1.6.1-rc.11` is released before merging.
- Promote the reviewed v1.7 tree to `main` only after release checks pass.
- Complete the planned seven-day soak after promotion.
- Confirm the Artillery patch remains compatible with future Artillery releases.
- Verify the tracked lockfile resolves `csv-parse` to `7.0.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->