### PR TITLE
fix(watchers): cap cron deadlines at the supported timer limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Monthly and longer watcher schedules could expire scans after 1 ms.** The scan deadline was twice the cron interval, which overflowed Node's timer limit and cleared the in-flight scan guard almost immediately. Deadlines now stop at the largest supported delay, preserving the existing ten-minute floor and shorter schedule behavior.
+
 - **Containers on a floating tag that drydock first saw before v1.5.0-rc.17 could stay marked Current forever, even when the registry had a newer digest.** `image.digest.watch` was written once at first discovery and never revisited, so a row discovered before the digest-watch default changed from `!isDockerHubDomain(domain)` to "watch when the tag is meaningful" (v1.5.0-rc.17) kept the old `false` default permanently; only recreating the container picked up the new one. It is now re-derived every scan, the same way `isLocalImage` and `digest.repoDigests` already are, and an explicit `dd.watch.digest` label or imgset override still wins. Ported from the v1.7 line ([#1108](https://github.com/CodesWhat/drydock/pull/1108)). ([#1070](https://github.com/CodesWhat/drydock/issues/1070))
 
 ## [1.6.1-rc.10] — 2026-09-06

--- a/app/watchers/providers/docker/docker-cron-watch.test.ts
+++ b/app/watchers/providers/docker/docker-cron-watch.test.ts
@@ -186,6 +186,26 @@ describe('watchFromCronOrchestration', () => {
     expect(watcher.queueMaintenanceWindowWatch).not.toHaveBeenCalled();
   });
 
+  test('keeps a monthly scan pending instead of overflowing the real deadline timer', async () => {
+    const deferred = createDeferred<ContainerReport[]>();
+    const watcher = createWatcher({
+      watch: vi.fn().mockReturnValue(deferred.promise),
+      getNextScheduledRunDate: vi.fn((fromDate?: Date) =>
+        fromDate ? new Date('2026-02-01T00:00:00Z') : new Date('2026-01-01T00:00:00Z'),
+      ),
+    });
+    const call = watchFromCronOrchestration(watcher, { reason: 'schedule' });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(watcher.log?.warn).not.toHaveBeenCalled();
+      expect(watcher.cronWatchInFlight).toBeDefined();
+    } finally {
+      deferred.resolve([]);
+      await call;
+      resetCronWatchState(watcher);
+    }
+  });
+
   test.each([
     {
       label: 'no interval is available',
@@ -206,6 +226,21 @@ describe('watchFromCronOrchestration', () => {
       label: "the interval's multiple exceeds the floor",
       intervalMs: 20 * 60 * 1000,
       expectedDeadlineMs: 40 * 60 * 1000,
+    },
+    {
+      label: "the interval's multiple is below Node's timer ceiling",
+      intervalMs: 1073741823,
+      expectedDeadlineMs: 2147483646,
+    },
+    {
+      label: "the interval's multiple exceeds Node's timer ceiling",
+      intervalMs: 1073741824,
+      expectedDeadlineMs: 2147483647,
+    },
+    {
+      label: 'the interval spans a month',
+      intervalMs: 31 * 24 * 60 * 60 * 1000,
+      expectedDeadlineMs: 2147483647,
     },
   ])('sizes the in-flight deadline when $label', async ({ intervalMs, expectedDeadlineMs }) => {
     vi.useFakeTimers();

--- a/app/watchers/providers/docker/docker-cron-watch.ts
+++ b/app/watchers/providers/docker/docker-cron-watch.ts
@@ -122,15 +122,16 @@ export function resetCronWatchState(watcher: CronWatchOrchestrationWatcher): voi
  */
 const CRON_WATCH_DEADLINE_INTERVAL_MULTIPLIER = 2;
 const CRON_WATCH_DEADLINE_FLOOR_MS = 10 * 60 * 1000; // 10 minutes
+const CRON_WATCH_DEADLINE_CEILING_MS = 2147483647; // Larger Node timers expire after 1ms.
 
 function getCronWatchDeadlineMs(watcher: CronWatchOrchestrationWatcher): number {
   const intervalMs = getCronIntervalMs(watcher);
   if (!intervalMs || intervalMs <= 0) {
     return CRON_WATCH_DEADLINE_FLOOR_MS;
   }
-  return Math.max(
-    intervalMs * CRON_WATCH_DEADLINE_INTERVAL_MULTIPLIER,
-    CRON_WATCH_DEADLINE_FLOOR_MS,
+  return Math.min(
+    CRON_WATCH_DEADLINE_CEILING_MS,
+    Math.max(intervalMs * CRON_WATCH_DEADLINE_INTERVAL_MULTIPLIER, CRON_WATCH_DEADLINE_FLOOR_MS),
   );
 }
 


### PR DESCRIPTION
Fix the long-cron timer overflow found during images-manager QA. A monthly or longer schedule makes twice the interval exceed Node's timer ceiling. Node then schedules the deadline after 1 ms, clears the running scan guard, and logs a false stall.

Cap the deadline at 2147483647 ms. Keep the existing ten-minute floor and interval-based behavior below that ceiling. Add a real-timer monthly regression and boundary tests. The regressions fail against the old implementation, and all 33 watcher tests pass with the fix.

The full pre-push gate and backend build pass, including app and UI coverage. Add the fix to the not-yet-published rc.11 notes. This holds the maintenance cut until the fix is merged and both exact-source release workflows pass again. Forward ports are prepared for 1.7 and 1.8.

Threat model: ordinary operator cron configuration in a Docker-management service. No hostile local user or new scheduling subsystem is involved.
