### PR TITLE
fix(deps): refresh v1.8 security prerequisites

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -3071,9 +3071,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
-      "integrity": "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "drydock-e2e",
       "version": "1.7.0",
+      "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@cucumber/cucumber": "12.9.0",
@@ -3847,9 +3848,9 @@
       }
     },
     "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-7.0.2.tgz",
+      "integrity": "sha512-uKZghv9UmPkMVLYy//KZ9HFAIJsl7wkhoEdIL0+rhuSY9pZQlhaeGEDPIe+/w7eh81MOql8Q/9+inAGWG6ZHYA==",
       "dev": true,
       "license": "MIT"
     },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
+    "postinstall": "node ../scripts/patch-artillery-csv.mjs",
     "format": "biome format --write .",
     "lint:fix": "biome check --fix .",
     "lint": "biome check .",
@@ -37,6 +38,7 @@
     "lodash": "4.18.1"
   },
   "overrides": {
+    "csv-parse": "7.0.2",
     "brace-expansion": "5.0.9",
     "fflate": "0.8.3",
     "js-yaml": "3.15.2",

--- a/e2e/tests/artillery-csv.test.js
+++ b/e2e/tests/artillery-csv.test.js
@@ -1,0 +1,48 @@
+const assert = require('node:assert/strict');
+const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const test = require('node:test');
+const { promisify } = require('node:util');
+const { parse } = require('csv-parse');
+
+test('duplicate CSV headers remain own properties without replacing the record prototype', async () => {
+  const [record] = await promisify(parse)('__proto__,__proto__,name\na,b,example\n', {
+    columns: true,
+    group_columns_by_name: true,
+  });
+  assert.equal(Object.getPrototypeOf(record), Object.prototype);
+  assert.equal(Object.hasOwn(record, '__proto__'), true);
+  assert.deepEqual(Object.getOwnPropertyDescriptor(record, '__proto__').value, ['a', 'b']);
+  assert.equal(record.name, 'example');
+});
+
+test('Artillery prepares a CSV payload using the patched parser', async (t) => {
+  const directory = mkdtempSync(join(tmpdir(), 'drydock-csv-payload-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const previous = global.artillery;
+  global.artillery = { testRunId: 'csv-compatibility' };
+  t.after(() => {
+    if (previous === undefined) delete global.artillery;
+    else global.artillery = previous;
+  });
+  const csvPath = join(directory, 'users.csv');
+  const configPath = join(directory, 'scenario.json');
+  writeFileSync(csvPath, 'name,count\n"Doe, Jane",2\n\n');
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      config: {
+        target: 'http://127.0.0.1:1',
+        phases: [{ duration: 1, arrivalCount: 1 }],
+        payload: { path: csvPath, fields: ['name', 'count'], skipHeader: true },
+      },
+      scenarios: [{ flow: [{ get: { url: '/' } }] }],
+    }),
+  );
+  const { default: prepare } = await import(
+    '../node_modules/artillery/dist/lib/util/prepare-test-execution-plan.js'
+  );
+  const plan = await prepare([configPath], {});
+  assert.deepEqual(plan.config.payload[0].data, [['Doe, Jane', 2]]);
+});

--- a/e2e/tests/artillery-csv.test.js
+++ b/e2e/tests/artillery-csv.test.js
@@ -1,10 +1,14 @@
 const assert = require('node:assert/strict');
 const { mkdtempSync, rmSync, writeFileSync } = require('node:fs');
+const { createRequire } = require('node:module');
 const { tmpdir } = require('node:os');
 const { join } = require('node:path');
 const test = require('node:test');
 const { promisify } = require('node:util');
-const { parse } = require('csv-parse');
+const artilleryRequire = createRequire(
+  join(__dirname, '../node_modules/artillery/dist/lib/util/prepare-test-execution-plan.js'),
+);
+const { parse } = artilleryRequire('csv-parse');
 
 test('duplicate CSV headers remain own properties without replacing the record prototype', async () => {
   const [record] = await promisify(parse)('__proto__,__proto__,name\na,b,example\n', {

--- a/scripts/patch-artillery-csv.mjs
+++ b/scripts/patch-artillery-csv.mjs
@@ -1,0 +1,28 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Artillery 2.0.34 still imports the default export removed by csv-parse 5.
+// Keep its CSV payload support while overriding the vulnerable parser to 7.0.2.
+const directory =
+  process.argv[2] ?? fileURLToPath(new URL('../e2e/node_modules/artillery', import.meta.url));
+const imports = [
+  ['dist/lib/cmds/run.js', '_csv'],
+  ['dist/lib/util/prepare-test-execution-plan.js', 'csv'],
+];
+const changes = imports.map(([file, alias]) => {
+  const path = join(directory, file);
+  const source = readFileSync(path, 'utf8');
+  const before = `import ${alias} from 'csv-parse';`;
+  const after = `import { parse as ${alias} } from 'csv-parse';`;
+  if (source.includes(after)) return { path, source, patched: source };
+  if (!source.includes(before)) {
+    throw new Error(
+      `Unexpected Artillery csv-parse import in ${file}; review the compatibility patch`,
+    );
+  }
+  return { path, source, patched: source.replace(before, after) };
+});
+for (const { path, source, patched } of changes) {
+  if (source !== patched) writeFileSync(path, patched);
+}

--- a/scripts/patch-artillery-csv.test.mjs
+++ b/scripts/patch-artillery-csv.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(new URL('./patch-artillery-csv.mjs', import.meta.url));
+const files = ['dist/lib/cmds/run.js', 'dist/lib/util/prepare-test-execution-plan.js'];
+const aliases = ['_csv', 'csv'];
+
+function fixture(t) {
+  const directory = mkdtempSync(join(tmpdir(), 'drydock-artillery-csv-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  for (const [index, file] of files.entries()) {
+    mkdirSync(dirname(join(directory, file)), { recursive: true });
+    writeFileSync(join(directory, file), `import ${aliases[index]} from 'csv-parse';\n`);
+  }
+  return directory;
+}
+
+test('adapts both Artillery runtime imports to the patched parser and is idempotent', (t) => {
+  const directory = fixture(t);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const result = spawnSync(process.execPath, [script, directory], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    for (const [index, file] of files.entries()) {
+      assert.equal(
+        readFileSync(join(directory, file), 'utf8'),
+        `import { parse as ${aliases[index]} } from 'csv-parse';\n`,
+      );
+    }
+  }
+});
+
+test('an unexpected upstream import fails before either runtime file is changed', (t) => {
+  const directory = fixture(t);
+  writeFileSync(join(directory, files[1]), 'unexpected upstream layout\n');
+  const result = spawnSync(process.execPath, [script, directory], { encoding: 'utf8' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unexpected Artillery csv-parse import/u);
+  assert.equal(readFileSync(join(directory, files[0]), 'utf8'), "import _csv from 'csv-parse';\n");
+});

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -65,6 +65,39 @@ test('Joi includes the rename and custom-message prototype fixes in app and e2e'
   }
 });
 
+test('Nodemailer includes the address parser and legacy content-access fixes', () => {
+  assert.ok(compareSemver(readJson('app/package.json').dependencies.nodemailer, '9.1.1') >= 0);
+  let resolutions = 0;
+  for (const workspace of ['.', 'app', 'ui', 'e2e', 'apps/demo', 'apps/web']) {
+    for (const [path, entry] of Object.entries(
+      readJson(`${workspace}/package-lock.json`).packages,
+    )) {
+      if (!path.endsWith('node_modules/nodemailer')) continue;
+      resolutions += 1;
+      assert.ok(compareSemver(entry.version, '9.1.1') >= 0, `${workspace}/${path}`);
+    }
+  }
+  assert.ok(resolutions > 0, 'expected Nodemailer resolutions in workspace locks');
+});
+
+test('every js-yaml resolution counts empty merge sources against its budget', () => {
+  assert.ok(compareSemver(readJson('e2e/package.json').overrides['js-yaml'], '3.15.2') >= 0);
+  let resolutions = 0;
+  for (const workspace of ['.', 'app', 'ui', 'e2e', 'apps/demo', 'apps/web']) {
+    for (const [path, entry] of Object.entries(
+      readJson(`${workspace}/package-lock.json`).packages,
+    )) {
+      if (!path.endsWith('node_modules/js-yaml')) continue;
+      resolutions += 1;
+      const major = Number(entry.version.split('.')[0]);
+      assert.ok(major === 3 || major === 4, `${workspace}/${path} must use a vetted major`);
+      const floor = major === 3 ? '3.15.2' : '4.3.2';
+      assert.ok(compareSemver(entry.version, floor) >= 0, `${workspace}/${path}`);
+    }
+  }
+  assert.ok(resolutions > 0, 'expected js-yaml resolutions in workspace locks');
+});
+
 test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
   const manifest = readJson('e2e/package.json');
   const lockfile = readJson('e2e/package-lock.json');

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -38,6 +38,33 @@ test('every baseline-browser-mapping resolution includes the invalid-input fix',
   assert.ok(resolutions > 0, 'expected baseline-browser-mapping resolutions in workspace locks');
 });
 
+test('Vitest and its mocker include the redirect path validation fix', () => {
+  for (const workspace of ['.', 'app', 'ui', 'apps/demo']) {
+    const manifest = readJson(`${workspace}/package.json`);
+    assert.ok(compareSemver(manifest.devDependencies.vitest, '4.1.11') >= 0, workspace);
+    const lockfile = readJson(`${workspace}/package-lock.json`);
+    for (const [path, entry] of Object.entries(lockfile.packages)) {
+      if (!/node_modules\/(?:vitest|@vitest\/mocker)$/.test(path)) continue;
+      assert.ok(compareSemver(entry.version, '4.1.11') >= 0, `${workspace}/${path}`);
+    }
+  }
+});
+
+test('Joi includes the template rename prototype fix in app and e2e', () => {
+  for (const workspace of ['app', 'e2e']) {
+    const manifest = readJson(`${workspace}/package.json`);
+    assert.ok(
+      compareSemver(manifest.dependencies?.joi ?? manifest.overrides?.joi, '18.2.4') >= 0,
+      workspace,
+    );
+    const lockfile = readJson(`${workspace}/package-lock.json`);
+    for (const [path, entry] of Object.entries(lockfile.packages)) {
+      if (!path.endsWith('node_modules/joi')) continue;
+      assert.ok(compareSemver(entry.version, '18.2.4') >= 0, `${workspace}/${path}`);
+    }
+  }
+});
+
 test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
   const manifest = readJson('e2e/package.json');
   const lockfile = readJson('e2e/package-lock.json');
@@ -122,21 +149,21 @@ test('sharp is pinned to a patched release in the website', () => {
   const manifest = readJson('apps/web/package.json');
   const lockfile = readJson('apps/web/package-lock.json');
 
-  assert.equal(manifest.overrides?.sharp, '0.35.4');
-  assert.ok(compareSemver(resolvedVersion(lockfile, 'sharp'), '0.35.3') >= 0);
+  assert.ok(compareSemver(manifest.overrides?.sharp, '0.35.4') >= 0);
+  assert.ok(compareSemver(resolvedVersion(lockfile, 'sharp'), '0.35.4') >= 0);
 });
 
-test('Next.js is pinned past the 16.2.9 security advisory batch', () => {
+test('Next.js is pinned past the Windows server execution advisory', () => {
   const manifest = readJson('apps/web/package.json');
   const lockfile = readJson('apps/web/package-lock.json');
 
-  // Floor, not an exact pin: 16.2.11 closed the advisory batch, and routine
+  // Floor, not an exact pin: 16.3.3 closed the advisory, and routine
   // Renovate bumps past it must not fail the guard (16.x only — a new major
   // is a deliberate migration, not a routine bump).
   const manifestNext = manifest.dependencies?.next;
   assert.ok(manifestNext?.startsWith('16.'), 'apps/web next must stay on the vetted 16.x line');
-  assert.ok(compareSemver(manifestNext, '16.2.11') >= 0);
-  assert.ok(compareSemver(resolvedVersion(lockfile, 'next'), '16.2.11') >= 0);
+  assert.ok(compareSemver(manifestNext, '16.3.3') >= 0);
+  assert.ok(compareSemver(resolvedVersion(lockfile, 'next'), '16.3.3') >= 0);
 });
 
 test('the rc.5 changelog records the Next.js security refresh', () => {

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -163,7 +163,9 @@ test('Next.js is pinned past the Windows server execution advisory', () => {
   const manifestNext = manifest.dependencies?.next;
   assert.ok(manifestNext?.startsWith('16.'), 'apps/web next must stay on the vetted 16.x line');
   assert.ok(compareSemver(manifestNext, '16.3.3') >= 0);
-  assert.ok(compareSemver(resolvedVersion(lockfile, 'next'), '16.3.3') >= 0);
+  const resolvedNext = resolvedVersion(lockfile, 'next');
+  assert.match(resolvedNext, /^16\./, 'apps/web lockfile next must stay on the vetted 16.x line');
+  assert.ok(compareSemver(resolvedNext, '16.3.3') >= 0);
 });
 
 test('the rc.5 changelog records the Next.js security refresh', () => {

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -50,17 +50,17 @@ test('Vitest and its mocker include the redirect path validation fix', () => {
   }
 });
 
-test('Joi includes the template rename prototype fix in app and e2e', () => {
+test('Joi includes the rename and custom-message prototype fixes in app and e2e', () => {
   for (const workspace of ['app', 'e2e']) {
     const manifest = readJson(`${workspace}/package.json`);
     assert.ok(
-      compareSemver(manifest.dependencies?.joi ?? manifest.overrides?.joi, '18.2.4') >= 0,
+      compareSemver(manifest.dependencies?.joi ?? manifest.overrides?.joi, '18.2.5') >= 0,
       workspace,
     );
     const lockfile = readJson(`${workspace}/package-lock.json`);
     for (const [path, entry] of Object.entries(lockfile.packages)) {
       if (!path.endsWith('node_modules/joi')) continue;
-      assert.ok(compareSemver(entry.version, '18.2.4') >= 0, `${workspace}/${path}`);
+      assert.ok(compareSemver(entry.version, '18.2.5') >= 0, `${workspace}/${path}`);
     }
   }
 });

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -26,7 +26,10 @@ test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
   const manifest = readJson('e2e/package.json');
   const lockfile = readJson('e2e/package-lock.json');
   assert.equal(manifest.overrides?.['csv-parse'], '7.0.2');
-  assert.equal(resolvedVersion(lockfile, 'csv-parse'), '7.0.2');
+  const artilleryCsv =
+    resolvedVersion(lockfile, 'artillery/node_modules/csv-parse') ??
+    resolvedVersion(lockfile, 'csv-parse');
+  assert.equal(artilleryCsv, '7.0.2');
   assert.equal(manifest.scripts.postinstall, 'node ../scripts/patch-artillery-csv.mjs');
 });
 

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -22,6 +22,22 @@ function resolvedVersion(lockfile, packageName) {
   return lockfile.packages?.[`node_modules/${packageName}`]?.version;
 }
 
+test('every baseline-browser-mapping resolution includes the invalid-input fix', () => {
+  let resolutions = 0;
+  for (const workspace of ['.', 'app', 'ui', 'e2e', 'apps/demo', 'apps/web']) {
+    const lockfile = readJson(`${workspace}/package-lock.json`);
+    for (const [path, entry] of Object.entries(lockfile.packages)) {
+      if (!path.endsWith('node_modules/baseline-browser-mapping')) continue;
+      resolutions += 1;
+      assert.ok(
+        compareSemver(entry.version, '2.11.0') >= 0,
+        `${workspace}/${path} ${entry.version} predates the GHSA-w5vr-8v7q-w6rv fix`,
+      );
+    }
+  }
+  assert.ok(resolutions > 0, 'expected baseline-browser-mapping resolutions in workspace locks');
+});
+
 test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
   const manifest = readJson('e2e/package.json');
   const lockfile = readJson('e2e/package-lock.json');

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -22,6 +22,14 @@ function resolvedVersion(lockfile, packageName) {
   return lockfile.packages?.[`node_modules/${packageName}`]?.version;
 }
 
+test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
+  const manifest = readJson('e2e/package.json');
+  const lockfile = readJson('e2e/package-lock.json');
+  assert.equal(manifest.overrides?.['csv-parse'], '7.0.2');
+  assert.equal(resolvedVersion(lockfile, 'csv-parse'), '7.0.2');
+  assert.equal(manifest.scripts.postinstall, 'node ../scripts/patch-artillery-csv.mjs');
+});
+
 // Only the 4.x line is vetted now: 4.1.3 carries the August 2026 host-confusion
 // and SSRF fixes in addition to the earlier CVE-2026-16221 fix.
 // The transitional 3.1.4 branch was dropped once the override moved to 4.x,

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -80,8 +80,31 @@ test('Nodemailer includes the address parser and legacy content-access fixes', (
   assert.ok(resolutions > 0, 'expected Nodemailer resolutions in workspace locks');
 });
 
+function isJsYamlPatched(version) {
+  const major = Number(version.split('.')[0]);
+  return (
+    (major === 3 && compareSemver(version, '3.15.2') >= 0) ||
+    (major === 4 && compareSemver(version, '4.3.2') >= 0)
+  );
+}
+
+test('isJsYamlPatched accepts only patched releases on vetted major lines', () => {
+  for (const [version, expected] of [
+    ['3.15.1', false],
+    ['3.15.2', true],
+    ['3.16.0', true],
+    ['4.0.0', false],
+    ['4.3.1', false],
+    ['4.3.2', true],
+    ['4.4.0', true],
+    ['5.0.0', false],
+  ]) {
+    assert.equal(isJsYamlPatched(version), expected, version);
+  }
+});
+
 test('every js-yaml resolution counts empty merge sources against its budget', () => {
-  assert.ok(compareSemver(readJson('e2e/package.json').overrides['js-yaml'], '3.15.2') >= 0);
+  assert.ok(isJsYamlPatched(readJson('e2e/package.json').overrides['js-yaml']));
   let resolutions = 0;
   for (const workspace of ['.', 'app', 'ui', 'e2e', 'apps/demo', 'apps/web']) {
     for (const [path, entry] of Object.entries(
@@ -89,10 +112,7 @@ test('every js-yaml resolution counts empty merge sources against its budget', (
     )) {
       if (!path.endsWith('node_modules/js-yaml')) continue;
       resolutions += 1;
-      const major = Number(entry.version.split('.')[0]);
-      assert.ok(major === 3 || major === 4, `${workspace}/${path} must use a vetted major`);
-      const floor = major === 3 ? '3.15.2' : '4.3.2';
-      assert.ok(compareSemver(entry.version, floor) >= 0, `${workspace}/${path}`);
+      assert.ok(isJsYamlPatched(entry.version), `${workspace}/${path}`);
     }
   }
   assert.ok(resolutions > 0, 'expected js-yaml resolutions in workspace locks');


### PR DESCRIPTION
Carry the dependency-security prerequisites onto dev/v1.8 without the image, fleet, inventory, or cron feature changes.

- Resolve Artillery's CSV parser to 7.0.2 and carry the tested named-import compatibility patch and actual-resolver regression test.
- Resolve the website's baseline-browser-mapping to 2.11.20.
- Guard the already-patched Nodemailer and js-yaml resolutions, and constrain both Next.js manifest and lockfile to the vetted 16.x line.
- Carry the shared Vitest, Joi, Next.js, and sharp security guards, including Joi's 18.2.5 floor. Keep v1.8's existing Vitest 4.1.11, Joi 18.2.8, Next.js 16.3.4, and sharp 0.35.4 pins.

Validation: fresh npm ci passed in all six workspaces with zero audit findings; 19 dependency/CSV checks and 394 focused app/UI security tests passed. The final normal pre-push gate passed in 330.30s, including 16,064 app tests and 5,133 UI tests at 100% coverage, builds, script/workflow tests, and static checks. Website script tests passed in the preceding full gate on the same website changes.

Pass-two guard fix: js-yaml manifest overrides and lock entries share vetted-major floors (3.x >= 3.15.2, 4.x >= 4.3.2). A temporary 4.0.0 override passed the old guard and failed the new one; the manifest was restored unchanged. All 16 focused guard tests passed. No dependency or runtime changes.

Review threat model: normal runtime, build, and test consumers of these dependencies, including malformed CSV input. Hostile operators attacking their own host and maintainers writing deliberately evasive workflows are out of scope. Check the dependency resolutions, compatibility patch, and security floors; no unrelated cleanup or new subsystems.

Release prerequisites cleared: [v1.6.1-rc.12](https://github.com/CodesWhat/drydock/releases/tag/v1.6.1-rc.12) and [v1.7.0-rc.14](https://github.com/CodesWhat/drydock/releases/tag/v1.7.0-rc.14) are published and independently verified. This PR still requires its own exact-head CI and final review before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- ✨ Added the Artillery CSV compatibility patch and regression tests.
- ✨ Added security guards for Vitest, Joi, Next.js, sharp, `baseline-browser-mapping`, Nodemailer, js-yaml, and `csv-parse`.
- 🔧 Pinned Artillery `csv-parse` to `7.0.2`.
- 🔧 Constrained Next.js to vetted `16.x` versions.
- 🔧 Enforced major-specific js-yaml security floors.
- 🔧 Updated `baseline-browser-mapping` to `2.11.20`.
- 🐛 Fixed CSV handling for duplicate `__proto__` headers.
- 🔒 Retained vetted pins for Vitest `4.1.11`, Joi `18.2.8`, Next.js `16.3.4`, and sharp `0.35.4`.

## Concerns

- Resolve the v1.6 and v1.7 security release prerequisites before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
