### PR TITLE
fix(v1.7): forward-port dependency security guards

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -3071,9 +3071,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
-      "integrity": "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -65,6 +65,39 @@ test('Joi includes the rename and custom-message prototype fixes in app and e2e'
   }
 });
 
+test('Nodemailer includes the address parser and legacy content-access fixes', () => {
+  assert.ok(compareSemver(readJson('app/package.json').dependencies.nodemailer, '9.1.1') >= 0);
+  let resolutions = 0;
+  for (const workspace of ['.', 'app', 'ui', 'e2e', 'apps/demo', 'apps/web']) {
+    for (const [path, entry] of Object.entries(
+      readJson(`${workspace}/package-lock.json`).packages,
+    )) {
+      if (!path.endsWith('node_modules/nodemailer')) continue;
+      resolutions += 1;
+      assert.ok(compareSemver(entry.version, '9.1.1') >= 0, `${workspace}/${path}`);
+    }
+  }
+  assert.ok(resolutions > 0, 'expected Nodemailer resolutions in workspace locks');
+});
+
+test('every js-yaml resolution counts empty merge sources against its budget', () => {
+  assert.ok(compareSemver(readJson('e2e/package.json').overrides['js-yaml'], '3.15.2') >= 0);
+  let resolutions = 0;
+  for (const workspace of ['.', 'app', 'ui', 'e2e', 'apps/demo', 'apps/web']) {
+    for (const [path, entry] of Object.entries(
+      readJson(`${workspace}/package-lock.json`).packages,
+    )) {
+      if (!path.endsWith('node_modules/js-yaml')) continue;
+      resolutions += 1;
+      const major = Number(entry.version.split('.')[0]);
+      assert.ok(major === 3 || major === 4, `${workspace}/${path} must use a vetted major`);
+      const floor = major === 3 ? '3.15.2' : '4.3.2';
+      assert.ok(compareSemver(entry.version, floor) >= 0, `${workspace}/${path}`);
+    }
+  }
+  assert.ok(resolutions > 0, 'expected js-yaml resolutions in workspace locks');
+});
+
 test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
   const manifest = readJson('e2e/package.json');
   const lockfile = readJson('e2e/package-lock.json');

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -38,6 +38,33 @@ test('every baseline-browser-mapping resolution includes the invalid-input fix',
   assert.ok(resolutions > 0, 'expected baseline-browser-mapping resolutions in workspace locks');
 });
 
+test('Vitest and its mocker include the redirect path validation fix', () => {
+  for (const workspace of ['.', 'app', 'ui', 'apps/demo']) {
+    const manifest = readJson(`${workspace}/package.json`);
+    assert.ok(compareSemver(manifest.devDependencies.vitest, '4.1.11') >= 0, workspace);
+    const lockfile = readJson(`${workspace}/package-lock.json`);
+    for (const [path, entry] of Object.entries(lockfile.packages)) {
+      if (!/node_modules\/(?:vitest|@vitest\/mocker)$/.test(path)) continue;
+      assert.ok(compareSemver(entry.version, '4.1.11') >= 0, `${workspace}/${path}`);
+    }
+  }
+});
+
+test('Joi includes the template rename prototype fix in app and e2e', () => {
+  for (const workspace of ['app', 'e2e']) {
+    const manifest = readJson(`${workspace}/package.json`);
+    assert.ok(
+      compareSemver(manifest.dependencies?.joi ?? manifest.overrides?.joi, '18.2.4') >= 0,
+      workspace,
+    );
+    const lockfile = readJson(`${workspace}/package-lock.json`);
+    for (const [path, entry] of Object.entries(lockfile.packages)) {
+      if (!path.endsWith('node_modules/joi')) continue;
+      assert.ok(compareSemver(entry.version, '18.2.4') >= 0, `${workspace}/${path}`);
+    }
+  }
+});
+
 test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
   const manifest = readJson('e2e/package.json');
   const lockfile = readJson('e2e/package-lock.json');
@@ -122,21 +149,21 @@ test('sharp is pinned to a patched release in the website', () => {
   const manifest = readJson('apps/web/package.json');
   const lockfile = readJson('apps/web/package-lock.json');
 
-  assert.equal(manifest.overrides?.sharp, '0.35.4');
-  assert.ok(compareSemver(resolvedVersion(lockfile, 'sharp'), '0.35.3') >= 0);
+  assert.ok(compareSemver(manifest.overrides?.sharp, '0.35.4') >= 0);
+  assert.ok(compareSemver(resolvedVersion(lockfile, 'sharp'), '0.35.4') >= 0);
 });
 
-test('Next.js is pinned past the 16.2.9 security advisory batch', () => {
+test('Next.js is pinned past the Windows server execution advisory', () => {
   const manifest = readJson('apps/web/package.json');
   const lockfile = readJson('apps/web/package-lock.json');
 
-  // Floor, not an exact pin: 16.2.11 closed the advisory batch, and routine
+  // Floor, not an exact pin: 16.3.3 closed the advisory, and routine
   // Renovate bumps past it must not fail the guard (16.x only — a new major
   // is a deliberate migration, not a routine bump).
   const manifestNext = manifest.dependencies?.next;
   assert.ok(manifestNext?.startsWith('16.'), 'apps/web next must stay on the vetted 16.x line');
-  assert.ok(compareSemver(manifestNext, '16.2.11') >= 0);
-  assert.ok(compareSemver(resolvedVersion(lockfile, 'next'), '16.2.11') >= 0);
+  assert.ok(compareSemver(manifestNext, '16.3.3') >= 0);
+  assert.ok(compareSemver(resolvedVersion(lockfile, 'next'), '16.3.3') >= 0);
 });
 
 test('the rc.5 changelog records the Next.js security refresh', () => {

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -43,10 +43,13 @@ test('Vitest and its mocker include the redirect path validation fix', () => {
     const manifest = readJson(`${workspace}/package.json`);
     assert.ok(compareSemver(manifest.devDependencies.vitest, '4.1.11') >= 0, workspace);
     const lockfile = readJson(`${workspace}/package-lock.json`);
+    const found = new Set();
     for (const [path, entry] of Object.entries(lockfile.packages)) {
       if (!/node_modules\/(?:vitest|@vitest\/mocker)$/.test(path)) continue;
+      found.add(path.endsWith('node_modules/vitest') ? 'vitest' : '@vitest/mocker');
       assert.ok(compareSemver(entry.version, '4.1.11') >= 0, `${workspace}/${path}`);
     }
+    assert.deepEqual([...found].sort(), ['@vitest/mocker', 'vitest'], `${workspace} resolutions`);
   }
 });
 

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -163,7 +163,9 @@ test('Next.js is pinned past the Windows server execution advisory', () => {
   const manifestNext = manifest.dependencies?.next;
   assert.ok(manifestNext?.startsWith('16.'), 'apps/web next must stay on the vetted 16.x line');
   assert.ok(compareSemver(manifestNext, '16.3.3') >= 0);
-  assert.ok(compareSemver(resolvedVersion(lockfile, 'next'), '16.3.3') >= 0);
+  const resolvedNext = resolvedVersion(lockfile, 'next');
+  assert.match(resolvedNext, /^16\./, 'apps/web lockfile next must stay on the vetted 16.x line');
+  assert.ok(compareSemver(resolvedNext, '16.3.3') >= 0);
 });
 
 test('the rc.5 changelog records the Next.js security refresh', () => {

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -50,17 +50,17 @@ test('Vitest and its mocker include the redirect path validation fix', () => {
   }
 });
 
-test('Joi includes the template rename prototype fix in app and e2e', () => {
+test('Joi includes the rename and custom-message prototype fixes in app and e2e', () => {
   for (const workspace of ['app', 'e2e']) {
     const manifest = readJson(`${workspace}/package.json`);
     assert.ok(
-      compareSemver(manifest.dependencies?.joi ?? manifest.overrides?.joi, '18.2.4') >= 0,
+      compareSemver(manifest.dependencies?.joi ?? manifest.overrides?.joi, '18.2.5') >= 0,
       workspace,
     );
     const lockfile = readJson(`${workspace}/package-lock.json`);
     for (const [path, entry] of Object.entries(lockfile.packages)) {
       if (!path.endsWith('node_modules/joi')) continue;
-      assert.ok(compareSemver(entry.version, '18.2.4') >= 0, `${workspace}/${path}`);
+      assert.ok(compareSemver(entry.version, '18.2.5') >= 0, `${workspace}/${path}`);
     }
   }
 });

--- a/scripts/security-dependency-versions.test.mjs
+++ b/scripts/security-dependency-versions.test.mjs
@@ -22,6 +22,22 @@ function resolvedVersion(lockfile, packageName) {
   return lockfile.packages?.[`node_modules/${packageName}`]?.version;
 }
 
+test('every baseline-browser-mapping resolution includes the invalid-input fix', () => {
+  let resolutions = 0;
+  for (const workspace of ['.', 'app', 'ui', 'e2e', 'apps/demo', 'apps/web']) {
+    const lockfile = readJson(`${workspace}/package-lock.json`);
+    for (const [path, entry] of Object.entries(lockfile.packages)) {
+      if (!path.endsWith('node_modules/baseline-browser-mapping')) continue;
+      resolutions += 1;
+      assert.ok(
+        compareSemver(entry.version, '2.11.0') >= 0,
+        `${workspace}/${path} ${entry.version} predates the GHSA-w5vr-8v7q-w6rv fix`,
+      );
+    }
+  }
+  assert.ok(resolutions > 0, 'expected baseline-browser-mapping resolutions in workspace locks');
+});
+
 test('Artillery uses csv-parse with the duplicate-column prototype fix', () => {
   const manifest = readJson('e2e/package.json');
   const lockfile = readJson('e2e/package-lock.json');


### PR DESCRIPTION
Forward-port the website browser-mapping fix before rc.14. The website lock moves from 2.10.11 to 2.11.20, and a regression guard checks every matching resolution across all six workspace locks against the 2.11.0 security floor.

This fixes GHSA-w5vr-8v7q-w6rv. The website uses the package through Next's browser targeting; it isn't copied into the Drydock Docker image.

The 1.7 line already has patched Vitest/mocker 4.1.11, Joi 18.2.8, Next 16.3.4, Nodemailer 9.1.1 and js-yaml 3.15.2. Those versions stay unchanged. The shared guards cover Joi's custom-message prototype fix at 18.2.5, the new Nodemailer and js-yaml floors, and the vetted Next 16.x boundary for both manifest and lockfile. The guard also requires both Vitest and its mocker to be present in each applicable lockfile. Missing-entry mutations verified that the test cannot pass vacuously. No release identities change here.

Fresh website install, all 86 website script tests and the production build pass. All 15 security regression tests pass. The full normal push gate passed on final head 3d02a34f0 in 306.55 seconds, including 100% backend/UI coverage, both builds, lint, static analysis, script/workflow tests and UI typecheck.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

- 🔒 Updated the website lockfile from `2.10.11` to `2.11.20`.
- 🔒 Added security-version guards across six workspace manifests and lockfiles.
- 🔒 Added guards for `baseline-browser-mapping`, Vitest, `@vitest/mocker`, Joi, Nodemailer, and `js-yaml`.
- 🔒 Prevented missing Vitest and `@vitest/mocker` entries from passing guards vacuously.
- 🔧 Updated the Sharp lockfile minimum from `0.35.3` to `0.35.4`.
- 🔧 Updated the Next.js advisory guard to `16.3.3` and enforced the `16.x` lockfile boundary.

## Concerns

- Verify that all six workspace locks enforce the `2.11.0` security floor.
- Verify that the `16.3.3` Next.js guard matches the intended advisory policy.
- Verify that the Vitest and `@vitest/mocker` presence checks cover every applicable lockfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->