### PR TITLE
fix(release): select changelog predecessor from the same line

### DIFF
--- a/.github/tests/release-cut-previous-release.test.ts
+++ b/.github/tests/release-cut-previous-release.test.ts
@@ -1,0 +1,166 @@
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadWorkflow } from './workflow-test-utils';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+const workflowPath = join(repoRoot, '.github/workflows/release-cut.yml');
+
+// Keep the selector in the real workflow: the boundary stub executes its
+// --jq expression against fixture API data, rather than supplying a chosen tag.
+const stubGh = `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > "\${GH_ARGS_PATH}"
+if [ "$1" != release ] || [ "$2" != list ]; then exit 97; fi
+if [ "\${LOOKUP_FAIL}" = true ]; then exit 1; fi
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = --jq ]; then
+    jq -r "$2" "\${RELEASES_PATH}"
+    exit 0
+  fi
+  shift
+done
+exit 98
+`;
+
+function release(tagName: string, createdAt: string, isDraft = false) {
+  return { tagName, createdAt, isDraft };
+}
+
+function runNotes(releaseTag: string, releases: ReturnType<typeof release>[], lookupFail = false) {
+  const step = loadWorkflow(workflowPath).jobs?.release?.steps?.find(
+    (candidate) => candidate.id === 'release_notes',
+  );
+  if (!step?.run) throw new Error('Missing release notes run block');
+  const workdir = mkdtempSync(join(tmpdir(), 'release-cut-previous-release-'));
+  try {
+    mkdirSync(join(workdir, 'bin'));
+    mkdirSync(join(workdir, 'dist'));
+    writeFileSync(join(workdir, 'bin/gh'), stubGh, { mode: 0o755 });
+    cpSync(join(repoRoot, 'scripts'), join(workdir, 'scripts'), { recursive: true });
+    cpSync(join(repoRoot, 'UPGRADE-NOTES.md'), join(workdir, 'UPGRADE-NOTES.md'));
+    const changelogPath = join(workdir, 'changelog.md');
+    writeFileSync(
+      changelogPath,
+      `## [${releaseTag.slice(1)}] - 2026-09-09\n\n### Fixed\n\n- Preserved release entry.\n`,
+    );
+    const releasesPath = join(workdir, 'releases.json');
+    writeFileSync(releasesPath, JSON.stringify(releases));
+    const argsPath = join(workdir, 'gh-args');
+    const outputPath = join(workdir, 'output');
+    execFileSync('bash', ['-c', step.run], {
+      cwd: workdir,
+      encoding: 'utf8',
+      env: {
+        PATH: `${join(workdir, 'bin')}:${process.env.PATH ?? ''}`,
+        RELEASE_TAG: releaseTag,
+        REPO: 'CodesWhat/drydock',
+        CHANGELOG_PATH: changelogPath,
+        EXTRACT_SCRIPT: join(repoRoot, 'scripts/extract-changelog-entry.mjs'),
+        IS_MAINTENANCE_CUT: 'false',
+        SOAK_OVERRIDE_USED: 'false',
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_STEP_SUMMARY: join(workdir, 'summary'),
+        RELEASES_PATH: releasesPath,
+        GH_ARGS_PATH: argsPath,
+        LOOKUP_FAIL: String(lookupFail),
+      },
+    });
+    const notesPath = join(workdir, 'dist', `release-notes-${releaseTag}.md`);
+    expect(readFileSync(outputPath, 'utf8')).toBe(`path=dist/release-notes-${releaseTag}.md\n`);
+    const args = readFileSync(argsPath, 'utf8').trim().split('\n');
+    expect(args.slice(0, 6)).toEqual([
+      'release',
+      'list',
+      '--repo',
+      'CodesWhat/drydock',
+      '--limit',
+      '100',
+    ]);
+    expect(args[args.indexOf('--json') + 1].split(',')).toEqual([
+      'tagName',
+      'createdAt',
+      'isDraft',
+    ]);
+    const notes = readFileSync(notesPath, 'utf8');
+    expect(notes).toContain('- Preserved release entry.');
+    return notes;
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+}
+
+test.each([
+  ['v1.7.0-rc.14', 'v1.7.0-rc.13', 'v1.6.1-rc.12'],
+  ['v1.6.1-rc.12', 'v1.6.1-rc.11', 'v1.7.0-rc.14'],
+])(
+  'compares %s with its own line despite a newer release on another line',
+  (target, previous, other) => {
+    const notes = runNotes(target, [
+      release(other, '2026-09-08T23:16:33Z'),
+      release(previous, '2026-09-07T18:55:42Z'),
+    ]);
+    expect(notes).toContain(
+      `**Full Changelog**: https://github.com/CodesWhat/drydock/compare/${previous}...${target}`,
+    );
+    expect(notes).not.toContain(`${other}...`);
+  },
+);
+
+test.each([
+  ['v1.7.2-rc.1', 'v1.7.1'],
+  ['v1.7.0', 'v1.7.0-rc.14'],
+  ['v1.6.1', 'v1.6.1-rc.12'],
+  ['v1.7.2', 'v1.7.1-rc.1'],
+])(
+  'keeps chronological same-line selection across patch/GA/RC transitions for %s',
+  (target, previous) => {
+    const notes = runNotes(target, [
+      release(previous, '2026-09-08T00:00:00Z'),
+      release(`${target}-older`, '2026-09-07T00:00:00Z'),
+    ]);
+    expect(notes).toContain(`/compare/${previous}...${target}`);
+  },
+);
+
+test('excludes drafts and the current tag on a partial-release rerun', () => {
+  const notes = runNotes('v1.7.0-rc.14', [
+    release('v1.7.0-rc.15', '2026-09-10T00:00:00Z', true),
+    release('v1.7.0-rc.14', '2026-09-09T00:00:00Z'),
+    release('v1.7.0-rc.13', '2026-09-08T00:00:00Z'),
+  ]);
+  expect(notes).toContain('/compare/v1.7.0-rc.13...v1.7.0-rc.14');
+});
+
+test('matches both major and minor exactly rather than a partial prefix', () => {
+  const notes = runNotes('v1.7.0-rc.14', [
+    release('v1.70.0', '2026-09-10T00:00:00Z'),
+    release('v11.7.0', '2026-09-09T00:00:00Z'),
+    release('v1.7.0-rc.13', '2026-09-08T00:00:00Z'),
+  ]);
+  expect(notes).toContain('/compare/v1.7.0-rc.13...v1.7.0-rc.14');
+});
+
+test.each([
+  { releases: [] },
+  { releases: [release('v1.7.0', '2026-09-08T00:00:00Z')] },
+  { releases: [release('v1.8.0-rc.1', '2026-09-08T00:00:00Z')] },
+  { releases: [release('v1.8.0-rc.0', '2026-09-08T00:00:00Z', true)] },
+])('omits the comparison when no published predecessor exists: %j', ({ releases }) => {
+  expect(runNotes('v1.8.0-rc.1', releases)).not.toContain('Full Changelog');
+});
+
+test('keeps release notes without a comparison when the lookup fails', () => {
+  expect(runNotes('v1.7.0', [release('v1.7.0-rc.14', '2026-09-08T00:00:00Z')], true)).not.toContain(
+    'Full Changelog',
+  );
+});
+
+test('still appends standing upgrade notes through the real script', () => {
+  const notes = runNotes('v1.5.2', [release('v1.5.1', '2026-09-08T00:00:00Z')]);
+  expect(notes).toContain('/compare/v1.5.1...v1.5.2');
+  expect(notes).toContain('<!-- upgrade-notes-marker -->');
+});

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1439,12 +1439,15 @@ jobs:
           fi
 
           # Resolve the previous release for a Full Changelog compare link. The
-          # current tag is not pushed yet, so the newest existing release is the
-          # predecessor; the select() guards re-runs after a partial release.
+          # predecessor is the newest published release on this major.minor
+          # line; exclude the current tag to support partial-release re-runs.
           prev_tag="$(gh release list --repo "${REPO}" --limit 100 \
-            --json tagName,createdAt \
-            --jq 'sort_by(.createdAt) | reverse | map(.tagName)
-                  | map(select(. != env.RELEASE_TAG)) | .[0] // empty' \
+            --json tagName,createdAt,isDraft \
+            --jq 'sort_by(.createdAt) | reverse
+                  | map(select(.isDraft == false) | .tagName)
+                  | map(select(. != env.RELEASE_TAG
+                      and startswith(env.RELEASE_TAG | split(".")[0:2] | join(".") + ".")))
+                  | .[0] // empty' \
             2>/dev/null || true)"
 
           {


### PR DESCRIPTION
## Summary

Release notes were choosing the newest release across the whole repository. With interleaved maintenance and mainline cuts, that made v1.7.0-rc.14 compare against v1.6.1-rc.12 instead of v1.7.0-rc.13.

Restrict the existing selector to published releases on the exact major/minor line, excluding drafts and the current tag. Keep chronological ordering, the 100-release lookup limit, and the existing no-link behavior when the lookup fails or no predecessor exists. GA still uses the newest matching release, including an RC; this does not introduce a different GA comparison policy.

Only two files change: the release workflow selector/comment and an executable workflow regression suite. No dependency, runtime, version metadata, candidate digest, signing, provenance, or soak changes. No release was dispatched.

## Validation

- First two tests failed on the actual generated opposite-line comparison URLs before the fix, not on argument-shape checks.
- All 14 new tests pass. They execute the real notes run block with only the GitHub CLI boundary stubbed; the real jq filter, changelog extractor, and upgrade-note append script run against isolated fixtures.
- Covered interleaved 1.6/1.7 releases, patch/GA/RC transitions, chronological ordering, current-tag reruns, drafts, exact 1.7 versus 1.70/11.7 matching, missing predecessors, lookup failure, and standing upgrade notes.
- Full workflow suite: 263 tests pass. Affected script checks: 22 tests pass. Biome, actionlint/ShellCheck, and offline Zizmor pass.
- Final normal push gate passed in 277.44 seconds on `e41513023860b3ed910d85e6cc1cb6efbfc029f6`: all 215 script tests, all 263 workflow tests, 100% backend/frontend coverage, both builds, and workflow security checks. No hook bypass or reduced test settings.
- Hosted [CI Verify](https://github.com/CodesWhat/drydock/actions/runs/34341649747) passed on this head: coverage 13m47s, build 3m37s, with every required check passed or correctly skipped for this workflow-only change. CodeRabbit's actual first review completed on the exact two-file change with no actionable findings, run b478a433-e2c4-4428-8875-6de3e3d4f1b4 (summary 5600543658, updated 16:55:14Z). The earlier quota-only attempt was not counted as a review. Greptile was requested but has returned no actual review.

Two earlier local gates failed before any push: first from stale v1.8 installed app dependencies after switching to v1.7, then from a Vitest worker-start timeout that skipped the dashboard suite. Exact lockfile installation restored the app dependencies; 182 previously failing tests passed. The dashboard suite and consumer then passed 163 tests with 100% module coverage. A separate incomplete npm 12.0.2 Corepack cache was restored to the same version without changing defaults, dependencies, or locks before the successful normal gate.

## Review scope

Threat model: a maintainer dispatching the existing release workflow against interleaved published and draft releases. Check exact release-line selection, current-tag reruns and no-predecessor behavior without changing artifact publication, signing, provenance or soak policy. Hostile-maintainer scenarios and new release subsystems are out of scope. This is the first review pass. Forward-port to dev/v1.8 after this reviewed dev/v1.7 change lands; the active workflow on main changes only through the normal reviewed dev-to-main sync.
