### PR TITLE
fix(agent): retire disconnected component registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Stop an edge agent's in-flight component initialization from publishing after disconnect and replacing its reconnected owner. Retired registrations clean up only their own components, and disconnected Docker proxy requests fail without opening new timers or sending frames.
+- Stop an edge agent's in-flight component initialization from publishing after disconnect and replacing its reconnected owner. Retired registrations clean up only their own components. Disconnected Docker proxy, log, delete, and exec requests now fail immediately without creating new request state or sending frames.
 
 ## [1.6.1-rc.12] — 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stop an edge agent's in-flight component initialization from publishing after disconnect and replacing its reconnected owner. Retired registrations clean up only their own components, and disconnected Docker proxy requests fail without opening new timers or sending frames.
+
 ## [1.6.1-rc.12] — 2026-09-08
 
 ### Security

--- a/app/agent/AgentClient.test.ts
+++ b/app/agent/AgentClient.test.ts
@@ -8469,6 +8469,80 @@ describe('AgentClient', () => {
   });
 
   describe('handleComponentSync (edge agent public shim)', () => {
+    const ownedWatcher = {
+      type: 'docker',
+      name: 'owned',
+      configuration: { transport: 'docker-api', execution: 'controller', events: 'portwing' },
+    };
+
+    test('an already retired sync never deregisters the replacement', async () => {
+      await client.handleComponentSync([ownedWatcher], [], () => false);
+      expect(registry.deregisterAgentComponents).not.toHaveBeenCalled();
+      expect(registry.registerComponent).not.toHaveBeenCalled();
+      expect(client.isRegisteringComponents).toBe(false);
+    });
+
+    test('retirement during deregistration skips new registrations and cache publication', async () => {
+      let valid = true;
+      vi.mocked(registry.deregisterAgentComponents).mockImplementationOnce(async () => {
+        valid = false;
+      });
+      await client.handleComponentSync([ownedWatcher], [], () => valid);
+      expect(registry.registerComponent).not.toHaveBeenCalled();
+      expect(client.getWatcherSnapshot('docker', 'owned')).toBeUndefined();
+      expect(client.isRegisteringComponents).toBe(false);
+    });
+
+    test('retirement after watcher registration skips its synthetic trigger and cache', async () => {
+      let valid = true;
+      vi.mocked(registry.registerComponent).mockImplementationOnce(async () => {
+        valid = false;
+      });
+      await client.handleComponentSync([ownedWatcher], [], () => valid);
+      expect(registry.registerComponent).toHaveBeenCalledTimes(1);
+      expect(client.getWatcherSnapshot('docker', 'owned')).toBeUndefined();
+      expect(registry.deregisterAgentComponents).toHaveBeenCalledTimes(1);
+    });
+
+    test('retirement after a synthetic trigger skips the next watcher and cache', async () => {
+      let valid = true;
+      vi.mocked(registry.registerComponent)
+        .mockResolvedValueOnce(undefined)
+        .mockImplementationOnce(async () => {
+          valid = false;
+        });
+      await client.handleComponentSync(
+        [ownedWatcher, { ...ownedWatcher, name: 'second' }],
+        [],
+        () => valid,
+      );
+      expect(registry.registerComponent).toHaveBeenCalledTimes(2);
+      expect(client.getWatcherSnapshot('docker', 'owned')).toBeUndefined();
+    });
+
+    test('a current owner preserves the original registration failure and transactional rollback', async () => {
+      const failure = new Error('registration failed');
+      vi.mocked(registry.registerComponent).mockRejectedValueOnce(failure);
+      await expect(client.handleComponentSync([ownedWatcher], [], () => true)).rejects.toBe(
+        failure,
+      );
+      expect(registry.deregisterAgentComponents).toHaveBeenCalledTimes(2);
+    });
+
+    test('a retired registration failure never rolls back the new owner by name', async () => {
+      let valid = true;
+      vi.mocked(registry.registerComponent).mockImplementationOnce(async () => {
+        valid = false;
+        throw new Error('abandoned cleanup failed');
+      });
+      await client.handleComponentSync([ownedWatcher], [], () => valid);
+      expect(registry.deregisterAgentComponents).toHaveBeenCalledTimes(1);
+      expect(client.getWatcherSnapshot('docker', 'owned')).toBeUndefined();
+      expect(client.log.warn).toHaveBeenCalledWith(
+        expect.stringContaining('abandoned cleanup failed'),
+      );
+    });
+
     test('keeps isRegisteringComponents true through edge component replacement and resets it after success (#605)', async () => {
       const watchers = [{ type: 'docker', name: 'local', configuration: {} }];
       const triggers = [{ type: 'mock', name: 'update', configuration: {} }];

--- a/app/agent/AgentClient.ts
+++ b/app/agent/AgentClient.ts
@@ -1004,8 +1004,10 @@ export class AgentClient {
   private async registerAgentComponents(
     kind: 'watcher' | 'trigger',
     remoteComponents: AgentComponentDescriptor[],
+    isOwnerValid?: () => boolean,
   ) {
     for (const remoteComponent of remoteComponents) {
+      if (isOwnerValid && !isOwnerValid()) return;
       this.log.debug(`Registering agent ${kind} ${remoteComponent.type}.${remoteComponent.name}`);
       await registry.registerComponent({
         kind,
@@ -1014,8 +1016,10 @@ export class AgentClient {
         configuration: remoteComponent.configuration,
         componentPath: 'agent/components',
         agent: this.name,
+        isOwnerValid,
       });
 
+      if (isOwnerValid && !isOwnerValid()) return;
       if (kind === 'watcher' && isControllerDockerTransportWatcher(remoteComponent)) {
         await registry.registerComponent({
           kind: 'trigger',
@@ -1029,6 +1033,7 @@ export class AgentClient {
           },
           componentPath: 'agent/components',
           agent: this.name,
+          isOwnerValid,
         });
       }
     }
@@ -1036,10 +1041,12 @@ export class AgentClient {
 
   private async registerAgentWatchersTransactional(
     watchers: AgentComponentDescriptor[],
+    isOwnerValid?: () => boolean,
   ): Promise<void> {
     try {
-      await this.registerAgentComponents('watcher', watchers);
+      await this.registerAgentComponents('watcher', watchers, isOwnerValid);
     } catch (registrationError: unknown) {
+      if (isOwnerValid && !isOwnerValid()) throw registrationError;
       try {
         // A controller-transport watcher starts a cron and loopback bridge
         // before its synthetic Docker trigger is registered. Tear down every
@@ -2357,17 +2364,24 @@ export class AgentClient {
   async handleComponentSync(
     watchers: AgentComponentDescriptor[],
     triggers: AgentComponentDescriptor[],
+    isOwnerValid?: () => boolean,
   ): Promise<void> {
+    if (isOwnerValid && !isOwnerValid()) return;
     // Same deregister → re-register window as _doHandshake(): keep transient
     // eligibility blockers soft while components are being replaced.
     this.isRegisteringComponents = true;
     try {
       this.setControllerDockerTransportWatchers([]);
       await registry.deregisterAgentComponents(this.name);
-      await this.registerAgentWatchersTransactional(watchers);
+      if (isOwnerValid && !isOwnerValid()) return;
+      await this.registerAgentWatchersTransactional(watchers, isOwnerValid);
+      if (isOwnerValid && !isOwnerValid()) return;
       this.setControllerDockerTransportWatchers(watchers);
       this.seedWatcherSnapshotCacheFromHandshake(watchers);
-      await this.registerAgentComponents('trigger', triggers);
+      await this.registerAgentComponents('trigger', triggers, isOwnerValid);
+    } catch (error: unknown) {
+      if (!isOwnerValid || isOwnerValid()) throw error;
+      this.log.warn(`Retired edge component sync stopped (${getErrorMessage(error)})`);
     } finally {
       this.isRegisteringComponents = false;
     }

--- a/app/agent/EdgeAgentAdapter.test.ts
+++ b/app/agent/EdgeAgentAdapter.test.ts
@@ -165,6 +165,30 @@ function sendFrame(ws: ReturnType<typeof createMockWs>, type: string, data: unkn
   ws.emit('message', JSON.stringify({ type, data }));
 }
 
+describe('EdgeAgentAdapter — retired proxy admission', () => {
+  test.each(['sendRequest', 'sendStreamRequest'] as const)(
+    '%s rejects after disconnect without creating a timer or sending a frame',
+    async (method) => {
+      vi.useFakeTimers();
+      const { adapter, ws } = createAdapter();
+      try {
+        adapter.activate();
+        await adapter.onDisconnect();
+        vi.mocked(ws.send).mockClear();
+        const timersBefore = vi.getTimerCount();
+        const result = adapter[method]('GET', '/containers/json').catch((error: Error) => error);
+        expect(ws.send).not.toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(timersBefore);
+        await expect(result).resolves.toMatchObject({ message: 'connection closed' });
+      } finally {
+        await adapter.onDisconnect();
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    },
+  );
+});
+
 describe('EdgeAgentAdapter — activate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -212,7 +236,13 @@ describe('EdgeAgentAdapter — frame dispatch', () => {
 
     expect(
       (client as unknown as { handleComponentSync: ReturnType<typeof vi.fn> }).handleComponentSync,
-    ).toHaveBeenCalledWith(watchers, triggers);
+    ).toHaveBeenCalledWith(watchers, triggers, expect.any(Function));
+    const isOwnerValid = vi.mocked(client.handleComponentSync).mock.calls[0][2];
+    expect(isOwnerValid?.()).toBe(true);
+    vi.mocked(manager.getAgent).mockReturnValueOnce(undefined);
+    expect(isOwnerValid?.()).toBe(false);
+    await adapter.onDisconnect();
+    expect(isOwnerValid?.()).toBe(false);
   });
 
   test('serializes component sync before the following container sync in wire order', async () => {
@@ -2652,7 +2682,7 @@ describe('EdgeAgentAdapter — false-branch coverage for ternary fallbacks', () 
 
     expect(
       (client as unknown as { handleComponentSync: ReturnType<typeof vi.fn> }).handleComponentSync,
-    ).toHaveBeenCalledWith([], []);
+    ).toHaveBeenCalledWith([], [], expect.any(Function));
   });
 
   test('metrics frame with zero memoryTotal and zero uptime uses fallback values', async () => {

--- a/app/agent/EdgeAgentAdapter.test.ts
+++ b/app/agent/EdgeAgentAdapter.test.ts
@@ -3,6 +3,7 @@
  */
 import { emitAgentConnected, emitAgentDisconnected } from '../event/index.js';
 import * as registry from '../registry/index.js';
+import * as ids from '../util/uuid.js';
 import { AgentClient } from './AgentClient.js';
 import {
   buildEdgeSentinelConfig,
@@ -166,6 +167,97 @@ function sendFrame(ws: ReturnType<typeof createMockWs>, type: string, data: unkn
 }
 
 describe('EdgeAgentAdapter — retired proxy admission', () => {
+  test.each(['requestContainerLogs', 'deleteContainer', 'startExec'] as const)(
+    '%s rejects after disconnect without allocating request state',
+    async (method) => {
+      vi.useFakeTimers();
+      const { adapter, ws } = createAdapter();
+      const allocateId = vi.spyOn(ids, 'uuidv7');
+      const state = adapter as unknown as {
+        pendingRequests: Map<string, unknown>;
+        containerRequestQueues: Map<string, unknown>;
+        execSessions: Map<string, unknown>;
+      };
+      try {
+        adapter.activate();
+        await adapter.onDisconnect();
+        vi.mocked(ws.send).mockClear();
+        allocateId.mockClear();
+        const timersBefore = vi.getTimerCount();
+        const request =
+          method === 'startExec' ? adapter.startExec('c1', ['true']) : adapter[method]('c1');
+        const result = request.catch((error: Error) => error);
+        expect(ws.send).not.toHaveBeenCalled();
+        expect(allocateId).not.toHaveBeenCalled();
+        expect(vi.getTimerCount()).toBe(timersBefore);
+        expect(state.pendingRequests.size).toBe(0);
+        expect(state.containerRequestQueues.size).toBe(0);
+        expect(state.execSessions.size).toBe(0);
+        await expect(result).resolves.toMatchObject({ message: 'connection closed' });
+
+        // Retirement takes precedence over the live connection's capacity errors.
+        for (let index = 0; index < 100; index++) {
+          state.pendingRequests.set(String(index), {});
+          state.execSessions.set(String(index), {});
+        }
+        const fullRequest =
+          method === 'startExec' ? adapter.startExec('c1', ['true']) : adapter[method]('c1');
+        await expect(fullRequest).rejects.toThrow('connection closed');
+        expect(allocateId).not.toHaveBeenCalled();
+      } finally {
+        state.pendingRequests.clear();
+        state.containerRequestQueues.clear();
+        state.execSessions.clear();
+        allocateId.mockRestore();
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  test('retired log streams synchronously report one error and return an inert cancel handle', async () => {
+    vi.useFakeTimers();
+    const { adapter, ws } = createAdapter();
+    const allocateId = vi.spyOn(ids, 'uuidv7');
+    const state = adapter as unknown as {
+      pendingRequests: Map<string, unknown>;
+      liveContainerLogStreams: Map<string, unknown>;
+    };
+    const handlers = { onChunk: vi.fn(), onEnd: vi.fn(), onError: vi.fn() };
+    try {
+      adapter.activate();
+      await adapter.onDisconnect();
+      vi.mocked(ws.send).mockClear();
+      allocateId.mockClear();
+      const timersBefore = vi.getTimerCount();
+      const handle = adapter.streamContainerLogs('c1', {}, handlers);
+      expect(handlers.onError).toHaveBeenCalledExactlyOnceWith(new Error('connection closed'));
+      handle.cancel();
+      handle.cancel();
+      await adapter.onDisconnect();
+      expect(handlers.onError).toHaveBeenCalledTimes(1);
+      expect(handlers.onChunk).not.toHaveBeenCalled();
+      expect(handlers.onEnd).not.toHaveBeenCalled();
+      expect(ws.send).not.toHaveBeenCalled();
+      expect(allocateId).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(timersBefore);
+      expect(state.pendingRequests.size).toBe(0);
+      expect(state.liveContainerLogStreams.size).toBe(0);
+
+      for (let index = 0; index < 100; index++) state.pendingRequests.set(String(index), {});
+      const fullHandlers = { onChunk: vi.fn(), onEnd: vi.fn(), onError: vi.fn() };
+      adapter.streamContainerLogs('c1', {}, fullHandlers).cancel();
+      expect(fullHandlers.onError).toHaveBeenCalledExactlyOnceWith(new Error('connection closed'));
+      expect(allocateId).not.toHaveBeenCalled();
+    } finally {
+      state.pendingRequests.clear();
+      state.liveContainerLogStreams.clear();
+      allocateId.mockRestore();
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   test.each(['sendRequest', 'sendStreamRequest'] as const)(
     '%s rejects after disconnect without creating a timer or sending a frame',
     async (method) => {

--- a/app/agent/EdgeAgentAdapter.ts
+++ b/app/agent/EdgeAgentAdapter.ts
@@ -466,7 +466,11 @@ export class EdgeAgentAdapter {
     const triggers = Array.isArray(data.triggers)
       ? (data.triggers as AgentComponentDescriptor[])
       : [];
-    await this.client.handleComponentSync(watchers, triggers);
+    await this.client.handleComponentSync(
+      watchers,
+      triggers,
+      () => !this.disconnected && getAgent(this.agentName) === this.client,
+    );
   }
 
   private handleMetrics(data: Record<string, unknown>): void {
@@ -1108,6 +1112,7 @@ export class EdgeAgentAdapter {
     headers?: Record<string, string>,
     body?: unknown,
   ): Promise<unknown> {
+    if (this.disconnected) return Promise.reject(new Error('connection closed'));
     if (this.pendingRequests.size >= MAX_PENDING_REQUESTS) {
       return Promise.reject(new Error('concurrent request limit reached'));
     }
@@ -1147,6 +1152,7 @@ export class EdgeAgentAdapter {
     headers?: Record<string, string>,
     body?: unknown,
   ): Promise<unknown> {
+    if (this.disconnected) return Promise.reject(new Error('connection closed'));
     if (this.pendingRequests.size >= MAX_PENDING_REQUESTS) {
       const requestId = uuidv7();
       try {

--- a/app/agent/EdgeAgentAdapter.ts
+++ b/app/agent/EdgeAgentAdapter.ts
@@ -938,6 +938,7 @@ export class EdgeAgentAdapter {
       timestamps?: boolean;
     } = {},
   ): Promise<string> {
+    if (this.disconnected) return Promise.reject(new Error('connection closed'));
     if (this.pendingRequests.size >= MAX_PENDING_REQUESTS) {
       return Promise.reject(new Error('concurrent request limit reached'));
     }
@@ -996,6 +997,10 @@ export class EdgeAgentAdapter {
     },
     handlers: ContainerLogStreamHandlers,
   ): ContainerLogStreamHandle {
+    if (this.disconnected) {
+      handlers.onError(new Error('connection closed'));
+      return { cancel: () => {} };
+    }
     if (this.pendingRequests.size + this.liveContainerLogStreams.size >= MAX_PENDING_REQUESTS) {
       handlers.onError(new Error('concurrent request limit reached'));
       return { cancel: () => {} };
@@ -1057,6 +1062,7 @@ export class EdgeAgentAdapter {
    * the legacy fallback. See that doc comment for the full explanation.
    */
   deleteContainer(containerId: string): Promise<void> {
+    if (this.disconnected) return Promise.reject(new Error('connection closed'));
     if (this.pendingRequests.size >= MAX_PENDING_REQUESTS) {
       return Promise.reject(new Error('concurrent request limit reached'));
     }
@@ -1212,6 +1218,7 @@ export class EdgeAgentAdapter {
       outputCallback?: (data: Buffer) => void;
     },
   ): Promise<string> {
+    if (this.disconnected) return Promise.reject(new Error('connection closed'));
     if (this.execSessions.size >= MAX_EXEC_SESSIONS) {
       return Promise.reject(new Error('session limit reached'));
     }

--- a/app/agent/edge-registration-ownership.test.ts
+++ b/app/agent/edge-registration-ownership.test.ts
@@ -1,0 +1,226 @@
+import { EventEmitter } from 'node:events';
+import type { Server } from 'node:http';
+import * as registry from '../registry/index.js';
+import * as store from '../store/index.js';
+import { AgentClient } from './AgentClient.js';
+import AgentTrigger from './components/AgentTrigger.js';
+import AgentWatcher from './components/AgentWatcher.js';
+import { EdgeAgentAdapter } from './EdgeAgentAdapter.js';
+import { getAgent, removeAgent } from './manager.js';
+import { PortwingDockerBridge } from './PortwingDockerBridge.js';
+
+const initializeTrigger = AgentTrigger.prototype.init;
+
+class TestSocket extends EventEmitter {
+  send = vi.fn((raw: string) => {
+    const frame = JSON.parse(raw);
+    if (frame.type !== 'request') return;
+    expect(frame.data.method).toBe('GET');
+    queueMicrotask(() =>
+      this.emit(
+        'message',
+        JSON.stringify({
+          type: 'response',
+          data: {
+            requestId: frame.data.requestId,
+            statusCode: 200,
+            headers: { 'content-type': 'application/json' },
+            body: [],
+          },
+        }),
+      ),
+    );
+  });
+
+  close() {
+    this.emit('close');
+  }
+}
+
+const descriptor = {
+  type: 'docker',
+  name: 'docker',
+  configuration: { transport: 'docker-api', execution: 'controller', events: 'portwing' },
+};
+const syncFrame = JSON.stringify({
+  type: 'dd:component_sync',
+  data: { watchers: [descriptor], triggers: [] },
+});
+
+function orderedFrames(adapter: EdgeAgentAdapter) {
+  return (adapter as unknown as { orderedStateFrameChain: Promise<void> }).orderedStateFrameChain;
+}
+
+function watcherResources(watcher: AgentWatcher) {
+  return watcher as unknown as {
+    controllerBridge?: PortwingDockerBridge;
+    controllerWatcher?: { watchCron?: unknown };
+  };
+}
+
+describe('edge registration ownership with real component lifecycles', () => {
+  const adapters: EdgeAgentAdapter[] = [];
+  const watchers: AgentWatcher[] = [];
+  const triggers: AgentTrigger[] = [];
+
+  function connect() {
+    const client = new AgentClient('ownership-agent', { host: '127.0.0.1', port: 1, secret: '' });
+    const ws = new TestSocket();
+    const adapter = new EdgeAgentAdapter(client, ws);
+    client.edgeAdapter = adapter;
+    adapter.activate();
+    adapters.push(adapter);
+    return { client, ws, adapter };
+  }
+
+  beforeEach(async () => {
+    await store.init({ memory: true });
+    const init = AgentWatcher.prototype.init;
+    vi.spyOn(AgentWatcher.prototype, 'init').mockImplementation(async function () {
+      watchers.push(this);
+      await init.call(this);
+    });
+    vi.spyOn(AgentTrigger.prototype, 'init').mockImplementation(async function () {
+      triggers.push(this);
+      await initializeTrigger.call(this);
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    for (const adapter of adapters.splice(0)) await adapter.onDisconnect();
+    await registry.deregisterAgentComponents('ownership-agent');
+    for (const watcher of watchers.splice(0)) await watcher.deregister();
+    for (const trigger of triggers.splice(0)) await trigger.deregister();
+    removeAgent('ownership-agent');
+  });
+
+  test.each([false, true])(
+    'a disconnected initializer cannot replace the new owner (cleanup throws: %s)',
+    async (cleanupThrows) => {
+      const old = connect();
+      const ready = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      const start = PortwingDockerBridge.prototype.start;
+      let first = true;
+      vi.spyOn(PortwingDockerBridge.prototype, 'start').mockImplementation(async function () {
+        const endpoint = await start.call(this);
+        if (first) {
+          first = false;
+          expect((this as unknown as { server: Server }).server.listening).toBe(true);
+          ready.resolve();
+          await resume.promise;
+        }
+        return endpoint;
+      });
+      old.ws.emit('message', syncFrame);
+      const oldSync = orderedFrames(old.adapter);
+      await ready.promise;
+      try {
+        if (cleanupThrows) {
+          const retired = watchers[0];
+          const deregister = retired.deregister;
+          vi.spyOn(retired, 'deregister').mockImplementationOnce(async () => {
+            await deregister.call(retired);
+            throw new Error('abandoned cleanup failed');
+          });
+        }
+        await old.adapter.onDisconnect();
+        old.ws.close();
+        const replacement = connect();
+        replacement.ws.emit('message', syncFrame);
+        await orderedFrames(replacement.adapter);
+        const liveWatcher = Object.values(registry.getState().watcher)[0];
+        const liveTrigger = Object.values(registry.getState().trigger)[0];
+        resume.resolve();
+        await oldSync;
+
+        expect(getAgent(old.client.name)).toBe(replacement.client);
+        expect(old.client.getWatcherSnapshot('docker', 'docker')).toBeUndefined();
+        expect(Object.values(registry.getState().watcher)).toHaveLength(1);
+        expect(Object.values(registry.getState().watcher)[0] === liveWatcher).toBe(true);
+        expect(Object.values(registry.getState().trigger)).toHaveLength(1);
+        expect(Object.values(registry.getState().trigger)[0] === liveTrigger).toBe(true);
+        expect(watcherResources(watchers[0]).controllerBridge).toBeUndefined();
+        expect(watcherResources(watchers[0]).controllerWatcher).toBeUndefined();
+        expect(watcherResources(watchers[1]).controllerBridge).toBeDefined();
+        expect(watcherResources(watchers[1]).controllerWatcher?.watchCron).toBeDefined();
+        await replacement.adapter.onDisconnect();
+        expect(watchers.every((watcher) => !watcherResources(watcher).controllerBridge)).toBe(true);
+      } finally {
+        resume.resolve();
+        await oldSync;
+      }
+    },
+  );
+
+  test('wire-ordered repeated syncs replace and clean up the previous live watcher', async () => {
+    const current = connect();
+    current.ws.emit('message', syncFrame);
+    current.ws.emit('message', syncFrame);
+    await orderedFrames(current.adapter);
+    expect(watchers).toHaveLength(2);
+    expect(watcherResources(watchers[0]).controllerBridge).toBeUndefined();
+    expect(Object.values(registry.getState().watcher)[0] === watchers[1]).toBe(true);
+    expect(current.client.getWatcherSnapshot('docker', 'docker')).toBeDefined();
+    await current.adapter.onDisconnect();
+    expect(watchers.every((watcher) => !watcherResources(watcher).controllerBridge)).toBe(true);
+    expect(Object.keys(registry.getState().watcher)).toHaveLength(0);
+    expect(Object.keys(registry.getState().trigger)).toHaveLength(0);
+  });
+
+  test.each(['synthetic', 'remote'])(
+    'a retired %s trigger initializer cannot publish over the replacement',
+    async (kind) => {
+      const old = connect();
+      const ready = Promise.withResolvers<void>();
+      const resume = Promise.withResolvers<void>();
+      vi.mocked(AgentTrigger.prototype.init).mockImplementationOnce(async function () {
+        triggers.push(this);
+        await initializeTrigger.call(this);
+        ready.resolve();
+        await resume.promise;
+      });
+      const frame =
+        kind === 'synthetic'
+          ? syncFrame
+          : JSON.stringify({
+              type: 'dd:component_sync',
+              data: {
+                watchers: [],
+                triggers: [
+                  { type: 'mock', name: 'notice', configuration: {} },
+                  { type: 'mock', name: 'second', configuration: {} },
+                ],
+              },
+            });
+      old.ws.emit('message', frame);
+      const oldSync = orderedFrames(old.adapter);
+      await ready.promise;
+      try {
+        await old.adapter.onDisconnect();
+        const replacement = connect();
+        replacement.ws.emit('message', frame);
+        await orderedFrames(replacement.adapter);
+        const live = Object.values(registry.getState().trigger);
+        const count = triggers.length;
+        const disposeOld = vi.spyOn(triggers[0], 'deregister');
+        resume.resolve();
+        await oldSync;
+        expect(
+          Object.values(registry.getState().trigger).every((item, index) => item === live[index]),
+        ).toBe(true);
+        expect(triggers).toHaveLength(count);
+        expect(disposeOld).toHaveBeenCalledTimes(1);
+        if (kind === 'synthetic')
+          expect(old.client.getWatcherSnapshot('docker', 'docker')).toBeUndefined();
+        await replacement.adapter.onDisconnect();
+        expect(Object.keys(registry.getState().trigger)).toHaveLength(0);
+        expect(watchers.every((watcher) => !watcherResources(watcher).controllerBridge)).toBe(true);
+      } finally {
+        resume.resolve();
+        await oldSync;
+      }
+    },
+  );
+});

--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -70,6 +70,7 @@ interface RegisterComponentOptions {
   configuration: ComponentConfiguration;
   componentPath: string;
   agent?: string;
+  isOwnerValid?: () => boolean;
 }
 
 interface ProviderConfiguration {
@@ -167,6 +168,10 @@ export async function registerComponent(options: RegisterComponentOptions): Prom
       agent,
     );
 
+    if (options.isOwnerValid && !options.isOwnerValid()) {
+      await component.deregister();
+      throw new Error('Agent component registration owner retired');
+    }
     addComponentToState(kind, component);
     return componentRegistered;
   } catch (e: unknown) {


### PR DESCRIPTION
## Current review status

CodeRabbit's actual second review is clean on `8a4d8c612` (run 882893b2, completed 2026-09-10T00:24:38Z). The first review's remaining post-disconnect admission gap was reproduced and fixed with four real-adapter regressions. The full normal local gate, exact-head hosted fleet soak and Playwright passed. All required hosted checks now pass or correctly skip: CI Verify 34420822936 is successful, including 12m40s coverage, 4m24s build, 4m3s Cucumber and 1m42s Grype. The only external error is non-required Qlty's exhausted minutes, not a code finding. No release has happened yet.

## Summary

Stop a disconnected edge agent's in-flight watcher or trigger registration from publishing over its replacement. The adapter now supplies an owner-validity check through component sync. The registry checks ownership after asynchronous initialization, before publication, and tears down only the abandoned instance. A retired caller skips synthetic-trigger creation, cache publication, and name-wide rollback. Native handshake registration and the adapter's existing FIFO frame ordering stay unchanged.

Disconnected Docker proxy requests, including streamed requests, now reject before creating timers or sending frames. Dedicated log download, delete and exec requests also reject immediately; continuous log streams synchronously report one connection-closed error and return an inert cancel handle. The guard runs before capacity checks and request-ID allocation.

## Reproduction and scope

The v1.6.1-rc.12 reproduction uses the real adapter disconnect/replacement path, real component registry, AgentWatcher, and a real loopback Docker bridge. It pauses the old initializer after the bridge has actually begun listening, completes a replacement connection, then releases the old initializer. Before this fix, the old registration replaces the live watcher and normal fleet cleanup leaves a bridge and cron timers behind.

That pause is a controlled asynchronous interleaving, not evidence of a naturally occurring failure frequency on 1.6. The 1.7 candidate was independently reproduced at its real pending Docker inventory request boundary. No real Docker daemon is used in these regressions.

This PR targets dev/v1.6 only. After reviewed landing, the fix is planned for the 1.7 and 1.8 lines. Updated runtime bytes on the maintained release lines require fresh release candidates and new seven-day soaks from their publication times. This PR does not cut a release or claim either current candidate is ready for GA promotion.

## Verification

- Real-lifecycle tests cover retired watcher initialization, cleanup rejection, synthetic and remote trigger initialization, replacement preservation, and normal FIFO replacement/cleanup. Removing the registry publication guard makes all four retired-owner cases fail while the FIFO control passes.
- AgentClient boundary tests cover retirement before and during deregistration, watcher-to-synthetic-trigger and synthetic-trigger-to-next-watcher transitions, cache omission, current-owner error propagation, and skipping stale name-wide rollback.
- Both proxy request paths reject after disconnect without adding timers or sending frames.
- Four new real-adapter admission tests first failed on emitted frames or the missing synchronous stream error. They now prove no request/session/stream state, timers, IDs or frames are created after disconnect, including when the live-connection capacity limit would otherwise apply. Repeated stream cancel/disconnect does not duplicate callbacks.
- Focused suites: 881 tests passed. AgentClient, EdgeAgentAdapter, and registry each have 100% line, branch, function, and statement coverage.
- Full normal pre-push gate on `8a4d8c612` passed in 274.27 seconds: 12,903 backend tests and 4,310 UI tests, each at 100% coverage; backend/UI builds, UI typecheck, static checks, 192 script tests and 97 workflow tests passed. Website/workflow-security conditional steps did not apply to this follow-up; both passed on the earlier head's full gate.
- Rebuilt real-adapter admission proof: retained AgentClient log/delete calls and adapter exec reject immediately; the continuous stream reports one synchronous error. There are zero sent frames, retained entries or timers, and only two stdio handles remain. The original gap created two 30-second timers for log download/delete, while continuous streams had no deadline and exec resolved an ID immediately.
- Independently rerun compiled reproduction: all three child processes exit successfully. Standard cleanup already leaves only the two stdio handles, with no retained bridge/cron and no Docker requests.
- On current head `8a4d8c612`, [fleet soak](https://github.com/CodesWhat/drydock/actions/runs/34420822198/job/102695627078) passed all six assertions: eight agents, 48 exec sessions/frames, one slow reconnect and two reconnect storms (17 total reconnects). RSS growth was 27,770,880 bytes and heap growth 942,688 bytes, both below their bounds. Results finished at 00:21:47.229Z, the soak exited at 00:21:50Z, evidence uploaded at 00:21:51Z, and the job completed at 00:21:58Z without a retained-liveness tail. Tested merge `147e801a` has parents `013b1b49` and `8a4d8c612`; its tree exactly equals the current head. [Artifact 10130856212](https://github.com/CodesWhat/drydock/actions/runs/34420822198/artifacts/10130856212) is present. Portwing's tested source remains `d6ba7a925`.
- Current-head [Playwright](https://github.com/CodesWhat/drydock/actions/runs/34420822239) passed in 6m53s. CodeRabbit's second review selected both changed Adapter files and reported no actionable comments on the exact head. Greptile was requested once for this new head; no actual output has been received.
- On the earlier head `89bff6cfd`, hosted [cross-repo fleet soak](https://github.com/CodesWhat/drydock/actions/runs/34342180107/job/102435279699) passed all six assertions and exited normally. It covered eight agents, 48 exec sessions/frames and both reconnect storms, with memory growth under its bounds. Results finished at 10:50:46Z, evidence uploaded at 10:50:50Z, and the job completed at 10:50:54Z, without the earlier retained-liveness tail. The tested PR merge tree exactly matched that earlier head; [the evidence artifact](https://github.com/CodesWhat/drydock/actions/runs/34342180107/artifacts/10100264471) is present.
- Hosted [Playwright](https://github.com/CodesWhat/drydock/actions/runs/34342180097) and the required CI passed on the earlier head. New-head hosted results are pending verification. External Qlty reported exhausted minutes, not a source finding; both local static gates passed.

Current source, remote verified: 8a4d8c6125e46a3f914c62e65b9cd997e4cb6c85.

## Review scope

Threat model: an authenticated fleet controller with enrolled edge agents disconnecting and reconnecting while component initialization is in flight. Check exact connection ownership, replacement preservation, abandoned resource cleanup, FIFO/native compatibility and refusal of post-disconnect requests. Hostile operators attacking their own Docker host and new global registration/scheduling subsystems are out of scope. Two actual CodeRabbit passes are complete; the second checked and cleared the first pass's admission fix.
