### PR TITLE
fix(release): select changelog predecessor from the same line

### DIFF
--- a/.github/tests/release-cut-previous-release.test.ts
+++ b/.github/tests/release-cut-previous-release.test.ts
@@ -1,0 +1,166 @@
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadWorkflow } from './workflow-test-utils';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+const workflowPath = join(repoRoot, '.github/workflows/release-cut.yml');
+
+// Keep the selector in the real workflow: the boundary stub executes its
+// --jq expression against fixture API data, rather than supplying a chosen tag.
+const stubGh = `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > "\${GH_ARGS_PATH}"
+if [ "$1" != release ] || [ "$2" != list ]; then exit 97; fi
+if [ "\${LOOKUP_FAIL}" = true ]; then exit 1; fi
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = --jq ]; then
+    jq -r "$2" "\${RELEASES_PATH}"
+    exit 0
+  fi
+  shift
+done
+exit 98
+`;
+
+function release(tagName: string, createdAt: string, isDraft = false) {
+  return { tagName, createdAt, isDraft };
+}
+
+function runNotes(releaseTag: string, releases: ReturnType<typeof release>[], lookupFail = false) {
+  const step = loadWorkflow(workflowPath).jobs?.release?.steps?.find(
+    (candidate) => candidate.id === 'release_notes',
+  );
+  if (!step?.run) throw new Error('Missing release notes run block');
+  const workdir = mkdtempSync(join(tmpdir(), 'release-cut-previous-release-'));
+  try {
+    mkdirSync(join(workdir, 'bin'));
+    mkdirSync(join(workdir, 'dist'));
+    writeFileSync(join(workdir, 'bin/gh'), stubGh, { mode: 0o755 });
+    cpSync(join(repoRoot, 'scripts'), join(workdir, 'scripts'), { recursive: true });
+    cpSync(join(repoRoot, 'UPGRADE-NOTES.md'), join(workdir, 'UPGRADE-NOTES.md'));
+    const changelogPath = join(workdir, 'changelog.md');
+    writeFileSync(
+      changelogPath,
+      `## [${releaseTag.slice(1)}] - 2026-09-09\n\n### Fixed\n\n- Preserved release entry.\n`,
+    );
+    const releasesPath = join(workdir, 'releases.json');
+    writeFileSync(releasesPath, JSON.stringify(releases));
+    const argsPath = join(workdir, 'gh-args');
+    const outputPath = join(workdir, 'output');
+    execFileSync('bash', ['-c', step.run], {
+      cwd: workdir,
+      encoding: 'utf8',
+      env: {
+        PATH: `${join(workdir, 'bin')}:${process.env.PATH ?? ''}`,
+        RELEASE_TAG: releaseTag,
+        REPO: 'CodesWhat/drydock',
+        CHANGELOG_PATH: changelogPath,
+        EXTRACT_SCRIPT: join(repoRoot, 'scripts/extract-changelog-entry.mjs'),
+        IS_MAINTENANCE_CUT: 'false',
+        SOAK_OVERRIDE_USED: 'false',
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_STEP_SUMMARY: join(workdir, 'summary'),
+        RELEASES_PATH: releasesPath,
+        GH_ARGS_PATH: argsPath,
+        LOOKUP_FAIL: String(lookupFail),
+      },
+    });
+    const notesPath = join(workdir, 'dist', `release-notes-${releaseTag}.md`);
+    expect(readFileSync(outputPath, 'utf8')).toBe(`path=dist/release-notes-${releaseTag}.md\n`);
+    const args = readFileSync(argsPath, 'utf8').trim().split('\n');
+    expect(args.slice(0, 6)).toEqual([
+      'release',
+      'list',
+      '--repo',
+      'CodesWhat/drydock',
+      '--limit',
+      '100',
+    ]);
+    expect(args[args.indexOf('--json') + 1].split(',')).toEqual([
+      'tagName',
+      'createdAt',
+      'isDraft',
+    ]);
+    const notes = readFileSync(notesPath, 'utf8');
+    expect(notes).toContain('- Preserved release entry.');
+    return notes;
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+}
+
+test.each([
+  ['v1.7.0-rc.14', 'v1.7.0-rc.13', 'v1.6.1-rc.12'],
+  ['v1.6.1-rc.12', 'v1.6.1-rc.11', 'v1.7.0-rc.14'],
+])(
+  'compares %s with its own line despite a newer release on another line',
+  (target, previous, other) => {
+    const notes = runNotes(target, [
+      release(other, '2026-09-08T23:16:33Z'),
+      release(previous, '2026-09-07T18:55:42Z'),
+    ]);
+    expect(notes).toContain(
+      `**Full Changelog**: https://github.com/CodesWhat/drydock/compare/${previous}...${target}`,
+    );
+    expect(notes).not.toContain(`${other}...`);
+  },
+);
+
+test.each([
+  ['v1.7.2-rc.1', 'v1.7.1'],
+  ['v1.7.0', 'v1.7.0-rc.14'],
+  ['v1.6.1', 'v1.6.1-rc.12'],
+  ['v1.7.2', 'v1.7.1-rc.1'],
+])(
+  'keeps chronological same-line selection across patch/GA/RC transitions for %s',
+  (target, previous) => {
+    const notes = runNotes(target, [
+      release(previous, '2026-09-08T00:00:00Z'),
+      release(`${target}-older`, '2026-09-07T00:00:00Z'),
+    ]);
+    expect(notes).toContain(`/compare/${previous}...${target}`);
+  },
+);
+
+test('excludes drafts and the current tag on a partial-release rerun', () => {
+  const notes = runNotes('v1.7.0-rc.14', [
+    release('v1.7.0-rc.15', '2026-09-10T00:00:00Z', true),
+    release('v1.7.0-rc.14', '2026-09-09T00:00:00Z'),
+    release('v1.7.0-rc.13', '2026-09-08T00:00:00Z'),
+  ]);
+  expect(notes).toContain('/compare/v1.7.0-rc.13...v1.7.0-rc.14');
+});
+
+test('matches both major and minor exactly rather than a partial prefix', () => {
+  const notes = runNotes('v1.7.0-rc.14', [
+    release('v1.70.0', '2026-09-10T00:00:00Z'),
+    release('v11.7.0', '2026-09-09T00:00:00Z'),
+    release('v1.7.0-rc.13', '2026-09-08T00:00:00Z'),
+  ]);
+  expect(notes).toContain('/compare/v1.7.0-rc.13...v1.7.0-rc.14');
+});
+
+test.each([
+  { releases: [] },
+  { releases: [release('v1.7.0', '2026-09-08T00:00:00Z')] },
+  { releases: [release('v1.8.0-rc.1', '2026-09-08T00:00:00Z')] },
+  { releases: [release('v1.8.0-rc.0', '2026-09-08T00:00:00Z', true)] },
+])('omits the comparison when no published predecessor exists: %j', ({ releases }) => {
+  expect(runNotes('v1.8.0-rc.1', releases)).not.toContain('Full Changelog');
+});
+
+test('keeps release notes without a comparison when the lookup fails', () => {
+  expect(runNotes('v1.7.0', [release('v1.7.0-rc.14', '2026-09-08T00:00:00Z')], true)).not.toContain(
+    'Full Changelog',
+  );
+});
+
+test('still appends standing upgrade notes through the real script', () => {
+  const notes = runNotes('v1.5.2', [release('v1.5.1', '2026-09-08T00:00:00Z')]);
+  expect(notes).toContain('/compare/v1.5.1...v1.5.2');
+  expect(notes).toContain('<!-- upgrade-notes-marker -->');
+});

--- a/.github/tests/release-cut-previous-release.test.ts
+++ b/.github/tests/release-cut-previous-release.test.ts
@@ -16,9 +16,13 @@ set -euo pipefail
 printf '%s\\n' "$@" > "\${GH_ARGS_PATH}"
 if [ "$1" != release ] || [ "$2" != list ]; then exit 97; fi
 if [ "\${LOOKUP_FAIL}" = true ]; then exit 1; fi
+fields=""
 while [ "$#" -gt 0 ]; do
+  if [ "$1" = --json ]; then fields="$2"; shift; fi
   if [ "$1" = --jq ]; then
-    jq -r "$2" "\${RELEASES_PATH}"
+    jq --arg fields "$fields" \\
+      'map(with_entries(select(.key as $key | $fields | split(",") | index($key))))' \\
+      "\${RELEASES_PATH}" | jq -r "$2"
     exit 0
   fi
   shift
@@ -26,8 +30,13 @@ done
 exit 98
 `;
 
-function release(tagName: string, createdAt: string, isDraft = false) {
-  return { tagName, createdAt, isDraft };
+function release(
+  tagName: string,
+  createdAt: string,
+  isDraft = false,
+  publishedAt: string | null = isDraft ? null : createdAt,
+) {
+  return { tagName, createdAt, publishedAt, isDraft };
 }
 
 function runNotes(releaseTag: string, releases: ReturnType<typeof release>[], lookupFail = false) {
@@ -82,7 +91,7 @@ function runNotes(releaseTag: string, releases: ReturnType<typeof release>[], lo
     ]);
     expect(args[args.indexOf('--json') + 1].split(',')).toEqual([
       'tagName',
-      'createdAt',
+      'publishedAt',
       'isDraft',
     ]);
     const notes = readFileSync(notesPath, 'utf8');
@@ -133,6 +142,17 @@ test('excludes drafts and the current tag on a partial-release rerun', () => {
     release('v1.7.0-rc.13', '2026-09-08T00:00:00Z'),
   ]);
   expect(notes).toContain('/compare/v1.7.0-rc.13...v1.7.0-rc.14');
+});
+
+test('selects the latest publication even when its draft was created earlier', () => {
+  const notes = runNotes('v1.7.0-rc.15', [
+    release('v1.7.0-rc.14', '2026-09-07T00:00:00Z', false, '2026-09-09T00:00:00Z'),
+    release('v1.7.0-rc.13', '2026-09-08T00:00:00Z', false, '2026-09-08T00:00:00Z'),
+    release('v1.7.0-rc.16', '2026-09-10T00:00:00Z', true, null),
+  ]);
+  expect(notes).toContain('/compare/v1.7.0-rc.14...v1.7.0-rc.15');
+  expect(notes).not.toContain('/compare/v1.7.0-rc.13...');
+  expect(notes).not.toContain('/compare/v1.7.0-rc.16...');
 });
 
 test('matches both major and minor exactly rather than a partial prefix', () => {

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1433,12 +1433,15 @@ jobs:
           fi
 
           # Resolve the previous release for a Full Changelog compare link. The
-          # current tag is not pushed yet, so the newest existing release is the
-          # predecessor; the select() guards re-runs after a partial release.
+          # predecessor is the newest published release on this major.minor
+          # line; exclude the current tag to support partial-release re-runs.
           prev_tag="$(gh release list --repo "${REPO}" --limit 100 \
-            --json tagName,createdAt \
-            --jq 'sort_by(.createdAt) | reverse | map(.tagName)
-                  | map(select(. != env.RELEASE_TAG)) | .[0] // empty' \
+            --json tagName,createdAt,isDraft \
+            --jq 'sort_by(.createdAt) | reverse
+                  | map(select(.isDraft == false) | .tagName)
+                  | map(select(. != env.RELEASE_TAG
+                      and startswith(env.RELEASE_TAG | split(".")[0:2] | join(".") + ".")))
+                  | .[0] // empty' \
             2>/dev/null || true)"
 
           {

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1436,8 +1436,8 @@ jobs:
           # predecessor is the newest published release on this major.minor
           # line; exclude the current tag to support partial-release re-runs.
           prev_tag="$(gh release list --repo "${REPO}" --limit 100 \
-            --json tagName,createdAt,isDraft \
-            --jq 'sort_by(.createdAt) | reverse
+            --json tagName,publishedAt,isDraft \
+            --jq 'sort_by(.publishedAt) | reverse
                   | map(select(.isDraft == false) | .tagName)
                   | map(select(. != env.RELEASE_TAG
                       and startswith(env.RELEASE_TAG | split(".")[0:2] | join(".") + ".")))


### PR DESCRIPTION
## Scope

Current head: `0dbf2319ba701a06ecfa1fb8cd4e9dd16d6ae494`. First actual CodeRabbit review completed on f6b289e at2026-09-11T03:13:10Z, review5174636225/run47511f93, with one minor pagination finding3985611867. The 100-release lookup can omit an older same-line predecessor. The fix is now pushed: two genuine failures, then18 focused and289 workflow tests pass. It aggregates paginated REST results before publication sorting and discards partial results on lookup failure. This does not affect RC15's already-verified correct comparison link.

The first normal push and one unchanged retry failed during repeated Mac sleep-related test timeouts. After the host returned to AC power with its lid open, unchanged push8401 passed in306.76seconds:16,265 backend tests/505files and5,290 UI tests/248files, both100% configuredcoverage, bothbuilds,217scripts,289workflows,UItypecheck,staticchecksandZizmor. Website scripts andoptionalDocker skipped normally. Remote matches exact0dbf; tree clean, no generated drift or owned processes. No test timeout, source, dependency, power setting or protection was relaxed. Hosted checks and actual second review of0dbf remain separate gates.

Previous head: f6b289e787a97a4a7f505e84e4967401e8b2f073. This also ports reviewed #1171 publication-order selection: request and sort publishedAt, not creation time. Its two-file +26/-6 delta has exactly the reviewed 1.7 patch ID, and the regression file is byte-identical. A fresh real-workflow RED chose rc13 instead of the later-published rc14; all286 workflow tests then passed after the fix. No changes to draft filtering, current-tag exclusion, exact release-line matching or failed-lookup fallback.

Normal f6b289e push67483 passed in323.65seconds:16,265 backend tests/505files and5,290 UI tests/248files, configured100% coverage, bothbuilds,217scripts,286workflows,typecheck/static/Zizmor. Unchangedwebsite-script step andoptionalDocker correctlyskipped. Remoteexact, checkoutclean, noicondrift orownedprocesses. No dependencies changed orinstalled. The initial automatic review attempt was quota-only; the later actual first review is recorded above. All evidence below names older8c54 explicitly and does not replace newhead hostedchecks.

## Historical scope and verification on 8c54

Forward-port reviewed #1160 from dev/v1.7 into dev/v1.8. The release-note selector uses the exact major/minor line, excludes drafts/current tag and preserves chronological selection and safe omission. No artifact, signing, provenance, soak, runtime, dependency or version metadata changes.

Local branch fix/v1.8-release-note-predecessor, head 8c54d1e2a, base ccc27f6e2. Normal cherry-pick of landed ad04f8b7fa5e847ae120fec812434395242803cc, no conflicts or history rewrite. Exactly two files, +174/-5. Result tree 4e8fe6cf31e39efd8a9853463a204e78d16743d5 equals the clean merge preview. The test file is byte-identical to reviewed 1.7.

## Verification

- Original 1.7 TDD reproduced the actual opposite-line comparison URL before the selector fix. The unchanged 14-case regression executes the real workflow notes block, jq selector, changelog extractor and upgrade-note append script.
- Fresh 1.8 workflow suite: 285 tests in 30 files pass. Related release/changelog/upgrade scripts: 72 tests pass. Two printed stubbed-network errors are expected regression output; the workflow suite passed.
- Biome checks the TypeScript test, actionlint (with installed ShellCheck) accepts the workflow, offline Zizmor reports no findings. Diff check passes. All six workspace manifest/lock pairs were unchanged from the notification checkout; no installation or lock edits occurred.
- Normal full push gate passed in 339.28 seconds (session 84905): backend/UI 100% coverage, both builds, 217 script tests, 285 workflow tests, 95 website-script tests, UI typecheck, Biome, Knip, Qlty and Zizmor. Docker build skipped under its normal condition. No reduced settings or bypasses.
- Fetched remote branch matches exact `8c54d1e2a021ee540fba6afc56ab259566f7626d`; the actual three-dot diff remains two files, +174/-5. Checkout is clean and owned push/coverage processes have exited. The temporary checkout switch was clean and notification branch restored to exact `358e52f3468b2b529bc7ab19eb58743994af030e`. Generated app/UI builds belong to the release-note branch, not that notification source. Successful coverage reports are retained in logs; the gate intentionally removes its temporary JSON reports.

## Hosted interruption

The first [CI attempt](https://github.com/CodesWhat/drydock/actions/runs/34421667759/job/102698228067) stopped after 14m41, below its unchanged 20-minute job limit. All 16,265 backend tests passed; UI suites were passing immediately before the runner logged an explicit shutdown signal at 00:46:20.2368762Z, followed by cancellation. No test assertion failure or OOM diagnostic was found. There was no competing run in the same branch/workflow concurrency group. The reason for the host shutdown remains unknown.

One unchanged-head failed-job rerun with debug logging was requested at 2026-09-10T01:08Z. Attempt 2 passed: coverage job102705987438 in12m22 and build in7m39. All 11 required checks now pass or correctly skip; browser/Cucumber/Grype jobs correctly skip for this workflow-only diff. No worker limits, timeouts, source files or assertions changed.

The successful attempt retained runner and worker diagnostics. They show successful step completion, without a memory or shutdown event, and do not explain the original runner's shutdown. Two other successful runs of the identical coverage workflow exceeded15 minutes while blocking the same infrastructure domains. No network-permission change is justified by this evidence.

All eleven required checks on0dbf now pass or validly skip. Actual CodeRabbit second review completed clean at2026-09-13T01:31:10Z, run `e03110c2-1dff-4a6d-bc14-1ea6bdf16a9f`, reviewing both changed files fromf6 to0dbf. No actionable findings remain. Greptile exact-head request5649480892 was posted and fetched; no actual Greptile result is claimed.

Threat model: ordinary maintainer dispatch with interleaved maintained release lines, late-published drafts and pagination. This is a forward-port of a reviewed two-file fix, not a new release subsystem. The first actual finding is fixed, both local and hosted gates pass, and actual second review is clean. Quota-only notices are not reviews.
