### PR TITLE
docs(release): clarify architecture probe registry requirements

### DIFF
--- a/scripts/check-image-arch.sh
+++ b/scripts/check-image-arch.sh
@@ -9,7 +9,9 @@
 # "exec /sbin/tini: exec format error" on first start. That is drydock#1021.
 #
 # Usage: scripts/check-image-arch.sh <image-ref> <platform>
-#   scripts/check-image-arch.sh drydock:dev linux/arm64
+#   scripts/check-image-arch.sh 'ghcr.io/codeswhat/drydock@sha256:<digest>' linux/arm64
+# Requires a registry-accessible image reference, not a local-only image.
+# Registry inspection runs first; docker run uses --pull always for the probe.
 set -euo pipefail
 
 image_ref="${1:-}"
@@ -70,9 +72,9 @@ echo "Checking ${image_ref} (${platform}) for ${expected_arch} binaries, e_machi
 # fails the second time: docker's classic image store cannot hold two
 # platform variants under one digest, and aborts with "cannot overwrite
 # digest sha256:<index>". Resolve the platform's own manifest digest first so
-# each docker run pulls a distinct reference. A reference that is not an
-# index at all (no digest, or already a single-platform manifest) has
-# nothing to resolve, so it runs unchanged.
+# each docker run pulls a distinct reference. Tag references can also resolve to an index.
+# A reference whose registry response is a single-platform manifest has nothing
+# to resolve, so it runs unchanged.
 repository="${image_ref%@*}"
 last_segment="${repository##*/}"
 if [[ ${last_segment} == *:* ]]; then

--- a/scripts/check-image-arch.test.mjs
+++ b/scripts/check-image-arch.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { chmod, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -13,6 +13,23 @@ const scriptPath = fileURLToPath(new URL('check-image-arch.sh', import.meta.url)
 const ARM64 = 'b7 00';
 const AMD64 = '3e 00';
 const BINARIES = ['/sbin/tini', '/usr/local/bin/node', '/bin/healthcheck'];
+
+test('documents registry access, a digest example, and tag-index resolution', async () => {
+  const script = await readFile(scriptPath, 'utf8');
+  const comments = script
+    .split('\n')
+    .filter((line) => line.startsWith('#'))
+    .join('\n');
+
+  assert.match(comments, /Requires a registry-accessible image reference/u);
+  assert.match(
+    comments,
+    /scripts\/check-image-arch\.sh 'ghcr\.io\/codeswhat\/drydock@sha256:<digest>' linux\/arm64/u,
+  );
+  assert.match(comments, /docker run uses --pull always/u);
+  assert.match(comments, /Tag references can also resolve to an index/u);
+  assert.doesNotMatch(comments, /no digest, or already a single-platform manifest/u);
+});
 
 function probeLines(bytesByBinary) {
   // busybox `od -An` prefixes its output with a space, so the real probe emits
@@ -86,21 +103,28 @@ async function runGuard({
   probeOutput = allBinaries(ARM64),
   dockerExit = 0,
   dockerStderr = '',
+  inspectExit = 0,
+  inspectStderr = '',
   rawManifest = SINGLE_PLATFORM_MANIFEST,
   args = ['drydock:test', 'linux/arm64'],
 } = {}) {
   const dir = await mkdtemp(join(tmpdir(), 'drydock-image-arch-'));
-  const probeFile = join(dir, 'probe-output');
-  const manifestFile = join(dir, 'raw-manifest');
-  const argsLog = join(dir, 'docker-args.log');
-  await writeFile(probeFile, probeOutput === '' ? '' : `${probeOutput}\n`);
-  await writeFile(manifestFile, rawManifest);
+  try {
+    const probeFile = join(dir, 'probe-output');
+    const manifestFile = join(dir, 'raw-manifest');
+    const argsLog = join(dir, 'docker-args.log');
+    await writeFile(probeFile, probeOutput === '' ? '' : `${probeOutput}\n`);
+    await writeFile(manifestFile, rawManifest);
 
-  const fakeDocker = join(dir, 'docker');
-  await writeFile(
-    fakeDocker,
-    `#!/bin/sh
+    const fakeDocker = join(dir, 'docker');
+    await writeFile(
+      fakeDocker,
+      `#!/bin/sh
 if [ "$1" = "buildx" ] && [ "$2" = "imagetools" ] && [ "$3" = "inspect" ]; then
+  if [ "$INSPECT_EXIT" != "0" ]; then
+    printf '%s\\n' "$INSPECT_STDERR" >&2
+    exit "$INSPECT_EXIT"
+  fi
   cat "$RAW_MANIFEST_FILE"
   exit 0
 fi
@@ -113,38 +137,66 @@ if [ "$DOCKER_EXIT" != "0" ]; then
 fi
 cat "$PROBE_OUTPUT_FILE"
 `,
-  );
-  await chmod(fakeDocker, 0o755);
+    );
+    await chmod(fakeDocker, 0o755);
 
-  const env = {
-    ...process.env,
-    DOCKER_ARGS_LOG: argsLog,
-    DOCKER_EXIT: String(dockerExit),
-    DOCKER_STDERR: dockerStderr,
-    PROBE_OUTPUT_FILE: probeFile,
-    RAW_MANIFEST_FILE: manifestFile,
-    PATH: `${dir}:${process.env.PATH}`,
-  };
-
-  const readArgs = async () => {
-    try {
-      return await readFile(argsLog, 'utf8');
-    } catch {
-      return '';
-    }
-  };
-
-  try {
-    const { stdout, stderr } = await execFileAsync('bash', [scriptPath, ...args], { env });
-    return { code: 0, output: `${stdout}${stderr}`, dockerArgs: await readArgs() };
-  } catch (error) {
-    return {
-      code: error.code,
-      output: `${error.stdout ?? ''}${error.stderr ?? ''}`,
-      dockerArgs: await readArgs(),
+    const env = {
+      ...process.env,
+      DOCKER_ARGS_LOG: argsLog,
+      DOCKER_EXIT: String(dockerExit),
+      DOCKER_STDERR: dockerStderr,
+      INSPECT_EXIT: String(inspectExit),
+      INSPECT_STDERR: inspectStderr,
+      PROBE_OUTPUT_FILE: probeFile,
+      RAW_MANIFEST_FILE: manifestFile,
+      PATH: `${dir}:${process.env.PATH}`,
     };
+
+    const readArgs = async () => {
+      try {
+        return await readFile(argsLog, 'utf8');
+      } catch {
+        return '';
+      }
+    };
+
+    try {
+      const { stdout, stderr } = await execFileAsync('bash', [scriptPath, ...args], { env });
+      return { code: 0, output: `${stdout}${stderr}`, dockerArgs: await readArgs() };
+    } catch (error) {
+      return {
+        code: error.code,
+        output: `${error.stdout ?? ''}${error.stderr ?? ''}`,
+        dockerArgs: await readArgs(),
+      };
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
   }
 }
+
+test('refuses an inaccessible registry reference before an otherwise successful probe', async () => {
+  const result = await runGuard({
+    inspectExit: 1,
+    inspectStderr: 'pull access denied for drydock:test',
+  });
+
+  assert.equal(result.code, 1);
+  assert.match(result.output, /Could not inspect drydock:test: pull access denied/u);
+  assert.equal(result.dockerArgs, '');
+  assert.doesNotMatch(result.output, /All 3 binaries/u);
+});
+
+test('resolves a tag reference to its platform manifest when the tag names an index', async () => {
+  const result = await runGuard({
+    args: ['ghcr.io/codeswhat/drydock:dev', 'linux/arm64'],
+    rawManifest: twoPlatformIndex(),
+  });
+
+  assert.equal(result.code, 0);
+  assert.match(result.dockerArgs, new RegExp(`ghcr.io/codeswhat/drydock@${ARM64_DIGEST}`, 'u'));
+  assert.match(result.dockerArgs, /--pull always/u);
+});
 
 test('passes when every binary is aarch64 on linux/arm64', async () => {
   const result = await runGuard();


### PR DESCRIPTION
# Architecture probe registry requirements

Base: `dev/v1.8`, verified source `ccc27f6e2bedc2ac2e775adf59d3012bf30ce662`.
Branch: `fix/v1.8-image-arch-usage`.
Head: `f926ded22c299fd2b757e4672e3786477e90fbeb`.

## Scope

The architecture probe advertised a local-only `drydock:dev` example even though it first inspects the registry and then invokes Docker with `--pull always`. DR-120 explicitly permits correcting the documentation instead of adding local-only image support.

The header now requires a registry-accessible reference, uses a quoted digest-reference example, and explains registry inspection and `--pull always`. The index-resolution comment now acknowledges that tag references can also name indexes. The false claim that no digest means non-index is gone.

Exactly two files change, +96/-42: `scripts/check-image-arch.sh` and its existing test file. Most test churn indents the existing fixture setup under an outer `try/finally`. The helper removes only its own exact `mkdtemp` directory after reading process output, including setup-error cleanup.

Shell non-comment bytes were independently compared with the base and are identical. No runtime behavior, release workflow, publisher, permissions, caller, dependency, or version metadata changes. The sole release caller already passes tag plus digest. No backport unless a maintained cut actually needs it.

## Verification

- TDD: the new documentation contract failed against the old comments on the missing registry-access requirement, then passed after the comment correction.
- Two additional real-script boundary regressions characterize unchanged behavior, not new runtime fixes: failed registry inspection reports the inspection error without reaching an otherwise successful fake Docker probe; a registry tag naming an index resolves to the requested platform digest and retains `--pull always`.
- 38 focused script tests passed: 23 architecture-probe tests and 15 base-index tests. Final architecture suite rerun after quoting the placeholder: 23 passed.
- Five release platform-guard workflow tests passed. An initial invocation used a nonexistent configuration path and failed before loading tests; the corrected invocation used `.github/tests/vitest.config.mjs` and passed.
- Bash syntax, ShellCheck, Node parse, Biome, `git diff --check`, and normal commit hooks passed.
- Normal full push session20358: terminal PASS in 333.73 seconds. Clean-tree, directive guard, Biome, app/UI Knip, Qlty, advisory smells, script tests, workflow tests, UI typecheck, website script tests, app/UI coverage at 100%, both builds, and Zizmor passed. Docker build skipped under the normal condition. No bypass or reduced settings. Coverage took 254.45 seconds; builds took 2.82 seconds. Zizmor reported no findings (two ignored, 51 suppressed).
- Remote branch was fetched independently after the push and matches exact head `f926ded22c299fd2b757e4672e3786477e90fbeb`. Checkout is clean, with no generated glyph changes. The true diff remains exactly the two files above.
- Hosted [CI Verify 34424063539](https://github.com/CodesWhat/drydock/actions/runs/34424063539) and [Playwright 34424062881](https://github.com/CodesWhat/drydock/actions/runs/34424062881) both completed successfully on that exact head. All 11 required checks are satisfied: 10 success, with the website build/scripts check skipped by its normal path condition.
- The separate, non-required `qlty check` integration reports an error. Required `Quality: Lint` and `Quality: Test & Coverage` passed; this is not a claim that every optional integration is green.

## Review scope

Hosted CI is complete. CodeRabbit inspected the exact source and tests in its [first actual source review](https://github.com/CodesWhat/drydock/pull/1167#issuecomment-5650417048) and found no actionable findings. The automatic formal-review command remained rate-limited; its status is not the review evidence. There are no open review threads. The current dev/v1.8 merge forecast is clean.

Threat model: the existing maintainer-run release architecture probe, with registry access required and Docker replaced only at the external boundary in tests. No hostile-maintainer shell parsing or local-image feature expansion.
