### PR TITLE
fix(release): order predecessors by publication time

### DIFF
--- a/.github/tests/release-cut-previous-release.test.ts
+++ b/.github/tests/release-cut-previous-release.test.ts
@@ -16,9 +16,13 @@ set -euo pipefail
 printf '%s\\n' "$@" > "\${GH_ARGS_PATH}"
 if [ "$1" != release ] || [ "$2" != list ]; then exit 97; fi
 if [ "\${LOOKUP_FAIL}" = true ]; then exit 1; fi
+fields=""
 while [ "$#" -gt 0 ]; do
+  if [ "$1" = --json ]; then fields="$2"; shift; fi
   if [ "$1" = --jq ]; then
-    jq -r "$2" "\${RELEASES_PATH}"
+    jq --arg fields "$fields" \\
+      'map(with_entries(select(.key as $key | $fields | split(",") | index($key))))' \\
+      "\${RELEASES_PATH}" | jq -r "$2"
     exit 0
   fi
   shift
@@ -26,8 +30,13 @@ done
 exit 98
 `;
 
-function release(tagName: string, createdAt: string, isDraft = false) {
-  return { tagName, createdAt, isDraft };
+function release(
+  tagName: string,
+  createdAt: string,
+  isDraft = false,
+  publishedAt: string | null = isDraft ? null : createdAt,
+) {
+  return { tagName, createdAt, publishedAt, isDraft };
 }
 
 function runNotes(releaseTag: string, releases: ReturnType<typeof release>[], lookupFail = false) {
@@ -82,7 +91,7 @@ function runNotes(releaseTag: string, releases: ReturnType<typeof release>[], lo
     ]);
     expect(args[args.indexOf('--json') + 1].split(',')).toEqual([
       'tagName',
-      'createdAt',
+      'publishedAt',
       'isDraft',
     ]);
     const notes = readFileSync(notesPath, 'utf8');
@@ -133,6 +142,17 @@ test('excludes drafts and the current tag on a partial-release rerun', () => {
     release('v1.7.0-rc.13', '2026-09-08T00:00:00Z'),
   ]);
   expect(notes).toContain('/compare/v1.7.0-rc.13...v1.7.0-rc.14');
+});
+
+test('selects the latest publication even when its draft was created earlier', () => {
+  const notes = runNotes('v1.7.0-rc.15', [
+    release('v1.7.0-rc.14', '2026-09-07T00:00:00Z', false, '2026-09-09T00:00:00Z'),
+    release('v1.7.0-rc.13', '2026-09-08T00:00:00Z', false, '2026-09-08T00:00:00Z'),
+    release('v1.7.0-rc.16', '2026-09-10T00:00:00Z', true, null),
+  ]);
+  expect(notes).toContain('/compare/v1.7.0-rc.14...v1.7.0-rc.15');
+  expect(notes).not.toContain('/compare/v1.7.0-rc.13...');
+  expect(notes).not.toContain('/compare/v1.7.0-rc.16...');
 });
 
 test('matches both major and minor exactly rather than a partial prefix', () => {

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1442,8 +1442,8 @@ jobs:
           # predecessor is the newest published release on this major.minor
           # line; exclude the current tag to support partial-release re-runs.
           prev_tag="$(gh release list --repo "${REPO}" --limit 100 \
-            --json tagName,createdAt,isDraft \
-            --jq 'sort_by(.createdAt) | reverse
+            --json tagName,publishedAt,isDraft \
+            --jq 'sort_by(.publishedAt) | reverse
                   | map(select(.isDraft == false) | .tagName)
                   | map(select(. != env.RELEASE_TAG
                       and startswith(env.RELEASE_TAG | split(".")[0:2] | join(".") + ".")))


### PR DESCRIPTION
# fix(release): order predecessors by publication time

Use publication time to choose the newest published predecessor on the same release line. Creation time can put a draft published later behind an older public release, producing the wrong Full Changelog comparison.

Merged normally at2026-09-10T18:32:59Z as a06bdafc6a65ed4834fd19fbd23654e14b534837. The fetched complete tree7907429e4d9d926a7d97135fb553039a3930438a exactly equals reviewed head683b95ed6, and the actual squash message has a short explicit body. All eleven required checks passed or were normally skipped. Promotion #1170 is being reconciled to this reviewed dev result; no RC15 cut yet.

This addresses the verified first-review finding on promotion #1170: https://github.com/CodesWhat/drydock/pull/1170#discussion_r3981960789. The fix lands through dev/v1.7 before that promotion is updated. No main-only content, release dispatch, registry mutation or GA promotion is included.

Head: 683b95ed6ebdb53c9628e6cf5f0cfc934ee722a0, based on reviewed merged dev000de5191f4ca23dd18b2df0286c8dd4b4496661. Two files, +26/-6. The workflow requests and sorts publishedAt. Draft filtering, current-tag exclusion, exact major/minor matching and lookup-failure fallback are unchanged.

The regression runs the real release-notes shell block and jq selector. Its API boundary stub projects only requested JSON fields. An earlier-created draft published later must win, while an unpublished draft with null publication time remains excluded. Before the fix, that test failed because the comparison chose rc13 instead of rc14; the other fourteen cases passed. All 264 workflow tests now pass, along with Biome, actionlint and offline Zizmor.

The parent read the complete diff. Normal push verification passed in303.84seconds on exact683b95ed6: fresh backend13,832tests/425files and UI4,791tests/228files, configured100% across all metrics, both builds and every applicable normal gate. Optional Docker build was skipped. Remote matches exactly. The build regenerated only two known icon definitions; those generated differences were inspected and restored to committed bytes, the checkout is clean, and owned gate/worker processes have exited.

Actual CodeRabbit pass one completed clean at2026-09-10T18:12:27Z, runc55a1739-ba7d-4108-9431-4d96d2379842, exact000de519 to683b95ed6, both changed files selected and no actionable findings. The separate invocation reply also inspected the exact commit and confirmed the selector and regression. CI34511760338 completed successfully, including coverage13m35 and build10m25; Cucumber and Grype were normally skipped. Playwright34511759201 also completed with its browser job normally skipped for this workflow-only diff.

An additional parent-local predecessor rerun had14passes and one5second timeout in the v1.6.1 transition case; its shell step took9.53seconds. That run is retained as a failure, and its chained precheck did not execute. An unchanged rerun then passed all15tests in3.34seconds, and a separately executed strict RC15 precheck passed. No source or test-timeout settings changed. The machine's power log shows repeated maintenance sleep/dark-wake cycles during this period. The prior complete local gate and current hosted gate remain successful. Threat model: ordinary delayed draft publication and correct release metadata, not a hostile maintainer.
